### PR TITLE
Re-read the device fix on every trip-plan request (#2134)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -165,6 +165,13 @@ data class TripPlanFormState(
     val canSubmit: Boolean
         get() = from.hasCoordinates && to.hasCoordinates
 
+    /**
+     * Either end of the trip is the device's own position, so a re-plan has to re-read the fix first —
+     * see [withDeviceLocationAt].
+     */
+    val hasDeviceLocationEndpoint: Boolean
+        get() = from.isDeviceLocation || to.isDeviceLocation
+
     /** The endpoint currently in [slot]. */
     fun endpointAt(slot: TripEndpointSlot): TripEndpoint = when (slot) {
         TripEndpointSlot.FROM -> from
@@ -218,6 +225,27 @@ data class TripPlanFormState(
         val filled = withEndpoint(slot, endpoint)
         if (here == null || !endpointAt(slot.other).isEmpty) return filled
         return filled.withEndpoint(slot.other, here)
+    }
+
+    /**
+     * This form with either end that is the device's own position moved to [here], the latest fix (#2134).
+     *
+     * "My location" names *where the rider is*, not where they were standing when they tapped it — but
+     * a [TripEndpoint.CurrentLocation] carries the coordinate it was built from, so without this every
+     * re-plan after the first (a mode change, a date nudge, editing the other end) re-sent the fix the
+     * endpoint was created with and the trip kept starting from where the form was first filled in. The
+     * fix is re-read at submit for the same reason the clock is — see [toParams].
+     *
+     * A null [here] — no fix yet, or the location permission is gone — leaves both ends alone: the
+     * coordinate an endpoint already holds is the best answer available, and blanking it would only turn
+     * a submittable form unsubmittable.
+     */
+    fun withDeviceLocationAt(here: TripEndpoint.CurrentLocation?): TripPlanFormState {
+        if (here == null) return this
+        return copy(
+            from = if (from.isDeviceLocation) here else from,
+            to = if (to.isDeviceLocation) here else to
+        )
     }
 
     /** The current advanced options, for persistence by the host. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
@@ -105,10 +106,12 @@ class TripPlanViewModel @Inject constructor(
     // pipeline below. Keyed by slot rather than held as a from/to pair so the pipeline is written once.
     private val queries = TripEndpointSlot.entries.associateWith { MutableStateFlow("") }
 
-    // Reverse-geocoded names, keyed by the coordinate that produced them. Re-planning re-submits the same
-    // points — a date or arrive-by change, an advanced-settings apply, or editing *the other* endpoint all
-    // re-plan — and what a point is called doesn't change between them, so the lookup is worth exactly
-    // once. Only successes are remembered, so a failed lookup is retried rather than cached as "unnamed".
+    // Reverse-geocoded names, keyed by the coordinate that produced them. Re-planning mostly re-submits
+    // the same points — a date or arrive-by change, an advanced-settings apply, or editing *the other*
+    // endpoint all re-plan — and what a point is called doesn't change between them, so the lookup is
+    // worth exactly once. (A "my location" end that has moved since is a genuinely different point, and
+    // is looked up again; see replanOrClearResult.) Only successes are remembered, so a failed lookup is
+    // retried rather than cached as "unnamed".
     // Read and written only from the plan collector, which runs on the main dispatcher.
     private val reverseNames = mutableMapOf<Pair<Double, Double>, String>()
 
@@ -383,7 +386,14 @@ class TripPlanViewModel @Inject constructor(
      * [PlanResult.Success]). Emitting supersedes any in-flight plan via the collector's [mapLatest].
      */
     private fun replanOrClearResult() {
-        val form = _formState.value
+        // Re-read the device fix here, at submit, so a "my location" end plans from where the rider is
+        // now rather than from where they were when they set it (#2134) — the same moving-anchor
+        // argument as the clock below. The form moves with it, so what it holds and what was sent stay
+        // the same trip. Only read when an end actually is the device's position: while no fix has been
+        // established lastKnownLocation() polls the providers, and a place-to-place trip has no reason
+        // to pay for that on every mode or date change.
+        val here = if (_formState.value.hasDeviceLocationEndpoint) currentLocation() else null
+        val form = _formState.updateAndGet { it.withDeviceLocationAt(here) }
         // Read the clock here, at submit, so a "depart now" trip left sitting in an open form plans
         // from the moment it is sent rather than the moment the ViewModel was built.
         planInputs.trySend(if (form.canSubmit) form.toParams(timeProvider.now()) else null)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
@@ -21,13 +21,18 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * The "directions from/to here" pairing rule (#2092), which the ViewModel delegates to. Kept here
- * rather than in the ViewModel test because a real fix means an `android.location.Location`, which a
- * plain JVM test can't build — this side of the seam is plain coordinates.
+ * The two current-location rules the ViewModel delegates to: the "directions from/to here" pairing
+ * (#2092) and moving a my-location endpoint to the latest fix at submit (#2134). Kept here rather than
+ * in the ViewModel test because a real fix means an `android.location.Location`, which a plain JVM test
+ * can't build — this side of the seam is plain coordinates.
  */
 class TripPlanFormStateTest {
 
     private val here = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
+
+    /** Where the rider has walked to by the time the trip is re-planned. */
+    private val movedHere = TripEndpoint.CurrentLocation(lat = 47.62, lon = -122.31)
+
     private val pressed = TripEndpoint.MapPoint(lat = 47.7, lon = -122.2)
     private val named = TripEndpoint.Geocoded("Pike Place Market", lat = 47.61, lon = -122.34)
 
@@ -107,6 +112,57 @@ class TripPlanFormStateTest {
         assertFalse(TripEndpoint.MapPoint(lat = 47.6, lon = -122.3).isDeviceLocation)
         assertFalse(named.isDeviceLocation)
         assertFalse(TripEndpoint.FreeText("here").isDeviceLocation)
+    }
+
+    @Test
+    fun `a my-location endpoint moves to the latest fix`() {
+        val form = TripPlanFormState(from = here, to = named)
+
+        val moved = form.withDeviceLocationAt(movedHere)
+
+        assertEquals(movedHere, moved.from)
+        assertEquals(named, moved.to) // a place the rider named stays where they named it
+    }
+
+    @Test
+    fun `both ends move when the rider is planning a trip from here to here`() {
+        val form = TripPlanFormState(from = here, to = here)
+
+        val moved = form.withDeviceLocationAt(movedHere)
+
+        assertEquals(movedHere, moved.from)
+        assertEquals(movedHere, moved.to)
+    }
+
+    @Test
+    fun `a map point the rider pressed on themselves is not moved`() {
+        // Same coordinate as the fix, but it names a place, not the rider — see isDeviceLocation.
+        val form = TripPlanFormState(from = pressed, to = TripEndpoint.MapPoint(lat = 47.6, lon = -122.3))
+
+        val moved = form.withDeviceLocationAt(movedHere)
+
+        assertEquals(pressed, moved.from)
+        assertEquals(TripEndpoint.MapPoint(lat = 47.6, lon = -122.3), moved.to)
+    }
+
+    @Test
+    fun `with no fix the my-location endpoint keeps the coordinate it has`() {
+        // Better a fix from a minute ago than an unsubmittable form: losing the fix (or the permission)
+        // must not empty an end the rider already set.
+        val form = TripPlanFormState(from = here, to = named)
+
+        val moved = form.withDeviceLocationAt(here = null)
+
+        assertEquals(here, moved.from)
+        assertTrue(moved.canSubmit)
+    }
+
+    @Test
+    fun `only a form with a my-location end has a fix worth re-reading`() {
+        assertTrue(TripPlanFormState(from = here, to = named).hasDeviceLocationEndpoint)
+        assertTrue(TripPlanFormState(from = named, to = here).hasDeviceLocationEndpoint)
+        assertFalse(TripPlanFormState(from = named, to = pressed).hasDeviceLocationEndpoint)
+        assertFalse(TripPlanFormState().hasDeviceLocationEndpoint)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -88,8 +88,10 @@ class TripPlanViewModelTest {
 
     private class FakeTripPlanRepository(var result: Result<List<TripItinerary>>) : TripPlanRepository {
         var calls = 0
+        var lastParams: TripPlanParams? = null
         override suspend fun plan(params: TripPlanParams): Result<List<TripItinerary>> {
             calls++
+            lastParams = params
             return result
         }
 
@@ -521,6 +523,26 @@ class TripPlanViewModelTest {
         runCurrent()
 
         assertEquals(PlanResult.Error(TripPlanError.Unknown), vm.planState.value)
+    }
+
+    @Test
+    fun `a my-location endpoint survives a re-plan when there is no fresh fix`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(plan = plan)
+        val setFrom = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3)
+        vm.setEndpoint(TripEndpointSlot.FROM, setFrom)
+        vm.setEndpoint(TripEndpointSlot.TO, destination)
+        advanceUntilIdle()
+
+        vm.setArriving(true)
+        advanceUntilIdle()
+
+        // The re-read at submit (#2134) finds nothing — the fake reports no fix — so the endpoint must
+        // stay exactly as the rider set it, both in the form and in the request. Moving it to a *newer*
+        // fix is TripPlanFormStateTest's job: a real one is an android.location.Location.
+        assertEquals(2, plan.calls)
+        assertEquals(setFrom, vm.formState.value.from)
+        assertEquals(setFrom, plan.lastParams?.from)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2134.

## The bug

A `TripEndpoint.CurrentLocation` carries the coordinate it was built from, and `TripPlanViewModel.replanOrClearResult()` read the form as-is. So only the *first* plan started from where the rider actually was — every re-plan after that (a mode change, a date nudge, an advanced-settings apply, editing the other end) re-sent the fix captured when they tapped "My Location", and the trip kept starting from wherever the form was first filled in.

## The fix

Re-read the fix at submit, for the same reason the clock already is: "my location" is a *moving* anchor, exactly like "depart now".

- **`TripPlanFormState.withDeviceLocationAt(here)`** — the pure rule: moves either end that `isDeviceLocation` onto the latest fix. A map point the rider happened to press on top of themselves still names a place, not the rider, so it isn't moved.
- **`replanOrClearResult()`** — reads the fix and applies it to `_formState` before building the params, so what the form holds and what was sent stay the same trip (and `PlanResult.Success.params` carries the coordinates actually used).

Two deliberate edges:

- **A null fix leaves the endpoint where it is** rather than blanking it. No fix yet, or the permission is gone — a coordinate from a minute ago beats turning a submittable form unsubmittable.
- **The fix is only read when an end actually is the device's position** (`hasDeviceLocationEndpoint`). While no fix has been established `lastKnownLocation()` polls the providers on the main thread, and an ordinary place-to-place trip has no reason to pay for that on every mode or date change.

Downstream: a my-location end that has moved is a genuinely different point, so it is reverse-geocoded again for the itinerary's terminal name (#2006) rather than hitting the `reverseNames` cache. That's the correct answer — the place name really did change — and the existing `REVERSE_GEOCODE_TIMEOUT` still keeps naming off the plan's critical path. The cache comment is updated to say so.

**Not** changed: `TripPlanMonitor`'s background re-plan. It runs from a serialized bundle to check whether *the itinerary the rider chose* still holds; refreshing its origin would change what that check means. Happy to take that on separately if it's wanted.

## Tests

- `TripPlanFormStateTest` (5 new): moves a my-location end while leaving a named place alone; moves both ends on a here→here trip; leaves a map point on the same coordinate alone; keeps the existing coordinate when there's no fix; the `hasDeviceLocationEndpoint` gate.
- `TripPlanViewModelTest` (1 new): pins the ViewModel wiring on the no-fix path — the endpoint survives a re-plan unchanged, in both the form and the request.

The pure rule is tested at the form-state layer for the reason that file already documents: a real fix means an `android.location.Location`, which a plain JVM unit test can't build.

Verified locally: `testObaGoogleDebugUnitTest` green, `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` clean under `-PwarningsAsErrors=true`, `spotlessCheck` passes. Lint left to CI per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Trip plans using “My Location” now use the most recent available device location when submitted.
  * Both endpoints update together when they reference the device location.
  * Existing locations remain unchanged when no fresh location is available.
  * Map-selected points are preserved during location updates.
* **Bug Fixes**
  * Improved reliability when re-planning trips as the device moves.
  * Added retry support for failed or outdated endpoint name lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->