### PR TITLE
Name the routes on a stop marker at transit-centre zoom (#2107)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/RouteBadgeBitmapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/RouteBadgeBitmapTest.kt
@@ -24,9 +24,10 @@ import org.junit.runner.RunWith
 
 /**
  * The stacked route-label bitmap (#2083): a label naming an interchangeable ride draws one row per route,
- * each filled with that route's own line colour. Instrumented rather than a JVM test because this is
- * `Canvas` drawing — the unit-test `android.graphics` stubs draw nothing — so the rows are checked the only
- * way they can be: by reading the pixels back.
+ * each filled with that route's own line colour — and, where a single column would grow too tall, several
+ * columns of them (#2107). Instrumented rather than a JVM test because this is `Canvas` drawing — the
+ * unit-test `android.graphics` stubs draw nothing — so the cells are checked the only way they can be: by
+ * reading the pixels back.
  */
 @RunWith(AndroidJUnit4::class)
 class RouteBadgeBitmapTest {
@@ -89,7 +90,38 @@ class RouteBadgeBitmapTest {
         assertEquals(green, stacked.rowFill(row = 1, rows = 2))
     }
 
+    @Test
+    fun aGridIsAsWideAsItsColumns_eachSizedToItsOwnWidestName() {
+        // The transit-centre stop label (#2107) widens instead of overflowing, and a column is only as wide
+        // as something in it: the narrow column beside a long name stays narrow.
+        val short = listOf(BadgedRoute("8", blue), BadgedRoute("40", blue))
+        val long = listOf(BadgedRoute("Seattle - Bremerton", green), BadgedRoute("Bainbridge", green))
+        val grid = grid(listOf(short, long))
+
+        // Exactly its two columns side by side — not two of the wider one.
+        assertEquals(badge(short).width + badge(long).width, grid.width)
+        // Two rows, as tall as a single column of two.
+        assertEquals(badge(short).height, grid.height)
+        // Each column carries its own routes' colour, left to right.
+        assertEquals(blue, grid.getPixel(SAMPLE_INSET_PX, rowCenterY(grid, row = 0, rows = 2)))
+        assertEquals(green, grid.getPixel(grid.width - SAMPLE_INSET_PX, rowCenterY(grid, row = 1, rows = 2)))
+    }
+
+    @Test
+    fun oneColumnDrawsExactlyWhatTheUnstackedBadgeDoes() {
+        // badge() is badgeGrid()'s single-column case, so a label on a line is unaffected by the grid.
+        val routes = listOf(BadgedRoute("1 Line", blue), BadgedRoute("2 Line", green))
+        val single = badge(routes)
+        val asGrid = grid(listOf(routes))
+
+        assertEquals(single.width, asGrid.width)
+        assertEquals(single.height, asGrid.height)
+        assertTrue(single.sameAs(asGrid))
+    }
+
     private fun badge(routes: List<BadgedRoute>, scale: Float = 1f): Bitmap = ContinuationBadgeBitmaps.badge(routes, density = 1f, darkMode = false, scale = scale)
+
+    private fun grid(columns: List<List<BadgedRoute>>): Bitmap = ContinuationBadgeBitmaps.badgeGrid(columns, density = 1f, darkMode = false, scale = 1f)
 
     /** The fill colour of one row, read from inside its leading padding. */
     private fun Bitmap.rowFill(row: Int, rows: Int): Int = getPixel(SAMPLE_INSET_PX, rowCenterY(this, row, rows))

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
@@ -161,6 +161,14 @@ internal class GoogleStopMarkerLayer(
         }
     }
 
+    /**
+     * The shared descriptor for a label naming [routes], drawn in the current theme.
+     *
+     * A live label is re-iconed only when its routes change (see [renderLabel]) — the theme can't change
+     * under one, since a light/dark switch recreates the activity and with it the map, this layer and this
+     * cache. The label is drawn from the unrendered [StopRoute]s that survive that recreate in the view
+     * model, which is what re-colours the labels rather than restoring the ones drawn before the switch.
+     */
     private fun labelIcon(routes: List<StopRoute>): BitmapDescriptor {
         val darkMode = ThemeUtils.isInDarkMode(context)
         return labelIcons.get(StopRouteLabelBitmaps.labelKey(routes, darkMode)) {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
@@ -22,11 +22,11 @@ import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
-import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.STOP_ROUTE_LABEL_Z_INDEX
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.StopRoute
 import org.onebusaway.android.map.render.StopRouteLabelBitmaps
 import org.onebusaway.android.map.render.stopIconKind
 import org.onebusaway.android.map.render.stopRouteLabel
@@ -46,7 +46,7 @@ internal class GoogleStopMarkerLayer(
     // than redrawn: at the zoom these appear the map still loads stops on every pan, and labels torn down
     // and re-added on each of those publishes would blink while the markers under them held still.
     private val labelByStopId = HashMap<String, Marker>()
-    private val labelRoutesByStopId = HashMap<String, List<BadgedRoute>>()
+    private val labelRoutesByStopId = HashMap<String, List<StopRoute>>()
 
     // One descriptor per distinct set of routes: a transit centre's bays repeat each other's routes, and a
     // label bitmap is mostly transparent lift, so sharing them is worth more here than for a stop icon.
@@ -161,7 +161,7 @@ internal class GoogleStopMarkerLayer(
         labelRoutesByStopId.remove(stopId)
     }
 
-    private fun labelIcon(routes: List<BadgedRoute>): BitmapDescriptor {
+    private fun labelIcon(routes: List<StopRoute>): BitmapDescriptor {
         val darkMode = ThemeUtils.isInDarkMode(context)
         val key = StopRouteLabelBitmaps.labelKey(routes, darkMode)
         return labelIcons.get(key) ?: BitmapDescriptorFactory

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.map.googlemapsv2
 
 import android.content.Context
-import android.util.LruCache
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
@@ -46,11 +45,12 @@ internal class GoogleStopMarkerLayer(
     // than redrawn: at the zoom these appear the map still loads stops on every pan, and labels torn down
     // and re-added on each of those publishes would blink while the markers under them held still.
     private val labelByStopId = HashMap<String, Marker>()
-    private val labelRoutesByStopId = HashMap<String, List<StopRoute>>()
 
     // One descriptor per distinct set of routes: a transit centre's bays repeat each other's routes, and a
     // label bitmap is mostly transparent lift, so sharing them is worth more here than for a stop icon.
-    private val labelIcons = LruCache<String, BitmapDescriptor>(LABEL_ICON_CACHE_SIZE)
+    // The flavor's own memoizer, so the label bitmap is built only on a miss (see [BitmapDescriptorCache]).
+    private val labelIcons =
+        BitmapDescriptorCache(LABEL_ICON_CACHE_SIZE) { BitmapDescriptorFactory.fromBitmap(it) }
 
     fun render(stops: List<StopMarker>, focusedStopId: String?, band: StopBand) {
         val markerStops = stops.filterNot(StopMarker::routeStop)
@@ -115,8 +115,7 @@ internal class GoogleStopMarkerLayer(
         markerByStopId.clear()
         labelByStopId.values.forEach(Marker::remove)
         labelByStopId.clear()
-        labelRoutesByStopId.clear()
-        labelIcons.evictAll()
+        labelIcons.clear()
         stopByMarker.clear()
         kindByStopId.clear()
     }
@@ -146,11 +145,13 @@ internal class GoogleStopMarkerLayer(
             labelByStopId[stop.id] = marker
             stopByMarker[marker] = stop
         } else {
-            if (labelRoutesByStopId[stop.id] != routes) existing.setIcon(labelIcon(routes))
-            if (stopByMarker[existing]?.point != stop.point) existing.position = stop.point.toLatLng()
+            // The label's own previous stop, which is what it was drawn from — a label exists only where
+            // the last render was in the labelling band, so its routes are the ones on the pill.
+            val previous = stopByMarker[existing]
+            if (previous?.routes != routes) existing.setIcon(labelIcon(routes))
+            if (previous?.point != stop.point) existing.position = stop.point.toLatLng()
             stopByMarker[existing] = stop
         }
-        labelRoutesByStopId[stop.id] = routes
     }
 
     private fun removeLabel(stopId: String) {
@@ -158,15 +159,13 @@ internal class GoogleStopMarkerLayer(
             stopByMarker.remove(it)
             it.remove()
         }
-        labelRoutesByStopId.remove(stopId)
     }
 
     private fun labelIcon(routes: List<StopRoute>): BitmapDescriptor {
         val darkMode = ThemeUtils.isInDarkMode(context)
-        val key = StopRouteLabelBitmaps.labelKey(routes, darkMode)
-        return labelIcons.get(key) ?: BitmapDescriptorFactory
-            .fromBitmap(StopRouteLabelBitmaps.label(context, routes, darkMode))
-            .also { labelIcons.put(key, it) }
+        return labelIcons.get(StopRouteLabelBitmaps.labelKey(routes, darkMode)) {
+            StopRouteLabelBitmaps.label(context, routes, darkMode)
+        }
     }
 
     private fun icon(stop: StopMarker, kind: StopIconKind): BitmapDescriptor = when (kind) {

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
@@ -16,15 +16,22 @@
 package org.onebusaway.android.map.googlemapsv2
 
 import android.content.Context
+import android.util.LruCache
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
+import org.onebusaway.android.map.render.BadgedRoute
+import org.onebusaway.android.map.render.STOP_ROUTE_LABEL_Z_INDEX
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.StopRouteLabelBitmaps
 import org.onebusaway.android.map.render.stopIconKind
+import org.onebusaway.android.map.render.stopRouteLabel
 import org.onebusaway.android.map.render.stopZIndex
+import org.onebusaway.android.util.ThemeUtils
 
 /** Owns non-route stop marker identity, icon reconciliation, tap lookup, and disposal. */
 internal class GoogleStopMarkerLayer(
@@ -34,6 +41,16 @@ internal class GoogleStopMarkerLayer(
     private val markerByStopId = HashMap<String, Marker>()
     private val stopByMarker = HashMap<Marker, StopMarker>()
     private val kindByStopId = HashMap<String, StopIconKind>()
+
+    // The transit-centre route label beside each stop (#2107), reconciled alongside its marker rather
+    // than redrawn: at the zoom these appear the map still loads stops on every pan, and labels torn down
+    // and re-added on each of those publishes would blink while the markers under them held still.
+    private val labelByStopId = HashMap<String, Marker>()
+    private val labelRoutesByStopId = HashMap<String, List<BadgedRoute>>()
+
+    // One descriptor per distinct set of routes: a transit centre's bays repeat each other's routes, and a
+    // label bitmap is mostly transparent lift, so sharing them is worth more here than for a stop icon.
+    private val labelIcons = LruCache<String, BitmapDescriptor>(LABEL_ICON_CACHE_SIZE)
 
     fun render(stops: List<StopMarker>, focusedStopId: String?, band: StopBand) {
         val markerStops = stops.filterNot(StopMarker::routeStop)
@@ -46,6 +63,7 @@ internal class GoogleStopMarkerLayer(
                 kindByStopId.remove(entry.key)
                 entry.value.remove()
                 gone.remove()
+                removeLabel(entry.key)
             }
         }
 
@@ -83,6 +101,11 @@ internal class GoogleStopMarkerLayer(
             }
             kindByStopId[stop.id] = kind
         }
+
+        // A second pass, after every marker exists: markers added in one pass with their labels would
+        // leave each label under the icons of the stops added after it (the SDK breaks a z-index tie by
+        // add order), which at these zooms is exactly the neighbour a rider is comparing against.
+        for (stop in markerStops) renderLabel(stop, band)
     }
 
     fun stopForMarker(marker: Marker): StopMarker? = stopByMarker[marker]
@@ -90,8 +113,60 @@ internal class GoogleStopMarkerLayer(
     fun dispose() {
         markerByStopId.values.forEach(Marker::remove)
         markerByStopId.clear()
+        labelByStopId.values.forEach(Marker::remove)
+        labelByStopId.clear()
+        labelRoutesByStopId.clear()
+        labelIcons.evictAll()
         stopByMarker.clear()
         kindByStopId.clear()
+    }
+
+    /**
+     * Add, re-stamp or drop [stop]'s route label so it matches what the stop names at [band]. Its marker
+     * is registered in [stopByMarker] like the stop's own, so tapping a label focuses the stop it labels
+     * — it reads as part of that marker, and a label that swallowed the tap would read as a dead one.
+     */
+    private fun renderLabel(stop: StopMarker, band: StopBand) {
+        val routes = stopRouteLabel(stop, band)
+        if (routes.isEmpty()) {
+            removeLabel(stop.id)
+            return
+        }
+        val existing = labelByStopId[stop.id]
+        if (existing == null) {
+            val marker = map.addMarkerOrFail(
+                MarkerOptions()
+                    .position(stop.point.toLatLng())
+                    .icon(labelIcon(routes))
+                    // The lift above the stop is baked into the bitmap, so the label is centered on the
+                    // stop's own point exactly as a route label is on its line (see StopRouteLabelBitmaps).
+                    .anchor(0.5f, 0.5f)
+                    .zIndex(STOP_ROUTE_LABEL_Z_INDEX)
+            )
+            labelByStopId[stop.id] = marker
+            stopByMarker[marker] = stop
+        } else {
+            if (labelRoutesByStopId[stop.id] != routes) existing.setIcon(labelIcon(routes))
+            if (stopByMarker[existing]?.point != stop.point) existing.position = stop.point.toLatLng()
+            stopByMarker[existing] = stop
+        }
+        labelRoutesByStopId[stop.id] = routes
+    }
+
+    private fun removeLabel(stopId: String) {
+        labelByStopId.remove(stopId)?.let {
+            stopByMarker.remove(it)
+            it.remove()
+        }
+        labelRoutesByStopId.remove(stopId)
+    }
+
+    private fun labelIcon(routes: List<BadgedRoute>): BitmapDescriptor {
+        val darkMode = ThemeUtils.isInDarkMode(context)
+        val key = StopRouteLabelBitmaps.labelKey(routes, darkMode)
+        return labelIcons.get(key) ?: BitmapDescriptorFactory
+            .fromBitmap(StopRouteLabelBitmaps.label(context, routes, darkMode))
+            .also { labelIcons.put(key, it) }
     }
 
     private fun icon(stop: StopMarker, kind: StopIconKind): BitmapDescriptor = when (kind) {
@@ -110,5 +185,10 @@ internal class GoogleStopMarkerLayer(
             StopIconFactory.anchorX(context, stop.direction) to
                 StopIconFactory.anchorY(context, stop.direction)
         else -> 0.5f to 0.5f
+    }
+
+    private companion object {
+        /** Comfortably more distinct route sets than a viewport at transit-centre zoom holds stops. */
+        const val LABEL_ICON_CACHE_SIZE = 64
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -509,16 +509,27 @@ class StopsMapController(
             renderState.setFocusedStopId(null)
             return
         }
-        val newlyAccumulated = !stopAccum.containsKey(stop.id)
-        if (newlyAccumulated) {
-            routes?.let { cacheRoutes(it) }
+        // Cached before the marker is built or re-labelled, and whether or not the stop is new: these are
+        // the routes serving the stop the caller is focusing, and they are what its label names. An
+        // already-accumulated stop is the case that matters — one rendered from the persistent cache
+        // carries no route names at all (see [labelRoutes]), so dropping the ones the arrivals response
+        // just handed us would leave the *focused* stop the one stop on screen with no label.
+        routes?.let { cacheRoutes(it) }
+        val existing = stopAccum[stop.id]
+        val labelled = labelRoutes(stop)
+        val markerChanged = existing == null || existing.routes != labelled
+        if (existing == null) {
             stopAccum[stop.id] = toStopMarker(stop)
+        } else if (markerChanged) {
+            // Only the label changes: everything else about an accumulated marker came from the nearby
+            // load and stays as it is, so a copy keeps the rest referentially stable for the renderers.
+            stopAccum[stop.id] = existing.copy(routes = labelled)
         }
         // Focus before publishing (like clearStops): publishStops reads focusedStopId for the
         // presentation's keep-the-focused-stop fallback. With a route presentation active the marker
         // list keys off the focus even for an already-accumulated stop, so republish then too.
         renderState.setFocusedStopId(stop.id)
-        if (newlyAccumulated || routePresentation != null) {
+        if (markerChanged || routePresentation != null) {
             publishStops()
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -51,9 +51,9 @@ import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.GeoPoint
-import org.onebusaway.android.util.ROUTE_NAME_ORDER
 import org.onebusaway.android.util.RegionUtils
 import org.onebusaway.android.util.getRouteDisplayName
+import org.onebusaway.android.util.inInterchangeableOrder
 import org.onebusaway.android.util.toGeoPoint
 
 /**
@@ -563,11 +563,9 @@ class StopsMapController(
     private fun labelRoutes(stop: ObaStop): List<StopRoute> = stop.routeIds
         .mapNotNull { cachedRoutes[it] }
         .map { StopRoute(getRouteDisplayName(it), it.color) }
-        // The app's one route-name order, so the label reads a stop's routes the way every other list of
-        // them does. Deduplicated by name because the label has only the name to show: two routes that
-        // share one (the feeds do collide) would draw as the same row twice.
-        .distinctBy(StopRoute::shortName)
-        .sortedWith(compareBy(ROUTE_NAME_ORDER, StopRoute::shortName))
+        // The order every other set of badged routes is read in — deduplicated by name and in the app's
+        // one route-name order.
+        .inInterchangeableOrder(StopRoute::shortName)
 
     /** Rebuild the rendered marker list from canonical nearby data and the current route presentation. */
     private fun publishStops() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -38,8 +38,10 @@ import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.database.oba.CachedViewport
 import org.onebusaway.android.database.oba.StopCacheRepository
 import org.onebusaway.android.location.LocationRepository
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.primaryRouteType
 import org.onebusaway.android.map.render.stopZoomBand
@@ -50,7 +52,9 @@ import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.ROUTE_NAME_ORDER
 import org.onebusaway.android.util.RegionUtils
+import org.onebusaway.android.util.getRouteDisplayName
 import org.onebusaway.android.util.toGeoPoint
 
 /**
@@ -460,7 +464,8 @@ class StopsMapController(
                     existing.point == marker.point &&
                     existing.direction == marker.direction &&
                     existing.routeType == marker.routeType &&
-                    existing.favorite == marker.favorite
+                    existing.favorite == marker.favorite &&
+                    existing.routes == marker.routes
                 ) {
                     existing
                 } else {
@@ -542,9 +547,32 @@ class StopsMapController(
             direction,
             routeType,
             stop,
-            favorite = stop.id in favoriteIds
+            favorite = stop.id in favoriteIds,
+            routes = labelRoutes(stop)
         )
     }
+
+    /**
+     * The routes serving [stop], for the marker's transit-centre label (#2107), named and coloured
+     * exactly as they would be on their own lines. Resolved from [cachedRoutes] — the routes the stop
+     * responses reported — so a stop whose routes haven't been loaded yet simply carries none and draws
+     * no label until they have, the same graceful degradation [primaryRouteType] already makes for the
+     * icon. (That is the persistent stop cache's case: it stores each route's *type* but not its name, so
+     * a cache render labels nothing until the network response for the same viewport lands.)
+     */
+    private fun labelRoutes(stop: ObaStop): List<BadgedRoute> = stop.routeIds
+        .mapNotNull { cachedRoutes[it] }
+        .map { route ->
+            BadgedRoute(
+                getRouteDisplayName(route),
+                mapRouteLineColorOrNull(route.color) ?: DEFAULT_ROUTE_LINE_COLOR
+            )
+        }
+        // The app's one route-name order, so the label reads a stop's routes the way every other list of
+        // them does. Deduplicated by name because the label has only the name to show: two routes that
+        // share one (the feeds do collide) would draw as the same row twice.
+        .distinctBy(BadgedRoute::routeShortName)
+        .sortedWith(compareBy(ROUTE_NAME_ORDER, BadgedRoute::routeShortName))
 
     /** Rebuild the rendered marker list from canonical nearby data and the current route presentation. */
     private fun publishStops() {
@@ -591,7 +619,13 @@ internal fun applyRouteStopPresentation(
     return source.values.map { marker ->
         marker.copy(
             point = presentation.projectedPoints[marker.id] ?: marker.point,
-            presentedRoutes = presentation.routeDirectionsByStopId[marker.id].orEmpty()
+            presentedRoutes = presentation.routeDirectionsByStopId[marker.id].orEmpty(),
+            // No transit-centre route labels (#2107) in a route presentation. A presentation names the
+            // routes on screen itself — labelled on the lines they belong to, and in adjacency view
+            // through a palette that deliberately assigns each one a distinct hue so they can be told
+            // apart (#2043). A stop label built from the routes' own GTFS colours would name those same
+            // routes a second time, in a second colour, right beside the line saying otherwise.
+            routes = emptyList()
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -38,11 +38,10 @@ import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.database.oba.CachedViewport
 import org.onebusaway.android.database.oba.StopCacheRepository
 import org.onebusaway.android.location.LocationRepository
-import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
-import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.StopRoute
 import org.onebusaway.android.map.render.primaryRouteType
 import org.onebusaway.android.map.render.stopZoomBand
 import org.onebusaway.android.models.NearbyStops
@@ -553,26 +552,22 @@ class StopsMapController(
     }
 
     /**
-     * The routes serving [stop], for the marker's transit-centre label (#2107), named and coloured
-     * exactly as they would be on their own lines. Resolved from [cachedRoutes] — the routes the stop
-     * responses reported — so a stop whose routes haven't been loaded yet simply carries none and draws
-     * no label until they have, the same graceful degradation [primaryRouteType] already makes for the
-     * icon. (That is the persistent stop cache's case: it stores each route's *type* but not its name, so
-     * a cache render labels nothing until the network response for the same viewport lands.)
+     * The routes serving [stop], for the marker's transit-centre label (#2107): their names and the
+     * colours the agency published, left unrendered for the renderer to draw through the badge policy
+     * (see [StopRoute]). Resolved from [cachedRoutes] — the routes the stop responses reported — so a
+     * stop whose routes haven't been loaded yet simply carries none and draws no label until they have,
+     * the same graceful degradation [primaryRouteType] already makes for the icon. (That is the persistent
+     * stop cache's case: it stores each route's *type* but not its name, so a cache render labels nothing
+     * until the network response for the same viewport lands.)
      */
-    private fun labelRoutes(stop: ObaStop): List<BadgedRoute> = stop.routeIds
+    private fun labelRoutes(stop: ObaStop): List<StopRoute> = stop.routeIds
         .mapNotNull { cachedRoutes[it] }
-        .map { route ->
-            BadgedRoute(
-                getRouteDisplayName(route),
-                mapRouteLineColorOrNull(route.color) ?: DEFAULT_ROUTE_LINE_COLOR
-            )
-        }
+        .map { StopRoute(getRouteDisplayName(it), it.color) }
         // The app's one route-name order, so the label reads a stop's routes the way every other list of
         // them does. Deduplicated by name because the label has only the name to show: two routes that
         // share one (the feeds do collide) would draw as the same row twice.
-        .distinctBy(BadgedRoute::routeShortName)
-        .sortedWith(compareBy(ROUTE_NAME_ORDER, BadgedRoute::routeShortName))
+        .distinctBy(StopRoute::shortName)
+        .sortedWith(compareBy(ROUTE_NAME_ORDER, StopRoute::shortName))
 
     /** Rebuild the rendered marker list from canonical nearby data and the current route presentation. */
     private fun publishStops() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -100,7 +100,9 @@ object ContinuationBadgeBitmaps {
      * remainder pads it with a blank cell of its own choosing rather than leaving a hole. Stated rather
      * than handled, because a hole is a hole in the *pill* — the rounded rect and its casing enclose the
      * whole grid — so what fills it is a colour decision belonging to whoever knows what the label is,
-     * not a default this drawing can pick.
+     * not a default this drawing can pick. Such a cell marks itself [blank][BadgedRoute.blank], which is
+     * what keeps its fill out of the badge's [casing][casingColor] — the one place the drawing asks what
+     * colours the *routes* on it are rather than what to paint where.
      */
     fun badgeGrid(columns: List<List<BadgedRoute>>, density: Float, darkMode: Boolean, scale: Float): Bitmap {
         val rowCount = columns.firstOrNull()?.size ?: 0
@@ -203,13 +205,15 @@ object ContinuationBadgeBitmaps {
 
     /**
      * [badgeKey] for a [badgeGrid]. The column boundaries take part too, since the same names in one
-     * column and in two are different pills.
+     * column and in two are different pills — as does each cell's [blank][BadgedRoute.blank], which the
+     * casing reads, so a padded grid and one whose last cell really names a colourless route case
+     * differently and can't share a bitmap.
      */
     fun badgeGridKey(columns: List<List<BadgedRoute>>, darkMode: Boolean, scale: Float): String = columns.joinToString(
         separator = "/",
         prefix = "route-badge:$darkMode:$scale:"
     ) { cells ->
-        cells.joinToString(separator = "|") { "${it.routeShortName}:${it.color}:${it.textColor}" }
+        cells.joinToString(separator = "|") { "${it.routeShortName}:${it.color}:${it.textColor}:${it.blank}" }
     }
 
     /**
@@ -219,8 +223,14 @@ object ContinuationBadgeBitmaps {
      * a badge that really does hold several colors has no hue to case with — picking one row's would say
      * that row is the badge — so it takes the same tone with the hue dropped, a neutral that reads against
      * every band it encloses.
+     *
+     * The [blank][BadgedRoute.blank] cells padding a grid out to a rectangle are not routes and so are not
+     * counted: they carry whatever fill their producer gave them, which need not be any route's, and a
+     * label reading one hue would otherwise case itself grey for the sole reason that its route count
+     * didn't divide evenly into its columns.
      */
     internal fun casingColor(routes: List<BadgedRoute>, darkMode: Boolean): Int = routes
+        .filterNot(BadgedRoute::blank)
         .map(BadgedRoute::color)
         .distinct()
         .singleOrNull()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -91,6 +91,11 @@ object ContinuationBadgeBitmaps {
      * taller than the thing it labels, which today is a transit-centre stop naming more routes than fit
      * (#2107).
      *
+     * Each column is as wide as its own widest name, so the grid is not a uniform table: a column holding
+     * "1" and "8" stays narrow beside one holding "Seattle - Bremerton". Ragged divider spacing is the
+     * price, and worth paying — the alternative pads every column out to the longest name anywhere in the
+     * label, which on a map is width spent on nothing, in the direction a label can least afford it.
+     *
      * The grid is **rectangular**: every column holds the same number of cells, and a caller with a
      * remainder pads it with a blank cell of its own choosing rather than leaving a hole. Stated rather
      * than handled, because a hole is a hole in the *pill* — the rounded rect and its casing enclose the
@@ -120,13 +125,18 @@ object ContinuationBadgeBitmaps {
         // — the row boundaries are also where the dividers are drawn, and a fractional band would drift
         // away from them down the stack.
         val rowHeight = ceil((metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * scale * 2)
-        // One width for every column, measured across the whole grid rather than per column: columns of
-        // their own widths would put the dividers at ragged intervals, and a grid reads as a grid.
-        val columnWidth = columns
-            .flatten()
-            .maxOf { route -> textPaint.measureText(route.routeShortName) + HORIZONTAL_PADDING_PX * scale * 2 }
-            .coerceAtLeast(cornerRadius * 2 / columns.size)
-        val width = columnWidth * columns.size
+        // Each column takes the width of its own widest name — a column is only as wide as something in
+        // it, so one long name doesn't pad out every column beside it. Rows still share one height across
+        // the grid, and deliberately: type sets a row's height whatever it reads, while its width is the
+        // name's own.
+        val columnWidths = columns.map { cells ->
+            cells
+                .maxOf { route -> textPaint.measureText(route.routeShortName) + HORIZONTAL_PADDING_PX * scale * 2 }
+                .coerceAtLeast(cornerRadius * 2 / columns.size)
+        }
+        // Where each column starts, and (last) the whole pill's width.
+        val columnLefts = columnWidths.runningFold(0f, Float::plus)
+        val width = columnLefts.last()
         val height = rowHeight * rowCount
 
         val bitmap = createBitmap(width.toInt(), height.toInt())
@@ -144,14 +154,15 @@ object ContinuationBadgeBitmaps {
         val pill = Path().apply { addRoundRect(badgeBounds, cornerRadius, cornerRadius, Path.Direction.CW) }
         canvas.withClip(pill) {
             columns.forEachIndexed { column, cells ->
-                val left = columnWidth * column
+                val left = columnLefts[column]
+                val right = columnLefts[column + 1]
                 cells.forEachIndexed { row, route ->
                     val top = rowHeight * row
                     band.color = Color.rgb(Color.red(route.color), Color.green(route.color), Color.blue(route.color))
-                    drawRect(RectF(left, top, left + columnWidth, top + rowHeight), band)
+                    drawRect(RectF(left, top, right, top + rowHeight), band)
                     textPaint.color = route.textColor ?: MarkerRendering.legibleOn(route.color)
                     val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
-                    drawText(route.routeShortName, left + columnWidth / 2f, baseline, textPaint)
+                    drawText(route.routeShortName, (left + right) / 2f, baseline, textPaint)
                 }
             }
         }
@@ -167,7 +178,7 @@ object ContinuationBadgeBitmaps {
             canvas.drawLine(badgeBounds.left, y, badgeBounds.right, y, line)
         }
         for (column in 1 until columns.size) {
-            val x = columnWidth * column
+            val x = columnLefts[column]
             canvas.drawLine(x, badgeBounds.top, x, badgeBounds.bottom, line)
         }
         canvas.drawRoundRect(badgeBounds, cornerRadius, cornerRadius, line)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -74,20 +74,41 @@ object ContinuationBadgeBitmaps {
      * joined chip gives (`RouteBadgeChip`): the routes on it are one ride the rider may board any of
      * (#2010/#2083), not separate lines that happen to meet here. The stack goes downwards rather than
      * across because a map label's neighbour is the basemap — a name-per-column pill grows into the
-     * corridor it labels, while rows keep the label roughly as wide as its widest name.
+     * corridor it labels, while rows keep the label roughly as wide as its widest name. A label with more
+     * names than a single column can hold does take a second one ([badgeGrid]) — but that is a last
+     * resort, not the shape a label reaches for.
      *
      * [scale] multiplies every dimension of the pill — type, padding, corner, casing — so a scaled label
      * is the same drawing at a different size rather than a differently-proportioned one. A renderer
      * resolves it from the camera through the label's [RouteBadgeScaleProfile] (#2102).
      */
-    fun badge(routes: List<BadgedRoute>, density: Float, darkMode: Boolean, scale: Float): Bitmap {
-        require(routes.isNotEmpty()) { "a route badge has to name a route to draw one" }
+    fun badge(routes: List<BadgedRoute>, density: Float, darkMode: Boolean, scale: Float): Bitmap = badgeGrid(listOf(routes), density, darkMode, scale)
+
+    /**
+     * [badge] in several columns: the same pill, its names laid out in [columns] read top to bottom and
+     * then left to right, with dividers wherever two cells meet. One column is the ordinary badge — every
+     * label on a line is drawn through this — and a second only appears where a single column would grow
+     * taller than the thing it labels, which today is a transit-centre stop naming more routes than fit
+     * (#2107).
+     *
+     * The grid is **rectangular**: every column holds the same number of cells, and a caller with a
+     * remainder pads it with a blank cell of its own choosing rather than leaving a hole. Stated rather
+     * than handled, because a hole is a hole in the *pill* — the rounded rect and its casing enclose the
+     * whole grid — so what fills it is a colour decision belonging to whoever knows what the label is,
+     * not a default this drawing can pick.
+     */
+    fun badgeGrid(columns: List<List<BadgedRoute>>, density: Float, darkMode: Boolean, scale: Float): Bitmap {
+        val rowCount = columns.firstOrNull()?.size ?: 0
+        require(rowCount > 0) { "a route badge has to name a route to draw one" }
+        require(columns.all { it.size == rowCount }) {
+            "a route badge grid is rectangular; got columns of ${columns.map(List<BadgedRoute>::size)}"
+        }
         // Stated rather than clamped: a non-positive scale has no smallest sensible pill to fall back to,
         // and would otherwise surface far from its cause as a zero-size bitmap allocation.
         require(scale > 0f) { "a route badge drawn at scale $scale would have no pixels" }
-        // One paint for every row: they share a size and weight, so only the text color changes down the
-        // stack — set per row, exactly as the band's is. That also makes the metrics below the whole pill's:
-        // its rows are equal bands whatever they read.
+        // One paint for every cell: they share a size and weight, so only the text color changes across
+        // the grid — set per cell, exactly as the band's is. That also makes the metrics below the whole
+        // pill's: its rows are equal bands whatever they read.
         val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             textSize = TEXT_SIZE_PX * scale
             isFakeBoldText = true
@@ -99,10 +120,14 @@ object ContinuationBadgeBitmaps {
         // — the row boundaries are also where the dividers are drawn, and a fractional band would drift
         // away from them down the stack.
         val rowHeight = ceil((metrics.descent - metrics.ascent) + VERTICAL_PADDING_PX * scale * 2)
-        val width = routes
+        // One width for every column, measured across the whole grid rather than per column: columns of
+        // their own widths would put the dividers at ragged intervals, and a grid reads as a grid.
+        val columnWidth = columns
+            .flatten()
             .maxOf { route -> textPaint.measureText(route.routeShortName) + HORIZONTAL_PADDING_PX * scale * 2 }
-            .coerceAtLeast(cornerRadius * 2)
-        val height = rowHeight * routes.size
+            .coerceAtLeast(cornerRadius * 2 / columns.size)
+        val width = columnWidth * columns.size
+        val height = rowHeight * rowCount
 
         val bitmap = createBitmap(width.toInt(), height.toInt())
         val canvas = Canvas(bitmap)
@@ -118,25 +143,32 @@ object ContinuationBadgeBitmaps {
         // interior ones stay square where they meet.
         val pill = Path().apply { addRoundRect(badgeBounds, cornerRadius, cornerRadius, Path.Direction.CW) }
         canvas.withClip(pill) {
-            routes.forEachIndexed { index, route ->
-                val top = rowHeight * index
-                band.color = Color.rgb(Color.red(route.color), Color.green(route.color), Color.blue(route.color))
-                drawRect(RectF(0f, top, width, top + rowHeight), band)
-                textPaint.color = route.textColor ?: MarkerRendering.legibleOn(route.color)
-                val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
-                drawText(route.routeShortName, width / 2f, baseline, textPaint)
+            columns.forEachIndexed { column, cells ->
+                val left = columnWidth * column
+                cells.forEachIndexed { row, route ->
+                    val top = rowHeight * row
+                    band.color = Color.rgb(Color.red(route.color), Color.green(route.color), Color.blue(route.color))
+                    drawRect(RectF(left, top, left + columnWidth, top + rowHeight), band)
+                    textPaint.color = route.textColor ?: MarkerRendering.legibleOn(route.color)
+                    val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
+                    drawText(route.routeShortName, left + columnWidth / 2f, baseline, textPaint)
+                }
             }
         }
         val line = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = casingColor(routes, darkMode)
+            color = casingColor(columns.flatten(), darkMode)
             style = Paint.Style.STROKE
             strokeWidth = outlineWidth
         }
-        // Where two rows meet, in the same color as the outline around them all — so the badge reads as
+        // Where two cells meet, in the same color as the outline around them all — so the badge reads as
         // one bounded object holding several names, even when its routes share a color or have none.
-        for (index in 1..routes.lastIndex) {
-            val y = rowHeight * index
+        for (row in 1 until rowCount) {
+            val y = rowHeight * row
             canvas.drawLine(badgeBounds.left, y, badgeBounds.right, y, line)
+        }
+        for (column in 1 until columns.size) {
+            val x = columnWidth * column
+            canvas.drawLine(x, badgeBounds.top, x, badgeBounds.bottom, line)
         }
         canvas.drawRoundRect(badgeBounds, cornerRadius, cornerRadius, line)
         return bitmap
@@ -156,10 +188,18 @@ object ContinuationBadgeBitmaps {
      * hand back whichever it drew first. Density is fixed for the lifetime of a renderer's cache, so it
      * distinguishes nothing within one.
      */
-    fun badgeKey(routes: List<BadgedRoute>, darkMode: Boolean, scale: Float): String = routes.joinToString(
-        separator = "|",
+    fun badgeKey(routes: List<BadgedRoute>, darkMode: Boolean, scale: Float): String = badgeGridKey(listOf(routes), darkMode, scale)
+
+    /**
+     * [badgeKey] for a [badgeGrid]. The column boundaries take part too, since the same names in one
+     * column and in two are different pills.
+     */
+    fun badgeGridKey(columns: List<List<BadgedRoute>>, darkMode: Boolean, scale: Float): String = columns.joinToString(
+        separator = "/",
         prefix = "route-badge:$darkMode:$scale:"
-    ) { "${it.routeShortName}:${it.color}:${it.textColor}" }
+    ) { cells ->
+        cells.joinToString(separator = "|") { "${it.routeShortName}:${it.color}:${it.textColor}" }
+    }
 
     /**
      * The color of the badge's outline and of the lines dividing its rows. A badge with one color between

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/ContinuationBadgeBitmaps.kt
@@ -66,8 +66,9 @@ object ContinuationBadgeBitmaps {
     /**
      * The badge bitmap naming [routes] — a rounded-rect pill sized to fit the widest name, with one row
      * per route filled in that route's own line color, stacked top to bottom in the order given. Each
-     * row's text is black or white, whichever contrasts better with the row it sits on, so the badge
-     * stays legible across the full range of GTFS route colors.
+     * row's text is the ink its route names ([BadgedRoute.textColor]) or, when it names none, black or
+     * white — whichever contrasts better with the row it sits on, so the badge stays legible across the
+     * full range of GTFS route colors.
      *
      * One pill holding several names, rather than several pills, for the reason the directions drawer's
      * joined chip gives (`RouteBadgeChip`): the routes on it are one ride the rider may board any of
@@ -121,7 +122,7 @@ object ContinuationBadgeBitmaps {
                 val top = rowHeight * index
                 band.color = Color.rgb(Color.red(route.color), Color.green(route.color), Color.blue(route.color))
                 drawRect(RectF(0f, top, width, top + rowHeight), band)
-                textPaint.color = MarkerRendering.legibleOn(route.color)
+                textPaint.color = route.textColor ?: MarkerRendering.legibleOn(route.color)
                 val baseline = top + rowHeight / 2f - (metrics.ascent + metrics.descent) / 2f
                 drawText(route.routeShortName, width / 2f, baseline, textPaint)
             }
@@ -146,8 +147,9 @@ object ContinuationBadgeBitmaps {
      * two can't disagree about which of them the key names (as [VehicleBitmaps.iconKey] is). A renderer
      * caches one wrapper (a Google `BitmapDescriptor`) per key.
      *
-     * Every name and color on the badge takes part, so two labels differing only in a stacked route can't
-     * share a bitmap — and so does [darkMode], which the casing reads: the same routes case differently
+     * Every name and color on the badge takes part — including a row's own ink, since two rows can share a
+     * fill and read in different colors — so two labels differing only in a stacked route can't
+     * share a bitmap. So does [darkMode], which the casing reads: the same routes case differently
      * either side of a light/dark switch, and a key blind to it would serve the pre-switch pill. [scale]
      * takes part for the same reason it does in [VehicleBitmaps.iconKey]: a zoom-scheduled label (#2102)
      * draws the same routes at several sizes over one camera session, and a key blind to the size would
@@ -157,7 +159,7 @@ object ContinuationBadgeBitmaps {
     fun badgeKey(routes: List<BadgedRoute>, darkMode: Boolean, scale: Float): String = routes.joinToString(
         separator = "|",
         prefix = "route-badge:$darkMode:$scale:"
-    ) { "${it.routeShortName}:${it.color}" }
+    ) { "${it.routeShortName}:${it.color}:${it.textColor}" }
 
     /**
      * The color of the badge's outline and of the lines dividing its rows. A badge with one color between

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -219,9 +219,8 @@ data class BikeMarker(
  * rather than only a boolean, lets a stop-focus handoff preserve every shared route's color.
  *
  * [routes] are the routes that serve this stop, in the order the marker's label reads them at
- * transit-centre zoom (#2107) — see [stopRouteLabel]. Named and coloured as [BadgedRoute]s (the same
- * type a route label on a line carries) so the two ways the map names a route can't drift apart. Empty
- * where the producer has no route lookup for the stop yet, which simply draws no label.
+ * transit-centre zoom (#2107) — see [stopRouteLabel]. Empty where the producer has no route lookup for
+ * the stop yet, which simply draws no label.
  */
 data class StopMarker(
     val id: String,
@@ -231,7 +230,7 @@ data class StopMarker(
     val stop: ObaStop,
     val favorite: Boolean = false,
     val presentedRoutes: Set<RouteDirectionKey> = emptySet(),
-    val routes: List<BadgedRoute> = emptyList()
+    val routes: List<StopRoute> = emptyList()
 ) {
     val routeStop: Boolean get() = presentedRoutes.isNotEmpty()
 }
@@ -254,8 +253,30 @@ data class ContinuationBadge(
  * One route named on a [RouteBadge]: what it reads, and the colour the map draws that route's line in
  * (already through the map's route-line policy — see [org.onebusaway.android.map.mapRouteLineColor]),
  * so a name and the line it belongs to can't disagree.
+ *
+ * [textColor] is the colour the name is drawn in, for a producer whose colour policy pairs a fill with a
+ * matching ink — the stop route label (#2107) draws the arrivals drawer's badge, whose pastel fill and
+ * deep same-hue text are only correct together (see `routeBadgeChipColor`). Null, the default, leaves the
+ * choice to the drawing, which takes black or white by measured contrast ([MarkerRendering.legibleOn]) —
+ * the right answer for a label filled with a saturated route-line colour, and one no producer of those
+ * has to state.
  */
-data class BadgedRoute(val routeShortName: String, val color: Int)
+data class BadgedRoute(val routeShortName: String, val color: Int, val textColor: Int? = null)
+
+/**
+ * One route serving a stop, as that stop's marker label names it (#2107): what it reads, and the colour
+ * the agency published for it — **unrendered**, unlike [BadgedRoute]'s.
+ *
+ * The difference is deliberate and is about where the theme is known. A stop label is drawn as the
+ * arrivals drawer's badge chip, a policy that flips with light/dark; the renderer knows the theme (and
+ * already re-keys its icon cache on it), while the controller producing these does not. Carrying the
+ * source this far and rendering it at the end is what lets a theme change re-colour the labels, instead of
+ * leaving them the colour they happened to be produced in.
+ *
+ * Null [routeColor] where the agency publishes none or publishes an achromatic one, which the label draws
+ * as a neutral chip exactly as the drawer does.
+ */
+data class StopRoute(val shortName: String, val routeColor: Int?)
 
 /**
  * What a tap on a [RouteBadge] does. The two map views that label their lines want different things of

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -218,9 +218,12 @@ data class BikeMarker(
  * and renders as the trip-map-style circle instead of the direction-anchored icon. Carrying identities,
  * rather than only a boolean, lets a stop-focus handoff preserve every shared route's color.
  *
- * [routes] are the routes that serve this stop, in the order the marker's label reads them at
- * transit-centre zoom (#2107) — see [stopRouteLabel]. Empty where the producer has no route lookup for
- * the stop yet, which simply draws no label.
+ * [routes] are the routes this marker's **label** names at transit-centre zoom (#2107) — see
+ * [stopRouteLabel] — in the order it reads them. Deliberately "what the label says" rather than "what
+ * serves this stop", which is the wider fact and lives on [stop]: a producer that wants no label says so
+ * by naming no routes, and empty is therefore both "not looked up yet" and "not labelled here", neither of
+ * which the renderer has to tell apart. That is what lets a route presentation suppress the labels
+ * (`applyRouteStopPresentation`) without a second flag riding the snapshot.
  */
 data class StopMarker(
     val id: String,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -217,6 +217,11 @@ data class BikeMarker(
  * this stop. A non-empty set makes [routeStop] true: [point] is projected onto the route centerline
  * and renders as the trip-map-style circle instead of the direction-anchored icon. Carrying identities,
  * rather than only a boolean, lets a stop-focus handoff preserve every shared route's color.
+ *
+ * [routes] are the routes that serve this stop, in the order the marker's label reads them at
+ * transit-centre zoom (#2107) — see [stopRouteLabel]. Named and coloured as [BadgedRoute]s (the same
+ * type a route label on a line carries) so the two ways the map names a route can't drift apart. Empty
+ * where the producer has no route lookup for the stop yet, which simply draws no label.
  */
 data class StopMarker(
     val id: String,
@@ -225,7 +230,8 @@ data class StopMarker(
     val routeType: Int,
     val stop: ObaStop,
     val favorite: Boolean = false,
-    val presentedRoutes: Set<RouteDirectionKey> = emptySet()
+    val presentedRoutes: Set<RouteDirectionKey> = emptySet(),
+    val routes: List<BadgedRoute> = emptyList()
 ) {
     val routeStop: Boolean get() = presentedRoutes.isNotEmpty()
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -263,8 +263,20 @@ data class ContinuationBadge(
  * choice to the drawing, which takes black or white by measured contrast ([MarkerRendering.legibleOn]) —
  * the right answer for a label filled with a saturated route-line colour, and one no producer of those
  * has to state.
+ *
+ * [blank] marks a cell that names no route at all — the padding a caller adds to keep a multi-column
+ * [ContinuationBadgeBitmaps.badgeGrid] rectangular (#2107). It is drawn like any other cell, in whatever
+ * fill its producer chose, but it is *not* a route, so it takes no part in the decisions the drawing makes
+ * about the routes on the badge — the casing colour above all ([ContinuationBadgeBitmaps.casingColor]).
+ * Stated by the producer rather than inferred from an empty name: the padding is a fact the caller knows,
+ * and reading it back out of the drawing's own inputs would be a guess.
  */
-data class BadgedRoute(val routeShortName: String, val color: Int, val textColor: Int? = null)
+data class BadgedRoute(
+    val routeShortName: String,
+    val color: Int,
+    val textColor: Int? = null,
+    val blank: Boolean = false
+)
 
 /**
  * One route serving a stop, as that stop's marker label names it (#2107): what it reads, and the colour

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+/**
+ * What a stop marker's route label reads (#2107): the rows of the pill drawn beside a stop once the
+ * camera reaches the transit-centre band. Pure and shared, so the two map flavors label a stop with the
+ * same routes in the same order and the decision is unit-testable off-device; the drawing is
+ * [StopRouteLabelBitmaps].
+ */
+
+/**
+ * The most routes a stop's label names before it overflows. A label is read at a glance beside a marker,
+ * and a downtown bay serving a dozen routes would otherwise draw a column taller than the block it
+ * labels — covering the very neighbours the rider is comparing it against. Tunable.
+ */
+const val STOP_ROUTE_LABEL_MAX_ROWS = 5
+
+/**
+ * The overflow row's fill: a plain neutral, so it reads as a count rather than as one more route with a
+ * colour of its own. A fixed dark grey (white text lands on it via [MarkerRendering.legibleOn]) rather
+ * than a theme-aware one, matching the deliberate theme independence of every other route colour on this
+ * basemap (see `MapRouteColors`).
+ */
+private const val OVERFLOW_ROW_COLOR = 0xFF444444.toInt()
+
+/**
+ * The routes [stop]'s label names at [band] — empty below [StopBand.ROUTES], which draws no label at all.
+ * The single place either flavor asks "does this stop name its routes right now", so a band crossing
+ * can't show a label on one map and not the other.
+ */
+fun stopRouteLabel(stop: StopMarker, band: StopBand): List<BadgedRoute> = if (band == StopBand.ROUTES) stopRouteLabel(stop.routes) else emptyList()
+
+/**
+ * [routes] as label rows: every route when they fit in [maxRows], otherwise the first `maxRows - 1` plus
+ * a final `+N` row counting the rest. Overflowing is stated rather than silent — a label that just
+ * stopped at five would read as the whole truth about a stop and be wrong about it, which is worse for a
+ * rider hunting a route than being told there are more.
+ */
+fun stopRouteLabel(routes: List<BadgedRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS): List<BadgedRoute> {
+    // Two is the smallest label that can overflow at all (one route plus the count); at one there'd be
+    // nothing left to name beside the "+N", so the label would say only that it isn't saying anything.
+    require(maxRows >= 2) { "a route label of $maxRows row(s) has no room to both name a route and count the rest" }
+    if (routes.size <= maxRows) return routes
+    val shown = routes.take(maxRows - 1)
+    return shown + BadgedRoute("+${routes.size - shown.size}", OVERFLOW_ROW_COLOR)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
@@ -21,14 +21,14 @@ import org.onebusaway.android.util.routeBadgeChipColor
 import org.onebusaway.android.util.routeBadgeChipTextColor
 
 /**
- * What a stop marker's route label reads (#2107) and how it is coloured: the rows of the pill drawn
- * beside a stop once the camera reaches the transit-centre band. Pure and shared, so the two map flavors
- * label a stop with the same routes in the same order and the decision is unit-testable off-device; the
- * drawing is [StopRouteLabelBitmaps].
+ * What a stop marker's route label reads (#2107), how it is laid out and how it is coloured: the cells of
+ * the pill drawn beside a stop once the camera reaches the transit-centre band. Pure and shared, so the
+ * two map flavors label a stop with the same routes in the same arrangement and the decisions are
+ * unit-testable off-device; the drawing is [StopRouteLabelBitmaps].
  */
 
 /**
- * The most routes a stop's label names before it overflows. A label is read at a glance beside a marker,
+ * How tall a stop's label may grow before it widens instead. A label is read at a glance beside a marker,
  * and a downtown bay serving a dozen routes would otherwise draw a column taller than the block it
  * labels — covering the very neighbours the rider is comparing it against. Tunable.
  */
@@ -39,31 +39,36 @@ const val STOP_ROUTE_LABEL_MAX_ROWS = 5
  * The single place either flavor asks "does this stop name its routes right now", so a band crossing
  * can't show a label on one map and not the other.
  */
-fun stopRouteLabel(stop: StopMarker, band: StopBand): List<StopRoute> = if (band == StopBand.ROUTES) stopRouteLabel(stop.routes) else emptyList()
+fun stopRouteLabel(stop: StopMarker, band: StopBand): List<StopRoute> = if (band == StopBand.ROUTES) stop.routes else emptyList()
 
 /**
- * [routes] as label rows: every route when they fit in [maxRows], otherwise the first `maxRows - 1` plus
- * a final `+N` row counting the rest. Overflowing is stated rather than silent — a label that just
- * stopped at five would read as the whole truth about a stop and be wrong about it, which is worse for a
- * rider hunting a route than being told there are more.
+ * [routes] laid out in columns of at most [maxRows], read top to bottom and then left to right, so a stop
+ * naming more routes than fit in one column widens rather than lengthening — and names every one of them.
+ * A `+N` overflow row was the alternative and is worse where it matters: a rider hunting their route at a
+ * transit centre is exactly the person for whom "and 6 more" is no answer.
  *
- * The overflow row carries no colour, so it draws as the neutral chip a colourless route would: it is a
- * count, not one more route, and giving it a hue of its own would say otherwise.
+ * The columns are **balanced**, not filled to [maxRows] and then spilled: seven routes read 4 + 3, not
+ * 5 + 2. Both are as wide, so the taller one is only taller, and a nearly-empty second column reads as an
+ * afterthought rather than as one label.
+ *
+ * The grid is rectangular — [badgeGrid][ContinuationBadgeBitmaps.badgeGrid] requires it, since a hole is a
+ * hole in the pill — so a trailing remainder is padded with `null`, a blank cell for
+ * [stopRouteLabelGrid] to colour.
  */
-fun stopRouteLabel(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS): List<StopRoute> {
-    // Two is the smallest label that can overflow at all (one route plus the count); at one there'd be
-    // nothing left to name beside the "+N", so the label would say only that it isn't saying anything.
-    require(maxRows >= 2) { "a route label of $maxRows row(s) has no room to both name a route and count the rest" }
-    if (routes.size <= maxRows) return routes
-    val shown = routes.take(maxRows - 1)
-    return shown + StopRoute("+${routes.size - shown.size}", routeColor = null)
+fun stopRouteLabelColumns(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS): List<List<StopRoute?>> {
+    require(maxRows >= 1) { "a route label of $maxRows row(s) has nowhere to name a route" }
+    if (routes.isEmpty()) return emptyList()
+    val columns = ceilingDivide(routes.size, maxRows)
+    val rows = ceilingDivide(routes.size, columns)
+    // Padded to `columns * rows` first, so the chunks come out rectangular without a special last case.
+    return List(columns * rows) { routes.getOrNull(it) }.chunked(rows)
 }
 
 /**
- * [routes] rendered for drawing: the arrivals drawer's route badge, row for row — the agency's hue at the
- * badge's capped chroma and light tone, with the deep same-hue ink that tone is paired with
- * ([routeBadgeChipColor] / [routeBadgeChipTextColor]), or the neutral chip when a route publishes no
- * usable colour.
+ * [stopRouteLabelColumns] rendered for drawing: the arrivals drawer's route badge, cell for cell — the
+ * agency's hue at the badge's capped chroma and light tone, with the deep same-hue ink that tone is paired
+ * with ([routeBadgeChipColor] / [routeBadgeChipTextColor]), or the neutral chip for a route that publishes
+ * no usable colour and for the blank cells padding the last column.
  *
  * Deliberately the *drawer's* policy rather than the basemap's (`mapRouteLineColorOrNull`), which is what
  * every route **line** on this map is drawn in. A stop label is not a line: it is a small block of type
@@ -74,12 +79,23 @@ fun stopRouteLabel(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_
  *
  * Resolved here, at draw time, because these colours flip with [dark] (see [StopRoute]).
  */
-fun stopRouteLabelRows(routes: List<StopRoute>, dark: Boolean): List<BadgedRoute> = routes.map { route ->
-    BadgedRoute(
-        route.shortName,
-        // Both tones come from the same source, so they are null together — an achromatic or absent route
-        // colour takes the whole neutral chip, exactly as `rememberRouteBadgeColors` gives the drawer.
-        routeBadgeChipColor(route.routeColor, dark) ?: neutralBadgeChipColor(dark),
-        routeBadgeChipTextColor(route.routeColor, dark) ?: neutralBadgeChipTextColor(dark)
-    )
+fun stopRouteLabelGrid(
+    routes: List<StopRoute>,
+    dark: Boolean,
+    maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS
+): List<List<BadgedRoute>> = stopRouteLabelColumns(routes, maxRows).map { column ->
+    column.map { route ->
+        BadgedRoute(
+            // A blank cell names nothing; it exists only so the pill stays a rectangle.
+            route?.shortName.orEmpty(),
+            // Both tones come from the same source, so they are null together — an achromatic or absent
+            // route colour takes the whole neutral chip, exactly as `rememberRouteBadgeColors` gives the
+            // drawer, and so does a blank cell (which has no source at all).
+            routeBadgeChipColor(route?.routeColor, dark) ?: neutralBadgeChipColor(dark),
+            routeBadgeChipTextColor(route?.routeColor, dark) ?: neutralBadgeChipTextColor(dark)
+        )
+    }
 }
+
+/** [dividend] / [divisor] rounded up, for positive operands — how many columns hold this many routes. */
+private fun ceilingDivide(dividend: Int, divisor: Int): Int = (dividend + divisor - 1) / divisor

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
@@ -92,7 +92,10 @@ fun stopRouteLabelGrid(routes: List<StopRoute>, dark: Boolean): List<List<Badged
             // route colour takes the whole neutral chip, exactly as `rememberRouteBadgeColors` gives the
             // drawer, and so does a blank cell (which has no source at all).
             routeBadgeChipColor(route?.routeColor, dark) ?: neutralBadgeChipColor(dark),
-            routeBadgeChipTextColor(route?.routeColor, dark) ?: neutralBadgeChipTextColor(dark)
+            routeBadgeChipTextColor(route?.routeColor, dark) ?: neutralBadgeChipTextColor(dark),
+            // Told to the drawing, so the neutral a blank cell is filled with doesn't read as a second
+            // colour on the pill and case a one-colour label grey (see [ContinuationBadgeBitmaps.casingColor]).
+            blank = route == null
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
@@ -15,11 +15,16 @@
  */
 package org.onebusaway.android.map.render
 
+import org.onebusaway.android.util.neutralBadgeChipColor
+import org.onebusaway.android.util.neutralBadgeChipTextColor
+import org.onebusaway.android.util.routeBadgeChipColor
+import org.onebusaway.android.util.routeBadgeChipTextColor
+
 /**
- * What a stop marker's route label reads (#2107): the rows of the pill drawn beside a stop once the
- * camera reaches the transit-centre band. Pure and shared, so the two map flavors label a stop with the
- * same routes in the same order and the decision is unit-testable off-device; the drawing is
- * [StopRouteLabelBitmaps].
+ * What a stop marker's route label reads (#2107) and how it is coloured: the rows of the pill drawn
+ * beside a stop once the camera reaches the transit-centre band. Pure and shared, so the two map flavors
+ * label a stop with the same routes in the same order and the decision is unit-testable off-device; the
+ * drawing is [StopRouteLabelBitmaps].
  */
 
 /**
@@ -30,31 +35,51 @@ package org.onebusaway.android.map.render
 const val STOP_ROUTE_LABEL_MAX_ROWS = 5
 
 /**
- * The overflow row's fill: a plain neutral, so it reads as a count rather than as one more route with a
- * colour of its own. A fixed dark grey (white text lands on it via [MarkerRendering.legibleOn]) rather
- * than a theme-aware one, matching the deliberate theme independence of every other route colour on this
- * basemap (see `MapRouteColors`).
- */
-private const val OVERFLOW_ROW_COLOR = 0xFF444444.toInt()
-
-/**
  * The routes [stop]'s label names at [band] — empty below [StopBand.ROUTES], which draws no label at all.
  * The single place either flavor asks "does this stop name its routes right now", so a band crossing
  * can't show a label on one map and not the other.
  */
-fun stopRouteLabel(stop: StopMarker, band: StopBand): List<BadgedRoute> = if (band == StopBand.ROUTES) stopRouteLabel(stop.routes) else emptyList()
+fun stopRouteLabel(stop: StopMarker, band: StopBand): List<StopRoute> = if (band == StopBand.ROUTES) stopRouteLabel(stop.routes) else emptyList()
 
 /**
  * [routes] as label rows: every route when they fit in [maxRows], otherwise the first `maxRows - 1` plus
  * a final `+N` row counting the rest. Overflowing is stated rather than silent — a label that just
  * stopped at five would read as the whole truth about a stop and be wrong about it, which is worse for a
  * rider hunting a route than being told there are more.
+ *
+ * The overflow row carries no colour, so it draws as the neutral chip a colourless route would: it is a
+ * count, not one more route, and giving it a hue of its own would say otherwise.
  */
-fun stopRouteLabel(routes: List<BadgedRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS): List<BadgedRoute> {
+fun stopRouteLabel(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS): List<StopRoute> {
     // Two is the smallest label that can overflow at all (one route plus the count); at one there'd be
     // nothing left to name beside the "+N", so the label would say only that it isn't saying anything.
     require(maxRows >= 2) { "a route label of $maxRows row(s) has no room to both name a route and count the rest" }
     if (routes.size <= maxRows) return routes
     val shown = routes.take(maxRows - 1)
-    return shown + BadgedRoute("+${routes.size - shown.size}", OVERFLOW_ROW_COLOR)
+    return shown + StopRoute("+${routes.size - shown.size}", routeColor = null)
+}
+
+/**
+ * [routes] rendered for drawing: the arrivals drawer's route badge, row for row — the agency's hue at the
+ * badge's capped chroma and light tone, with the deep same-hue ink that tone is paired with
+ * ([routeBadgeChipColor] / [routeBadgeChipTextColor]), or the neutral chip when a route publishes no
+ * usable colour.
+ *
+ * Deliberately the *drawer's* policy rather than the basemap's (`mapRouteLineColorOrNull`), which is what
+ * every route **line** on this map is drawn in. A stop label is not a line: it is a small block of type
+ * that a rider reads against the route badges elsewhere in the app — the arrivals list this label is a
+ * shortcut into, above all — so it takes the colour those badges have. The faded fill also matters at
+ * this size: a column of fully saturated bars beside every marker in a transit centre reads as the
+ * subject of the map, which the stops around the rider are not.
+ *
+ * Resolved here, at draw time, because these colours flip with [dark] (see [StopRoute]).
+ */
+fun stopRouteLabelRows(routes: List<StopRoute>, dark: Boolean): List<BadgedRoute> = routes.map { route ->
+    BadgedRoute(
+        route.shortName,
+        // Both tones come from the same source, so they are null together — an achromatic or absent route
+        // colour takes the whole neutral chip, exactly as `rememberRouteBadgeColors` gives the drawer.
+        routeBadgeChipColor(route.routeColor, dark) ?: neutralBadgeChipColor(dark),
+        routeBadgeChipTextColor(route.routeColor, dark) ?: neutralBadgeChipTextColor(dark)
+    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabel.kt
@@ -20,11 +20,11 @@ import org.onebusaway.android.util.neutralBadgeChipTextColor
 import org.onebusaway.android.util.routeBadgeChipColor
 import org.onebusaway.android.util.routeBadgeChipTextColor
 
-/**
+/*
  * What a stop marker's route label reads (#2107), how it is laid out and how it is coloured: the cells of
  * the pill drawn beside a stop once the camera reaches the transit-centre band. Pure and shared, so the
  * two map flavors label a stop with the same routes in the same arrangement and the decisions are
- * unit-testable off-device; the drawing is [StopRouteLabelBitmaps].
+ * unit-testable off-device; the drawing is StopRouteLabelBitmaps.
  */
 
 /**
@@ -36,29 +36,33 @@ const val STOP_ROUTE_LABEL_MAX_ROWS = 5
 
 /**
  * The routes [stop]'s label names at [band] — empty below [StopBand.ROUTES], which draws no label at all.
- * The single place either flavor asks "does this stop name its routes right now", so a band crossing
- * can't show a label on one map and not the other.
+ * The single place either flavor asks "is this stop naming its routes right now", so a band crossing can't
+ * show a label on one map and not the other.
+ *
+ * Compared as an ordering rather than for equality, because [StopBand] widens: a band added above
+ * [StopBand.ROUTES] would show everything this one does and more, and an equality test would silently
+ * switch the labels back off at the very zoom that wants them most.
  */
-fun stopRouteLabel(stop: StopMarker, band: StopBand): List<StopRoute> = if (band == StopBand.ROUTES) stop.routes else emptyList()
+fun stopRouteLabel(stop: StopMarker, band: StopBand): List<StopRoute> = if (band >= StopBand.ROUTES) stop.routes else emptyList()
 
 /**
- * [routes] laid out in columns of at most [maxRows], read top to bottom and then left to right, so a stop
- * naming more routes than fit in one column widens rather than lengthening — and names every one of them.
- * A `+N` overflow row was the alternative and is worse where it matters: a rider hunting their route at a
- * transit centre is exactly the person for whom "and 6 more" is no answer.
+ * [routes] laid out in columns of at most [STOP_ROUTE_LABEL_MAX_ROWS], read top to bottom and then left to
+ * right, so a stop naming more routes than fit in one column widens rather than lengthening — and names
+ * every one of them. A `+N` overflow row was the alternative and is worse where it matters: a rider
+ * hunting their route at a transit centre is exactly the person for whom "and 6 more" is no answer.
  *
- * The columns are **balanced**, not filled to [maxRows] and then spilled: seven routes read 4 + 3, not
+ * The columns are **balanced**, not filled to the cap and then spilled: seven routes read 4 + 3, not
  * 5 + 2. Both are as wide, so the taller one is only taller, and a nearly-empty second column reads as an
  * afterthought rather than as one label.
  *
  * The grid is rectangular — [badgeGrid][ContinuationBadgeBitmaps.badgeGrid] requires it, since a hole is a
  * hole in the pill — so a trailing remainder is padded with `null`, a blank cell for
- * [stopRouteLabelGrid] to colour.
+ * [stopRouteLabelGrid] to colour. That padding is why this is internal: the nullable cell is how the
+ * layout meets the drawing, not something a caller outside this file should have to reason about.
  */
-fun stopRouteLabelColumns(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS): List<List<StopRoute?>> {
-    require(maxRows >= 1) { "a route label of $maxRows row(s) has nowhere to name a route" }
+internal fun stopRouteLabelColumns(routes: List<StopRoute>): List<List<StopRoute?>> {
     if (routes.isEmpty()) return emptyList()
-    val columns = ceilingDivide(routes.size, maxRows)
+    val columns = ceilingDivide(routes.size, STOP_ROUTE_LABEL_MAX_ROWS)
     val rows = ceilingDivide(routes.size, columns)
     // Padded to `columns * rows` first, so the chunks come out rectangular without a special last case.
     return List(columns * rows) { routes.getOrNull(it) }.chunked(rows)
@@ -79,11 +83,7 @@ fun stopRouteLabelColumns(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LAB
  *
  * Resolved here, at draw time, because these colours flip with [dark] (see [StopRoute]).
  */
-fun stopRouteLabelGrid(
-    routes: List<StopRoute>,
-    dark: Boolean,
-    maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS
-): List<List<BadgedRoute>> = stopRouteLabelColumns(routes, maxRows).map { column ->
+fun stopRouteLabelGrid(routes: List<StopRoute>, dark: Boolean): List<List<BadgedRoute>> = stopRouteLabelColumns(routes).map { column ->
     column.map { route ->
         BadgedRoute(
             // A blank cell names nothing; it exists only so the pill stays a rectangle.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.core.graphics.createBitmap
+import kotlin.math.ceil
+
+/**
+ * The label naming the routes that serve a stop, floated just above its marker at transit-centre zoom
+ * (#2107). The pill itself is the map's one route label ([ContinuationBadgeBitmaps.badge]) — same rows,
+ * same casing, same legibility rules — so a route named beside a stop looks like the same route named on
+ * its line; only the size and the placement are this label's own. Flavor-neutral (like [StopBitmaps]), so
+ * each renderer just wraps the [Bitmap] as its marker icon.
+ */
+object StopRouteLabelBitmaps {
+
+    /**
+     * How large the pill is drawn relative to a route label on a line. Smaller, deliberately: a line's
+     * label names the map's subject, while these name every stop in the viewport at once, so at full size
+     * a transit centre's worth of them would cover the centre. Tunable.
+     */
+    private const val SCALE = 0.6f
+
+    /**
+     * How far above the stop's point the pill's bottom edge sits, in dp. The stop circle is drawn from
+     * `map_stop_shadow_size_6` (22dp across, 1.35× that in the Google flavor for its route glyph, and
+     * 1.5× again when focused), so this clears the largest of those with a few dp to spare — and stays
+     * put when a stop is focused, since a label that jumped on selection would read as a second marker.
+     * A visual offset rather than a derived geometry, so it's one tunable here rather than three
+     * flavor-private constants imported into one place.
+     */
+    private const val LIFT_DP = 26f
+
+    /**
+     * The label bitmap naming [routes], ready to be anchored at the **centre** on the stop's own point.
+     *
+     * Centre-anchored — with the lift baked in as transparent padding below the pill rather than applied
+     * as an anchor offset — because that is the only placement both flavors can express: maplibre's
+     * classic Marker has no per-marker anchor at all and always centres its icon (the same reason the
+     * route-continuation badge is centred in its bitmap). The cost is a bitmap about twice the pill's
+     * height, most of it empty, which is why callers cache these by [labelKey] rather than per stop:
+     * every stop served by the same routes shares one.
+     */
+    fun label(context: Context, routes: List<BadgedRoute>, darkMode: Boolean): Bitmap {
+        val density = context.resources.displayMetrics.density
+        return liftedAbove(
+            ContinuationBadgeBitmaps.badge(routes, density, darkMode, SCALE),
+            LIFT_DP * density
+        )
+    }
+
+    /**
+     * A stable key identifying the bitmap [label] draws for these inputs, beside the function itself so
+     * the two can't disagree about which of them the key names (as [ContinuationBadgeBitmaps.badgeKey]
+     * is). Delegates to the pill's own key — the pill is the whole of the drawing that varies — under a
+     * distinct prefix, so a stop label and a line's label naming the same routes can't collide in a
+     * renderer that happens to cache both in one map. Scale and lift are fixed here, so neither
+     * distinguishes anything.
+     */
+    fun labelKey(routes: List<BadgedRoute>, darkMode: Boolean): String = "stop-route-label:" + ContinuationBadgeBitmaps.badgeKey(routes, darkMode, SCALE)
+
+    /**
+     * [pill] drawn at the top of a canvas tall enough that the canvas centre — where the marker is
+     * anchored — sits [liftPx] below the pill's bottom edge, leaving the pill floating that far above the
+     * stop's point.
+     */
+    private fun liftedAbove(pill: Bitmap, liftPx: Float): Bitmap {
+        val bitmap = createBitmap(pill.width, ceil(2f * (pill.height + liftPx)).toInt())
+        Canvas(bitmap).drawBitmap(pill, 0f, 0f, null)
+        return bitmap
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
@@ -23,11 +23,11 @@ import kotlin.math.ceil
 
 /**
  * The label naming the routes that serve a stop, floated just above its marker at transit-centre zoom
- * (#2107). The pill itself is the map's one route label ([ContinuationBadgeBitmaps.badge]) — same rows,
- * same casing, same dividers — so the map draws one kind of route label however many things it labels;
- * the size, the placement and the colours ([stopRouteLabelRows], which takes the arrivals drawer's badge
- * rather than the basemap's line colour) are this label's own. Flavor-neutral (like [StopBitmaps]), so
- * each renderer just wraps the [Bitmap] as its marker icon.
+ * (#2107). The pill itself is the map's one route label ([ContinuationBadgeBitmaps.badgeGrid]) — same
+ * cells, same casing, same dividers — so the map draws one kind of route label however many things it
+ * labels; the size, the placement, the columns and the colours ([stopRouteLabelGrid], which takes the
+ * arrivals drawer's badge rather than the basemap's line colour) are this label's own. Flavor-neutral
+ * (like [StopBitmaps]), so each renderer just wraps the [Bitmap] as its marker icon.
  */
 object StopRouteLabelBitmaps {
 
@@ -61,7 +61,7 @@ object StopRouteLabelBitmaps {
     fun label(context: Context, routes: List<StopRoute>, darkMode: Boolean): Bitmap {
         val density = context.resources.displayMetrics.density
         return liftedAbove(
-            ContinuationBadgeBitmaps.badge(stopRouteLabelRows(routes, darkMode), density, darkMode, SCALE),
+            ContinuationBadgeBitmaps.badgeGrid(stopRouteLabelGrid(routes, darkMode), density, darkMode, SCALE),
             LIFT_DP * density
         )
     }
@@ -74,7 +74,7 @@ object StopRouteLabelBitmaps {
      * renderer that happens to cache both in one map. Scale and lift are fixed here, so neither
      * distinguishes anything.
      */
-    fun labelKey(routes: List<StopRoute>, darkMode: Boolean): String = "stop-route-label:" + ContinuationBadgeBitmaps.badgeKey(stopRouteLabelRows(routes, darkMode), darkMode, SCALE)
+    fun labelKey(routes: List<StopRoute>, darkMode: Boolean): String = "stop-route-label:" + ContinuationBadgeBitmaps.badgeGridKey(stopRouteLabelGrid(routes, darkMode), darkMode, SCALE)
 
     /**
      * [pill] drawn at the top of a canvas tall enough that the canvas centre — where the marker is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
@@ -39,14 +39,23 @@ object StopRouteLabelBitmaps {
     private const val SCALE = 0.6f
 
     /**
-     * How far above the stop's point the pill's bottom edge sits, in dp. The stop circle is drawn from
-     * `map_stop_shadow_size_6` (22dp across, 1.35× that in the Google flavor for its route glyph, and
-     * 1.5× again when focused), so this clears the largest of those with a few dp to spare — and stays
-     * put when a stop is focused, since a label that jumped on selection would read as a second marker.
-     * A visual offset rather than a derived geometry, so it's one tunable here rather than three
-     * flavor-private constants imported into one place.
+     * How far above the stop's point the pill's bottom edge sits, in dp — the label's whole distance from
+     * the stop, not the visible gap, which is this less whatever the marker itself reaches up to.
+     *
+     * Set on device to leave a few dp of daylight over an ordinary stop circle, which is drawn from
+     * `map_stop_shadow_size_6` (22dp across, 1.35× that in the Google flavor for its route glyph) and so
+     * reaches about 15dp above the point. Two things deliberately reach further and are *let* into the
+     * label, which draws above them ([STOP_ROUTE_LABEL_Z_INDEX]): a focused stop's circle, which grows
+     * half again, and a direction arrow that happens to point north. Both were cleared by an earlier,
+     * larger lift, and the daylight that bought over every other stop — the overwhelming majority — read
+     * as the label belonging to nothing in particular.
+     *
+     * One value for every stop, rather than one that clears whatever each marker reaches: a per-stop lift
+     * would set the labels of neighbouring bays at different heights, and a lift that answered focus would
+     * make a label jump on selection and read as a second marker. A visual offset rather than a derived
+     * geometry, so it's one tunable here rather than three flavor-private constants imported into one place.
      */
-    private const val LIFT_DP = 26f
+    private const val LIFT_DP = 18.5f
 
     /**
      * The label bitmap naming [routes], ready to be anchored at the **centre** on the stop's own point.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
@@ -24,8 +24,9 @@ import kotlin.math.ceil
 /**
  * The label naming the routes that serve a stop, floated just above its marker at transit-centre zoom
  * (#2107). The pill itself is the map's one route label ([ContinuationBadgeBitmaps.badge]) — same rows,
- * same casing, same legibility rules — so a route named beside a stop looks like the same route named on
- * its line; only the size and the placement are this label's own. Flavor-neutral (like [StopBitmaps]), so
+ * same casing, same dividers — so the map draws one kind of route label however many things it labels;
+ * the size, the placement and the colours ([stopRouteLabelRows], which takes the arrivals drawer's badge
+ * rather than the basemap's line colour) are this label's own. Flavor-neutral (like [StopBitmaps]), so
  * each renderer just wraps the [Bitmap] as its marker icon.
  */
 object StopRouteLabelBitmaps {
@@ -57,10 +58,10 @@ object StopRouteLabelBitmaps {
      * height, most of it empty, which is why callers cache these by [labelKey] rather than per stop:
      * every stop served by the same routes shares one.
      */
-    fun label(context: Context, routes: List<BadgedRoute>, darkMode: Boolean): Bitmap {
+    fun label(context: Context, routes: List<StopRoute>, darkMode: Boolean): Bitmap {
         val density = context.resources.displayMetrics.density
         return liftedAbove(
-            ContinuationBadgeBitmaps.badge(routes, density, darkMode, SCALE),
+            ContinuationBadgeBitmaps.badge(stopRouteLabelRows(routes, darkMode), density, darkMode, SCALE),
             LIFT_DP * density
         )
     }
@@ -73,7 +74,7 @@ object StopRouteLabelBitmaps {
      * renderer that happens to cache both in one map. Scale and lift are fixed here, so neither
      * distinguishes anything.
      */
-    fun labelKey(routes: List<BadgedRoute>, darkMode: Boolean): String = "stop-route-label:" + ContinuationBadgeBitmaps.badgeKey(routes, darkMode, SCALE)
+    fun labelKey(routes: List<StopRoute>, darkMode: Boolean): String = "stop-route-label:" + ContinuationBadgeBitmaps.badgeKey(stopRouteLabelRows(routes, darkMode), darkMode, SCALE)
 
     /**
      * [pill] drawn at the top of a canvas tall enough that the canvas centre — where the marker is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopRouteLabelBitmaps.kt
@@ -65,7 +65,8 @@ object StopRouteLabelBitmaps {
      * classic Marker has no per-marker anchor at all and always centres its icon (the same reason the
      * route-continuation badge is centred in its bitmap). The cost is a bitmap about twice the pill's
      * height, most of it empty, which is why callers cache these by [labelKey] rather than per stop:
-     * every stop served by the same routes shares one.
+     * every stop served by the same routes shares one, and a transit centre's bays repeat each other's
+     * routes heavily.
      */
     fun label(context: Context, routes: List<StopRoute>, darkMode: Boolean): Bitmap {
         val density = context.resources.displayMetrics.density
@@ -78,12 +79,20 @@ object StopRouteLabelBitmaps {
     /**
      * A stable key identifying the bitmap [label] draws for these inputs, beside the function itself so
      * the two can't disagree about which of them the key names (as [ContinuationBadgeBitmaps.badgeKey]
-     * is). Delegates to the pill's own key — the pill is the whole of the drawing that varies — under a
-     * distinct prefix, so a stop label and a line's label naming the same routes can't collide in a
-     * renderer that happens to cache both in one map. Scale and lift are fixed here, so neither
-     * distinguishes anything.
+     * is). Its own prefix keeps it clear of a line's label naming the same routes, in a renderer that
+     * caches both in one map. Scale and lift are fixed here, so neither distinguishes anything.
+     *
+     * Keyed on the **unrendered** routes rather than on the grid they draw as, unlike
+     * [ContinuationBadgeBitmaps.badgeGridKey], which keys a grid it is handed. The grid is a pure function
+     * of exactly these inputs, so the two keys separate the same bitmaps — and this one costs a string
+     * where that one would cost the whole colour policy (four HCT conversions per cell, over every route
+     * of every labelled stop) on a path a cache *hit* also walks. Layout and colour are then run once, on
+     * a miss, inside [label].
      */
-    fun labelKey(routes: List<StopRoute>, darkMode: Boolean): String = "stop-route-label:" + ContinuationBadgeBitmaps.badgeGridKey(stopRouteLabelGrid(routes, darkMode), darkMode, SCALE)
+    fun labelKey(routes: List<StopRoute>, darkMode: Boolean): String = routes.joinToString(
+        separator = "|",
+        prefix = "stop-route-label:$darkMode:"
+    ) { "${it.shortName}:${it.routeColor}" }
 
     /**
      * [pill] drawn at the top of a canvas tall enough that the canvas centre — where the marker is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -22,6 +22,18 @@ package org.onebusaway.android.map.render
  */
 const val STOP_DOT_ZOOM_THRESHOLD = 15f
 
+/**
+ * The zoom at or above which a stop marker also names the routes serving it (#2107) — the transit-centre
+ * band. A rider standing in a transit centre otherwise has to open every bay in turn to find the one that
+ * serves their route, and the zoom the map is already at when they do that is what this keys off.
+ *
+ * Chosen for the viewport width it corresponds to. Marker zoom is density-independent (256**dp** tiles),
+ * so at zoom z a map covers 156543·cos(latitude)/2^z metres per dp: on a ~400dp-wide phone at mid
+ * latitudes that is ~160 m at zoom 18 — one or two city blocks, the "about a block wide" the issue asks
+ * for — against ~320 m at 17, which is a neighbourhood and would label far more stops than fit. Tunable.
+ */
+const val STOP_ROUTES_ZOOM_THRESHOLD = 18f
+
 /** Smallest focused route-stop circle scale at the zoomed-out end of the detail ramp. */
 const val STOP_FOCUS_ROUTE_MIN_SCALE = 0.3f
 
@@ -35,11 +47,30 @@ fun stopZIndex(routeStop: Boolean, favorite: Boolean): Float = when {
     else -> 0f
 }
 
-/** Whether a stop renders as a small dot (distant zoom) or its full directional icon (close zoom). */
-enum class StopBand { DOT, FULL }
+/**
+ * A stop's route label (#2107) draws above every stop marker — including the enlarged focused one, whose
+ * icon would otherwise cover the label of the stop behind it. Below the route labels a selected line
+ * carries (`ROUTE_BADGE_Z_INDEX`), which name the map's current subject rather than what's merely nearby.
+ */
+const val STOP_ROUTE_LABEL_Z_INDEX = 1f
 
-/** The [StopBand] a stop falls in at [zoom]: a dot below [STOP_DOT_ZOOM_THRESHOLD], else the full icon. */
-fun stopZoomBand(zoom: Float): StopBand = if (zoom < STOP_DOT_ZOOM_THRESHOLD) StopBand.DOT else StopBand.FULL
+/**
+ * How much of a stop a marker shows at the current zoom: a small dot far out (declutter), its full
+ * directional icon closer in, and closer still that icon plus a label naming the routes that serve it
+ * (#2107). Widening bands, so a [ROUTES] stop draws everything a [FULL] one does and more — which is why
+ * [stopIconKind] treats the two alike.
+ */
+enum class StopBand { DOT, FULL, ROUTES }
+
+/**
+ * The [StopBand] a stop falls in at [zoom]: a dot below [STOP_DOT_ZOOM_THRESHOLD], its full icon from
+ * there, and from [STOP_ROUTES_ZOOM_THRESHOLD] that icon plus its route label.
+ */
+fun stopZoomBand(zoom: Float): StopBand = when {
+    zoom < STOP_DOT_ZOOM_THRESHOLD -> StopBand.DOT
+    zoom < STOP_ROUTES_ZOOM_THRESHOLD -> StopBand.FULL
+    else -> StopBand.ROUTES
+}
 
 /**
  * Stop-circle-specific detail scale applied while a route is focused, whether through focused-stop
@@ -76,6 +107,9 @@ enum class StopIconKind {
  * instead of the directional icon/dot (#1680). The focused stop always gets the matching focused
  * variant so a selection stays visible. Pure, so renderer icon-change decisions are unit-testable and
  * identical across both map flavors.
+ *
+ * [StopBand.ROUTES] takes the same icon as [StopBand.FULL]: what that band adds is the separate route
+ * label beside the marker (#2107, see [stopRouteLabel]), not a different icon.
  */
 fun stopIconKind(
     focused: Boolean,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -27,12 +27,14 @@ const val STOP_DOT_ZOOM_THRESHOLD = 15f
  * band. A rider standing in a transit centre otherwise has to open every bay in turn to find the one that
  * serves their route, and the zoom the map is already at when they do that is what this keys off.
  *
- * Chosen for the viewport width it corresponds to. Marker zoom is density-independent (256**dp** tiles),
- * so at zoom z a map covers 156543·cos(latitude)/2^z metres per dp: on a ~400dp-wide phone at mid
- * latitudes that is ~160 m at zoom 18 — one or two city blocks, the "about a block wide" the issue asks
- * for — against ~320 m at 17, which is a neighbourhood and would label far more stops than fit. Tunable.
+ * **Set on device**, by zooming to where the map reads as one transit centre rather than a neighbourhood
+ * and taking the number off the debug zoom readout. It is a judgement about when the labels start
+ * earning their clutter, which is not a thing to derive: for scale, marker zoom is density-independent
+ * (256**dp** tiles), so at zoom z a map covers 156543·cos(latitude)/2^z metres per dp — on a ~400dp-wide
+ * phone at mid latitudes about 230 m here, against ~160 m at 18 (which held the labels back until the
+ * rider had already zoomed past the centre) and ~320 m at 17. Tunable, but retune it the same way.
  */
-const val STOP_ROUTES_ZOOM_THRESHOLD = 18f
+const val STOP_ROUTES_ZOOM_THRESHOLD = 17.5f
 
 /** Smallest focused route-stop circle scale at the zoomed-out end of the detail ramp. */
 const val STOP_FOCUS_ROUTE_MIN_SCALE = 0.3f

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -95,6 +95,7 @@ import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.routeLineWidthScale
+import org.onebusaway.android.map.render.stopZoomBand
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.ui.home.CurrentFocus
 import org.onebusaway.android.ui.home.FocusedStop
@@ -113,7 +114,8 @@ import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.PreferenceUtils
 
 // Temporary calibration aid; retain the implementation so it can be restored with a one-line toggle.
-private const val SHOW_DEBUG_ZOOM_INDICATOR = false
+// Currently ON to tune the stop-band thresholds (#2107) against what the map actually shows.
+private const val SHOW_DEBUG_ZOOM_INDICATOR = true
 
 /**
  * The self-wiring map feature module: renders [ObaMap] and owns everything that used to be map glue
@@ -456,9 +458,12 @@ fun MapFeature(
             Text(
                 text = String.format(
                     Locale.US,
-                    "Zoom %.2f · route %.2f×",
+                    "Zoom %.2f · route %.2f× · %s",
                     zoom,
-                    routeLineWidthScale(zoom)
+                    routeLineWidthScale(zoom),
+                    // The stop band this zoom falls in, so the dot/full/routes thresholds can be tuned
+                    // against the map rather than by arithmetic (#2107).
+                    stopZoomBand(zoom)
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.labelMedium,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -114,8 +114,7 @@ import org.onebusaway.android.util.PermissionUtils
 import org.onebusaway.android.util.PreferenceUtils
 
 // Temporary calibration aid; retain the implementation so it can be restored with a one-line toggle.
-// Currently ON to tune the stop-band thresholds (#2107) against what the map actually shows.
-private const val SHOW_DEBUG_ZOOM_INDICATOR = true
+private const val SHOW_DEBUG_ZOOM_INDICATOR = false
 
 /**
  * The self-wiring map feature module: renders [ObaMap] and owns everything that used to be map glue

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.util
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import androidx.core.graphics.toColorInt
 import com.google.android.material.color.utilities.Hct
 import kotlin.math.min
@@ -124,13 +125,10 @@ fun routeBadgeChipTextColor(routeColor: Int?, dark: Boolean): Int? = routeColorA
  * taken to the badge tone stays grey. A Compose caller should keep using [rememberRouteBadgeColors];
  * these exist for the callers that can't.
  */
-fun neutralBadgeChipColor(dark: Boolean): Int = routeCasingColor(NEUTRAL_CHIP_SOURCE, if (dark) BADGE_CHIP_TONE_DARK else BADGE_CHIP_TONE_LIGHT)
+fun neutralBadgeChipColor(dark: Boolean): Int = routeCasingColor(Color.GRAY, if (dark) BADGE_CHIP_TONE_DARK else BADGE_CHIP_TONE_LIGHT)
 
 /** The text drawn on a [neutralBadgeChipColor] fill — the neutral counterpart of [routeBadgeChipTextColor]. */
-fun neutralBadgeChipTextColor(dark: Boolean): Int = routeCasingColor(NEUTRAL_CHIP_SOURCE, if (dark) BADGE_CHIP_TEXT_TONE_DARK else BADGE_CHIP_TEXT_TONE_LIGHT)
-
-/** Any achromatic colour would do — only its (absent) hue and chroma survive the re-tone. */
-private const val NEUTRAL_CHIP_SOURCE = 0xFF888888.toInt()
+fun neutralBadgeChipTextColor(dark: Boolean): Int = routeCasingColor(Color.GRAY, if (dark) BADGE_CHIP_TEXT_TONE_DARK else BADGE_CHIP_TEXT_TONE_LIGHT)
 
 /**
  * The hue a ride is *presented* in, wherever it is presented: the agency's own [routeColor] when it has a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -114,6 +114,25 @@ fun routeBadgeChipColor(routeColor: Int?, dark: Boolean): Int? = routeColorAtTon
 fun routeBadgeChipTextColor(routeColor: Int?, dark: Boolean): Int? = routeColorAtTone(routeColor, dark, if (dark) BADGE_CHIP_TEXT_TONE_DARK else BADGE_CHIP_TEXT_TONE_LIGHT)
 
 /**
+ * The chip a route with no usable colour takes where there is no Material palette to fall back to: the
+ * map's stop route label (#2107) is a bitmap drawn on a basemap, not a composable on a container, so it
+ * cannot reach the theme's `surfaceVariant` pair that [rememberRouteBadgeColors] uses. The badge's own
+ * tones with the hue dropped — grey where the coloured rows are coloured, at the same lightness — so a
+ * colourless route sits in the same tonal family as the routes beside it rather than at a tone of its own.
+ *
+ * Hueless by construction: [routeCasingColor] deliberately doesn't decline an achromatic source, so grey
+ * taken to the badge tone stays grey. A Compose caller should keep using [rememberRouteBadgeColors];
+ * these exist for the callers that can't.
+ */
+fun neutralBadgeChipColor(dark: Boolean): Int = routeCasingColor(NEUTRAL_CHIP_SOURCE, if (dark) BADGE_CHIP_TONE_DARK else BADGE_CHIP_TONE_LIGHT)
+
+/** The text drawn on a [neutralBadgeChipColor] fill — the neutral counterpart of [routeBadgeChipTextColor]. */
+fun neutralBadgeChipTextColor(dark: Boolean): Int = routeCasingColor(NEUTRAL_CHIP_SOURCE, if (dark) BADGE_CHIP_TEXT_TONE_DARK else BADGE_CHIP_TEXT_TONE_LIGHT)
+
+/** Any achromatic colour would do — only its (absent) hue and chroma survive the re-tone. */
+private const val NEUTRAL_CHIP_SOURCE = 0xFF888888.toInt()
+
+/**
  * The hue a ride is *presented* in, wherever it is presented: the agency's own [routeColor] when it has a
  * usable one, else [COLOURLESS_RIDE_HUE_ANCHOR]. A hue source, not a rendered colour — each surface still
  * renders it through its own policy (the map line and the drawer badge through the badge tone, the drawer's

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteDisplay.kt
@@ -35,9 +35,11 @@ val ROUTE_NAME_ORDER: Comparator<String> = AlphanumComparator()
  * whichever of them the trip planner picked, and which one it did pick is still on the option card's
  * header line and its ETA strip.
  *
- * Shared by the two places a ride's routes are *badged* — the drawer/picker's joined chip (`legBadge`) and
- * the label on its line on the map (`itineraryRouteBadges`, #2083) — so a rider looking at both at once
- * can't be shown one ride named in two orders. It is deliberately not what
+ * Shared by the places routes are *badged together* — the drawer/picker's joined chip (`legBadge`), the
+ * label on a ride's line on the map (`itineraryRouteBadges`, #2083), and the routes a stop marker names at
+ * transit-centre zoom (#2107) — so a rider looking at two at once can't be shown one set of routes named in
+ * two orders. The dedupe is a badge's rule wherever it applies: a badge has only the name to show, so two
+ * routes sharing one (the feeds do collide) would draw as the same row twice. It is deliberately not what
  * [org.onebusaway.android.directions.model.interchangeableRoutes] applies when it produces the candidates:
  * that list is also what the map's route focus loads (#2063), so it sorts by the same order but keeps every
  * route, name collisions included. Deduplication is a badge's rule, not the plan's.

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
@@ -46,7 +46,6 @@ internal class MapLibreStopMarkerLayer(
     // than redrawn: at the zoom these appear the map still loads stops on every pan, and labels torn down
     // and re-added on each of those publishes would blink while the markers under them held still.
     private val labelByStopId = HashMap<String, Marker>()
-    private val labelRoutesByStopId = HashMap<String, List<StopRoute>>()
 
     // One Icon per distinct set of routes: a transit centre's bays repeat each other's routes, and a label
     // bitmap is mostly transparent lift, so sharing them is worth more here than for a stop icon. Bounded
@@ -108,7 +107,6 @@ internal class MapLibreStopMarkerLayer(
         if (annotations.isNotEmpty()) map.removeAnnotations(annotations)
         markerByStopId.clear()
         labelByStopId.clear()
-        labelRoutesByStopId.clear()
         labelIcons.evictAll()
         stopByMarker.clear()
         kindByStopId.clear()
@@ -135,11 +133,13 @@ internal class MapLibreStopMarkerLayer(
             labelByStopId[stop.id] = marker
             stopByMarker[marker] = stop
         } else {
-            if (labelRoutesByStopId[stop.id] != routes) existing.icon = labelIcon(routes)
-            if (stopByMarker[existing]?.point != stop.point) existing.position = stop.point.toLatLng()
+            // The label's own previous stop, which is what it was drawn from — a label exists only where
+            // the last render was in the labelling band, so its routes are the ones on the pill.
+            val previous = stopByMarker[existing]
+            if (previous?.routes != routes) existing.icon = labelIcon(routes)
+            if (previous?.point != stop.point) existing.position = stop.point.toLatLng()
             stopByMarker[existing] = stop
         }
-        labelRoutesByStopId[stop.id] = routes
     }
 
     private fun removeLabel(stopId: String) {
@@ -147,7 +147,6 @@ internal class MapLibreStopMarkerLayer(
             stopByMarker.remove(it)
             map.removeAnnotation(it)
         }
-        labelRoutesByStopId.remove(stopId)
     }
 
     private fun labelIcon(routes: List<StopRoute>): Icon {

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
@@ -24,10 +24,10 @@ import org.maplibre.android.annotations.IconFactory
 import org.maplibre.android.annotations.Marker
 import org.maplibre.android.annotations.MarkerOptions
 import org.maplibre.android.maps.MapLibreMap
-import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.StopRoute
 import org.onebusaway.android.map.render.StopRouteLabelBitmaps
 import org.onebusaway.android.map.render.stopIconKind
 import org.onebusaway.android.map.render.stopRouteLabel
@@ -46,7 +46,7 @@ internal class MapLibreStopMarkerLayer(
     // than redrawn: at the zoom these appear the map still loads stops on every pan, and labels torn down
     // and re-added on each of those publishes would blink while the markers under them held still.
     private val labelByStopId = HashMap<String, Marker>()
-    private val labelRoutesByStopId = HashMap<String, List<BadgedRoute>>()
+    private val labelRoutesByStopId = HashMap<String, List<StopRoute>>()
 
     // One Icon per distinct set of routes: a transit centre's bays repeat each other's routes, and a label
     // bitmap is mostly transparent lift, so sharing them is worth more here than for a stop icon. Bounded
@@ -150,7 +150,7 @@ internal class MapLibreStopMarkerLayer(
         labelRoutesByStopId.remove(stopId)
     }
 
-    private fun labelIcon(routes: List<BadgedRoute>): Icon {
+    private fun labelIcon(routes: List<StopRoute>): Icon {
         val darkMode = ThemeUtils.isInDarkMode(context)
         val key = StopRouteLabelBitmaps.labelKey(routes, darkMode)
         return labelIcons.get(key) ?: iconFactory

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
@@ -94,9 +94,14 @@ internal class MapLibreStopMarkerLayer(
 
         // A second pass, after every marker exists: classic maplibre annotations have no z-index and draw
         // in add order, so labels added with their markers would each sit under the icons of the stops
-        // added after them — at these zooms exactly the neighbour a rider is comparing against. Only
-        // within one render; a stop that first appears in a later one still draws over earlier labels,
-        // which the SymbolManager migration (#1728) is what really fixes.
+        // added after them — at these zooms exactly the neighbour a rider is comparing against.
+        //
+        // Only within one render; a stop that first appears in a later one still draws over earlier
+        // labels. Re-adding every live label whenever a render adds a marker would order those too, and
+        // is deliberately not done: at this zoom a pan publishes new stops continuously, so it would tear
+        // down and re-add the whole viewport's labels over and over — the churn this reconcile exists to
+        // avoid — to correct an overlap that costs a stop circle's worth of one label. The fix that costs
+        // nothing is explicit layer ordering, which is the SymbolManager migration (#1728).
         for (stop in markerStops) renderLabel(stop, band)
     }
 
@@ -149,6 +154,14 @@ internal class MapLibreStopMarkerLayer(
         }
     }
 
+    /**
+     * The shared icon for a label naming [routes], drawn in the current theme.
+     *
+     * A live label is re-iconed only when its routes change (see [renderLabel]) — the theme can't change
+     * under one, since a light/dark switch recreates the activity and with it the map, this layer and this
+     * cache. The label is drawn from the unrendered [StopRoute]s that survive that recreate in the view
+     * model, which is what re-colours the labels rather than restoring the ones drawn before the switch.
+     */
     private fun labelIcon(routes: List<StopRoute>): Icon {
         val darkMode = ThemeUtils.isInDarkMode(context)
         val key = StopRouteLabelBitmaps.labelKey(routes, darkMode)

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
@@ -18,14 +18,20 @@
 package org.onebusaway.android.map.maplibre
 
 import android.content.Context
+import android.util.LruCache
 import org.maplibre.android.annotations.Icon
+import org.maplibre.android.annotations.IconFactory
 import org.maplibre.android.annotations.Marker
 import org.maplibre.android.annotations.MarkerOptions
 import org.maplibre.android.maps.MapLibreMap
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.StopRouteLabelBitmaps
 import org.onebusaway.android.map.render.stopIconKind
+import org.onebusaway.android.map.render.stopRouteLabel
+import org.onebusaway.android.util.ThemeUtils
 
 /** Owns non-route stop marker identity, icon reconciliation, tap lookup, and disposal. */
 internal class MapLibreStopMarkerLayer(
@@ -35,6 +41,19 @@ internal class MapLibreStopMarkerLayer(
     private val markerByStopId = HashMap<String, Marker>()
     private val stopByMarker = HashMap<Marker, StopMarker>()
     private val kindByStopId = HashMap<String, StopIconKind>()
+
+    // The transit-centre route label beside each stop (#2107), reconciled alongside its marker rather
+    // than redrawn: at the zoom these appear the map still loads stops on every pan, and labels torn down
+    // and re-added on each of those publishes would blink while the markers under them held still.
+    private val labelByStopId = HashMap<String, Marker>()
+    private val labelRoutesByStopId = HashMap<String, List<BadgedRoute>>()
+
+    // One Icon per distinct set of routes: a transit centre's bays repeat each other's routes, and a label
+    // bitmap is mostly transparent lift, so sharing them is worth more here than for a stop icon. Bounded
+    // for the reason the renderer's badge cache is — an Icon holds its bitmap for the lifetime of the map.
+    private val labelIcons = LruCache<String, Icon>(LABEL_ICON_CACHE_SIZE)
+
+    private val iconFactory = IconFactory.getInstance(context)
 
     fun render(stops: List<StopMarker>, focusedStopId: String?, band: StopBand) {
         val markerStops = stops.filterNot(StopMarker::routeStop)
@@ -47,6 +66,7 @@ internal class MapLibreStopMarkerLayer(
                 stopByMarker.remove(entry.value)
                 kindByStopId.remove(entry.key)
                 gone.remove()
+                removeLabel(entry.key)
             }
         }
 
@@ -72,15 +92,70 @@ internal class MapLibreStopMarkerLayer(
             }
             kindByStopId[stop.id] = kind
         }
+
+        // A second pass, after every marker exists: classic maplibre annotations have no z-index and draw
+        // in add order, so labels added with their markers would each sit under the icons of the stops
+        // added after them — at these zooms exactly the neighbour a rider is comparing against. Only
+        // within one render; a stop that first appears in a later one still draws over earlier labels,
+        // which the SymbolManager migration (#1728) is what really fixes.
+        for (stop in markerStops) renderLabel(stop, band)
     }
 
     fun stopForMarker(marker: Marker): StopMarker? = stopByMarker[marker]
 
     fun dispose() {
-        if (markerByStopId.isNotEmpty()) map.removeAnnotations(markerByStopId.values.toList())
+        val annotations = markerByStopId.values + labelByStopId.values
+        if (annotations.isNotEmpty()) map.removeAnnotations(annotations)
         markerByStopId.clear()
+        labelByStopId.clear()
+        labelRoutesByStopId.clear()
+        labelIcons.evictAll()
         stopByMarker.clear()
         kindByStopId.clear()
+    }
+
+    /**
+     * Add, re-stamp or drop [stop]'s route label so it matches what the stop names at [band]. Its marker
+     * is registered in [stopByMarker] like the stop's own, so tapping a label focuses the stop it labels
+     * — it reads as part of that marker, and a label that swallowed the tap would read as a dead one.
+     */
+    private fun renderLabel(stop: StopMarker, band: StopBand) {
+        val routes = stopRouteLabel(stop, band)
+        if (routes.isEmpty()) {
+            removeLabel(stop.id)
+            return
+        }
+        val existing = labelByStopId[stop.id]
+        if (existing == null) {
+            // The classic Marker always centres its icon on the point, which is the placement the label
+            // bitmap is built for — its lift above the stop is baked in (see StopRouteLabelBitmaps).
+            val marker = map.addMarker(
+                MarkerOptions().position(stop.point.toLatLng()).icon(labelIcon(routes))
+            )
+            labelByStopId[stop.id] = marker
+            stopByMarker[marker] = stop
+        } else {
+            if (labelRoutesByStopId[stop.id] != routes) existing.icon = labelIcon(routes)
+            if (stopByMarker[existing]?.point != stop.point) existing.position = stop.point.toLatLng()
+            stopByMarker[existing] = stop
+        }
+        labelRoutesByStopId[stop.id] = routes
+    }
+
+    private fun removeLabel(stopId: String) {
+        labelByStopId.remove(stopId)?.let {
+            stopByMarker.remove(it)
+            map.removeAnnotation(it)
+        }
+        labelRoutesByStopId.remove(stopId)
+    }
+
+    private fun labelIcon(routes: List<BadgedRoute>): Icon {
+        val darkMode = ThemeUtils.isInDarkMode(context)
+        val key = StopRouteLabelBitmaps.labelKey(routes, darkMode)
+        return labelIcons.get(key) ?: iconFactory
+            .fromBitmap(StopRouteLabelBitmaps.label(context, routes, darkMode))
+            .also { labelIcons.put(key, it) }
     }
 
     private fun icon(stop: StopMarker, kind: StopIconKind): Icon = when (kind) {
@@ -92,5 +167,10 @@ internal class MapLibreStopMarkerLayer(
         StopIconKind.FAVORITE_FOCUSED -> MapLibreStopIcons.focusedFavoriteIcon(context, stop.direction)
         StopIconKind.FAVORITE_DOT -> MapLibreStopIcons.favoriteDotIcon(context)
         StopIconKind.FAVORITE_DOT_FOCUSED -> MapLibreStopIcons.focusedFavoriteDotIcon(context)
+    }
+
+    private companion object {
+        /** Comfortably more distinct route sets than a viewport at transit-centre zoom holds stops. */
+        const val LABEL_ICON_CACHE_SIZE = 64
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteStopPresentationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteStopPresentationTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteDirectionKey
@@ -54,6 +55,22 @@ class RouteStopPresentationTest {
 
         assertEquals(focused.id, result.single().id)
         assertFalse(result.single().routeStop)
+    }
+
+    @Test
+    fun `a presentation drops the stops' own route labels — it names the routes on screen itself`() {
+        val focused = stop("focused")
+        val labelled = marker(focused).copy(routes = listOf(BadgedRoute("62", 0xFF00FF00.toInt())))
+        val presentation = RouteStopPresentation(
+            stops = emptyList(),
+            routes = emptyList(),
+            routeDirectionsByStopId = emptyMap(),
+            projectedPoints = emptyMap()
+        )
+
+        val result = applyRouteStopPresentation(listOf(labelled), focused.id, presentation, ::marker)
+
+        assertEquals(emptyList<BadgedRoute>(), result.single().routes)
     }
 
     private fun stop(id: String) = ObaStopElement(id = id, lat = 47.0, lon = -122.0)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteStopPresentationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteStopPresentationTest.kt
@@ -5,8 +5,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
-import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.StopMarker
+import org.onebusaway.android.map.render.StopRoute
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.util.GeoPoint
@@ -60,7 +60,7 @@ class RouteStopPresentationTest {
     @Test
     fun `a presentation drops the stops' own route labels — it names the routes on screen itself`() {
         val focused = stop("focused")
-        val labelled = marker(focused).copy(routes = listOf(BadgedRoute("62", 0xFF00FF00.toInt())))
+        val labelled = marker(focused).copy(routes = listOf(StopRoute("62", 0xFF00FF00.toInt())))
         val presentation = RouteStopPresentation(
             stops = emptyList(),
             routes = emptyList(),
@@ -70,7 +70,7 @@ class RouteStopPresentationTest {
 
         val result = applyRouteStopPresentation(listOf(labelled), focused.id, presentation, ::marker)
 
-        assertEquals(emptyList<BadgedRoute>(), result.single().routes)
+        assertEquals(emptyList<StopRoute>(), result.single().routes)
     }
 
     private fun stop(id: String) = ObaStopElement(id = id, lat = 47.0, lon = -122.0)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/ContinuationBadgeBitmapsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/ContinuationBadgeBitmapsTest.kt
@@ -68,5 +68,32 @@ class ContinuationBadgeBitmapsTest {
         )
     }
 
+    @Test
+    fun `the blank cells padding a grid do not count as a colour on it`() {
+        val blue = Hct.from(210.0, 75.0, 55.0).toInt()
+        val grey = Hct.from(0.0, 0.0, 90.0).toInt()
+        val hued = ContinuationBadgeBitmaps.routeBadgeOutlineColor(blue, darkMode = false)
+
+        // A padded grid (#2107: a route count that doesn't divide evenly into its columns) fills the
+        // remainder with a neutral of the producer's choosing. That fill is not a route's, so a label
+        // naming one colour still cases in that colour's hue rather than going grey on the strength of
+        // how many routes happened to be on it.
+        assertEquals(
+            hued,
+            casing(
+                listOf(
+                    BadgedRoute("8", blue),
+                    BadgedRoute("40", blue),
+                    BadgedRoute("", grey, blank = true)
+                )
+            )
+        )
+        // The same cell not marked blank is a colourless route, and two colours have no hue to case with.
+        assertEquals(
+            ContinuationBadgeBitmaps.neutralBadgeOutlineColor(darkMode = false),
+            casing(listOf(BadgedRoute("8", blue), BadgedRoute("40", blue), BadgedRoute("", grey)))
+        )
+    }
+
     private fun casing(routes: List<BadgedRoute>) = ContinuationBadgeBitmaps.casingColor(routes, darkMode = false)
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
@@ -174,6 +174,22 @@ class StopRouteLabelTest {
         val blank = stopRouteLabelGrid(routes(7), dark = false).last().last()
         assertEquals("", blank.routeShortName)
         assertEquals(neutralBadgeChipColor(dark = false), blank.color)
+        assertTrue(blank.blank)
+        // Only the padding says so: every cell that names a route is a route, colourless ones included.
+        assertEquals(1, stopRouteLabelGrid(routes(7), dark = false).flatten().count(BadgedRoute::blank))
+    }
+
+    @Test
+    fun `padding a label out to a rectangle does not change the colour it cases in`() {
+        // Seven routes need two columns of four, so one cell is blank; that neutral is not a colour on the
+        // label, and a label whose routes share a hue cases in it however its cells divided up.
+        val cased = ContinuationBadgeBitmaps.casingColor(stopRouteLabelGrid(routes(7), dark = false).flatten(), darkMode = false)
+        val unpadded = ContinuationBadgeBitmaps.casingColor(stopRouteLabelGrid(routes(6), dark = false).flatten(), darkMode = false)
+        assertEquals(unpadded, cased)
+        assertEquals(
+            ContinuationBadgeBitmaps.routeBadgeOutlineColor(checkNotNull(routeBadgeChipColor(vivid, dark = false)), darkMode = false),
+            cased
+        )
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.adapters.ObaStopElement
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * Pure-logic tests for what a stop marker's route label reads (#2107) — the zoom band that shows one at
+ * all and the overflow rule that keeps a downtown bay's label from burying its neighbours. The bitmap
+ * build and the marker reconcile are exercised on device.
+ */
+class StopRouteLabelTest {
+
+    private fun route(name: String) = BadgedRoute(name, 0xFF00FF00.toInt())
+
+    private fun marker(routes: List<BadgedRoute>) = StopMarker(
+        "stop",
+        GeoPoint(0.0, 0.0),
+        "null",
+        ObaRoute.TYPE_BUS,
+        ObaStopElement("stop", 0.0, 0.0, "stop", "stop"),
+        routes = routes
+    )
+
+    @Test
+    fun `only the routes band names a stop's routes`() {
+        val stop = marker(listOf(route("8"), route("40")))
+        assertEquals(emptyList<BadgedRoute>(), stopRouteLabel(stop, StopBand.DOT))
+        assertEquals(emptyList<BadgedRoute>(), stopRouteLabel(stop, StopBand.FULL))
+        assertEquals(stop.routes, stopRouteLabel(stop, StopBand.ROUTES))
+    }
+
+    @Test
+    fun `a stop with no routes resolved yet draws no label even in the routes band`() {
+        assertEquals(emptyList<BadgedRoute>(), stopRouteLabel(marker(emptyList()), StopBand.ROUTES))
+    }
+
+    @Test
+    fun `routes that fit are all named, in the order given`() {
+        val routes = listOf(route("8"), route("40"), route("550"))
+        assertEquals(routes, stopRouteLabel(routes, maxRows = 3))
+    }
+
+    @Test
+    fun `overflow keeps one row back to count what it dropped`() {
+        val routes = (1..10).map { route("route$it") }
+        val rows = stopRouteLabel(routes, maxRows = 4)
+        assertEquals(4, rows.size)
+        assertEquals(routes.take(3), rows.take(3))
+        // 10 routes, 3 named: the last row accounts for the other 7 rather than leaving them unsaid.
+        assertEquals("+7", rows.last().routeShortName)
+        assertTrue(rows.last().color != routes.first().color)
+    }
+
+    @Test
+    fun `exactly one row over the cap still overflows, counting the two it displaced`() {
+        val routes = listOf(route("a"), route("b"), route("c"))
+        assertEquals(listOf("a", "+2"), stopRouteLabel(routes, maxRows = 2).map(BadgedRoute::routeShortName))
+    }
+
+    @Test
+    fun `a label with no room to both name and count is a producer bug, not a silent empty label`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            stopRouteLabel(listOf(route("8"), route("40")), maxRows = 1)
+        }
+    }
+
+    @Test
+    fun `the default cap is five rows`() {
+        // A literal anchor, so retuning the constant is a deliberate change that has to update this test.
+        assertEquals(5, STOP_ROUTE_LABEL_MAX_ROWS)
+        assertEquals(5, stopRouteLabel((1..9).map { route("$it") }).size)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
@@ -17,7 +17,7 @@ package org.onebusaway.android.map.render
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.models.ObaRoute
@@ -28,16 +28,21 @@ import org.onebusaway.android.util.routeBadgeChipColor
 import org.onebusaway.android.util.routeBadgeChipTextColor
 
 /**
- * Pure-logic tests for what a stop marker's route label reads and how it is coloured (#2107) — the zoom
- * band that shows one at all, the overflow rule that keeps a downtown bay's label from burying its
- * neighbours, and that the rows take the arrivals drawer's badge rather than the basemap's line colour.
- * The bitmap build and the marker reconcile are exercised on device.
+ * Pure-logic tests for what a stop marker's route label reads, how it is laid out and how it is coloured
+ * (#2107) — the zoom band that shows one at all, the balanced columns a stop with more routes than fit
+ * takes, and that the cells are the arrivals drawer's badge rather than the basemap's line colour. The
+ * bitmap build and the marker reconcile are exercised on device.
  */
 class StopRouteLabelTest {
 
     private val vivid = 0xFF1E88E5.toInt()
 
     private fun route(name: String, color: Int? = vivid) = StopRoute(name, color)
+
+    private fun routes(count: Int) = (1..count).map { route("$it") }
+
+    /** The laid-out grid read as names, `null` for the blank cells padding the last column. */
+    private fun names(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS) = stopRouteLabelColumns(routes, maxRows).map { column -> column.map { it?.shortName } }
 
     private fun marker(routes: List<StopRoute>) = StopMarker(
         "stop",
@@ -59,36 +64,60 @@ class StopRouteLabelTest {
     @Test
     fun `a stop with no routes resolved yet draws no label even in the routes band`() {
         assertEquals(emptyList<StopRoute>(), stopRouteLabel(marker(emptyList()), StopBand.ROUTES))
+        assertEquals(emptyList<List<StopRoute?>>(), stopRouteLabelColumns(emptyList()))
+    }
+
+    // --- layout: columns, balanced, every route named ---
+
+    @Test
+    fun `routes that fit stay one column, in the order given`() {
+        assertEquals(listOf(listOf("8", "40", "550")), names(listOf(route("8"), route("40"), route("550"))))
+        assertEquals(1, stopRouteLabelColumns(routes(STOP_ROUTE_LABEL_MAX_ROWS)).size)
     }
 
     @Test
-    fun `routes that fit are all named, in the order given`() {
-        val routes = listOf(route("8"), route("40"), route("550"))
-        assertEquals(routes, stopRouteLabel(routes, maxRows = 3))
+    fun `one route over the cap opens a second column rather than lengthening`() {
+        // 6 routes, 5 rows allowed: two columns of 3 — read down, then across.
+        assertEquals(listOf(listOf("1", "2", "3"), listOf("4", "5", "6")), names(routes(6)))
     }
 
     @Test
-    fun `overflow keeps one row back to count what it dropped`() {
-        val routes = (1..10).map { route("route$it") }
-        val rows = stopRouteLabel(routes, maxRows = 4)
-        assertEquals(4, rows.size)
-        assertEquals(routes.take(3), rows.take(3))
-        // 10 routes, 3 named: the last row accounts for the other 7 rather than leaving them unsaid.
-        assertEquals("+7", rows.last().shortName)
-        // Colourless, so it draws as the neutral chip — it is a count, not one more route.
-        assertEquals(null, rows.last().routeColor)
+    fun `columns are balanced, not filled and spilled`() {
+        // 7 in two columns reads 4 + 3, not 5 + 2: both are as wide, so the taller one is only taller.
+        assertEquals(listOf(listOf("1", "2", "3", "4"), listOf("5", "6", "7", null)), names(routes(7)))
     }
 
     @Test
-    fun `exactly one row over the cap still overflows, counting the two it displaced`() {
-        val routes = listOf(route("a"), route("b"), route("c"))
-        assertEquals(listOf("a", "+2"), stopRouteLabel(routes, maxRows = 2).map(StopRoute::shortName))
+    fun `a third column opens only when two full ones would overflow`() {
+        assertEquals(2, stopRouteLabelColumns(routes(10)).size)
+        assertEquals(3, stopRouteLabelColumns(routes(11)).size)
+        // 11 over three columns is 4 + 4 + 3, so the grid is 4 rows with one blank.
+        assertEquals(listOf(4, 4, 4), stopRouteLabelColumns(routes(11)).map { it.size })
     }
 
     @Test
-    fun `a label with no room to both name and count is a producer bug, not a silent empty label`() {
-        assertThrows(IllegalArgumentException::class.java) {
-            stopRouteLabel(listOf(route("8"), route("40")), maxRows = 1)
+    fun `every route is named however many there are — no label ever says 'and N more'`() {
+        for (count in 1..40) {
+            val named = stopRouteLabelColumns(routes(count)).flatten().filterNotNull().map(StopRoute::shortName)
+            assertEquals("$count routes", routes(count).map(StopRoute::shortName), named)
+        }
+    }
+
+    @Test
+    fun `the grid is rectangular, so the pill it fills has no hole`() {
+        for (count in 1..40) {
+            val columns = stopRouteLabelColumns(routes(count))
+            assertEquals("$count routes", 1, columns.map { it.size }.distinct().size)
+            // Only the trailing cells are blank — a hole in the middle would break the reading order.
+            val cells = columns.flatten()
+            assertTrue("$count routes", cells.dropWhile { it != null }.all { it == null })
+        }
+    }
+
+    @Test
+    fun `no column is ever taller than the cap`() {
+        for (count in 1..40) {
+            assertTrue("$count routes", stopRouteLabelColumns(routes(count)).all { it.size <= STOP_ROUTE_LABEL_MAX_ROWS })
         }
     }
 
@@ -96,32 +125,40 @@ class StopRouteLabelTest {
     fun `the default cap is five rows`() {
         // A literal anchor, so retuning the constant is a deliberate change that has to update this test.
         assertEquals(5, STOP_ROUTE_LABEL_MAX_ROWS)
-        assertEquals(5, stopRouteLabel((1..9).map { route("$it") }).size)
+        assertEquals(listOf(5), stopRouteLabelColumns(routes(5)).map { it.size })
+        assertEquals(listOf(3, 3), stopRouteLabelColumns(routes(6)).map { it.size })
     }
 
     // --- colour: the arrivals drawer's badge, not the basemap's line ---
 
     @Test
-    fun `a row is the drawer's badge chip — its faded fill and the ink paired with it`() {
-        val row = stopRouteLabelRows(listOf(route("8")), dark = false).single()
-        assertEquals("8", row.routeShortName)
-        assertEquals(routeBadgeChipColor(vivid, dark = false), row.color)
-        assertEquals(routeBadgeChipTextColor(vivid, dark = false), row.textColor)
+    fun `a cell is the drawer's badge chip — its faded fill and the ink paired with it`() {
+        val cell = stopRouteLabelGrid(listOf(route("8")), dark = false).single().single()
+        assertEquals("8", cell.routeShortName)
+        assertEquals(routeBadgeChipColor(vivid, dark = false), cell.color)
+        assertEquals(routeBadgeChipTextColor(vivid, dark = false), cell.textColor)
     }
 
     @Test
     fun `a route with no usable colour takes the whole neutral chip, fill and ink together`() {
         for (source in listOf(null, 0xFF808080.toInt())) {
-            val row = stopRouteLabelRows(listOf(route("8", source)), dark = false).single()
-            assertEquals("neutral fill for $source", neutralBadgeChipColor(dark = false), row.color)
-            assertEquals("neutral ink for $source", neutralBadgeChipTextColor(dark = false), row.textColor)
+            val cell = stopRouteLabelGrid(listOf(route("8", source)), dark = false).single().single()
+            assertEquals("neutral fill for $source", neutralBadgeChipColor(dark = false), cell.color)
+            assertEquals("neutral ink for $source", neutralBadgeChipTextColor(dark = false), cell.textColor)
         }
     }
 
     @Test
-    fun `the rows flip with the theme, which is why the source is carried this far`() {
-        val light = stopRouteLabelRows(listOf(route("8")), dark = false).single()
-        val night = stopRouteLabelRows(listOf(route("8")), dark = true).single()
+    fun `a blank cell names nothing and takes the neutral chip, so the pill stays whole`() {
+        val blank = stopRouteLabelGrid(routes(7), dark = false).last().last()
+        assertEquals("", blank.routeShortName)
+        assertEquals(neutralBadgeChipColor(dark = false), blank.color)
+    }
+
+    @Test
+    fun `the cells flip with the theme, which is why the source is carried this far`() {
+        val light = stopRouteLabelGrid(listOf(route("8")), dark = false).single().single()
+        val night = stopRouteLabelGrid(listOf(route("8")), dark = true).single().single()
         assertNotEquals(light.color, night.color)
         assertNotEquals(light.textColor, night.textColor)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
@@ -16,23 +16,30 @@
 package org.onebusaway.android.map.render
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertThrows
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.neutralBadgeChipColor
+import org.onebusaway.android.util.neutralBadgeChipTextColor
+import org.onebusaway.android.util.routeBadgeChipColor
+import org.onebusaway.android.util.routeBadgeChipTextColor
 
 /**
- * Pure-logic tests for what a stop marker's route label reads (#2107) — the zoom band that shows one at
- * all and the overflow rule that keeps a downtown bay's label from burying its neighbours. The bitmap
- * build and the marker reconcile are exercised on device.
+ * Pure-logic tests for what a stop marker's route label reads and how it is coloured (#2107) — the zoom
+ * band that shows one at all, the overflow rule that keeps a downtown bay's label from burying its
+ * neighbours, and that the rows take the arrivals drawer's badge rather than the basemap's line colour.
+ * The bitmap build and the marker reconcile are exercised on device.
  */
 class StopRouteLabelTest {
 
-    private fun route(name: String) = BadgedRoute(name, 0xFF00FF00.toInt())
+    private val vivid = 0xFF1E88E5.toInt()
 
-    private fun marker(routes: List<BadgedRoute>) = StopMarker(
+    private fun route(name: String, color: Int? = vivid) = StopRoute(name, color)
+
+    private fun marker(routes: List<StopRoute>) = StopMarker(
         "stop",
         GeoPoint(0.0, 0.0),
         "null",
@@ -44,14 +51,14 @@ class StopRouteLabelTest {
     @Test
     fun `only the routes band names a stop's routes`() {
         val stop = marker(listOf(route("8"), route("40")))
-        assertEquals(emptyList<BadgedRoute>(), stopRouteLabel(stop, StopBand.DOT))
-        assertEquals(emptyList<BadgedRoute>(), stopRouteLabel(stop, StopBand.FULL))
+        assertEquals(emptyList<StopRoute>(), stopRouteLabel(stop, StopBand.DOT))
+        assertEquals(emptyList<StopRoute>(), stopRouteLabel(stop, StopBand.FULL))
         assertEquals(stop.routes, stopRouteLabel(stop, StopBand.ROUTES))
     }
 
     @Test
     fun `a stop with no routes resolved yet draws no label even in the routes band`() {
-        assertEquals(emptyList<BadgedRoute>(), stopRouteLabel(marker(emptyList()), StopBand.ROUTES))
+        assertEquals(emptyList<StopRoute>(), stopRouteLabel(marker(emptyList()), StopBand.ROUTES))
     }
 
     @Test
@@ -67,14 +74,15 @@ class StopRouteLabelTest {
         assertEquals(4, rows.size)
         assertEquals(routes.take(3), rows.take(3))
         // 10 routes, 3 named: the last row accounts for the other 7 rather than leaving them unsaid.
-        assertEquals("+7", rows.last().routeShortName)
-        assertTrue(rows.last().color != routes.first().color)
+        assertEquals("+7", rows.last().shortName)
+        // Colourless, so it draws as the neutral chip — it is a count, not one more route.
+        assertEquals(null, rows.last().routeColor)
     }
 
     @Test
     fun `exactly one row over the cap still overflows, counting the two it displaced`() {
         val routes = listOf(route("a"), route("b"), route("c"))
-        assertEquals(listOf("a", "+2"), stopRouteLabel(routes, maxRows = 2).map(BadgedRoute::routeShortName))
+        assertEquals(listOf("a", "+2"), stopRouteLabel(routes, maxRows = 2).map(StopRoute::shortName))
     }
 
     @Test
@@ -89,5 +97,32 @@ class StopRouteLabelTest {
         // A literal anchor, so retuning the constant is a deliberate change that has to update this test.
         assertEquals(5, STOP_ROUTE_LABEL_MAX_ROWS)
         assertEquals(5, stopRouteLabel((1..9).map { route("$it") }).size)
+    }
+
+    // --- colour: the arrivals drawer's badge, not the basemap's line ---
+
+    @Test
+    fun `a row is the drawer's badge chip — its faded fill and the ink paired with it`() {
+        val row = stopRouteLabelRows(listOf(route("8")), dark = false).single()
+        assertEquals("8", row.routeShortName)
+        assertEquals(routeBadgeChipColor(vivid, dark = false), row.color)
+        assertEquals(routeBadgeChipTextColor(vivid, dark = false), row.textColor)
+    }
+
+    @Test
+    fun `a route with no usable colour takes the whole neutral chip, fill and ink together`() {
+        for (source in listOf(null, 0xFF808080.toInt())) {
+            val row = stopRouteLabelRows(listOf(route("8", source)), dark = false).single()
+            assertEquals("neutral fill for $source", neutralBadgeChipColor(dark = false), row.color)
+            assertEquals("neutral ink for $source", neutralBadgeChipTextColor(dark = false), row.textColor)
+        }
+    }
+
+    @Test
+    fun `the rows flip with the theme, which is why the source is carried this far`() {
+        val light = stopRouteLabelRows(listOf(route("8")), dark = false).single()
+        val night = stopRouteLabelRows(listOf(route("8")), dark = true).single()
+        assertNotEquals(light.color, night.color)
+        assertNotEquals(light.textColor, night.textColor)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
@@ -122,6 +122,18 @@ class StopRouteLabelTest {
     }
 
     @Test
+    fun `every column names at least one route`() {
+        // A column is drawn as wide as its own widest name, so an all-blank one would be a bare sliver of
+        // pill — and balancing is what rules it out, since it never opens a column it can't fill.
+        for (count in 1..40) {
+            assertTrue(
+                "$count routes",
+                stopRouteLabelColumns(routes(count)).all { column -> column.any { it != null } }
+            )
+        }
+    }
+
+    @Test
     fun `the default cap is five rows`() {
         // A literal anchor, so retuning the constant is a deliberate change that has to update this test.
         assertEquals(5, STOP_ROUTE_LABEL_MAX_ROWS)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopRouteLabelTest.kt
@@ -42,7 +42,7 @@ class StopRouteLabelTest {
     private fun routes(count: Int) = (1..count).map { route("$it") }
 
     /** The laid-out grid read as names, `null` for the blank cells padding the last column. */
-    private fun names(routes: List<StopRoute>, maxRows: Int = STOP_ROUTE_LABEL_MAX_ROWS) = stopRouteLabelColumns(routes, maxRows).map { column -> column.map { it?.shortName } }
+    private fun names(routes: List<StopRoute>) = stopRouteLabelColumns(routes).map { column -> column.map { it?.shortName } }
 
     private fun marker(routes: List<StopRoute>) = StopMarker(
         "stop",
@@ -59,6 +59,15 @@ class StopRouteLabelTest {
         assertEquals(emptyList<StopRoute>(), stopRouteLabel(stop, StopBand.DOT))
         assertEquals(emptyList<StopRoute>(), stopRouteLabel(stop, StopBand.FULL))
         assertEquals(stop.routes, stopRouteLabel(stop, StopBand.ROUTES))
+    }
+
+    @Test
+    fun `the band is read as an ordering, so a band added above ROUTES still labels`() {
+        // StopBand widens — a band above ROUTES shows everything it does and more — so every band from
+        // ROUTES up labels. An equality test would switch the labels off at the zoom that wants them most.
+        val stop = marker(listOf(route("8")))
+        val labelling = StopBand.entries.filter { stopRouteLabel(stop, it).isNotEmpty() }
+        assertEquals(StopBand.entries.filter { it >= StopBand.ROUTES }, labelling)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
@@ -39,16 +39,26 @@ class StopZoomBandTest {
         assertEquals(StopBand.DOT, stopZoomBand(0f))
         assertEquals(StopBand.FULL, stopZoomBand(STOP_DOT_ZOOM_THRESHOLD))
         assertEquals(StopBand.FULL, stopZoomBand(STOP_DOT_ZOOM_THRESHOLD + 0.01f))
-        assertEquals(StopBand.FULL, stopZoomBand(21f))
     }
 
     @Test
-    fun `the band flips at zoom 15 (pins the threshold constant, not just the boundary)`() {
-        // Literal anchors (not STOP_DOT_ZOOM_THRESHOLD) so retuning the constant is a deliberate change
-        // that has to update this test — the ± boundary cases above would otherwise silently follow it.
+    fun `at or above the routes threshold a stop also names its routes`() {
+        assertEquals(StopBand.FULL, stopZoomBand(STOP_ROUTES_ZOOM_THRESHOLD - 0.01f))
+        assertEquals(StopBand.ROUTES, stopZoomBand(STOP_ROUTES_ZOOM_THRESHOLD))
+        assertEquals(StopBand.ROUTES, stopZoomBand(STOP_ROUTES_ZOOM_THRESHOLD + 0.01f))
+        assertEquals(StopBand.ROUTES, stopZoomBand(21f))
+    }
+
+    @Test
+    fun `the bands flip at zoom 15 and 18 (pins the threshold constants, not just the boundaries)`() {
+        // Literal anchors (not the constants) so retuning either is a deliberate change that has to
+        // update this test — the ± boundary cases above would otherwise silently follow it.
         assertEquals(15f, STOP_DOT_ZOOM_THRESHOLD, 0f)
+        assertEquals(18f, STOP_ROUTES_ZOOM_THRESHOLD, 0f)
         assertEquals(StopBand.DOT, stopZoomBand(14.99f))
         assertEquals(StopBand.FULL, stopZoomBand(15f))
+        assertEquals(StopBand.FULL, stopZoomBand(17.99f))
+        assertEquals(StopBand.ROUTES, stopZoomBand(18f))
     }
 
     @Test
@@ -89,6 +99,20 @@ class StopZoomBandTest {
         assertEquals(
             StopIconKind.FAVORITE_DOT_FOCUSED,
             stopIconKind(focused = true, band = StopBand.DOT, favorite = true)
+        )
+    }
+
+    @Test
+    fun `the routes band takes the full band's icons — what it adds is the label, not a new icon`() {
+        assertEquals(StopIconKind.FULL, stopIconKind(focused = false, band = StopBand.ROUTES))
+        assertEquals(StopIconKind.FULL_FOCUSED, stopIconKind(focused = true, band = StopBand.ROUTES))
+        assertEquals(
+            StopIconKind.FAVORITE,
+            stopIconKind(focused = false, band = StopBand.ROUTES, favorite = true)
+        )
+        assertEquals(
+            StopIconKind.FAVORITE_FOCUSED,
+            stopIconKind(focused = true, band = StopBand.ROUTES, favorite = true)
         )
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
@@ -50,15 +50,15 @@ class StopZoomBandTest {
     }
 
     @Test
-    fun `the bands flip at zoom 15 and 18 (pins the threshold constants, not just the boundaries)`() {
+    fun `the bands flip at zoom 15 and 17,5 (pins the threshold constants, not just the boundaries)`() {
         // Literal anchors (not the constants) so retuning either is a deliberate change that has to
         // update this test — the ± boundary cases above would otherwise silently follow it.
         assertEquals(15f, STOP_DOT_ZOOM_THRESHOLD, 0f)
-        assertEquals(18f, STOP_ROUTES_ZOOM_THRESHOLD, 0f)
+        assertEquals(17.5f, STOP_ROUTES_ZOOM_THRESHOLD, 0f)
         assertEquals(StopBand.DOT, stopZoomBand(14.99f))
         assertEquals(StopBand.FULL, stopZoomBand(15f))
-        assertEquals(StopBand.FULL, stopZoomBand(17.99f))
-        assertEquals(StopBand.ROUTES, stopZoomBand(18f))
+        assertEquals(StopBand.FULL, stopZoomBand(17.49f))
+        assertEquals(StopBand.ROUTES, stopZoomBand(17.5f))
     }
 
     @Test


### PR DESCRIPTION
Closes half of #2107 — point (1), "show a list of transit routes right on the stop marker". Point (2) (auto-peeking the arrivals drawer for every stop in view) is **not** in this PR.

## What it does

At a transit centre a rider had to open every bay in turn to find the one that serves their route: the markers are identical, and nothing on the map says which stop is which until it's tapped.

From **zoom 17.5** — about a block wide, so a viewport is one transit centre rather than a neighbourhood — each nearby stop marker now floats a label naming the routes that serve it. Tapping the label focuses the stop, exactly as tapping the marker does.

<!-- Screenshot of a transit centre at z17.5+ goes here. -->

## How

- **`StopBand` gains `ROUTES` above `FULL`.** The band already rides the render snapshot and re-fires both renderers, so the label needed no new plumbing. It takes `FULL`'s icons — what the band adds is the label, not a different marker. The bands widen, so they're compared as an ordering rather than for equality.
- **`StopMarker` carries the routes its label names** as `StopRoute` (name + the *unrendered* agency colour), resolved by `StopsMapController` from the routes the stop responses report, in the app's usual `inInterchangeableOrder`.
- **The pill is the map's existing route label** (`ContinuationBadgeBitmaps`) at 0.6×, so the map draws one kind of route label however many things it labels.
- **Colours are the arrivals drawer's badge** (`routeBadgeChipColor` + the deep same-hue ink it's paired with), not the basemap's route-line colour. A stop label isn't a line: it's a small block of type read against the badges elsewhere in the app — the arrivals list it's a shortcut into, above all — and a column of fully saturated bars beside every marker in a transit centre reads as the subject of the map, which the stops around the rider are not. The colour is resolved at *draw* time, since the badge policy flips with light/dark, so a theme change re-colours the labels.
- **More routes than fit widen the label into balanced columns** rather than overflowing to a `+N` row: five rows is a cap on height, not on how many routes get named. Seven routes read 4 + 3, not 5 + 2. Each column is as wide as its own widest name. A rider hunting their route at a transit centre is exactly the person for whom "and 6 more" is no answer.
- **Both flavors** anchor the label centred on the stop's point with its lift baked into the bitmap as padding — maplibre's classic `Marker` has no per-marker anchor, so that's the only placement both can express identically. It's reconciled alongside the stop marker (not redrawn) so it doesn't blink on every pan's stop load.

`ContinuationBadgeBitmaps.badge` is now the single-column case of a new `badgeGrid`; an instrumented test pins that one column still draws pixel-for-pixel what it did, so route labels on lines are untouched.

## Deliberate limitations

- **A cached-only stop draws no label** until the network response for that viewport lands (a moment later). The persistent stop cache stores each route's *type* but not its name; closing that gap needs an `AppDatabase` migration.
- **Column count is uncapped**, so a stop serving very many routes draws a wide label. Capping columns would reintroduce the overflow this replaces; if it crowds the map, the fix is a taller row cap, not a dropped route.
- **The label lets two markers reach into it** rather than clearing them: a focused stop's enlarged circle, and a direction arrow that happens to point north. Clearing them cost visible daylight over every *other* stop, which is the overwhelming majority.

## Testing

- New `StopRouteLabelTest` (layout, overflow, colour policy) and `RouteBadgeBitmapTest` cases (per-column widths, single-column equivalence); extended `StopZoomBandTest` and `RouteStopPresentationTest`.
- Both flavors compile clean under `-PwarningsAsErrors=true`.
- Exercised on device (Pixel 7 Pro) through the tuning of the zoom threshold, the colours, the column layout and the lift. The final review-cleanup commit is build- and unit-test-verified but was not re-run on device.

## Note for reviewers

`STOP_ROUTES_ZOOM_THRESHOLD`, the label `SCALE`, `LIFT_DP` and `STOP_ROUTE_LABEL_MAX_ROWS` are all visual judgements set on device, not derived values — each says so at its definition. They're the knobs to argue with.

One thing this PR routes around rather than fixes: `renderStatic` clear-and-redraws `routeBadges` on *every* snapshot emission, so any first-class snapshot badge blinks on a stops publish. That's why these labels live in the stop-marker layer and reconcile themselves. Giving the badge layer a keyed reconciler (the `RoutePolylineReconciler` treatment) would fix it for both, and is worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route labels to transit stop markers at high zoom levels.
  * Route labels support multiple columns, route colors, light and dark themes, and neutral styling when colors are unavailable.
  * Added route-label support across supported map providers, including marker updates, tap lookup, caching, and cleanup.
  * Enhanced debug map information to show the active stop zoom band.

* **Bug Fixes**
  * Prevented route labels from appearing on transit-centre stop presentations where they are not applicable.

* **Tests**
  * Added coverage for label visibility, layout, colors, zoom thresholds, badge grids, and marker presentation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->