### PR TITLE
Confirm before backing out of a shown directions itinerary

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsExitConfirmDialogTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsExitConfirmDialogTest.kt
@@ -43,22 +43,15 @@ class DirectionsExitConfirmDialogTest {
     private val cancelLabel = context.getString(R.string.cancel)
 
     @Test
-    fun itNamesTheTripBeingDiscardedAndOffersBothAnswers() {
-        renderDialog()
+    fun itNamesTheTripAndOnlyDiscardConfirmsTheExit() {
+        var confirmed = 0
+        var dismissed = 0
+        renderDialog(onConfirm = { confirmed++ }, onDismiss = { dismissed++ })
 
         composeRule.onNodeWithText(context.getString(R.string.directions_exit_confirm_title))
             .assertIsDisplayed()
         composeRule.onNodeWithText(context.getString(R.string.directions_exit_confirm_message))
             .assertIsDisplayed()
-        composeRule.onNodeWithText(discardLabel).assertIsDisplayed()
-        composeRule.onNodeWithText(cancelLabel).assertIsDisplayed()
-    }
-
-    @Test
-    fun onlyDiscardConfirmsTheExit() {
-        var confirmed = 0
-        var dismissed = 0
-        renderDialog(onConfirm = { confirmed++ }, onDismiss = { dismissed++ })
 
         composeRule.onNodeWithText(cancelLabel).performClick()
         assertEquals(0, confirmed)

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsExitConfirmDialogTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionsExitConfirmDialogTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/**
+ * On-device checks on the leave-directions confirmation (#2140). Its whole job is to make discarding a
+ * planned trip a deliberate act, so what matters is that the two answers stay wired to opposite
+ * outcomes — a swap here would silently restore the accidental erasure the dialog exists to prevent,
+ * while still looking correct.
+ */
+class DirectionsExitConfirmDialogTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val discardLabel = context.getString(R.string.directions_exit_confirm_discard)
+    private val cancelLabel = context.getString(R.string.cancel)
+
+    @Test
+    fun itNamesTheTripBeingDiscardedAndOffersBothAnswers() {
+        renderDialog()
+
+        composeRule.onNodeWithText(context.getString(R.string.directions_exit_confirm_title))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(context.getString(R.string.directions_exit_confirm_message))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(discardLabel).assertIsDisplayed()
+        composeRule.onNodeWithText(cancelLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun onlyDiscardConfirmsTheExit() {
+        var confirmed = 0
+        var dismissed = 0
+        renderDialog(onConfirm = { confirmed++ }, onDismiss = { dismissed++ })
+
+        composeRule.onNodeWithText(cancelLabel).performClick()
+        assertEquals(0, confirmed)
+        assertEquals(1, dismissed)
+
+        composeRule.onNodeWithText(discardLabel).performClick()
+        assertEquals(1, confirmed)
+        assertEquals(1, dismissed)
+    }
+
+    private fun renderDialog(
+        onConfirm: () -> Unit = {},
+        onDismiss: () -> Unit = {}
+    ) {
+        composeRule.setContent {
+            ObaTheme {
+                DirectionsExitConfirmDialog(onConfirm = onConfirm, onDismiss = onDismiss)
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -633,12 +633,6 @@ fun HomeScreen(
                                     homeViewModel.navigateBackInDirections()
                                 }
                             }
-                            // That last step doesn't leave outright when a trip is drawn — it stages this
-                            // question instead, as does a tap on the map background (#2140). The VM owns the
-                            // latch because both gestures reach it from different places (here, and the map's
-                            // own click callback); answering it either exits or leaves the trip untouched.
-                            val confirmDirectionsExit by homeViewModel.pendingDirectionsExit
-                                .collectAsStateWithLifecycle()
 
                             // Lift the FABs above the whole collapsed sheet peek; the target changes only on settle
                             // and MapChrome animates it. Local here since the screen holds the live SheetState. Only
@@ -834,7 +828,13 @@ fun HomeScreen(
                                         onDismiss = { longPressPoint = null }
                                     )
                                 }
-                                if (confirmDirectionsExit) {
+                                // Neither Back nor a tap on the map background leaves outright while a trip
+                                // is drawn — each stages this question instead (#2140). The VM owns the latch
+                                // because the two gestures reach it from different places (the BackHandler
+                                // above, and the map's own click callback), and it is answered here.
+                                val showExitConfirm by homeViewModel.pendingDirectionsExit
+                                    .collectAsStateWithLifecycle()
+                                if (showExitConfirm) {
                                     DirectionsExitConfirmDialog(
                                         onConfirm = homeViewModel::confirmExitDirections,
                                         onDismiss = homeViewModel::dismissDirectionsExit

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -90,6 +90,7 @@ import org.onebusaway.android.ui.home.chrome.MapTopChrome
 import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.home.directions.DirectionStopEtaStrip
 import org.onebusaway.android.ui.home.directions.DirectionsErrorSnackbar
+import org.onebusaway.android.ui.home.directions.DirectionsExitConfirmDialog
 import org.onebusaway.android.ui.home.directions.DirectionsFormCard
 import org.onebusaway.android.ui.home.directions.DirectionsLongPressMenu
 import org.onebusaway.android.ui.home.directions.DirectionsPickOverlay
@@ -632,6 +633,12 @@ fun HomeScreen(
                                     homeViewModel.navigateBackInDirections()
                                 }
                             }
+                            // That last step doesn't leave outright when a trip is drawn — it stages this
+                            // question instead, as does a tap on the map background (#2140). The VM owns the
+                            // latch because both gestures reach it from different places (here, and the map's
+                            // own click callback); answering it either exits or leaves the trip untouched.
+                            val confirmDirectionsExit by homeViewModel.pendingDirectionsExit
+                                .collectAsStateWithLifecycle()
 
                             // Lift the FABs above the whole collapsed sheet peek; the target changes only on settle
                             // and MapChrome animates it. Local here since the screen holds the live SheetState. Only
@@ -825,6 +832,12 @@ fun HomeScreen(
                                             longPressPoint = null
                                         },
                                         onDismiss = { longPressPoint = null }
+                                    )
+                                }
+                                if (confirmDirectionsExit) {
+                                    DirectionsExitConfirmDialog(
+                                        onConfirm = homeViewModel::confirmExitDirections,
+                                        onDismiss = homeViewModel::dismissDirectionsExit
                                     )
                                 }
                             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -551,6 +551,10 @@ class HomeViewModel @Inject constructor(
      */
     fun unfocusMapOneLevel() {
         val focus = _currentFocus.value
+        // A stray background tap is the cheapest gesture on the map, and from the itinerary overview it
+        // used to spend a planned trip outright — so when there is a trip drawn to lose, it asks first
+        // (#2140) rather than erasing it. Nothing drawn yet: leaving is free, so it just leaves.
+        if (stageDirectionsExitConfirmation(focus)) return
         val target = when (focus) {
             is CurrentFocus.Stop -> if (focus.selectedRoute == null) {
                 CurrentFocus.None
@@ -611,13 +615,17 @@ class HomeViewModel @Inject constructor(
         if (_currentFocus.value is CurrentFocus.Directions) return
         presentedRoutes = emptySet()
         pendingFocus = null
+        // A fresh entry has nothing drawn yet — the previous visit's trip is long off the map, and a
+        // stale record of it would make the first Back out of an empty form ask to discard it (#2140).
+        shownItinerary = null
         pushFocus(CurrentFocus.Directions(), undoViewport)
     }
 
     // The draw of the itinerary currently shown in directions mode, cached so returning from a route
     // sub-focus (a map-background tap) can redraw it — the results VM's selection flow doesn't re-emit on
     // its own. Held as the whole directive rather than just the itinerary, so a redraw reproduces the
-    // terminus pins the trip was drawn with instead of quietly restoring a suppressed one.
+    // terminus pins the trip was drawn with instead of quietly restoring a suppressed one. Null means
+    // there is no trip on the map, which is also what makes leaving directions free of a confirmation.
     private var shownItinerary: MapDirective.ShowItinerary? = null
 
     /**
@@ -772,7 +780,10 @@ class HomeViewModel @Inject constructor(
     }
 
     /** Clear the drawn itinerary while staying in directions (the plan became unsubmittable). */
-    fun clearShownItineraryOnMap() = emitMapDirective(MapDirective.ClearItinerary)
+    fun clearShownItineraryOnMap() {
+        shownItinerary = null
+        emitMapDirective(MapDirective.ClearItinerary)
+    }
 
     /** Show the resolved From/To endpoints as green/red pins (before a plan); a null endpoint drops it. */
     fun setDirectionsEndpointsOnMap(from: GeoPoint?, to: GeoPoint?) = emitMapDirective(MapDirective.SetDirectionsEndpoints(from, to))
@@ -780,20 +791,60 @@ class HomeViewModel @Inject constructor(
     // Leave directions focus, returning the map to nearby stops. Private: the only way out is
     // [navigateBackInDirections]'s last step, so a control can't jump straight out of a focused leg —
     // exactly the behaviour #2075 removed.
+    // [shownItinerary] deliberately survives this: backing *into* the directions focus we just left has to
+    // put the trip back on the map. A later fresh entry resets it (see [enterDirections]).
     private fun exitDirections() = clearMapFocus()
+
+    // Whether a gesture that would leave directions is waiting on the rider's confirmation. Set only by
+    // [stageDirectionsExitConfirmation]; the host shows a modal dialog off it and answers with
+    // [confirmExitDirections] / [dismissDirectionsExit]. It carries no "which gesture asked", because
+    // there is only one answer to give: every gesture that reaches it wants the same exit.
+    private val _pendingDirectionsExit = MutableStateFlow(false)
+    val pendingDirectionsExit: StateFlow<Boolean> = _pendingDirectionsExit.asStateFlow()
+
+    /**
+     * Intercept a gesture that would leave directions from [focus], staging a confirmation instead of
+     * exiting — and reporting whether it did, so the caller stops where it is (#2140).
+     *
+     * The gate is a trip actually *drawn* on the map ([shownItinerary]) at the plain itinerary overview:
+     * that is the state a planned trip lives in, and losing it costs the rider the whole plan. An
+     * unplanned form, or a drilled-into leg (which steps back to the overview rather than out), is not
+     * worth a dialog and doesn't get one.
+     */
+    private fun stageDirectionsExitConfirmation(focus: CurrentFocus): Boolean {
+        val leavesDrawnTrip = focus is CurrentFocus.Directions &&
+            focus.subFocus == null &&
+            shownItinerary != null
+        if (!leavesDrawnTrip) return false
+        _pendingDirectionsExit.value = true
+        return true
+    }
+
+    /** The rider confirmed the staged exit: leave directions, dropping the trip. */
+    fun confirmExitDirections() {
+        if (!_pendingDirectionsExit.value) return
+        exitDirections()
+    }
+
+    /** The rider declined the staged exit (or dismissed the dialog): stay on the trip. */
+    fun dismissDirectionsExit() {
+        _pendingDirectionsExit.value = false
+    }
 
     /**
      * The system Back gesture while in directions. A leg the user drilled into — its route, or an
      * on-street leg framed on its own — steps back out of that leg first, so Back reverses the drill-in
      * (restoring the camera it moved) instead of leaving the trip behind (#2075); only from the plain
-     * itinerary overview does Back exit directions. The map-background tap drops a level the same way,
-     * but jumps straight to the overview, while Back walks the legs the user visited in order — matching
-     * how a stop's route focus already behaves under each gesture.
+     * itinerary overview does Back exit directions — and with a trip drawn there, only after the rider
+     * confirms it (#2140). The map-background tap drops a level the same way, but jumps straight to the
+     * overview, while Back walks the legs the user visited in order — matching how a stop's route focus
+     * already behaves under each gesture.
      */
     fun navigateBackInDirections() {
         // The false guard is belt-and-braces: reaching a leg sub-focus always pushed the overview it was
         // entered from, so there is history to pop.
         if (directionsSubFocus != null && navigateBackFocus()) return
+        if (stageDirectionsExitConfirmation(_currentFocus.value)) return
         exitDirections()
     }
 
@@ -844,6 +895,9 @@ class HomeViewModel @Inject constructor(
 
     private fun replaceFocus(focus: CurrentFocus) {
         _currentFocus.value = focus
+        // A staged "leave the trip?" question is only ever asked of the focus that raised it, so any
+        // move off directions — the confirmed exit itself, or a deep link taking the map — answers it.
+        if (focus !is CurrentFocus.Directions) _pendingDirectionsExit.value = false
         CurrentFocusPersistence.write(savedState, focus)
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -313,8 +313,18 @@ class HomeViewModel @Inject constructor(
         _showWelcomeTutorial.value = false
     }
 
-    fun onBikeStationFocused(id: String) {
+    /**
+     * A bike dock was tapped on the map. Directions owns the map while a trip is being planned — and the
+     * docks drawn there are the trip's *own*, since the bike layer runs seeded from the itinerary — so a
+     * tap there is refused rather than allowed to take the screen, exactly as a stop tap is (#2097).
+     * Letting it through discarded the whole plan in one tap on the very screen #2140 protects.
+     *
+     * Returns whether the focus was taken, so the map can leave its own render state alone when it wasn't.
+     */
+    fun onBikeStationFocused(id: String): Boolean {
+        if (_currentFocus.value is CurrentFocus.Directions) return false
         pushFocus(CurrentFocus.BikeStation(id))
+        return true
     }
 
     /**
@@ -551,10 +561,6 @@ class HomeViewModel @Inject constructor(
      */
     fun unfocusMapOneLevel() {
         val focus = _currentFocus.value
-        // A stray background tap is the cheapest gesture on the map, and from the itinerary overview it
-        // used to spend a planned trip outright — so when there is a trip drawn to lose, it asks first
-        // (#2140) rather than erasing it. Nothing drawn yet: leaving is free, so it just leaves.
-        if (stageDirectionsExitConfirmation(focus)) return
         val target = when (focus) {
             is CurrentFocus.Stop -> if (focus.selectedRoute == null) {
                 CurrentFocus.None
@@ -571,6 +577,9 @@ class HomeViewModel @Inject constructor(
             is CurrentFocus.Route, is CurrentFocus.BikeStation -> CurrentFocus.None
             CurrentFocus.None -> return
         }
+        // A stray background tap is the cheapest gesture on the map; where it would take a planned trip
+        // off it, it asks first (#2140) — judged on the transition the `when` above just decided.
+        if (stageDirectionsExitConfirmation(focus, target)) return
         pushFocus(target)
         when {
             target is CurrentFocus.Stop -> emitMapDirective(MapDirective.ClearSelectedRoute)
@@ -624,8 +633,10 @@ class HomeViewModel @Inject constructor(
     // The draw of the itinerary currently shown in directions mode, cached so returning from a route
     // sub-focus (a map-background tap) can redraw it — the results VM's selection flow doesn't re-emit on
     // its own. Held as the whole directive rather than just the itinerary, so a redraw reproduces the
-    // terminus pins the trip was drawn with instead of quietly restoring a suppressed one. Null means
-    // there is no trip on the map, which is also what makes leaving directions free of a confirmation.
+    // terminus pins the trip was drawn with instead of quietly restoring a suppressed one. Read together
+    // with a directions focus it also answers "has the rider a trip to lose?" — the #2140 gate — which is
+    // why it is now cleared whenever the trip leaves the map. On its own it does not: it deliberately
+    // outlives the exit (see [exitDirections]), so the gate always pairs it with the focus.
     private var shownItinerary: MapDirective.ShowItinerary? = null
 
     /**
@@ -782,6 +793,9 @@ class HomeViewModel @Inject constructor(
     /** Clear the drawn itinerary while staying in directions (the plan became unsubmittable). */
     fun clearShownItineraryOnMap() {
         shownItinerary = null
+        // The trip this asked about is gone, so the question goes with it rather than being left on
+        // screen offering to discard something the rider can no longer see.
+        _pendingDirectionsExit.value = false
         emitMapDirective(MapDirective.ClearItinerary)
     }
 
@@ -803,24 +817,29 @@ class HomeViewModel @Inject constructor(
     val pendingDirectionsExit: StateFlow<Boolean> = _pendingDirectionsExit.asStateFlow()
 
     /**
-     * Intercept a gesture that would leave directions from [focus], staging a confirmation instead of
-     * exiting — and reporting whether it did, so the caller stops where it is (#2140).
+     * Intercept a focus change that would take a drawn trip off the map, staging a confirmation instead
+     * of making it — and reporting whether it did, so the caller stops where it is (#2140).
      *
-     * The gate is a trip actually *drawn* on the map ([shownItinerary]) at the plain itinerary overview:
-     * that is the state a planned trip lives in, and losing it costs the rider the whole plan. An
-     * unplanned form, or a drilled-into leg (which steps back to the overview rather than out), is not
-     * worth a dialog and doesn't get one.
+     * Judged on the transition ([from] → [to]), not on which gesture asked: every caller already decides
+     * where its gesture lands, so reading that decision keeps this from re-deriving — and later drifting
+     * from — the level rules they encode. Any move out of directions while a trip is drawn costs the
+     * rider their whole plan; every move that stays inside it, such as stepping back out of a
+     * drilled-into leg, costs them nothing. An unplanned form has no trip to lose, so it leaves free.
      */
-    private fun stageDirectionsExitConfirmation(focus: CurrentFocus): Boolean {
-        val leavesDrawnTrip = focus is CurrentFocus.Directions &&
-            focus.subFocus == null &&
+    private fun stageDirectionsExitConfirmation(from: CurrentFocus, to: CurrentFocus): Boolean {
+        val leavesDrawnTrip = from is CurrentFocus.Directions &&
+            to !is CurrentFocus.Directions &&
             shownItinerary != null
         if (!leavesDrawnTrip) return false
         _pendingDirectionsExit.value = true
         return true
     }
 
-    /** The rider confirmed the staged exit: leave directions, dropping the trip. */
+    /**
+     * The rider confirmed the staged exit: leave directions, dropping the trip. The guard is what keeps
+     * this from becoming a public door around [exitDirections] being private — without it a control
+     * could call it from a drilled-into leg and jump straight out, the behaviour #2075 removed.
+     */
     fun confirmExitDirections() {
         if (!_pendingDirectionsExit.value) return
         exitDirections()
@@ -844,7 +863,7 @@ class HomeViewModel @Inject constructor(
         // The false guard is belt-and-braces: reaching a leg sub-focus always pushed the overview it was
         // entered from, so there is history to pop.
         if (directionsSubFocus != null && navigateBackFocus()) return
-        if (stageDirectionsExitConfirmation(_currentFocus.value)) return
+        if (stageDirectionsExitConfirmation(_currentFocus.value, CurrentFocus.None)) return
         exitDirections()
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -603,6 +603,37 @@ fun DirectionsErrorSnackbar(
 }
 
 /**
+ * "Leave these directions?" — the modal shown when a gesture would close directions on a trip that is
+ * drawn on the map (#2140). A planned trip is several deliberate acts (two endpoints, a time, a mode,
+ * the option picked from the results), and the two gestures that discard it — Back, and a tap on the
+ * map background — are the two cheapest gestures on the screen, so it was far too easy to spend the
+ * whole plan by accident. Only a drawn trip is worth the interruption: an unplanned form still leaves
+ * on the first gesture (see [org.onebusaway.android.ui.home.HomeViewModel.pendingDirectionsExit]).
+ *
+ * The confirm button is the destructive one, so it names what it does ("Discard") rather than "OK";
+ * dismissing — the cancel button, an outside tap, or Back — keeps the trip.
+ */
+@Composable
+fun DirectionsExitConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.directions_exit_confirm_title)) },
+        text = { Text(stringResource(R.string.directions_exit_confirm_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.directions_exit_confirm_discard))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    )
+}
+
+/**
  * Pick a From/To point directly on the home map: a fixed center crosshair the map pans under, and a
  * bottom confirm. [onConfirm] captures the map's current center; the caller resolves it to a
  * [org.onebusaway.android.ui.tripplan.TripEndpoint.MapPoint].

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -213,8 +213,10 @@ fun MapFeature(
             override fun onBikeClick(station: BikeStation) {
                 val bikeId = homeViewModel.currentFocus.value.focusedBikeStationId
                 if (bikeId == null || !bikeId.equals(station.id, ignoreCase = true)) {
+                    // Refused (directions owns the map): leave before the map tears the trip down —
+                    // the same order the stop tap above uses, home focus first, map render after.
+                    if (!homeViewModel.onBikeStationFocused(station.id)) return
                     mapViewModel.clearAllFocus()
-                    homeViewModel.onBikeStationFocused(station.id)
                 }
                 AnalyticsEntryPoint.get(context).reportUiEvent(
                     PlausibleAnalytics.REPORT_BIKE_EVENT_URL,

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -979,6 +979,11 @@
     <!-- Spoken state of each departure drawn before that rule: one leaving before the rider can be at
          the stop. Read on the departure itself, since its dimmed appearance says nothing aloud. -->
     <string name="directions_stop_eta_departure_missed">Leaves before you get here</string>
+    <!-- Confirmation shown when a gesture (Back, or a tap on the map background) would close directions
+         while a planned trip is drawn on the map, since that discards the whole plan. -->
+    <string name="directions_exit_confirm_title">Leave these directions?</string>
+    <string name="directions_exit_confirm_message">Your planned trip will be discarded.</string>
+    <string name="directions_exit_confirm_discard">Discard</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -283,6 +283,21 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `a bike dock tapped on a drawn trip is refused, not allowed to take the map`() = runTest {
+        val vm = viewModel()
+        vm.enterDirectionsShowing()
+
+        // The docks drawn in directions are the trip's own, so tapping one used to discard the whole
+        // plan in a single tap — the same take-over a stop tap is already refused for (#2097).
+        assertFalse(vm.onBikeStationFocused("bike-7"))
+
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertNull(vm.currentFocus.value.focusedBikeStationId)
+        // Refused outright rather than asked about: nothing is lost, so there is nothing to confirm.
+        assertFalse(vm.pendingDirectionsExit.value)
+    }
+
+    @Test
     fun `a deep link taking the map drops the staged question`() = runTest {
         val vm = viewModel()
         vm.enterDirectionsShowing()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -183,12 +184,116 @@ class HomeViewModelTest {
         assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
         assertEquals(listOf(MapDirective.ClearItineraryLegFocus), map.sent)
 
-        // Only the second one leaves directions.
+        // The second one would leave, but the trip is drawn, so it asks first (#2140) and the answer
+        // is what actually leaves.
         vm.dropOneLevel()
+        advanceUntilIdle()
+        assertTrue(vm.pendingDirectionsExit.value)
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        vm.confirmExitDirections()
         advanceUntilIdle()
         assertEquals(CurrentFocus.None, vm.currentFocus.value)
         assertEquals(1, map.clearFocusCount)
         job.cancel()
+    }
+
+    /**
+     * Both gestures that would discard a drawn trip stage the same question, and declining it leaves the
+     * rider exactly where they were — still in directions, with nothing sent to the map.
+     */
+    private fun assertConfirmsBeforeDiscardingTrip(leave: HomeViewModel.() -> Unit) = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirectionsShowing()
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.leave()
+        advanceUntilIdle()
+        assertTrue(vm.pendingDirectionsExit.value)
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertTrue(map.sent.isEmpty())
+
+        vm.dismissDirectionsExit()
+        advanceUntilIdle()
+        assertFalse(vm.pendingDirectionsExit.value)
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        assertTrue(map.sent.isEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `back out of a drawn trip asks before discarding it`() = assertConfirmsBeforeDiscardingTrip(HomeViewModel::navigateBackInDirections)
+
+    @Test
+    fun `tapping off a drawn trip asks before discarding it`() = assertConfirmsBeforeDiscardingTrip(HomeViewModel::unfocusMapOneLevel)
+
+    /** With no trip drawn there is nothing to lose, so leaving directions costs no dialog. */
+    private fun assertLeavesUnplannedDirectionsOutright(leave: HomeViewModel.() -> Unit) = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        vm.enterDirections()
+
+        vm.leave()
+        advanceUntilIdle()
+
+        assertFalse(vm.pendingDirectionsExit.value)
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertEquals(1, map.clearFocusCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `back out of an unplanned form leaves directions outright`() = assertLeavesUnplannedDirectionsOutright(HomeViewModel::navigateBackInDirections)
+
+    @Test
+    fun `tapping off an unplanned form leaves directions outright`() = assertLeavesUnplannedDirectionsOutright(HomeViewModel::unfocusMapOneLevel)
+
+    @Test
+    fun `a trip cleared off the map no longer guards the way out`() = runTest {
+        val vm = viewModel()
+        vm.enterDirectionsShowing()
+        // The plan became unsubmittable, so the drawn trip went with it — there is nothing left to lose.
+        vm.clearShownItineraryOnMap()
+
+        vm.navigateBackInDirections()
+
+        assertFalse(vm.pendingDirectionsExit.value)
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+    }
+
+    @Test
+    fun `a fresh entry doesn't inherit the previous visit's trip`() = runTest {
+        val vm = viewModel()
+        vm.enterDirectionsShowing()
+        vm.navigateBackInDirections()
+        vm.confirmExitDirections()
+
+        // Planning again from an empty form: the trip that was on the map last time isn't on it now, so
+        // the first gesture out leaves rather than asking about a trip the rider can't see.
+        vm.enterDirections()
+        vm.navigateBackInDirections()
+
+        assertFalse(vm.pendingDirectionsExit.value)
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+    }
+
+    @Test
+    fun `a deep link taking the map drops the staged question`() = runTest {
+        val vm = viewModel()
+        vm.enterDirectionsShowing()
+        vm.navigateBackInDirections()
+        assertTrue(vm.pendingDirectionsExit.value)
+
+        // The question was asked of directions; a stop opened from elsewhere replaces that focus outright,
+        // so the dialog has nothing left to answer for.
+        vm.revealStop(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
+
+        assertFalse(vm.pendingDirectionsExit.value)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2140.

A planned trip is several deliberate acts — two endpoints, a time, a mode, and the option picked out of the results — but the two gestures that discarded it were the two cheapest gestures on the screen:

- the system **Back** from the itinerary overview, and
- a stray **tap on the map background** (`unfocusMapOneLevel`, which from the plain overview drops straight out of directions).

Either one erased the whole plan, with no way back to it.

## What changed

Both gestures now stage a confirmation instead of leaving, whenever there is a trip actually **drawn on the map**. `HomeViewModel` owns the latch (`pendingDirectionsExit`) because the two gestures reach it from different places — `HomeScreen`'s `BackHandler` and the map's own click callback — and `HomeScreen` renders the modal off it. Confirming exits; cancelling, an outside tap, or Back all keep the trip.

The confirm button is the destructive one, so it reads **Discard** rather than "OK".

## What deliberately still leaves on the first gesture

- An **unplanned form** — nothing drawn, nothing to lose.
- A **drilled-into leg** (route or on-street) — that gesture steps back to the itinerary overview rather than out of directions, which #2075 established.

The gate is `shownItinerary`, which is now cleared when the trip leaves the map (`clearShownItineraryOnMap`) and on a fresh entry into directions, so it can't ask about a trip the rider can't see. It deliberately still survives the exit itself, since backing *into* the focus we just left has to put the trip back on the map.

`replaceFocus` drops a staged question whenever focus moves off directions, so an incoming deep link that takes the map doesn't leave a dialog behind answering for a focus that is gone. Externally-driven navigation (a notification/deep link) is not itself gated on a dialog — it shouldn't be interrupted by one.

## Tests

- `HomeViewModelTest` — both gestures ask before discarding a drawn trip and declining changes nothing; both leave outright with no trip drawn; a cleared trip stops guarding the way out; a fresh entry doesn't inherit the previous visit's trip; a deep link drops the staged question. The existing leg-drop tests now answer the confirmation on their last step.
- `DirectionsExitConfirmDialogTest` (new, instrumented) — both answers are offered and stay wired to opposite outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when leaving directions with an active trip plan.
  * Users can cancel to keep directions or discard the plan to exit.
  * The prompt also supports Back presses and taps outside the dialog.
  * Improved handling when starting new trips, clearing itineraries, changing map focus, or selecting bike stations.

* **Tests**
  * Added coverage for confirmation, cancellation, dismissal, and immediate exits when no trip plan is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->