### PR TITLE
Surface service alerts in the trip planner (#2143)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/arrivals/ServiceAlertsDialogTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/arrivals/ServiceAlertsDialogTest.kt
@@ -18,9 +18,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.AlertItem
-import org.onebusaway.android.ui.arrivals.AlertSeverity
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.StopHeader
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 
 class ServiceAlertsDialogTest {

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/AlertAccessibilityTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/AlertAccessibilityTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.ui.test.hasStateDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.AlertSeverity
+import org.onebusaway.android.ui.compose.components.RouteBadge
+import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/** Accessibility coverage for the two severity indicators added to trip results by #2143. */
+class AlertAccessibilityTest {
+
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val severeLabel get() = context.getString(R.string.service_alert_severity_severe)
+
+    @Test
+    fun alertBannerAnnouncesItsSeverity() {
+        composeRule.setContent {
+            ObaTheme {
+                TripAlertBanner(
+                    TripAlertItem(
+                        contentId = "suspension",
+                        summary = "Service is suspended",
+                        description = null,
+                        url = null,
+                        severity = AlertSeverity.ERROR,
+                        routeLabels = listOf("1 Line")
+                    )
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNode(hasStateDescription(severeLabel)).assertExists()
+    }
+
+    @Test
+    fun alertedLegMarkerAnnouncesTheSameSeverity() {
+        val option = ItineraryOption(
+            symbols = listOf(
+                ModeSymbol.Transit(
+                    badge = LegBadge(
+                        routes = listOf(RouteBadge("1 Line", routeColor = null)),
+                        mode = TransitMode.RAIL,
+                        join = RouteBadgeJoin.ANY_OF
+                    ),
+                    alert = AlertSeverity.ERROR
+                )
+            ),
+            durationMinutes = 10,
+            startTime = ServerTime(0L),
+            endTime = ServerTime(10 * 60_000L)
+        )
+        composeRule.setContent {
+            ObaTheme {
+                TripResultsHeader(
+                    state = TripResultsUiState.Success(
+                        options = listOf(option),
+                        selectedIndex = 0,
+                        directions = emptyList()
+                    ),
+                    onSelectOption = {}
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription(
+            context.getString(R.string.directions_leg_service_alert, severeLabel),
+            useUnmergedTree = true
+        ).assertExists()
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/AlertAccessibilityTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/AlertAccessibilityTest.kt
@@ -47,8 +47,7 @@ class AlertAccessibilityTest {
                         summary = "Service is suspended",
                         description = null,
                         url = null,
-                        severity = AlertSeverity.ERROR,
-                        routeLabels = listOf("1 Line")
+                        severity = AlertSeverity.ERROR
                     )
                 )
             }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/ItineraryWinnerHighlightTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/ItineraryWinnerHighlightTest.kt
@@ -28,6 +28,7 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.util.PreferenceUtils
 
 /** Semantic coverage for the category emphasis in the itinerary option picker (#2054). */
 class ItineraryWinnerHighlightTest {
@@ -96,7 +97,8 @@ class ItineraryWinnerHighlightTest {
             )
         }
 
-        val zeroDistance = ConversionUtils.getFormattedDistanceParts(0.0, context)
+        val zeroDistance = ConversionUtils
+            .getFormattedDistanceParts(0.0, context, PreferenceUtils.getUnitsAreMetricFromPreferences(context))
             .joinToString(separator = "") { it.text }
         composeRule.onNodeWithText(zeroDistance).assertExists()
     }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardStreetMetricsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/OptionCardStreetMetricsTest.kt
@@ -26,6 +26,7 @@ import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.util.PreferenceUtils
 
 /**
  * Coverage for the option card's street-distance metric lines (#2122): a card measures **every** street
@@ -82,7 +83,8 @@ class OptionCardStreetMetricsTest {
     // ---- fixtures -----------------------------------------------------------------------------------
 
     /** The distance line's text, assembled from its parts exactly as the card draws them. */
-    private fun distance(meters: Double) = ConversionUtils.getFormattedDistanceParts(meters, context)
+    private fun distance(meters: Double) = ConversionUtils
+        .getFormattedDistanceParts(meters, context, PreferenceUtils.getUnitsAreMetricFromPreferences(context))
         .joinToString(separator = "") { it.text }
 
     private fun option(vararg distances: Pair<StreetMode, Double>) = ItineraryOption(

--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -123,6 +123,26 @@ query Plan(
                         from { stop { gtfsId } }
                         to { stop { gtfsId } }
                     }
+                    # Service alerts OTP itself considers applicable to this leg (#2143) — the ones the
+                    # rider needs before they trust the itinerary, e.g. "1 Line service is suspended
+                    # from Capitol Hill Station to Stadium Station". OTP scopes them two ways, and
+                    # both are the server's call, not this client's: to the entities the leg actually
+                    # uses (its route/trip/stops), and to the leg's own time window — verified against
+                    # the live server, where an alert whose active period ends today attaches to a leg
+                    # planned for today and not to the same leg planned for next week, while an
+                    # open-ended one attaches to both. So there is no active-window check on the client
+                    # side of this field.
+                    #
+                    # `alertHeaderText`/`alertDescriptionText`/`alertUrl` are the language-negotiated
+                    # singular forms; their `*Translations` siblings are @deprecated in the vendored
+                    # schema and would fail this repo's -PwarningsAsErrors gate.
+                    alerts {
+                        id
+                        alertHeaderText
+                        alertDescriptionText
+                        alertUrl
+                        alertSeverityLevel
+                    }
                     legGeometry {
                         points
                         length

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -22,6 +22,8 @@ import kotlin.time.toKotlinDuration
 import org.onebusaway.android.api.graphql.PlanQuery
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
 import org.onebusaway.android.directions.model.TripAbsoluteDirection
+import org.onebusaway.android.directions.model.TripAlert
+import org.onebusaway.android.directions.model.TripAlertSeverity
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripLegAlternative
@@ -89,7 +91,27 @@ private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
     // OTP's own alternative-leg search for this leg (#2010) — null on a non-transit leg, and carried
     // over unjudged: interchangeability is decided by `interchangeableRoutes()`, which needs the whole
     // itinerary (the next leg's departure) and so can't be answered leg-at-a-time here.
-    alternatives = nextLegs.orEmpty().map { it.toTripLegAlternative() }
+    alternatives = nextLegs.orEmpty().map { it.toTripLegAlternative() },
+    // Already scoped by OTP to this leg's entities and time window (#2143) — see the `alerts`
+    // selection in Plan.graphql. Empty rather than null on a leg with nothing to report.
+    alerts = alerts.orEmpty().filterNotNull().map { it.toTripAlert() }
+)
+
+/**
+ * Blank→null on every text field, same normalization the route names get above: OTP returns `""` for
+ * a translation the feed didn't publish (`alertDescriptionText` is even non-null in the schema), so
+ * without this the domain would carry an empty header that reads as present and renders as a blank
+ * row.
+ */
+private fun PlanQuery.Alert.toTripAlert(): TripAlert = TripAlert(
+    id = id,
+    header = alertHeaderText?.ifBlank { null },
+    description = alertDescriptionText.ifBlank { null },
+    url = alertUrl?.ifBlank { null },
+    // An unrecognized severity (a schema the server has moved past) lands on the same
+    // UNKNOWN_SEVERITY the wire vocabulary already has a token for, which the banner styles as a
+    // warning — an alert whose severity we can't read is still an alert.
+    severity = alertSeverityLevel?.rawValue.toEnum<TripAlertSeverity>() ?: TripAlertSeverity.UNKNOWN_SEVERITY
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -103,8 +103,45 @@ data class TripLeg(
     // (#2010) — the raw candidate set, straight off the wire. Includes later trips of this leg's own
     // route. Which of them the drawer may present as interchangeable is decided by
     // [interchangeableRoutes], not here. Always empty on the OTP1 path, which has no equivalent.
-    val alternatives: List<TripLegAlternative> = emptyList()
+    val alternatives: List<TripLegAlternative> = emptyList(),
+    // The service alerts OTP considers applicable to this leg (#2143) — already scoped by the server
+    // to the leg's own entities *and* its time window (see the `alerts` selection in Plan.graphql),
+    // so nothing here needs an active-window check. Always empty on the OTP1 path: the REST `/plan`
+    // response this app's regions serve carries no leg alerts at all (verified against the live OTP1
+    // server), so there is nothing to map rather than a mapping left undone.
+    val alerts: List<TripAlert> = emptyList()
 )
+
+/**
+ * One service alert attached to a [TripLeg] — a disruption the rider has to know about before they
+ * trust the itinerary, which is the whole point of surfacing it in the planner: an itinerary routed
+ * over suspended service looks perfectly ordinary otherwise (#2143).
+ *
+ * [id] is OTP's own global alert id, stable for as long as the feed publishes the alert under the
+ * same id. It is *not* used as the rider-facing row identity — a feed that republishes the same
+ * disruption under a fresh id would then read as a new alert, the #1593 failure — so the trip-results
+ * layer keys rows on the alert's content instead. It is kept because it is the only thing that
+ * identifies the alert back to OTP.
+ *
+ * [header] and [description] are GTFS-realtime `header_text`/`description_text`, already
+ * language-negotiated by OTP. Both are plain text, not HTML (unlike the OBA `situation` path's
+ * description) — GTFS-rt `TranslatedString` carries no markup.
+ */
+@Serializable
+data class TripAlert(
+    val id: String,
+    val header: String? = null,
+    val description: String? = null,
+    val url: String? = null,
+    val severity: TripAlertSeverity = TripAlertSeverity.UNKNOWN_SEVERITY
+)
+
+/**
+ * Mirrors OTP2's `AlertSeverityLevelType` wire vocabulary exactly (verified against the vendored
+ * `schema.graphqls`), same discipline as [TripMode]. Mapping it onto the app's three alert-banner
+ * styles is the presentation layer's job, not this model's.
+ */
+enum class TripAlertSeverity { INFO, WARNING, SEVERE, UNKNOWN_SEVERITY }
 
 /**
  * One departure from OTP's alternative-leg search for a [TripLeg] (OTP2 `Leg.nextLegs`, #2010): a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/ConversionUtils.kt
@@ -46,14 +46,14 @@ object ConversionUtils {
     private const val FEET_PER_METER = 3.281
 
     /**
-     * Return a formatted String for a distance. Should be in proper units according to
-     * preferences (either metric or imperial).
+     * Return a formatted String for a distance, in [metric] or imperial units.
      *
      * @param meters distance in meters
      * @param applicationContext context to look up resources
+     * @param metric whether to render metric units; see [getFormattedDistanceParts] on resolving it
      * @return formatted string of distance
      */
-    fun getFormattedDistance(meters: Double, applicationContext: Context): String = getFormattedDistanceParts(meters, applicationContext).joinToString(" ") { it.text }
+    fun getFormattedDistance(meters: Double, applicationContext: Context, metric: Boolean): String = getFormattedDistanceParts(meters, applicationContext, metric).joinToString(" ") { it.text }
 
     /**
      * The same distance as [getFormattedDistance], but as its structured value + unit parts (mirroring
@@ -61,14 +61,23 @@ object ConversionUtils {
      * bold value with a smaller unit — can do so without re-splitting a joined string. The value is the
      * emphasized part, the unit abbreviation the un-emphasized one.
      *
+     * The unit choice is a **parameter, not a preference read**: resolving it here would make a leaf
+     * formatter reach [PreferenceUtils.repo] — and through it `Application.get()` — which is fine on a
+     * device but throws under layoutlib, taking every Compose preview of a screen that shows a distance
+     * down with it. Callers resolve it once, high up: composables via
+     * [org.onebusaway.android.ui.compose.unitsAreMetric], others via
+     * [PreferenceUtils.getUnitsAreMetricFromPreferences].
+     *
      * @param meters distance in meters
      * @param applicationContext context to look up resources
+     * @param metric whether to render metric units
      */
     fun getFormattedDistanceParts(
         meters: Double,
-        applicationContext: Context
+        applicationContext: Context,
+        metric: Boolean
     ): List<DisplayFormat.EtaPart> {
-        val (value, unitRes) = if (PreferenceUtils.getUnitsAreMetricFromPreferences(applicationContext)) {
+        val (value, unitRes) = if (metric) {
             if (meters < 1000) {
                 String.format(Locale.getDefault(), OTPConstants.FORMAT_DISTANCE_METERS, meters) to
                     R.string.meters_abbreviation

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/DirectionsGenerator.kt
@@ -29,6 +29,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripRelativeDirection
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.util.PreferenceUtils
 
 /**
  * Generates a set of step-by-step directions that can be shown to the user from a list of trip
@@ -50,6 +51,13 @@ class DirectionsGenerator(
      * @return the totalDistance
      */
     var totalDistance = 0.0
+
+    /**
+     * The rider's unit system, read once here rather than per leg inside the generation loop —
+     * [ConversionUtils.getFormattedDistanceParts] takes it as a parameter precisely so its callers
+     * resolve it high up. Declared above [init], which is what runs the generation.
+     */
+    private val unitsAreMetric = PreferenceUtils.getUnitsAreMetricFromPreferences(applicationContext)
 
     init {
         convertToDirectionList()
@@ -127,7 +135,7 @@ class DirectionsGenerator(
         }
         mainDirectionText += "\n[" +
             ConversionUtils
-                .getFormattedDistance(leg.distance, applicationContext) +
+                .getFormattedDistance(leg.distance, applicationContext, unitsAreMetric) +
             " - " +
             ConversionUtils.getFormattedDurationTextNoSeconds(legDuration, false, applicationContext) +
             " ]"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -46,6 +46,7 @@ import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.time.ElapsedClock
 import org.onebusaway.android.time.ElapsedTime
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.SituationUtils
 import org.onebusaway.android.util.getRouteDisplayName
@@ -80,7 +81,7 @@ internal fun planActiveAlerts(
  */
 internal fun activeAlertFor(situationIds: List<String>, activeSituationIds: Set<String>): String? = situationIds.firstOrNull { it in activeSituationIds }
 
-/** Maps an ObaSituation severity onto the three banner styles, matching the legacy SituationAlert. */
+/** Maps an ObaSituation severity onto the shared [AlertSeverity] tones, matching the legacy SituationAlert. */
 internal fun severityOf(severity: String?): AlertSeverity = when (severity) {
     ObaSituation.SEVERITY_NO_IMPACT -> AlertSeverity.INFO
     ObaSituation.SEVERITY_SEVERE, ObaSituation.SEVERITY_VERY_SEVERE -> AlertSeverity.ERROR

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
@@ -83,6 +82,7 @@ import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.dialogs.StopDetailsHost
+import org.onebusaway.android.ui.compose.components.AlertSurface
 import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.icons.AppIcons
@@ -617,23 +617,7 @@ private fun SwipeToHide(onHide: () -> Unit, content: @Composable () -> Unit) {
 
 @Composable
 private fun AlertRow(alert: AlertItem, onClick: () -> Unit) {
-    val (container, onContainer) = when (alert.severity) {
-        AlertSeverity.ERROR ->
-            MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
-        AlertSeverity.WARNING ->
-            MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
-        AlertSeverity.INFO ->
-            MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
-    }
-    Surface(
-        color = container,
-        contentColor = onContainer,
-        shape = MaterialTheme.shapes.small,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 4.dp)
-            .clickable { onClick() }
-    ) {
+    AlertSurface(severity = alert.severity, onClick = onClick) {
         Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 painter = painterResource(R.drawable.baseline_warning_24),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.arrivals
 
 import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 
 /** The stop being viewed, for the arrivals screen header. */
 data class StopHeader(
@@ -66,9 +67,6 @@ data class AlertItem(
     val summary: String,
     val severity: AlertSeverity
 )
-
-/** Maps ObaSituation severity onto the three banner styles, matching the legacy SituationAlert. */
-enum class AlertSeverity { INFO, WARNING, ERROR }
 
 /** UI state for the arrivals screen. */
 sealed interface ArrivalsUiState {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/Units.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/Units.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
+import org.onebusaway.android.util.PreferenceUtils
+
+/**
+ * The metric/imperial choice already resolved for this subtree, or null where nothing has resolved it
+ * yet.
+ *
+ * Two kinds of host provide it. A **screen** provides it once at its root so the distance rows beneath
+ * it read a value instead of each re-resolving one — see the provider in `TripResultsList`. A
+ * **preview** provides it because the preference read behind [unitsAreMetric] goes through
+ * `PreferenceUtils` to `Application.get()`, which throws under layoutlib, so a preview of any screen
+ * that formats a distance dies without it.
+ *
+ * `static`, because the value can only change when the rider edits Settings: reads become plain lookups
+ * that register no snapshot observer, which matters when one is done per row of a long list.
+ */
+val LocalUnitsAreMetric = staticCompositionLocalOf<Boolean?> { null }
+
+/**
+ * Whether to render distances in metric units: [LocalUnitsAreMetric] where a host has resolved it,
+ * otherwise the rider's preference.
+ *
+ * Resolve this **once, at the composable that owns the screen**, provide it back through
+ * [LocalUnitsAreMetric], and pass the result down to
+ * [org.onebusaway.android.directions.util.ConversionUtils.getFormattedDistanceParts] — the formatter
+ * deliberately takes the choice as a parameter rather than reading it (see its KDoc). Calling this from
+ * a row is then just a local read; calling it from a row *without* a provider above means the
+ * preference — a Hilt entry-point hop, three string lookups and a locale query — per row that enters
+ * composition.
+ */
+@Composable
+fun unitsAreMetric(): Boolean {
+    val override = LocalUnitsAreMetric.current
+    val context = LocalContext.current
+    return override ?: remember(context) { PreferenceUtils.getUnitsAreMetricFromPreferences(context) }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 /**
@@ -31,8 +32,29 @@ import androidx.compose.ui.unit.dp
  * `severityOf` (`ArrivalsRepository`), OTP2's `AlertSeverityLevelType` by `TripAlertSeverity.tone`
  * (`TripAlerts`). Presentation lives here so a severe alert can't read as urgent on one screen and
  * merely advisory on another.
+ *
+ * **Declaration order is loudness order**, quietest first, and callers rely on it: the loudest alert of
+ * a set is its `max()`, and a list of alerts sorts worst-first by `sortedByDescending`. Any new tone
+ * must be declared in its place on that scale, not appended.
  */
 enum class AlertSeverity { INFO, WARNING, ERROR }
+
+/**
+ * The colour a service alert of [severity] is marked in when it *annotates* something else rather than
+ * filling a container of its own — the warning triangle beside an itinerary option's mode symbols
+ * (#2143). Foreground roles, since these are drawn on an ordinary card surface rather than on the
+ * matching `…Container` [AlertSurface] fills.
+ *
+ * Deliberately not the `md_theme_severity*` palette [TripPlanError][
+ * org.onebusaway.android.ui.tripplan.TripPlanError] uses: those are tuned to be legible on the
+ * *inverting* `inverseSurface` snackbar bar, so on an ordinary surface they read inverted.
+ */
+@Composable
+fun alertAccentColor(severity: AlertSeverity): Color = when (severity) {
+    AlertSeverity.ERROR -> MaterialTheme.colorScheme.error
+    AlertSeverity.WARNING -> MaterialTheme.colorScheme.tertiary
+    AlertSeverity.INFO -> MaterialTheme.colorScheme.secondary
+}
 
 /**
  * The severity-tinted rounded card a service alert is drawn on. Only the container is shared: each

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.compose.components
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -23,7 +24,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
 
 /**
  * How loudly a service alert is drawn — the app's single alert-severity vocabulary, shared by every
@@ -37,7 +42,11 @@ import androidx.compose.ui.unit.dp
  * a set is its `max()`, and a list of alerts sorts worst-first by `sortedByDescending`. Any new tone
  * must be declared in its place on that scale, not appended.
  */
-enum class AlertSeverity { INFO, WARNING, ERROR }
+enum class AlertSeverity(@StringRes val labelRes: Int) {
+    INFO(R.string.service_alert_severity_info),
+    WARNING(R.string.service_alert_severity_warning),
+    ERROR(R.string.service_alert_severity_severe)
+}
 
 /**
  * The colour a service alert of [severity] is marked in when it *annotates* something else rather than
@@ -63,7 +72,8 @@ fun alertAccentColor(severity: AlertSeverity): Color = when (severity) {
  * second copy of the table below would eventually get wrong.
  *
  * [onClick] makes the whole card the tap target; a card with nothing to open passes null and takes no
- * clickable at all rather than an empty one.
+ * clickable at all rather than an empty one. The card also exposes [severity] as a localized state
+ * description, because its container colour is otherwise invisible to a screen reader.
  */
 @Composable
 fun AlertSurface(
@@ -72,6 +82,7 @@ fun AlertSurface(
     onClick: (() -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
+    val severityDescription = stringResource(severity.labelRes)
     val (container, onContainer) = when (severity) {
         AlertSeverity.ERROR ->
             MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
@@ -87,7 +98,8 @@ fun AlertSurface(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 4.dp)
-            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier),
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+            .semantics { stateDescription = severityDescription },
         content = content
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * How loudly a service alert is drawn — the app's single alert-severity vocabulary, shared by every
+ * surface that shows one (the arrivals banner, the trip planner's directions, #2143). Each feed's own
+ * severity scale is mapped onto these three at its own wire boundary: the OBA `situation` scale by
+ * `severityOf` (`ArrivalsRepository`), OTP2's `AlertSeverityLevelType` by `TripAlertSeverity.tone`
+ * (`TripAlerts`). Presentation lives here so a severe alert can't read as urgent on one screen and
+ * merely advisory on another.
+ */
+enum class AlertSeverity { INFO, WARNING, ERROR }
+
+/**
+ * The severity-tinted rounded card a service alert is drawn on. Only the container is shared: each
+ * surface lays out its own contents (the arrivals banner is one line, the directions banner expands
+ * to the full description), and what they must agree on is the *colour* — which is exactly the part a
+ * second copy of the table below would eventually get wrong.
+ *
+ * [onClick] makes the whole card the tap target; a card with nothing to open passes null and takes no
+ * clickable at all rather than an empty one.
+ */
+@Composable
+fun AlertSurface(
+    severity: AlertSeverity,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    val (container, onContainer) = when (severity) {
+        AlertSeverity.ERROR ->
+            MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+        AlertSeverity.WARNING ->
+            MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+        AlertSeverity.INFO ->
+            MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+    }
+    Surface(
+        color = container,
+        contentColor = onContainer,
+        shape = MaterialTheme.shapes.small,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier),
+        content = content
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -99,6 +99,7 @@ import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.SheetDragHandle
 import org.onebusaway.android.ui.compose.components.SwitchRow
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
+import org.onebusaway.android.ui.compose.unitsAreMetric
 import org.onebusaway.android.ui.home.FocusedStop
 import org.onebusaway.android.ui.home.arrivals.rememberArrivalsSession
 import org.onebusaway.android.ui.icons.AppIcons
@@ -669,7 +670,7 @@ private fun DirectionsAdvancedSettingsDialog(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
-    val imperial = remember { !PreferenceUtils.getUnitsAreMetricFromPreferences(context) }
+    val imperial = !unitsAreMetric()
     // Which options this region can actually serve. OTP2 deleted `maxWalkDistance` from its routing
     // API, so the distance field would be silently ignored there (#1780 wired the OTP2 path without
     // it); OTP1 in turn has no cycling-optimization knob that doesn't collide with the `optimize`

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/regions/RegionsScreen.kt
@@ -51,6 +51,7 @@ import org.onebusaway.android.ui.compose.components.ListScreenScaffold
 import org.onebusaway.android.ui.compose.components.RemoveCustomRegionDialog
 import org.onebusaway.android.ui.compose.components.regionRowClickable
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.compose.unitsAreMetric
 import org.onebusaway.android.util.PreferenceUtils
 import org.onebusaway.android.util.RegionUtils
 
@@ -186,8 +187,7 @@ private fun distanceText(distanceMeters: Float?): String {
     if (distanceMeters == null) {
         return stringResource(R.string.region_unavailable)
     }
-    val context = LocalContext.current
-    val metric = remember { PreferenceUtils.getUnitsAreMetricFromPreferences(context) }
+    val metric = unitsAreMetric()
     val format = remember { NumberFormat.getInstance().apply { maximumFractionDigits = 1 } }
     return if (metric) {
         val km = distanceMeters / 1000.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -73,30 +73,54 @@ internal object ModeSymbols {
         // One badge per ride, at the leg it's boarded at; every other transit leg is a continuation the
         // rider never acts on, and is already named inside its leader's badge.
         val rides = Interlines.chains(legs).associate { chain ->
-            chain.leaderIndex to rideBadge(legs, chain, substitutable[chain.leaderIndex])
+            chain.leaderIndex to ModeSymbol.Transit(
+                badge = rideBadge(legs, chain, substitutable[chain.leaderIndex]),
+                // The whole ride, not just the leg boarded at: the rider stays aboard across an
+                // interline seam, so an alert on any leg of the chain is an alert on the one roundel
+                // that stands for it (#2143).
+                alert = legs.subList(chain.leaderIndex, chain.alightIndex + 1).loudestAlertTone()
+            )
         }
         val symbols = legs.mapIndexedNotNull { i, leg ->
             when {
-                leg.mode?.isTransit == true -> rides[i]?.let { ModeSymbol.Transit(it) }
+                leg.mode?.isTransit == true -> rides[i]
                 leg.mode?.isOnStreetNonTransit == true -> leg.streetSymbolOrNull()
                 else -> null
             }
         }
         // Two street legs in a row are one act to the rider ("walk, then walk"), so they draw one glyph.
-        val collapsed = symbols.filterConsecutiveDuplicateStreets()
+        val collapsed = symbols.mergeConsecutiveStreets()
         // "Unless it's the only icon": a trip that is nothing but a short stroll still has to say what
         // it is, so a sequence emptied by the threshold falls back to its longest street leg.
-        return collapsed.ifEmpty { listOfNotNull(legs.longestStreetLeg()?.let { ModeSymbol.Street(it.streetMode()) }) }
+        return collapsed.ifEmpty {
+            listOfNotNull(legs.longestStreetLeg()?.let { ModeSymbol.Street(it.streetMode(), it.loudestAlertTone()) })
+        }
     }
 
     /** The leg's symbol, or null when it's too short to be worth drawing ([NEGLIGIBLE_STREET_METERS]). */
-    private fun TripLeg.streetSymbolOrNull(): ModeSymbol.Street? = if (distance >= NEGLIGIBLE_STREET_METERS) ModeSymbol.Street(streetMode()) else null
+    private fun TripLeg.streetSymbolOrNull(): ModeSymbol.Street? = if (distance >= NEGLIGIBLE_STREET_METERS) {
+        ModeSymbol.Street(streetMode(), loudestAlertTone())
+    } else {
+        null
+    }
 
     /** The longest on-street leg, i.e. the one a street-only trip is really about; null if there is none. */
     private fun List<TripLeg>.longestStreetLeg(): TripLeg? = streetLegs().maxByOrNull { it.distance }
 
-    private fun List<ModeSymbol>.filterConsecutiveDuplicateStreets(): List<ModeSymbol> = filterIndexed { i, symbol ->
-        symbol !is ModeSymbol.Street || getOrNull(i - 1) != symbol
+    /**
+     * Collapses a run of same-mode street symbols into one, carrying the loudest alert any of them
+     * brought. A merge rather than a filter because the run is *one glyph standing for several legs*:
+     * dropping the later ones outright would drop an alert the rider is entitled to see beside it
+     * (see [ModeSymbol.alert]).
+     */
+    private fun List<ModeSymbol>.mergeConsecutiveStreets(): List<ModeSymbol> = fold(mutableListOf()) { acc, symbol ->
+        val previous = acc.lastOrNull()
+        if (symbol is ModeSymbol.Street && previous is ModeSymbol.Street && previous.mode == symbol.mode) {
+            acc[acc.lastIndex] = previous.copy(alert = listOfNotNull(previous.alert, symbol.alert).maxOrNull())
+        } else {
+            acc += symbol
+        }
+        acc
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.AlertSurface
+import org.onebusaway.android.ui.compose.components.linkifyUrls
+import org.onebusaway.android.ui.icons.AppIcons
+
+/**
+ * One service alert over the trip planner's directions (#2143), drawn on the app's shared
+ * severity-tinted [AlertSurface] so a suspension reads the same here as it does on the arrivals
+ * screen.
+ *
+ * Collapsed it is the rides the alert applies to plus the feed's headline — enough to know the
+ * itinerary below it is in doubt. Tapping expands the full description in place, plus the agency's own
+ * "more details" page when the alert names one. Expanding inline rather than opening a dialog keeps
+ * the alert beside the itinerary it contradicts, which is the comparison the rider is actually making;
+ * it also means this composable needs nothing from the host (no Activity, no callback threading)
+ * beyond the item itself.
+ *
+ * An alert with nothing behind the headline takes no tap target and draws no chevron, rather than
+ * offering an expansion that reveals nothing.
+ */
+@Composable
+internal fun TripAlertBanner(alert: TripAlertItem, modifier: Modifier = Modifier) {
+    // Keyed on the alert's content identity, so a re-plan that returns the same alert keeps it open and
+    // one that returns a different alert doesn't inherit the old one's expansion.
+    var expanded by rememberSaveable(alert.contentId) { mutableStateOf(false) }
+    AlertSurface(
+        severity = alert.severity,
+        modifier = modifier,
+        onClick = if (alert.hasDetail) ({ expanded = !expanded }) else null
+    ) {
+        // Top-aligned: the glyph and the chevron mark the alert, and on an expanded one they belong
+        // beside its first line rather than floating down beside the middle of the description.
+        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_warning_24),
+                contentDescription = null
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                if (alert.routeLabels.isNotEmpty()) {
+                    Text(
+                        text = alert.routeLabels.joinToString(),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Text(text = alert.summary, style = MaterialTheme.typography.bodyMedium)
+                if (expanded) {
+                    AlertDetail(alert)
+                }
+            }
+            if (alert.hasDetail) {
+                Icon(
+                    imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
+                    contentDescription = stringResource(
+                        if (expanded) {
+                            R.string.directions_alert_hide_details
+                        } else {
+                            R.string.directions_alert_show_details
+                        }
+                    ),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The expanded body: the feed's description with its bare URLs made tappable (GTFS-realtime
+ * `description_text` is plain text, so there is no markup to render — only links to find), then the
+ * alert's own page when it names one.
+ */
+@Composable
+private fun ColumnScope.AlertDetail(alert: TripAlertItem) {
+    // The banner's own content colour: the link has to stay legible on a severity-tinted container,
+    // which the theme's link colour isn't chosen against. Underlining is what marks it as a link.
+    val linkColor = LocalContentColor.current
+    alert.description?.let { description ->
+        Text(
+            text = linkifyUrls(description, linkColor),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+    alert.url?.let { url ->
+        val label = stringResource(R.string.situation_more_details)
+        Text(
+            text = buildAnnotatedString {
+                withLink(
+                    LinkAnnotation.Url(
+                        url,
+                        TextLinkStyles(
+                            style = SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)
+                        )
+                    )
+                ) {
+                    append(label)
+                }
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
@@ -53,8 +52,8 @@ import org.onebusaway.android.ui.icons.AppIcons
  * severity-tinted [AlertSurface] so a suspension reads the same here as it does on the arrivals
  * screen.
  *
- * Collapsed it is the rides the alert applies to plus the feed's headline — enough to know the
- * itinerary below it is in doubt. Tapping expands the full description in place, plus the agency's own
+ * Collapsed it is the feed's headline alone — enough, under the leg's own header, to know that ride is
+ * in doubt. Tapping expands the full description in place, plus the agency's own
  * "more details" page when the alert names one. Expanding inline rather than opening a dialog keeps
  * the alert beside the itinerary it contradicts, which is the comparison the rider is actually making;
  * it also means this composable needs nothing from the host (no Activity, no callback threading)
@@ -82,13 +81,6 @@ internal fun TripAlertBanner(alert: TripAlertItem, modifier: Modifier = Modifier
             )
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
-                if (alert.routeLabels.isNotEmpty()) {
-                    Text(
-                        text = alert.routeLabels.joinToString(),
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
                 Text(text = alert.summary, style = MaterialTheme.typography.bodyMedium)
                 if (expanded) {
                     AlertDetail(alert)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlerts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlerts.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.tripresults
 import org.onebusaway.android.directions.model.TripAlert
 import org.onebusaway.android.directions.model.TripAlertSeverity
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.ui.compose.components.AlertSeverity
 
@@ -74,7 +75,16 @@ fun TripItinerary.alertItems(): List<TripAlertItem> = legs
             routeLabels = group.mapNotNull { (_, label) -> label }.distinct()
         )
     }
-    .sortedByDescending { it.severity.ordinal }
+    .sortedByDescending { it.severity }
+
+/**
+ * The loudest tone among this leg's own alerts, or null when it carries none — what marks the leg's
+ * symbol on an itinerary option card (see [ModeSymbol.alert]).
+ */
+internal fun TripLeg.loudestAlertTone(): AlertSeverity? = alerts.map { it.severity.tone() }.maxOrNull()
+
+/** [loudestAlertTone] across several legs — what one symbol standing for all of them is marked with. */
+internal fun List<TripLeg>.loudestAlertTone(): AlertSeverity? = mapNotNull { it.loudestAlertTone() }.maxOrNull()
 
 /**
  * A key over the alert's rider-visible text — the same content-identity idea as
@@ -91,7 +101,7 @@ private fun TripAlert.contentKey(): String = listOf(header, description, url, se
  * (`severityOf`) — because an alert whose severity is unstated is still an alert, and silently
  * demoting it to INFO would hide the loudest thing OTP had to say about a leg.
  */
-private fun TripAlertSeverity.tone(): AlertSeverity = when (this) {
+internal fun TripAlertSeverity.tone(): AlertSeverity = when (this) {
     TripAlertSeverity.INFO -> AlertSeverity.INFO
     TripAlertSeverity.SEVERE -> AlertSeverity.ERROR
     TripAlertSeverity.WARNING, TripAlertSeverity.UNKNOWN_SEVERITY -> AlertSeverity.WARNING

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlerts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlerts.kt
@@ -17,38 +17,38 @@ package org.onebusaway.android.ui.tripresults
 
 import org.onebusaway.android.directions.model.TripAlert
 import org.onebusaway.android.directions.model.TripAlertSeverity
-import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
-import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.ui.compose.components.AlertSeverity
 
 /**
- * One service alert affecting the shown itinerary, as the directions banner draws it (#2143).
+ * One service alert affecting a leg of the shown itinerary, as the directions draw it (#2143).
  *
  * Identity is [contentId] — a key over the rider-visible text — not the alert id, for the same reason
  * the arrivals banner keys on content (#1593): a feed that republishes the same disruption under a
- * fresh id would otherwise read as a new alert, and within a single itinerary the *same* alert arrives
- * once per leg it applies to, which must collapse to one row.
+ * fresh id would otherwise read as a new alert, and one leg can be handed the same alert twice.
  *
- * [routeLabels] names the rides the alert came attached to, in travel order. It is what turns "service
- * is suspended" into something the rider can act on when a trip has more than one ride, and it is a
- * structural fact — which legs OTP hung the alert on — not an inference from the alert text.
+ * Nothing here names the affected ride, because nothing needs to: the row is drawn under that ride's
+ * own header in the directions, so its position states what a route label used to have to.
  */
 data class TripAlertItem(
     val contentId: String,
     val summary: String,
     val description: String?,
     val url: String?,
-    val severity: AlertSeverity,
-    val routeLabels: List<String>
+    val severity: AlertSeverity
 ) {
     /** Whether tapping the row reveals anything beyond [summary]. */
     val hasDetail: Boolean get() = !description.isNullOrBlank() || !url.isNullOrBlank()
 }
 
 /**
- * Every alert on this itinerary's legs, collapsed to one row per distinct alert and ordered
- * loudest-first so a suspension can't sit below a parking notice.
+ * This leg's own alerts as rows, one per distinct alert and loudest first so a suspension can't sit
+ * below a parking notice.
+ *
+ * Per **leg**, not per itinerary: the rows are drawn with the leg they belong to, which is what tells
+ * the rider *where* in the trip the trouble is. An alert OTP hangs on two legs of one trip therefore
+ * draws once under each — they are two separate facts about two separate rides, and collapsing them to
+ * a single row somewhere else is what the head-of-itinerary banner used to do.
  *
  * No active-window check: OTP has already scoped each leg's alerts to that leg's own time window (see
  * the `alerts` selection in `Plan.graphql`), so re-deciding it here would mean re-implementing the
@@ -59,23 +59,31 @@ data class TripAlertItem(
  *
  * Pure, so it is unit-testable without a plan, a `Context`, or a renderer.
  */
-fun TripItinerary.alertItems(): List<TripAlertItem> = legs
-    .flatMap { leg -> leg.alerts.map { alert -> alert to leg.routeDisplayLabel() } }
-    .groupBy { (alert, _) -> alert.contentKey() }
-    .mapNotNull { (contentId, group) ->
-        val alert = group.first().first
+internal fun TripLeg.alertItems(): List<TripAlertItem> = alerts
+    .mapNotNull { alert ->
         val summary = alert.header ?: alert.description ?: return@mapNotNull null
         TripAlertItem(
-            contentId = contentId,
+            contentId = alert.contentKey(),
             summary = summary,
             // Suppressed when it *is* the summary, so a header-less alert doesn't print its text twice.
             description = alert.description?.takeIf { it != summary },
             url = alert.url,
-            severity = alert.severity.tone(),
-            routeLabels = group.mapNotNull { (_, label) -> label }.distinct()
+            severity = alert.severity.tone()
         )
     }
-    .sortedByDescending { it.severity }
+    .asRows()
+
+/**
+ * Several legs' alerts as one leg's worth of rows — what a folded interline chain draws, the rider
+ * being aboard for all of them with only the leader's header to hang them under.
+ *
+ * Mirrors [loudestAlertTone]'s single/collection pair, and exists so "one row per distinct alert,
+ * loudest first" is stated once, here, rather than re-derived by whoever merges legs next.
+ */
+internal fun List<TripAlertItem>.mergedWith(others: List<TripAlertItem>): List<TripAlertItem> = (this + others).asRows()
+
+/** The shared rule: one row per distinct alert, loudest first. */
+private fun List<TripAlertItem>.asRows(): List<TripAlertItem> = distinctBy { it.contentId }.sortedByDescending { it.severity }
 
 /**
  * The loudest tone among this leg's own alerts, or null when it carries none — what marks the leg's

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlerts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlerts.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.onebusaway.android.directions.model.TripAlert
+import org.onebusaway.android.directions.model.TripAlertSeverity
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.ui.compose.components.AlertSeverity
+
+/**
+ * One service alert affecting the shown itinerary, as the directions banner draws it (#2143).
+ *
+ * Identity is [contentId] — a key over the rider-visible text — not the alert id, for the same reason
+ * the arrivals banner keys on content (#1593): a feed that republishes the same disruption under a
+ * fresh id would otherwise read as a new alert, and within a single itinerary the *same* alert arrives
+ * once per leg it applies to, which must collapse to one row.
+ *
+ * [routeLabels] names the rides the alert came attached to, in travel order. It is what turns "service
+ * is suspended" into something the rider can act on when a trip has more than one ride, and it is a
+ * structural fact — which legs OTP hung the alert on — not an inference from the alert text.
+ */
+data class TripAlertItem(
+    val contentId: String,
+    val summary: String,
+    val description: String?,
+    val url: String?,
+    val severity: AlertSeverity,
+    val routeLabels: List<String>
+) {
+    /** Whether tapping the row reveals anything beyond [summary]. */
+    val hasDetail: Boolean get() = !description.isNullOrBlank() || !url.isNullOrBlank()
+}
+
+/**
+ * Every alert on this itinerary's legs, collapsed to one row per distinct alert and ordered
+ * loudest-first so a suspension can't sit below a parking notice.
+ *
+ * No active-window check: OTP has already scoped each leg's alerts to that leg's own time window (see
+ * the `alerts` selection in `Plan.graphql`), so re-deciding it here would mean re-implementing the
+ * server's rule against a `to`/`from` pair this query doesn't even ask for.
+ *
+ * An alert with no rider-visible text at all is dropped rather than drawn as an empty row — there is
+ * nothing to tell the rider, and a blank severity-tinted card reads as a rendering failure.
+ *
+ * Pure, so it is unit-testable without a plan, a `Context`, or a renderer.
+ */
+fun TripItinerary.alertItems(): List<TripAlertItem> = legs
+    .flatMap { leg -> leg.alerts.map { alert -> alert to leg.routeDisplayLabel() } }
+    .groupBy { (alert, _) -> alert.contentKey() }
+    .mapNotNull { (contentId, group) ->
+        val alert = group.first().first
+        val summary = alert.header ?: alert.description ?: return@mapNotNull null
+        TripAlertItem(
+            contentId = contentId,
+            summary = summary,
+            // Suppressed when it *is* the summary, so a header-less alert doesn't print its text twice.
+            description = alert.description?.takeIf { it != summary },
+            url = alert.url,
+            severity = alert.severity.tone(),
+            routeLabels = group.mapNotNull { (_, label) -> label }.distinct()
+        )
+    }
+    .sortedByDescending { it.severity.ordinal }
+
+/**
+ * A key over the alert's rider-visible text — the same content-identity idea as
+ * [contentKey][org.onebusaway.android.models.contentKey] on the OBA situation path, over the fields
+ * OTP publishes. NUL-separated so adjacent values can't run together and collide across field
+ * boundaries.
+ */
+private fun TripAlert.contentKey(): String = listOf(header, description, url, severity.name)
+    .joinToString("\u0000") { it.orEmpty() }
+
+/**
+ * OTP2's severity scale mapped onto the app's shared banner tones. `UNKNOWN_SEVERITY` lands on
+ * [AlertSeverity.WARNING] — the same place the OBA situation path puts a severity it can't read
+ * (`severityOf`) — because an alert whose severity is unstated is still an alert, and silently
+ * demoting it to INFO would hide the loudest thing OTP had to say about a leg.
+ */
+private fun TripAlertSeverity.tone(): AlertSeverity = when (this) {
+    TripAlertSeverity.INFO -> AlertSeverity.INFO
+    TripAlertSeverity.SEVERE -> AlertSeverity.ERROR
+    TripAlertSeverity.WARNING, TripAlertSeverity.UNKNOWN_SEVERITY -> AlertSeverity.WARNING
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -142,7 +142,10 @@ object TripLogBuilder {
         },
         legPoints = legPoints,
         focusPoint = walk.focusPoint(),
-        legIndices = setOf(legIndex)
+        legIndices = setOf(legIndex),
+        // A walk carries alerts too (a closed dock, a blocked path) and has its own header to draw
+        // them under, so moving alerts onto the legs loses none of what the head banner used to pool.
+        alerts = leg.alertItems()
     )
 
     /**
@@ -174,7 +177,10 @@ object TripLogBuilder {
                 stopEvents(board),
             legPoints = leader.legPoints + legPoints,
             // The rider stays aboard across the seam, so the whole chain is one focus target.
-            legIndices = leader.legIndices + legIndex
+            legIndices = leader.legIndices + legIndex,
+            // Likewise one header to hang alerts under: the continuation's own alerts join the
+            // leader's, deduped so an alert scoped to the whole chain isn't drawn once per leg.
+            alerts = leader.alerts.mergedWith(leg.alertItems())
         )
     }
 
@@ -202,7 +208,8 @@ object TripLogBuilder {
             rideEvents = stopEvents(board),
             routeLeg = routeLeg,
             legPoints = legPoints,
-            legIndices = setOf(legIndex)
+            legIndices = setOf(legIndex),
+            alerts = leg.alertItems()
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -125,6 +125,7 @@ import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.components.RouteLineColors
 import org.onebusaway.android.ui.compose.components.ScrollChevronGutter
+import org.onebusaway.android.ui.compose.components.alertAccentColor
 import org.onebusaway.android.ui.compose.components.routeLineColors
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -299,6 +300,15 @@ private val SYMBOL_BADGE_SCALE = SYMBOL_HEIGHT / ROUTE_BADGE_HEIGHT
 private const val SYMBOL_SEPARATOR_ALPHA = 0.6f
 
 private val SYMBOL_GAP = 4.dp
+
+/**
+ * The warning triangle marking a mode symbol whose leg carries a service alert (#2143), and the gap
+ * between the two. Drawn distinctly smaller than [SYMBOL_HEIGHT] and tucked closer than [SYMBOL_GAP]:
+ * it annotates the symbol beside it rather than being one, and at equal size and spacing a row of
+ * `[walk] ⚠ > [1 Line] ⚠` would read as six steps instead of two legs with a caveat each.
+ */
+private val SYMBOL_ALERT_SIZE = 13.dp
+private val SYMBOL_ALERT_GAP = 2.dp
 
 /** The gap between two wrapped lines of the summary — [SYMBOL_GAP] itself, so the wrap reads as one
  *  evenly-spaced field of symbols rather than as two stacked rows, and stays so if that gap is retuned. */
@@ -531,9 +541,35 @@ private fun packLines(widths: List<Int>, limit: Int, gap: Int): List<IntRange> {
 /** How wide one of [packLines]' lines is: its symbols, plus a [gap] between each neighbouring pair. */
 private fun lineWidth(widths: List<Int>, line: IntRange, gap: Int): Int = line.sumOf { widths[it] } + gap * (line.last - line.first)
 
-/** One symbol of a card's summary line: a bare mode glyph, or the ride's route roundel. */
+/**
+ * One symbol of a card's summary line: a bare mode glyph, or the ride's route roundel — followed by a
+ * warning triangle when a service alert affects the leg(s) it stands for (#2143).
+ *
+ * The triangle rides *inside* the symbol, at a tighter gap than [SYMBOL_GAP] separates symbols by, so
+ * it reads as an annotation on the leg to its left rather than as a step of the trip in its own right —
+ * or, worse, as belonging to the symbol on the other side of the chevron.
+ */
 @Composable
 private fun ModeSymbolContent(symbol: ModeSymbol) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(SYMBOL_ALERT_GAP),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ModeSymbolGlyph(symbol)
+        symbol.alert?.let { severity ->
+            Icon(
+                painter = painterResource(R.drawable.baseline_warning_24),
+                contentDescription = stringResource(R.string.directions_leg_service_alert),
+                tint = alertAccentColor(severity),
+                modifier = Modifier.size(SYMBOL_ALERT_SIZE)
+            )
+        }
+    }
+}
+
+/** [ModeSymbolContent] without its alert marker: the symbol proper. */
+@Composable
+private fun ModeSymbolGlyph(symbol: ModeSymbol) {
     when (symbol) {
         // A glyph alone — there is nothing to name about a walk.
         is ModeSymbol.Street -> StreetMetric.of(symbol.mode)?.let { metric ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1031,6 +1031,15 @@ private fun TripLogList(
         // The picker scrolls with the steps (not pinned), so it recedes as you read down the list.
         item {
             TripResultsHeader(state, onSelectOption, scheduleWinnerMode)
+        }
+        // Directly under the option cards and above the directions, because an itinerary routed over
+        // suspended service is otherwise indistinguishable from a good one — the alert is the only
+        // thing that says so (#2143). Each is its own lazy item, keyed on content identity, so
+        // expanding one keeps its state across a refresh and doesn't recompose the log below it.
+        items(state.alerts, key = { "alert:${it.contentId}" }) { alert ->
+            TripAlertBanner(alert)
+        }
+        item {
             reminderControl()
             HorizontalDivider()
             Spacer(Modifier.height(LOG_EDGE_GAP))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -562,9 +562,10 @@ private fun ModeSymbolContent(symbol: ModeSymbol) {
     ) {
         ModeSymbolGlyph(symbol)
         symbol.alert?.let { severity ->
+            val severityLabel = stringResource(severity.labelRes)
             Icon(
                 painter = painterResource(R.drawable.baseline_warning_24),
-                contentDescription = stringResource(R.string.directions_leg_service_alert),
+                contentDescription = stringResource(R.string.directions_leg_service_alert, severityLabel),
                 tint = alertAccentColor(severity),
                 modifier = Modifier.size(SYMBOL_ALERT_SIZE)
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -303,11 +303,16 @@ private val SYMBOL_GAP = 4.dp
 
 /**
  * The warning triangle marking a mode symbol whose leg carries a service alert (#2143), and the gap
- * between the two. Drawn distinctly smaller than [SYMBOL_HEIGHT] and tucked closer than [SYMBOL_GAP]:
- * it annotates the symbol beside it rather than being one, and at equal size and spacing a row of
- * `[walk] ⚠ > [1 Line] ⚠` would read as six steps instead of two legs with a caveat each.
+ * between the two. Tucked closer than [SYMBOL_GAP] separates two symbols by, so it annotates the symbol
+ * beside it rather than reading as one — at equal spacing a row of `[walk] ⚠ > [1 Line] ⚠` reads as
+ * six steps instead of two legs with a caveat each.
+ *
+ * It sits a little *below* [SYMBOL_HEIGHT] rather than distinctly under it. The first cut was small
+ * enough to read as a footnote, which is the wrong register for "this train isn't running": a marker
+ * the rider is meant to catch while scanning the picker has to hold its own against the roundel it
+ * qualifies without displacing it as the thing being read. Tune both here.
  */
-private val SYMBOL_ALERT_SIZE = 13.dp
+private val SYMBOL_ALERT_SIZE = 17.dp
 private val SYMBOL_ALERT_GAP = 2.dp
 
 /** The gap between two wrapped lines of the summary — [SYMBOL_GAP] itself, so the wrap reads as one

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.tripresults
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.Typeface
@@ -56,10 +57,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
@@ -116,6 +119,8 @@ import org.onebusaway.android.directions.realtime.TripPlanMonitor
 import org.onebusaway.android.directions.realtime.TripPlanNotifications
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.LocalUnitsAreMetric
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.EtaPartsText
 import org.onebusaway.android.ui.compose.components.LoadingContent
@@ -130,6 +135,7 @@ import org.onebusaway.android.ui.compose.components.routeLineColors
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.compose.theme.isDarkTheme
+import org.onebusaway.android.ui.compose.unitsAreMetric
 import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.util.DisplayFormat
@@ -614,6 +620,8 @@ private fun ModeSymbolGlyph(symbol: ModeSymbol) {
 @Composable
 private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
     val context = LocalContext.current
+    // Named for the units, not `metric`, to stay clear of the StreetMetric the distance rows destructure.
+    val metricUnits = unitsAreMetric()
     val winnerOutlineColor = MaterialTheme.colorScheme.outline.copy(alpha = WINNER_OUTLINE_ALPHA)
     Column(
         modifier = Modifier.padding(CARD_SECTION_PADDING),
@@ -649,7 +657,7 @@ private fun StatsColumn(option: ItineraryOption, winners: Set<WinnerCategory>) {
                     outlineColor = winnerOutlineColor
                 ) {
                     EtaPartsText(
-                        ConversionUtils.getFormattedDistanceParts(meters, context),
+                        ConversionUtils.getFormattedDistanceParts(meters, context, metricUnits),
                         modifier = Modifier.alignByBaseline(),
                         numberSize = METRIC_NUMBER_SIZE,
                         unitSize = METRIC_UNIT_SIZE
@@ -849,34 +857,39 @@ fun TripResultsList(
     stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit = { _, _ -> },
     reminderControl: @Composable () -> Unit = {}
 ) {
-    Box(
-        modifier
-            .fillMaxSize()
-            .background(colorResource(R.color.md_theme_surfaceContainer))
-    ) {
-        when (state) {
-            TripResultsUiState.Loading -> LoadingContent(Modifier.align(Alignment.Center))
+    // Resolved once for the whole drawer rather than by each distance row: the rows below run one per
+    // walk step, and a leaf resolve is a Hilt entry-point hop plus a locale query every time one enters
+    // composition. A preview (or any other host) that has already pinned the units keeps its value.
+    CompositionLocalProvider(LocalUnitsAreMetric provides unitsAreMetric()) {
+        Box(
+            modifier
+                .fillMaxSize()
+                .background(colorResource(R.color.md_theme_surfaceContainer))
+        ) {
+            when (state) {
+                TripResultsUiState.Loading -> LoadingContent(Modifier.align(Alignment.Center))
 
-            is TripResultsUiState.Error -> Text(
-                text = state.message,
-                style = MaterialTheme.typography.bodyLarge,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(32.dp)
-            )
+                is TripResultsUiState.Error -> Text(
+                    text = state.message,
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(32.dp)
+                )
 
-            is TripResultsUiState.Success -> TripLogList(
-                state = state,
-                bottomInset = bottomInset,
-                scheduleWinnerMode = scheduleWinnerMode,
-                onSelectOption = onSelectOption,
-                onFocusRouteLeg = onFocusRouteLeg,
-                onFocusLeg = onFocusLeg,
-                onFocusPoint = onFocusPoint,
-                stopEtaStrip = stopEtaStrip,
-                reminderControl = reminderControl
-            )
+                is TripResultsUiState.Success -> TripLogList(
+                    state = state,
+                    bottomInset = bottomInset,
+                    scheduleWinnerMode = scheduleWinnerMode,
+                    onSelectOption = onSelectOption,
+                    onFocusRouteLeg = onFocusRouteLeg,
+                    onFocusLeg = onFocusLeg,
+                    onFocusPoint = onFocusPoint,
+                    stopEtaStrip = stopEtaStrip,
+                    reminderControl = reminderControl
+                )
+            }
         }
     }
 }
@@ -1041,16 +1054,47 @@ private fun TripLogList(
     reminderControl: @Composable () -> Unit
 ) {
     val entries = state.directions
+    val expanded = remember(entries) { mutableStateSetOf<Int>() }
+    val onToggle: (Int) -> Unit = remember(expanded) { { i -> if (!expanded.add(i)) expanded.remove(i) } }
+    // Snapshotted to a plain Set so it can key the memo in rememberLogRows — reading it here is also
+    // what makes a toggle recompose this list.
+    val rows = rememberLogRows(entries, expanded.toSet())
+
+    // The surface reaches the bottom edge; a bottom content padding lets the final leg row be scrolled
+    // clear of the nav chrome without an empty strip below the list.
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = bottomInset + LOG_EDGE_GAP)
+    ) {
+        // The picker scrolls with the steps (not pinned), so it recedes as you read down the list.
+        item {
+            TripResultsHeader(state, onSelectOption, scheduleWinnerMode)
+            reminderControl()
+            HorizontalDivider()
+            Spacer(Modifier.height(LOG_EDGE_GAP))
+        }
+        // Keyed by row identity, not position, so opening a leg doesn't discard the subcompositions of
+        // every row below it — a board row's live ETA session survives the insert.
+        items(rows, key = { it.key }) { row ->
+            LogRow(row, onToggle, onFocusRouteLeg, onFocusLeg, onFocusPoint, stopEtaStrip)
+        }
+    }
+}
+
+/**
+ * The [entries] flattened into timeline rows, with the spine and band colours this theme resolves.
+ *
+ * Held apart from [TripLogList] so a single leg can be rendered through the very same pipeline (see the
+ * leg previews at the foot of this file) — the colour resolution is the part a second call site would
+ * otherwise copy and let drift.
+ */
+@Composable
+private fun rememberLogRows(entries: List<TripLogEntry>, expandedEntries: Set<Int>): List<LogRowModel> {
     val dark = MaterialTheme.colorScheme.isDarkTheme()
     // A walk's spine and any route whose colour we can't use: an outline-toned line, with the surface
     // showing through as the glyph so a filled neutral node still reads.
     val neutral = RouteLineColors(MaterialTheme.colorScheme.outline, MaterialTheme.colorScheme.surface)
-    val expanded = remember(entries) { mutableStateSetOf<Int>() }
-    val onToggle: (Int) -> Unit = remember(expanded) { { i -> if (!expanded.add(i)) expanded.remove(i) } }
-    // Snapshotted to a plain Set so it can key the memo below — reading it here is also what makes a
-    // toggle recompose this list.
-    val expandedEntries = expanded.toSet()
-    val rows = remember(entries, expandedEntries, neutral, dark) {
+    return remember(entries, expandedEntries, neutral, dark) {
         flattenLog(
             entries = entries,
             expandedEntries = expandedEntries,
@@ -1062,35 +1106,6 @@ private fun TripLogList(
             // hue rather than three fallbacks.
             rideColors = { routeLineColors(ridePresentationColor(it.routeColorHex), dark, neutral) }
         )
-    }
-
-    // The surface reaches the bottom edge; a bottom content padding lets the final leg row be scrolled
-    // clear of the nav chrome without an empty strip below the list.
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = bottomInset + LOG_EDGE_GAP)
-    ) {
-        // The picker scrolls with the steps (not pinned), so it recedes as you read down the list.
-        item {
-            TripResultsHeader(state, onSelectOption, scheduleWinnerMode)
-        }
-        // Directly under the option cards and above the directions, because an itinerary routed over
-        // suspended service is otherwise indistinguishable from a good one — the alert is the only
-        // thing that says so (#2143). Each is its own lazy item, keyed on content identity, so
-        // expanding one keeps its state across a refresh and doesn't recompose the log below it.
-        items(state.alerts, key = { "alert:${it.contentId}" }) { alert ->
-            TripAlertBanner(alert)
-        }
-        item {
-            reminderControl()
-            HorizontalDivider()
-            Spacer(Modifier.height(LOG_EDGE_GAP))
-        }
-        // Keyed by row identity, not position, so opening a leg doesn't discard the subcompositions of
-        // every row below it — a board row's live ETA session survives the insert.
-        items(rows, key = { it.key }) { row ->
-            LogRow(row, onToggle, onFocusRouteLeg, onFocusLeg, onFocusPoint, stopEtaStrip)
-        }
     }
 }
 
@@ -1592,13 +1607,32 @@ private fun ColumnScope.WalkHeaderContent(entry: TripLogEntry.Walk) {
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onSurface
     )
-    val meta = walkMeta(entry, context)
+    val meta = walkMeta(entry, context, unitsAreMetric())
     if (meta.isNotEmpty()) {
         Text(
             text = meta,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+    }
+    // A walk gets its alerts under its header for the same reason a ride does — a closed dock or a
+    // blocked path is about this stretch of the trip, not the trip as a whole.
+    LegAlerts(entry.alerts)
+}
+
+/**
+ * A leg's service alerts, under its header (#2143), loudest first.
+ *
+ * Drawn inline in the leg's row rather than as lazy items of their own: an alert belongs to the leg the
+ * way its headsign does, and hanging it off the row keeps it inside the leg's band and spine, so it
+ * cannot drift away from the ride it qualifies as the list scrolls or a leg above it expands.
+ */
+@Composable
+private fun LegAlerts(alerts: List<TripAlertItem>) {
+    alerts.forEach { alert ->
+        key(alert.contentId) {
+            TripAlertBanner(alert)
+        }
     }
 }
 
@@ -1618,7 +1652,7 @@ private fun ColumnScope.StepContent(step: LogStep) {
 @Composable
 private fun ColumnScope.StepDistanceContent(distanceMeters: Double) {
     Text(
-        text = ConversionUtils.getFormattedDistance(distanceMeters, LocalContext.current),
+        text = ConversionUtils.getFormattedDistance(distanceMeters, LocalContext.current, unitsAreMetric()),
         style = MaterialTheme.typography.labelSmall,
         fontFamily = FontFamily.Monospace,
         color = MaterialTheme.colorScheme.outline
@@ -1686,6 +1720,11 @@ private fun ColumnScope.BoardContent(
             RealtimeChip(entry.realtime)
         }
     }
+    // Directly under the route header and above the boarding instruction (#2143): the alert is about
+    // *this* ride, so it belongs against the ride's name, and the rider reads that service is disrupted
+    // before being told which stop to wait at. Outside the identity block above, whose tap frames the
+    // leg on the map — an alert owns its own expand tap and must not spend that one.
+    LegAlerts(entry.alerts)
     entry.routeLeg.board?.let { stop ->
         Spacer(Modifier.height(6.dp))
         StopActionLabel(
@@ -1893,7 +1932,7 @@ private fun deltaText(minutes: Long, context: Context): String {
 }
 
 /** The walk leg's distance ("0.2 mi"); blank when the leg carries no distance. Its duration is the delta. */
-private fun walkMeta(entry: TripLogEntry.Walk, context: Context): String = if (entry.distanceMeters > 0.0) ConversionUtils.getFormattedDistance(entry.distanceMeters, context) else ""
+private fun walkMeta(entry: TripLogEntry.Walk, context: Context, metric: Boolean): String = if (entry.distanceMeters > 0.0) ConversionUtils.getFormattedDistance(entry.distanceMeters, context, metric) else ""
 
 /** The transit leg's stop count ("5 stops"); blank when unknown (e.g. the OTP2 path). Duration is the delta. */
 private fun transitMeta(entry: TripLogEntry.Transit, context: Context): String = if (entry.stopCount > 0) {
@@ -1902,156 +1941,384 @@ private fun transitMeta(entry: TripLogEntry.Transit, context: Context): String =
     ""
 }
 
-@Preview(showBackground = true)
+// ---- previews ------------------------------------------------------------------------------------
+//
+// The itinerary drawer, driven through [TripResultsList] — the seam where the sheet becomes pure state:
+// everything above it ([TripResultsSheet], [DirectionsResultsSheet]) needs the host Activity, a Hilt
+// ViewModel, and a running TripPlanMonitor, none of which exist under layoutlib.
+//
+// Every preview pins [LocalUnitsAreMetric]. Distances are formatted from it rather than from the
+// rider's preference precisely so these can render: the preference read reaches Application.get(),
+// which throws here. See ConversionUtils.getFormattedDistanceParts.
+//
+// The fixtures build one trip, shared by the whole-drawer previews and the single-leg ones below, so a
+// leg cannot read one way in the itinerary and another on its own.
+
+// ---- shared fixtures -----------------------------------------------------------------------------
+
+/** The ride boarded as the 8 that becomes the 12 underneath the rider (#2000/#2049), chevron-joined. */
+private val PREVIEW_BUS_CHAIN_BADGE = LegBadge(
+    listOf(RouteBadge("8", 0xFF1B6EF3.toInt()), RouteBadge("12", 0xFFD62828.toInt())),
+    TransitMode.BUS,
+    RouteBadgeJoin.THEN
+)
+
+/** Two interchangeable rail lines (#2010), slash-joined — board whichever comes first. */
+private val PREVIEW_RAIL_PAIR_BADGE = LegBadge(
+    listOf(RouteBadge("1 Line", 0xFF00A651.toInt()), RouteBadge("2 Line", 0xFF0075C4.toInt())),
+    TransitMode.RAIL,
+    RouteBadgeJoin.ANY_OF
+)
+
+private val PREVIEW_RIDE_STOPS = listOf(
+    RideEvent.Stop(LogStop("Capitol Hill Station")),
+    RideEvent.Stop(LogStop("23rd Ave & E Union St")),
+    RideEvent.Stop(LogStop("Rainier Ave S & S McClellan St"))
+)
+
+/** The stay-aboard seam the chevroned badge stands for, reached partway through the ride (#2071). */
+private val PREVIEW_INTERLINE_SEAM = RideEvent.Transition(
+    InterlineTransition(
+        badge = RouteBadge("12", 0xFFD62828.toInt()),
+        routeDisplayName = "Route 12",
+        headsign = "Interlaken Park",
+        stop = RouteStopRef("1_550", "550", "Mount Baker Transit Center", null)
+    )
+)
+
+// One alert per travelling leg, one per severity — enough to show each tone *and* that the placement is
+// per-leg: the walk's notice, the bus's reroute and the boat's cancellation each sit under their own
+// header rather than pooling at the top of the itinerary.
+
+private val PREVIEW_WALK_ALERT = TripAlertItem(
+    contentId = "alert_sidewalk",
+    summary = "Sidewalk closed on the east side of 5th Ave",
+    description = null,
+    url = null,
+    severity = AlertSeverity.INFO
+)
+
+private val PREVIEW_BUS_ALERT = TripAlertItem(
+    contentId = "alert_reroute",
+    summary = "Route 8 is rerouted around Denny Way construction",
+    description = "Buses are using Olive Way in both directions. Stops between Denny & Stewart are " +
+        "closed; use the temporary stop at Olive & Boren.",
+    url = "https://example.transit/alerts/route-8",
+    severity = AlertSeverity.WARNING
+)
+
+private val PREVIEW_FERRY_ALERT = TripAlertItem(
+    contentId = "alert_ferry_cancelled",
+    summary = "The 4:10 PM Bremerton sailing is cancelled",
+    description = "One vessel is out of service. The next sailing is at 5:30 PM.",
+    url = null,
+    severity = AlertSeverity.ERROR
+)
+
+/** One transit leg, defaulted to an ordinary bus ride so each caller states only what it varies. */
+private fun previewTransitLeg(
+    routeShortName: String? = "8",
+    routeDisplayName: String? = "Route 8",
+    mode: TransitMode = TransitMode.BUS,
+    routeColorHex: String? = "1B6EF3",
+    headsign: String? = "Rainier Beach",
+    realtime: RealtimeState = RealtimeState.OnTime,
+    rideEvents: List<RideEvent> = PREVIEW_RIDE_STOPS,
+    badge: LegBadge? = null,
+    alerts: List<TripAlertItem> = emptyList()
+) = TripLogEntry.Transit(
+    routeShortName = routeShortName,
+    routeDisplayName = routeDisplayName,
+    mode = mode,
+    routeColorHex = routeColorHex,
+    headsign = headsign,
+    reachStopTime = ServerTime(3 * 60_000L),
+    boardTime = ServerTime(4 * 60_000L),
+    exitTime = ServerTime(20 * 60_000L),
+    durationMinutes = 16,
+    realtime = realtime,
+    rideEvents = rideEvents,
+    routeLeg = RouteLegRef(
+        routeId = "1_100",
+        headsign = headsign,
+        board = RouteStopRef("1_500", "500", "Pine St & 3rd Ave", null),
+        alight = RouteStopRef("1_600", "600", "Rainier Ave S & S Alaska St", null),
+        badge = badge
+    ),
+    alerts = alerts
+)
+
+/**
+ * A Washington State Ferries run: no route short name, so no badge — the long name is the row's title
+ * and the boat glyph rides the spine. Built off [previewTransitLeg] and then re-timed, since an hour
+ * on a boat is the one thing about it that isn't a bus ride's shape.
+ */
+private fun previewFerryLeg(alerts: List<TripAlertItem> = emptyList()) = previewTransitLeg(
+    routeShortName = null,
+    routeDisplayName = "Seattle - Bremerton",
+    mode = TransitMode.FERRY,
+    routeColorHex = null,
+    headsign = "Bremerton",
+    realtime = RealtimeState.Unknown,
+    rideEvents = emptyList(),
+    alerts = alerts
+).copy(
+    reachStopTime = ServerTime(20 * 60_000L),
+    boardTime = ServerTime(24 * 60_000L),
+    exitTime = ServerTime(84 * 60_000L),
+    durationMinutes = 60,
+    routeLeg = RouteLegRef(
+        routeId = "95_74",
+        headsign = "Bremerton",
+        board = RouteStopRef("95_1", null, "Seattle Ferry Terminal", null),
+        alight = RouteStopRef("95_2", null, "Bremerton Ferry Terminal", null)
+    )
+)
+
+// ---- itinerary fixtures --------------------------------------------------------------------------
+
+/**
+ * The three option cards of the picker. With [alerted], the symbols standing for the legs that carry an
+ * alert below are marked — the walk and the bus, at the tones their own alerts have, so the card and the
+ * directions name the same two rides rather than pointing at different ones.
+ */
+private fun previewOptions(alerted: Boolean = false) = listOf(
+    ItineraryOption(
+        // Both joined badges side by side: a bus that becomes the 12 with the rider aboard,
+        // chevroned (#2049), then an interchangeable rail pair, slashed (#2010) — the
+        // transfer between them being too short to draw a glyph for (#2047).
+        symbols = listOf(
+            ModeSymbol.Street(StreetMode.WALK, alert = PREVIEW_WALK_ALERT.severity.takeIf { alerted }),
+            ModeSymbol.Transit(PREVIEW_BUS_CHAIN_BADGE, alert = PREVIEW_BUS_ALERT.severity.takeIf { alerted }),
+            ModeSymbol.Transit(PREVIEW_RAIL_PAIR_BADGE),
+            ModeSymbol.Street(StreetMode.WALK)
+        ),
+        durationMinutes = 32,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(32 * 60_000L),
+        streetDistanceMeters = mapOf(StreetMode.WALK to 800.0)
+    ),
+    ItineraryOption(
+        // The second leg is a ferry, which publishes no route short name — so it badges its
+        // long name, capped and ellipsized.
+        symbols = listOf(
+            ModeSymbol.Transit(LegBadge(listOf(RouteBadge("48", null)), TransitMode.BUS, RouteBadgeJoin.ANY_OF)),
+            ModeSymbol.Street(StreetMode.WALK),
+            ModeSymbol.Transit(LegBadge(listOf(RouteBadge("Seattle - Bremerton", null)), TransitMode.FERRY, RouteBadgeJoin.ANY_OF))
+        ),
+        durationMinutes = 41,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(41 * 60_000L),
+        streetDistanceMeters = mapOf(StreetMode.WALK to 400.0)
+    ),
+    ItineraryOption(
+        // A bikeshare trip: walk to the dock, ride, walk from it (#2047).
+        symbols = listOf(
+            ModeSymbol.Street(StreetMode.WALK),
+            ModeSymbol.Street(StreetMode.BIKESHARE),
+            ModeSymbol.Street(StreetMode.WALK)
+        ),
+        durationMinutes = 18,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(18 * 60_000L),
+        // Both of its street modes measured, the ride as well as the walk (#2122).
+        streetDistanceMeters = mapOf(StreetMode.WALK to 500.0, StreetMode.BIKESHARE to 2300.0)
+    )
+)
+
+/**
+ * The selected option's directions: a walk, the interlined bus ride its chevroned badge stands for, a
+ * ferry, and both terminals. With [alerted], each travelling leg also carries its own alert (#2143).
+ */
+private fun previewDirections(alerted: Boolean = false) = listOf(
+    TripLogEntry.Terminal(
+        kind = TerminalKind.START,
+        time = ServerTime(0L),
+        place = "5th Ave & Pine St"
+    ),
+    TripLogEntry.Walk(
+        mode = StreetMode.WALK,
+        durationMinutes = 4,
+        distanceMeters = 320.0,
+        isTransfer = false,
+        steps = listOf(LogStep("Head north on 5th Ave", distanceMeters = 107.0)),
+        alerts = listOfNotNull(PREVIEW_WALK_ALERT.takeIf { alerted })
+    ),
+    // The ride the first option's chevron badge stands for: boarded once as the 8, becoming the 12 at
+    // Mount Baker without the rider getting off. The header badges only the 8; the 12 arrives at its own
+    // seam row, which is why the seam sits among the stops rather than before them.
+    previewTransitLeg(
+        rideEvents = PREVIEW_RIDE_STOPS.take(2) + PREVIEW_INTERLINE_SEAM + PREVIEW_RIDE_STOPS.drop(2),
+        badge = PREVIEW_BUS_CHAIN_BADGE,
+        alerts = listOfNotNull(PREVIEW_BUS_ALERT.takeIf { alerted })
+    ),
+    previewFerryLeg(alerts = listOfNotNull(PREVIEW_FERRY_ALERT.takeIf { alerted })),
+    TripLogEntry.Terminal(
+        kind = TerminalKind.ARRIVE,
+        time = ServerTime(90 * 60_000L),
+        place = "Bremerton"
+    )
+)
+
+private fun previewSuccess(alerted: Boolean = false) = TripResultsUiState.Success(
+    options = previewOptions(alerted),
+    selectedIndex = 0,
+    directions = previewDirections(alerted)
+)
+
+/**
+ * Renders [state] as the drawer draws it. [metric] pins the unit system, which is both what makes these
+ * render at all and what lets one fixture be checked in either unit system.
+ */
+@Composable
+private fun TripDrawerPreviewFrame(state: TripResultsUiState, metric: Boolean = false) {
+    CompositionLocalProvider(LocalUnitsAreMetric provides metric) {
+        ObaTheme {
+            TripResultsList(state)
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 900, name = "Itinerary · full trip")
 @Composable
 private fun TripResultsPreview() {
-    ObaTheme {
-        val state = TripResultsUiState.Success(
-            options = listOf(
-                ItineraryOption(
-                    // Both joined badges side by side: a bus that becomes the 12 with the rider aboard,
-                    // chevroned (#2049), then an interchangeable rail pair, slashed (#2010) — the
-                    // transfer between them being too short to draw a glyph for (#2047).
-                    symbols = listOf(
-                        ModeSymbol.Street(StreetMode.WALK),
-                        ModeSymbol.Transit(
-                            LegBadge(
-                                listOf(
-                                    RouteBadge("8", 0xFF1B6EF3.toInt()),
-                                    RouteBadge("12", 0xFFD62828.toInt())
-                                ),
-                                TransitMode.BUS,
-                                RouteBadgeJoin.THEN
+    TripDrawerPreviewFrame(previewSuccess())
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 900, name = "Itinerary · metric units")
+@Composable
+private fun TripResultsMetricPreview() {
+    // The same trip in km/m. Worth its own preview because the unit swap changes how wide the option
+    // cards' distance lines run, which is where the summary symbols get squeezed.
+    TripDrawerPreviewFrame(previewSuccess(), metric = true)
+}
+
+/**
+ * Alerts on every travelling leg (#2143): a banner under each leg's own header, and the triangles on the
+ * option card marking the same two legs. Rendered in both themes — the severity container tints are the
+ * part most likely to go wrong in dark.
+ */
+@Preview(showBackground = true, widthDp = 400, heightDp = 900, name = "Itinerary · service alerts")
+@Preview(
+    showBackground = true,
+    widthDp = 400,
+    heightDp = 900,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "Itinerary · service alerts, dark"
+)
+@Composable
+private fun TripResultsAlertsPreview() {
+    TripDrawerPreviewFrame(previewSuccess(alerted = true))
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 240, name = "Itinerary · loading")
+@Composable
+private fun TripResultsLoadingPreview() {
+    TripDrawerPreviewFrame(TripResultsUiState.Loading)
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 240, name = "Itinerary · error")
+@Composable
+private fun TripResultsErrorPreview() {
+    TripDrawerPreviewFrame(TripResultsUiState.Error("No itineraries found between these places."))
+}
+
+// ---- transit-leg previews ------------------------------------------------------------------------
+//
+// One leg on its own, run through the same [rememberLogRows] pipeline the drawer uses, so what these
+// show is what the list draws — spine, band, nodes and all. A lone leg has no neighbouring leg to hand
+// its spine to, so the rail stops at the exit node rather than running on; that truncation is the
+// isolation, not a defect.
+
+/**
+ * Renders [entry] alone, [expanded] or not. The row callbacks are no-ops (nothing is tappable in a
+ * static preview) and the ETA strip is empty — it needs a live arrivals session, which is exactly the
+ * host dependency previewing one leg is meant to escape.
+ */
+@Composable
+private fun TransitLegPreviewFrame(entry: TripLogEntry.Transit, expanded: Boolean = false) {
+    CompositionLocalProvider(LocalUnitsAreMetric provides false) {
+        ObaTheme {
+            Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+                Column {
+                    rememberLogRows(listOf(entry), if (expanded) setOf(0) else emptySet()).forEach { row ->
+                        key(row.key) {
+                            LogRow(
+                                model = row,
+                                onToggle = {},
+                                onFocusRouteLeg = { _, _ -> },
+                                onFocusLeg = {},
+                                onFocusPoint = {},
+                                stopEtaStrip = { _, _ -> }
                             )
-                        ),
-                        ModeSymbol.Transit(
-                            LegBadge(
-                                listOf(
-                                    RouteBadge("1 Line", 0xFF00A651.toInt()),
-                                    RouteBadge("2 Line", 0xFF0075C4.toInt())
-                                ),
-                                TransitMode.RAIL,
-                                RouteBadgeJoin.ANY_OF
-                            )
-                        ),
-                        ModeSymbol.Street(StreetMode.WALK)
-                    ),
-                    durationMinutes = 32,
-                    startTime = ServerTime(0L),
-                    endTime = ServerTime(32 * 60_000L),
-                    streetDistanceMeters = mapOf(StreetMode.WALK to 800.0)
-                ),
-                ItineraryOption(
-                    // The second leg is a ferry, which publishes no route short name — so it badges its
-                    // long name, capped and ellipsized.
-                    symbols = listOf(
-                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("48", null)), TransitMode.BUS, RouteBadgeJoin.ANY_OF)),
-                        ModeSymbol.Street(StreetMode.WALK),
-                        ModeSymbol.Transit(LegBadge(listOf(RouteBadge("Seattle - Bremerton", null)), TransitMode.FERRY, RouteBadgeJoin.ANY_OF))
-                    ),
-                    durationMinutes = 41,
-                    startTime = ServerTime(0L),
-                    endTime = ServerTime(41 * 60_000L),
-                    streetDistanceMeters = mapOf(StreetMode.WALK to 400.0)
-                ),
-                ItineraryOption(
-                    // A bikeshare trip: walk to the dock, ride, walk from it (#2047).
-                    symbols = listOf(
-                        ModeSymbol.Street(StreetMode.WALK),
-                        ModeSymbol.Street(StreetMode.BIKESHARE),
-                        ModeSymbol.Street(StreetMode.WALK)
-                    ),
-                    durationMinutes = 18,
-                    startTime = ServerTime(0L),
-                    endTime = ServerTime(18 * 60_000L),
-                    // Both of its street modes measured, the ride as well as the walk (#2122).
-                    streetDistanceMeters = mapOf(StreetMode.WALK to 500.0, StreetMode.BIKESHARE to 2300.0)
-                )
-            ),
-            selectedIndex = 0,
-            directions = listOf(
-                TripLogEntry.Terminal(
-                    kind = TerminalKind.START,
-                    time = ServerTime(0L),
-                    place = "5th Ave & Pine St"
-                ),
-                TripLogEntry.Walk(
-                    mode = StreetMode.WALK,
-                    durationMinutes = 4,
-                    distanceMeters = 320.0,
-                    isTransfer = false,
-                    steps = listOf(LogStep("Head north on 5th Ave", distanceMeters = 107.0))
-                ),
-                TripLogEntry.Transit(
-                    routeShortName = "8",
-                    routeDisplayName = "Route 8",
-                    mode = TransitMode.BUS,
-                    routeColorHex = "1B6EF3",
-                    headsign = "Rainier Beach",
-                    reachStopTime = ServerTime(3 * 60_000L),
-                    boardTime = ServerTime(4 * 60_000L),
-                    exitTime = ServerTime(20 * 60_000L),
-                    durationMinutes = 16,
-                    realtime = RealtimeState.OnTime,
-                    // The same ride the first option's chevron badge stands for: boarded once as the 8,
-                    // becoming the 12 at Mount Baker without the rider getting off (#2000/#2049). Here
-                    // the header badges only the 8 and the 12 arrives at its own seam row (#2071).
-                    rideEvents = listOf(
-                        RideEvent.Stop(LogStop("Capitol Hill Station")),
-                        RideEvent.Stop(LogStop("23rd Ave & E Union St")),
-                        RideEvent.Transition(
-                            InterlineTransition(
-                                badge = RouteBadge("12", 0xFFD62828.toInt()),
-                                routeDisplayName = "Route 12",
-                                headsign = "Interlaken Park",
-                                stop = RouteStopRef("1_550", "550", "Mount Baker Transit Center", null)
-                            )
-                        ),
-                        RideEvent.Stop(LogStop("Rainier Ave S & S McClellan St"))
-                    ),
-                    routeLeg = RouteLegRef(
-                        routeId = "1_100",
-                        headsign = "Rainier Beach",
-                        board = RouteStopRef("1_500", "500", "Pine St & 3rd Ave", null),
-                        alight = RouteStopRef("1_600", "600", "Rainier & Alaska", null),
-                        badge = LegBadge(
-                            listOf(
-                                RouteBadge("8", 0xFF1B6EF3.toInt()),
-                                RouteBadge("12", 0xFFD62828.toInt())
-                            ),
-                            TransitMode.BUS,
-                            RouteBadgeJoin.THEN
-                        )
-                    )
-                ),
-                // A Washington State Ferries run: no route short name, so no badge — the long name is
-                // the row's title and the boat glyph rides the spine.
-                TripLogEntry.Transit(
-                    routeShortName = null,
-                    routeDisplayName = "Seattle - Bremerton",
-                    mode = TransitMode.FERRY,
-                    routeColorHex = null,
-                    headsign = "Bremerton",
-                    reachStopTime = ServerTime(20 * 60_000L),
-                    boardTime = ServerTime(24 * 60_000L),
-                    exitTime = ServerTime(84 * 60_000L),
-                    durationMinutes = 60,
-                    realtime = RealtimeState.Unknown,
-                    rideEvents = emptyList(),
-                    routeLeg = RouteLegRef(
-                        routeId = "95_74",
-                        headsign = "Bremerton",
-                        board = RouteStopRef("95_1", null, "Seattle Ferry Terminal", null),
-                        alight = RouteStopRef("95_2", null, "Bremerton Ferry Terminal", null)
-                    )
-                ),
-                TripLogEntry.Terminal(
-                    kind = TerminalKind.ARRIVE,
-                    time = ServerTime(90 * 60_000L),
-                    place = "Bremerton"
-                )
-            )
-        )
-        TripResultsList(state)
+                        }
+                    }
+                }
+            }
+        }
     }
+}
+
+@Preview(showBackground = true, widthDp = 400, name = "Transit leg · collapsed")
+@Composable
+private fun TransitLegPreview() {
+    // Board header, "N stops" meta + realtime chip, board stop — the ride's stops stay folded away.
+    TransitLegPreviewFrame(previewTransitLeg())
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 340, name = "Transit leg · expanded")
+@Composable
+private fun TransitLegExpandedPreview() {
+    // What the chevron reveals: every intermediate stop, on the ride's own coloured spine.
+    TransitLegPreviewFrame(previewTransitLeg(), expanded = true)
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 300, name = "Transit leg · service alert")
+@Composable
+private fun TransitLegAlertPreview() {
+    // The #2143 placement at leg scale: the banner sits under the route header and above "Get on at",
+    // which is the adjacency the whole change is about.
+    TransitLegPreviewFrame(previewTransitLeg(alerts = listOf(PREVIEW_BUS_ALERT)))
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 360, name = "Transit leg · two alerts")
+@Composable
+private fun TransitLegTwoAlertsPreview() {
+    // Loudest first, and two tinted cards stacked — the case where the leg header risks being crowded
+    // off the top of the row.
+    TransitLegPreviewFrame(previewTransitLeg(alerts = listOf(PREVIEW_FERRY_ALERT, PREVIEW_BUS_ALERT)))
+}
+
+@Preview(showBackground = true, widthDp = 400, name = "Transit leg · whichever comes first")
+@Composable
+private fun TransitLegInterchangeablePreview() {
+    // An interchangeable pair (#2010): one joined roundel plus the caption that says to board either.
+    TransitLegPreviewFrame(
+        previewTransitLeg(
+            routeShortName = "1 Line",
+            routeDisplayName = null,
+            mode = TransitMode.RAIL,
+            routeColorHex = "00A651",
+            headsign = "Angle Lake",
+            badge = PREVIEW_RAIL_PAIR_BADGE
+        )
+    )
+}
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 300, name = "Transit leg · interline seam")
+@Composable
+private fun TransitLegInterlinePreview() {
+    // A stay-aboard route change (#2000/#2071). The seam row shows whether or not the leg is expanded —
+    // it instructs the rider rather than merely annotating the ride — so this one stays collapsed.
+    TransitLegPreviewFrame(
+        previewTransitLeg(rideEvents = listOf(PREVIEW_RIDE_STOPS.first(), PREVIEW_INTERLINE_SEAM))
+    )
+}
+
+@Preview(showBackground = true, widthDp = 400, name = "Transit leg · unnamed route (ferry)")
+@Composable
+private fun TransitLegNoShortNamePreview() {
+    // No short name to badge, so the row leads with the long name and the boat glyph rides the spine —
+    // and with no GTFS colour, the whole leg falls back to one neutral hue rather than three.
+    TransitLegPreviewFrame(previewFerryLeg())
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -461,11 +461,15 @@ sealed interface TripResultsUiState {
      * @param options the itinerary option cards (1–3)
      * @param selectedIndex the currently-selected option
      * @param directions the directions for the selected option
+     * @param alerts the service alerts affecting the selected option (#2143), loudest first. Per
+     *   *option*, not per plan: which disruptions apply is exactly what distinguishes an itinerary
+     *   routed over suspended service from the one beside it that isn't.
      */
     data class Success(
         val options: List<ItineraryOption>,
         val selectedIndex: Int,
-        val directions: List<TripLogEntry>
+        val directions: List<TripLogEntry>,
+        val alerts: List<TripAlertItem> = emptyList()
     ) : TripResultsUiState
 
     data class Error(val message: String) : TripResultsUiState

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -66,9 +66,9 @@ sealed interface ModeSymbol {
      *
      * It marks only what the card draws. An alert on a leg the summary abbreviates away — one too short
      * for a glyph ([ModeSymbols.NEGLIGIBLE_STREET_METERS]), or a car leg the app has no art for — has no
-     * symbol to hang on, and is carried by the banner below the picker, which lists every alert
-     * unconditionally. Attributing it to a neighbouring symbol instead would point the rider at the
-     * wrong leg, which is worse than abbreviating it.
+     * symbol to hang on, and is carried by that leg's own row in the directions instead: the log draws
+     * every leg, however short, so the row is always there to hold it. Attributing it to a neighbouring
+     * symbol instead would point the rider at the wrong leg, which is worse than abbreviating it.
      */
     val alert: AlertSeverity?
 
@@ -179,7 +179,9 @@ sealed interface TripLogEntry {
         val steps: List<LogStep>,
         val legPoints: List<GeoPoint> = emptyList(),
         val focusPoint: GeoPoint? = null,
-        val legIndices: Set<Int> = emptySet()
+        val legIndices: Set<Int> = emptySet(),
+        /** This leg's service alerts, drawn under its header (#2143) — see [TripAlertItem]. */
+        val alerts: List<TripAlertItem> = emptyList()
     ) : TripLogEntry {
         /** This leg as the map's focus target — see [FocusedLeg]. */
         val focus: FocusedLeg get() = FocusedLeg(legPoints, legIndices)
@@ -222,7 +224,13 @@ sealed interface TripLogEntry {
         val rideEvents: List<RideEvent>,
         val routeLeg: RouteLegRef,
         val legPoints: List<GeoPoint> = emptyList(),
-        val legIndices: Set<Int> = emptySet()
+        val legIndices: Set<Int> = emptySet(),
+        /**
+         * This ride's service alerts, drawn under its route header (#2143) — see [TripAlertItem]. A
+         * folded interline chain carries the alerts of every leg it swallowed, deduped: the rider is
+         * aboard for all of them, and the chain draws only one header to hang them under.
+         */
+        val alerts: List<TripAlertItem> = emptyList()
     ) : TripLogEntry {
         /** This ride as the map's focus target — every leg of a folded chain; see [FocusedLeg]. */
         val focus: FocusedLeg get() = FocusedLeg(legPoints, legIndices)
@@ -476,16 +484,14 @@ sealed interface TripResultsUiState {
     /**
      * @param options the itinerary option cards (1–3)
      * @param selectedIndex the currently-selected option
-     * @param directions the directions for the selected option
-     * @param alerts the service alerts affecting the selected option (#2143), loudest first. Per
-     *   *option*, not per plan: which disruptions apply is exactly what distinguishes an itinerary
-     *   routed over suspended service from the one beside it that isn't.
+     * @param directions the directions for the selected option — each leg carrying its own service
+     *   alerts (#2143), so a disruption is drawn against the ride it actually affects rather than
+     *   pooled at the head of the itinerary
      */
     data class Success(
         val options: List<ItineraryOption>,
         val selectedIndex: Int,
-        val directions: List<TripLogEntry>,
-        val alerts: List<TripAlertItem> = emptyList()
+        val directions: List<TripLogEntry>
     ) : TripResultsUiState
 
     data class Error(val message: String) : TripResultsUiState

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -21,6 +21,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.GeoPoint
@@ -58,16 +59,31 @@ data class ItineraryOption(
 sealed interface ModeSymbol {
 
     /**
+     * The loudest service alert affecting the leg(s) this symbol stands for, or null when none do — the
+     * warning triangle the card draws beside it (#2143). Per *symbol* rather than per itinerary, so a
+     * card says **where** in the trip the trouble is: a rider scanning the picker can see that one
+     * option's rail leg is the suspended one while the option beside it rides a bus around it.
+     *
+     * It marks only what the card draws. An alert on a leg the summary abbreviates away — one too short
+     * for a glyph ([ModeSymbols.NEGLIGIBLE_STREET_METERS]), or a car leg the app has no art for — has no
+     * symbol to hang on, and is carried by the banner below the picker, which lists every alert
+     * unconditionally. Attributing it to a neighbouring symbol instead would point the rider at the
+     * wrong leg, which is worse than abbreviating it.
+     */
+    val alert: AlertSeverity?
+
+    /**
      * An on-street leg, drawn as its mode's glyph alone — how the rider covers the ground between (or
      * instead of) rides. Legs shorter than [ModeSymbols.NEGLIGIBLE_STREET_METERS] carry no symbol at
      * all; see there for why.
      */
-    data class Street(val mode: StreetMode) : ModeSymbol
+    data class Street(val mode: StreetMode, override val alert: AlertSeverity? = null) : ModeSymbol
 
     /** A ride, drawn as one route roundel — which names every route it can be taken on, or becomes
      *  along the way (see [LegBadge]), and falls back to the mode glyph for a ride that names no
-     *  route. One symbol per *boarding*, so a stay-aboard interline is one roundel, not two. */
-    data class Transit(val badge: LegBadge) : ModeSymbol
+     *  route. One symbol per *boarding*, so a stay-aboard interline is one roundel, not two — and one
+     *  triangle, marking an alert on any leg of the chain. */
+    data class Transit(val badge: LegBadge, override val alert: AlertSeverity? = null) : ModeSymbol
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
@@ -80,11 +80,9 @@ class TripResultsViewModel @Inject constructor(
                     _state.value = TripResultsUiState.Success(
                         options = options,
                         selectedIndex = selectedIndex,
-                        directions = directions,
-                        // A pure projection of the plan the server already sent (#2143) — no I/O, so
-                        // it doesn't go through the repository, and the banner can't lag the
-                        // directions it sits above.
-                        alerts = selected?.alertItems().orEmpty()
+                        // Each leg carries its own alerts (#2143), attached as the log is built, so an
+                        // alert can't lag or outlive the leg it is drawn under.
+                        directions = directions
                     )
                 },
                 onFailure = { error ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
@@ -73,13 +73,18 @@ class TripResultsViewModel @Inject constructor(
         viewModelScope.launch {
             repository.summarize(itineraries).fold(
                 onSuccess = { options ->
-                    val directions = itineraries.getOrNull(selectedIndex)
+                    val selected = itineraries.getOrNull(selectedIndex)
+                    val directions = selected
                         ?.let { repository.directionsFor(it).getOrDefault(emptyList()) }
                         .orEmpty()
                     _state.value = TripResultsUiState.Success(
                         options = options,
                         selectedIndex = selectedIndex,
-                        directions = directions
+                        directions = directions,
+                        // A pure projection of the plan the server already sent (#2143) — no I/O, so
+                        // it doesn't go through the repository, and the banner can't lag the
+                        // directions it sits above.
+                        alerts = selected?.alertItems().orEmpty()
                     )
                 },
                 onFailure = { error ->

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -983,9 +983,15 @@
          expands the alert to its full description. -->
     <string name="directions_alert_show_details">Show alert details</string>
     <string name="directions_alert_hide_details">Hide alert details</string>
+    <!-- Localized labels for the shared alert tones. These are announced on every severity-tinted
+         alert card and interpolated into the affected-leg marker below. -->
+    <string name="service_alert_severity_info">Information</string>
+    <string name="service_alert_severity_warning">Warning</string>
+    <string name="service_alert_severity_severe">Severe</string>
     <!-- Read after a leg's symbol on an itinerary option card when a service alert affects that leg.
-         Announced in place, so it reads e.g. "1 Line, service alert". -->
-    <string name="directions_leg_service_alert">service alert</string>
+         %1$s is the localized severity label, announced in place so it reads e.g.
+         "1 Line, Severe service alert". -->
+    <string name="directions_leg_service_alert">%1$s service alert</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -983,6 +983,9 @@
          expands the alert to its full description. -->
     <string name="directions_alert_show_details">Show alert details</string>
     <string name="directions_alert_hide_details">Hide alert details</string>
+    <!-- Read after a leg's symbol on an itinerary option card when a service alert affects that leg.
+         Announced in place, so it reads e.g. "1 Line, service alert". -->
+    <string name="directions_leg_service_alert">service alert</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -979,6 +979,10 @@
     <!-- Spoken state of each departure drawn before that rule: one leaving before the rider can be at
          the stop. Read on the departure itself, since its dimmed appearance says nothing aloud. -->
     <string name="directions_stop_eta_departure_missed">Leaves before you get here</string>
+    <!-- Content descriptions for the chevron on a service-alert banner above the directions, which
+         expands the alert to its full description. -->
+    <string name="directions_alert_show_details">Show alert details</string>
+    <string name="directions_alert_hide_details">Hide alert details</string>
     <!-- Content descriptions for the chevrons that hint the itinerary-option picker can scroll sideways -->
     <string name="trip_plan_options_scroll_previous">Show previous options</string>
     <string name="trip_plan_options_scroll_more">Show more options</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -29,8 +29,10 @@ import org.onebusaway.android.api.graphql.fragment.AlternativeRouteFields
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
 import org.onebusaway.android.api.graphql.fragment.RouteFields
 import org.onebusaway.android.api.graphql.type.AbsoluteDirection
+import org.onebusaway.android.api.graphql.type.AlertSeverityLevelType
 import org.onebusaway.android.api.graphql.type.Mode
 import org.onebusaway.android.api.graphql.type.RelativeDirection
+import org.onebusaway.android.directions.model.TripAlertSeverity
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripRelativeDirection
 import org.onebusaway.android.directions.model.TripVertexType
@@ -82,7 +84,9 @@ class Otp2PlanDecodeTest {
                 )
             ),
             // A non-transit leg has no alternatives — OTP returns null rather than erroring.
-            nextLegs = null
+            nextLegs = null,
+            // Nor any alerts; OTP returns an empty list rather than null on a leg with nothing to report.
+            alerts = emptyList()
         )
         val busLeg = PlanQuery.Leg(
             mode = Mode.BUS,
@@ -130,6 +134,24 @@ class Otp2PlanDecodeTest {
                     trip = PlanQuery.Trip1(tripHeadsign = "Downtown via 7th"),
                     from = PlanQuery.From1(stop = PlanQuery.Stop(gtfsId = "1_1001")),
                     to = PlanQuery.To1(stop = PlanQuery.Stop1(gtfsId = "1_1002"))
+                )
+            ),
+            // Two alerts OTP scoped to this leg (#2143): one it stated a severity for, one it did
+            // not, and one whose header/url the feed left blank.
+            alerts = listOf(
+                PlanQuery.Alert(
+                    id = "alert_1",
+                    alertHeaderText = "5 is on reroute",
+                    alertDescriptionText = "Detoured via 4th Ave. See https://example.org/detour",
+                    alertUrl = "https://example.org/detour",
+                    alertSeverityLevel = AlertSeverityLevelType.SEVERE
+                ),
+                PlanQuery.Alert(
+                    id = "alert_2",
+                    alertHeaderText = "",
+                    alertDescriptionText = "Elevator out of service",
+                    alertUrl = "",
+                    alertSeverityLevel = null
                 )
             )
         )
@@ -215,6 +237,23 @@ class Otp2PlanDecodeTest {
         assertEquals("1_1002", alternative.toStopId)
         // A walk leg's `nextLegs` is null on the wire, not an error — it maps to no alternatives.
         assertTrue(walk.alternatives.isEmpty())
+
+        // The leg's service alerts (#2143) come across as OTP scoped them, severity included.
+        assertEquals(2, bus.alerts.size)
+        val severe = bus.alerts[0]
+        assertEquals("alert_1", severe.id)
+        assertEquals("5 is on reroute", severe.header)
+        assertEquals("Detoured via 4th Ave. See https://example.org/detour", severe.description)
+        assertEquals("https://example.org/detour", severe.url)
+        assertEquals(TripAlertSeverity.SEVERE, severe.severity)
+        // Blank header/url normalize to null (one representation of "the feed didn't publish this"),
+        // and an unstated severity lands on the wire vocabulary's own UNKNOWN_SEVERITY token.
+        val unstated = bus.alerts[1]
+        assertNull(unstated.header)
+        assertNull(unstated.url)
+        assertEquals("Elevator out of service", unstated.description)
+        assertEquals(TripAlertSeverity.UNKNOWN_SEVERITY, unstated.severity)
+        assertTrue(walk.alerts.isEmpty())
     }
 
     /** An unrecognized wire `Mode` (Apollo's `UNKNOWN__` sentinel) must degrade to null, not throw. */
@@ -275,7 +314,8 @@ class Otp2PlanDecodeTest {
             stopCalls = stopCalls,
             legGeometry = null,
             steps = null,
-            nextLegs = null
+            nextLegs = null,
+            alerts = emptyList()
         )
         val node = PlanQuery.Node(
             start = itineraryStart,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsAlertPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsAlertPlanTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.contentKey
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 
 /**
  * Unit tests for [planActiveAlerts], the pure fold that turns a stop's situations into active-alert

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -31,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 
 /** The arguments of a single [ArrivalsRepository.favoriteRoute] call, for assertions. */
 private data class FavoriteRouteCall(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
@@ -357,7 +357,8 @@ class Otp2PlanResolveTest {
             stopCalls = emptyList(),
             legGeometry = null,
             steps = null,
-            nextLegs = null
+            nextLegs = null,
+            alerts = emptyList()
         )
         val node = PlanQuery.Node(
             start = "2026-07-11T10:00:00-07:00",

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
@@ -18,10 +18,13 @@ package org.onebusaway.android.ui.tripresults
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.TripAlert
+import org.onebusaway.android.directions.model.TripAlertSeverity
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 
 /**
  * JVM tests for [ModeSymbols]: an itinerary read as one left-to-right symbol sequence — the on-street
@@ -33,11 +36,16 @@ import org.onebusaway.android.directions.model.TripVertexType
  */
 class ModeSymbolsTest {
 
-    private fun transit(route: String, interline: Boolean = false) = TripLeg(
+    private fun transit(
+        route: String,
+        interline: Boolean = false,
+        alerts: List<TripAlert> = emptyList()
+    ) = TripLeg(
         mode = TripMode.BUS,
         routeId = route,
         routeShortName = route,
-        interlineWithPreviousLeg = interline
+        interlineWithPreviousLeg = interline,
+        alerts = alerts
     )
 
     private fun walk(meters: Double) = TripLeg(mode = TripMode.WALK, distance = meters)
@@ -216,6 +224,77 @@ class ModeSymbolsTest {
             listOf(walk(FAR), transit("8"), walk(NEAR)).streetDistancesMeters()
         )
     }
+
+    // ---- Per-symbol alert markers (#2143) --------------------------------------------------------
+
+    /** The alert tone marking each symbol, aligned to [symbolsOf]. */
+    private fun alertsOf(legs: List<TripLeg>): List<AlertSeverity?> = ModeSymbols.forLegs(legs, legs.map { emptyList() }).map { it.alert }
+
+    @Test
+    fun onlyTheAlertedLegsSymbolIsMarked() {
+        val legs = listOf(longWalk, transit("8", alerts = listOf(alert())), longWalk, transit("40"))
+
+        assertEquals(listOf(null, AlertSeverity.WARNING, null, null), alertsOf(legs))
+    }
+
+    /** The marker is the loudest of the leg's alerts — a suspension can't be hidden by a notice. */
+    @Test
+    fun aLegShowsItsLoudestAlert() {
+        val legs = listOf(
+            transit(
+                "8",
+                alerts = listOf(
+                    alert(TripAlertSeverity.INFO),
+                    alert(TripAlertSeverity.SEVERE),
+                    alert(TripAlertSeverity.WARNING)
+                )
+            )
+        )
+
+        assertEquals(listOf(AlertSeverity.ERROR), alertsOf(legs))
+    }
+
+    /**
+     * A stay-aboard interline is one roundel (see the folding tests above), so an alert on the leg the
+     * vehicle *continues* as still marks the ride the rider actually boards.
+     */
+    @Test
+    fun anInterlinedRideIsMarkedByAnAlertOnAnyLegOfTheChain() {
+        val legs = listOf(
+            transit("5"),
+            transit("12", interline = true, alerts = listOf(alert(TripAlertSeverity.SEVERE)))
+        )
+
+        assertEquals(listOf(listOf("5", "12")), symbolsOf(legs))
+        assertEquals(listOf(AlertSeverity.ERROR), alertsOf(legs))
+    }
+
+    /**
+     * Consecutive street legs collapse to one glyph, so the surviving glyph has to carry the alert the
+     * collapsed leg brought — otherwise the merge silently drops it.
+     */
+    @Test
+    fun aMergedRunOfWalksKeepsTheLoudestAlertAmongThem() {
+        val legs = listOf(
+            walk(FAR),
+            walk(FAR).copy(alerts = listOf(alert(TripAlertSeverity.SEVERE))),
+            walk(FAR).copy(alerts = listOf(alert(TripAlertSeverity.INFO)))
+        )
+
+        assertEquals(listOf(StreetMode.WALK), symbolsOf(legs))
+        assertEquals(listOf(AlertSeverity.ERROR), alertsOf(legs))
+    }
+
+    /** The street-only fallback is still a leg, and still says when that leg has an alert. */
+    @Test
+    fun theShortStrollFallbackCarriesItsAlert() {
+        val legs = listOf(walk(NEAR).copy(alerts = listOf(alert(TripAlertSeverity.SEVERE))))
+
+        assertEquals(listOf(StreetMode.WALK), symbolsOf(legs))
+        assertEquals(listOf(AlertSeverity.ERROR), alertsOf(legs))
+    }
+
+    private fun alert(severity: TripAlertSeverity = TripAlertSeverity.WARNING) = TripAlert(id = "a", header = "Heads up", severity = severity)
 
     private fun interchangeable(shortName: String) = InterchangeableRoute(
         routeId = "route_$shortName",

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripAlertsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripAlertsTest.kt
@@ -22,80 +22,85 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.TripAlert
 import org.onebusaway.android.directions.model.TripAlertSeverity
-import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.ui.compose.components.AlertSeverity
 
-/** Covers [alertItems], the pure projection of an itinerary's leg alerts onto the banner rows (#2143). */
+/** Covers [alertItems], the pure projection of a leg's own alerts onto the rows drawn under its header (#2143). */
 class TripAlertsTest {
 
+    /** The #1593 shape, scoped to one leg: a feed republishing the same disruption under a fresh id. */
     @Test
-    fun collapsesTheSameAlertAcrossLegsAndNamesEveryRideItApplies() {
+    fun aRepublishedDuplicateOnOneLegCollapsesToOneRow() {
         val suspension = alert(id = "a1", header = "1 Line service is suspended")
-        val plan = itinerary(
-            walkLeg(),
-            transitLeg(shortName = "1 Line", alerts = listOf(suspension)),
-            walkLeg(),
-            // The same disruption, republished under a fresh id — the #1593 shape. Identity is the
-            // content, so this must not become a second row.
-            transitLeg(shortName = "2 Line", alerts = listOf(suspension.copy(id = "a2")))
+        val leg = transitLeg(
+            shortName = "1 Line",
+            alerts = listOf(suspension, suspension.copy(id = "a2"))
         )
 
-        val items = plan.alertItems()
+        val items = leg.alertItems()
 
         assertEquals(1, items.size)
         assertEquals("1 Line service is suspended", items[0].summary)
-        assertEquals(listOf("1 Line", "2 Line"), items[0].routeLabels)
+    }
+
+    /**
+     * The point of placing alerts per leg: one disruption spanning two rides is a fact about *each* of
+     * them, and each leg draws it under its own header. Collapsing the pair into a single row is what
+     * the head-of-itinerary banner did, and it left the rider to work out which ride was affected.
+     */
+    @Test
+    fun theSameAlertOnTwoLegsIsDrawnUnderEach() {
+        val suspension = alert(id = "a1", header = "1 Line service is suspended")
+        val first = transitLeg(shortName = "1 Line", alerts = listOf(suspension))
+        // Republished under a fresh id on the second leg — still one row there, and still its own row.
+        val second = transitLeg(shortName = "2 Line", alerts = listOf(suspension.copy(id = "a2")))
+
+        assertEquals("1 Line service is suspended", first.alertItems().single().summary)
+        assertEquals("1 Line service is suspended", second.alertItems().single().summary)
     }
 
     @Test
-    fun ordersLoudestFirstAndKeepsTravelOrderWithinATone() {
-        val plan = itinerary(
-            transitLeg(
-                shortName = "5",
-                alerts = listOf(
-                    alert(id = "info", header = "Stop moved", severity = TripAlertSeverity.INFO),
-                    alert(id = "warn1", header = "Crowding expected", severity = TripAlertSeverity.WARNING),
-                    alert(id = "severe", header = "No service", severity = TripAlertSeverity.SEVERE),
-                    alert(id = "warn2", header = "Elevator out", severity = TripAlertSeverity.WARNING)
-                )
+    fun ordersLoudestFirstAndKeepsFeedOrderWithinATone() {
+        val leg = transitLeg(
+            shortName = "5",
+            alerts = listOf(
+                alert(id = "info", header = "Stop moved", severity = TripAlertSeverity.INFO),
+                alert(id = "warn1", header = "Crowding expected", severity = TripAlertSeverity.WARNING),
+                alert(id = "severe", header = "No service", severity = TripAlertSeverity.SEVERE),
+                alert(id = "warn2", header = "Elevator out", severity = TripAlertSeverity.WARNING)
             )
         )
 
         assertEquals(
             listOf("No service", "Crowding expected", "Elevator out", "Stop moved"),
-            plan.alertItems().map { it.summary }
+            leg.alertItems().map { it.summary }
         )
         assertEquals(
             listOf(AlertSeverity.ERROR, AlertSeverity.WARNING, AlertSeverity.WARNING, AlertSeverity.INFO),
-            plan.alertItems().map { it.severity }
+            leg.alertItems().map { it.severity }
         )
     }
 
     /** An unstated severity is still an alert — it must not be demoted below a stated warning. */
     @Test
     fun unstatedSeverityIsDrawnAsAWarning() {
-        val plan = itinerary(
-            transitLeg(
-                shortName = "5",
-                alerts = listOf(alert(id = "a", header = "Something happened", severity = TripAlertSeverity.UNKNOWN_SEVERITY))
-            )
+        val leg = transitLeg(
+            shortName = "5",
+            alerts = listOf(alert(id = "a", header = "Something happened", severity = TripAlertSeverity.UNKNOWN_SEVERITY))
         )
 
-        assertEquals(AlertSeverity.WARNING, plan.alertItems().single().severity)
+        assertEquals(AlertSeverity.WARNING, leg.alertItems().single().severity)
     }
 
     @Test
     fun headerlessAlertLeadsWithItsDescriptionAndDoesNotRepeatIt() {
-        val plan = itinerary(
-            transitLeg(
-                shortName = "5",
-                alerts = listOf(alert(id = "a", header = null, description = "Reroute in effect"))
-            )
+        val leg = transitLeg(
+            shortName = "5",
+            alerts = listOf(alert(id = "a", header = null, description = "Reroute in effect"))
         )
 
-        val item = plan.alertItems().single()
+        val item = leg.alertItems().single()
         assertEquals("Reroute in effect", item.summary)
         assertNull(item.description)
         // The url is still detail worth expanding for, so the row keeps its tap target.
@@ -104,47 +109,64 @@ class TripAlertsTest {
 
     @Test
     fun alertWithNoRiderVisibleTextIsDropped() {
-        val plan = itinerary(
-            transitLeg(shortName = "5", alerts = listOf(alert(id = "a", header = null, description = null)))
-        )
+        val leg = transitLeg(shortName = "5", alerts = listOf(alert(id = "a", header = null, description = null)))
 
-        assertTrue(plan.alertItems().isEmpty())
+        assertTrue(leg.alertItems().isEmpty())
     }
 
     /** A headline with nothing behind it takes no tap target — the row must say so. */
     @Test
     fun headlineOnlyAlertHasNoDetail() {
-        val plan = itinerary(
-            transitLeg(
-                shortName = "5",
-                alerts = listOf(alert(id = "a", header = "Crowding expected", description = null, url = null))
-            )
+        val leg = transitLeg(
+            shortName = "5",
+            alerts = listOf(alert(id = "a", header = "Crowding expected", description = null, url = null))
         )
 
-        assertFalse(plan.alertItems().single().hasDetail)
+        assertFalse(leg.alertItems().single().hasDetail)
     }
 
-    /** A leg whose route publishes no name at all contributes no label rather than a blank one. */
+    /**
+     * A walk carries alerts too, and has its own header to draw them under — so nothing an itinerary-wide
+     * banner used to pool is lost by moving the rows onto the legs.
+     */
     @Test
-    fun unnamedRouteContributesNoLabel() {
-        val plan = itinerary(
-            TripLeg(
-                mode = TripMode.FERRY,
-                alerts = listOf(alert(id = "a", header = "Dock closed"))
-            )
-        )
+    fun aWalkLegProjectsItsOwnAlerts() {
+        val leg = TripLeg(mode = TripMode.WALK, alerts = listOf(alert(id = "a", header = "Sidewalk closed")))
 
-        assertEquals(emptyList<String>(), plan.alertItems().single().routeLabels)
+        assertEquals("Sidewalk closed", leg.alertItems().single().summary)
     }
 
     @Test
-    fun anItineraryWithNoAlertsProducesNoRows() {
-        assertTrue(itinerary(walkLeg(), transitLeg(shortName = "5")).alertItems().isEmpty())
+    fun aLegWithNoAlertsProducesNoRows() {
+        assertTrue(transitLeg(shortName = "5").alertItems().isEmpty())
     }
 
-    private fun itinerary(vararg legs: TripLeg) = TripItinerary(legs = legs.toList())
+    /**
+     * What a folded interline chain draws: the continuation's alerts joined to the leader's under the
+     * one header they share — an alert scoped to the whole chain drawn once, and the merged set still
+     * loudest-first rather than in the order the legs happened to be folded.
+     */
+    @Test
+    fun mergingLegsKeepsOneRowPerAlertLoudestFirst() {
+        val chainWide = alert(id = "chain", header = "Bridge is up")
+        val leader = transitLeg(
+            shortName = "8",
+            alerts = listOf(chainWide, alert(id = "a", header = "Stop moved", severity = TripAlertSeverity.INFO))
+        ).alertItems()
+        // The same chain-wide alert again (republished id), plus one louder than anything the leader had.
+        val continuation = transitLeg(
+            shortName = "12",
+            alerts = listOf(
+                chainWide.copy(id = "chain2"),
+                alert(id = "b", header = "No service after 9 PM", severity = TripAlertSeverity.SEVERE)
+            )
+        ).alertItems()
 
-    private fun walkLeg() = TripLeg(mode = TripMode.WALK)
+        assertEquals(
+            listOf("No service after 9 PM", "Bridge is up", "Stop moved"),
+            leader.mergedWith(continuation).map { it.summary }
+        )
+    }
 
     private fun transitLeg(shortName: String, alerts: List<TripAlert> = emptyList()) = TripLeg(
         mode = TripMode.BUS,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripAlertsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripAlertsTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.directions.model.TripAlert
+import org.onebusaway.android.directions.model.TripAlertSeverity
+import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.ui.compose.components.AlertSeverity
+
+/** Covers [alertItems], the pure projection of an itinerary's leg alerts onto the banner rows (#2143). */
+class TripAlertsTest {
+
+    @Test
+    fun collapsesTheSameAlertAcrossLegsAndNamesEveryRideItApplies() {
+        val suspension = alert(id = "a1", header = "1 Line service is suspended")
+        val plan = itinerary(
+            walkLeg(),
+            transitLeg(shortName = "1 Line", alerts = listOf(suspension)),
+            walkLeg(),
+            // The same disruption, republished under a fresh id — the #1593 shape. Identity is the
+            // content, so this must not become a second row.
+            transitLeg(shortName = "2 Line", alerts = listOf(suspension.copy(id = "a2")))
+        )
+
+        val items = plan.alertItems()
+
+        assertEquals(1, items.size)
+        assertEquals("1 Line service is suspended", items[0].summary)
+        assertEquals(listOf("1 Line", "2 Line"), items[0].routeLabels)
+    }
+
+    @Test
+    fun ordersLoudestFirstAndKeepsTravelOrderWithinATone() {
+        val plan = itinerary(
+            transitLeg(
+                shortName = "5",
+                alerts = listOf(
+                    alert(id = "info", header = "Stop moved", severity = TripAlertSeverity.INFO),
+                    alert(id = "warn1", header = "Crowding expected", severity = TripAlertSeverity.WARNING),
+                    alert(id = "severe", header = "No service", severity = TripAlertSeverity.SEVERE),
+                    alert(id = "warn2", header = "Elevator out", severity = TripAlertSeverity.WARNING)
+                )
+            )
+        )
+
+        assertEquals(
+            listOf("No service", "Crowding expected", "Elevator out", "Stop moved"),
+            plan.alertItems().map { it.summary }
+        )
+        assertEquals(
+            listOf(AlertSeverity.ERROR, AlertSeverity.WARNING, AlertSeverity.WARNING, AlertSeverity.INFO),
+            plan.alertItems().map { it.severity }
+        )
+    }
+
+    /** An unstated severity is still an alert — it must not be demoted below a stated warning. */
+    @Test
+    fun unstatedSeverityIsDrawnAsAWarning() {
+        val plan = itinerary(
+            transitLeg(
+                shortName = "5",
+                alerts = listOf(alert(id = "a", header = "Something happened", severity = TripAlertSeverity.UNKNOWN_SEVERITY))
+            )
+        )
+
+        assertEquals(AlertSeverity.WARNING, plan.alertItems().single().severity)
+    }
+
+    @Test
+    fun headerlessAlertLeadsWithItsDescriptionAndDoesNotRepeatIt() {
+        val plan = itinerary(
+            transitLeg(
+                shortName = "5",
+                alerts = listOf(alert(id = "a", header = null, description = "Reroute in effect"))
+            )
+        )
+
+        val item = plan.alertItems().single()
+        assertEquals("Reroute in effect", item.summary)
+        assertNull(item.description)
+        // The url is still detail worth expanding for, so the row keeps its tap target.
+        assertTrue(item.hasDetail)
+    }
+
+    @Test
+    fun alertWithNoRiderVisibleTextIsDropped() {
+        val plan = itinerary(
+            transitLeg(shortName = "5", alerts = listOf(alert(id = "a", header = null, description = null)))
+        )
+
+        assertTrue(plan.alertItems().isEmpty())
+    }
+
+    /** A headline with nothing behind it takes no tap target — the row must say so. */
+    @Test
+    fun headlineOnlyAlertHasNoDetail() {
+        val plan = itinerary(
+            transitLeg(
+                shortName = "5",
+                alerts = listOf(alert(id = "a", header = "Crowding expected", description = null, url = null))
+            )
+        )
+
+        assertFalse(plan.alertItems().single().hasDetail)
+    }
+
+    /** A leg whose route publishes no name at all contributes no label rather than a blank one. */
+    @Test
+    fun unnamedRouteContributesNoLabel() {
+        val plan = itinerary(
+            TripLeg(
+                mode = TripMode.FERRY,
+                alerts = listOf(alert(id = "a", header = "Dock closed"))
+            )
+        )
+
+        assertEquals(emptyList<String>(), plan.alertItems().single().routeLabels)
+    }
+
+    @Test
+    fun anItineraryWithNoAlertsProducesNoRows() {
+        assertTrue(itinerary(walkLeg(), transitLeg(shortName = "5")).alertItems().isEmpty())
+    }
+
+    private fun itinerary(vararg legs: TripLeg) = TripItinerary(legs = legs.toList())
+
+    private fun walkLeg() = TripLeg(mode = TripMode.WALK)
+
+    private fun transitLeg(shortName: String, alerts: List<TripAlert> = emptyList()) = TripLeg(
+        mode = TripMode.BUS,
+        routeShortName = shortName,
+        alerts = alerts
+    )
+
+    private fun alert(
+        id: String,
+        header: String? = "Header",
+        description: String? = "Description",
+        url: String? = "https://example.org",
+        severity: TripAlertSeverity = TripAlertSeverity.WARNING
+    ) = TripAlert(id = id, header = header, description = description, url = url, severity = severity)
+}


### PR DESCRIPTION
Closes #2143.

An itinerary routed over suspended service looks exactly like a good one: same badges, same clock
times, a route line drawn across the map. Alerts reach the stop header and the arrivals drawer's route
rows, but nothing in the trip planner — so during the Link downtown suspension the planner kept
offering impossible trips with no way to tell.

## What it does

**Asks OTP for each leg's alerts** (`Leg.alerts` in `Plan.graphql`). It rides along with the plan, so
it costs no extra request.

**Draws them under the option cards**, above the directions, severity-tinted and expandable in place to
the feed's full description plus the agency's own page. Which alerts show follows the *selected*
option, since that is exactly what distinguishes a broken itinerary from the one next to it.

**Marks the affected legs on the option cards** with a warning triangle beside the mode symbol, so a
card says *where* the trouble is: `[walk] › [1 Line]⚠ › [walk]`. A rider scanning the picker can see
that one option's rail leg is the suspended one while the option beside it rides a bus around it.

## Server evidence, and what is deliberately *not* done here

OTP scopes `Leg.alerts` two ways — to the entities the leg uses, and to the leg's own time window.
The second was verified against the live server rather than assumed:

| plan for | alert ending today | open-ended derailment alert |
|---|---|---|
| today | attaches | attaches |
| Aug 3 / Aug 10 | **drops** | attaches |

So **there is no active-window check on the client side of this field**, and none should be added —
re-deciding it here would mean re-implementing the server's rule against a `to`/`from` pair this query
doesn't even ask for.

Rows are keyed on alert *content*, not id, so a republished duplicate (the #1593 shape) and the same
alert riding two legs of one trip both collapse to one row.

The OTP1 path stays empty by fact, not omission: the REST `/plan` those regions serve carries no leg
alerts at all (checked against the live OTP1 server), so it is documented alongside the existing
OTP2-only `alternatives` / `interlineWithPreviousLeg` fields.

## Also in the diff

`AlertSeverity` and the severity→container-colour table move to a shared `AlertSurface`, so a severe
alert can't read as urgent on the arrivals screen and merely advisory in the planner. That is why the
arrivals files are touched.

## Testing

- New `TripAlertsTest` (dedupe across legs, loudest-first ordering, unstated severity, header-less
  alerts, text-less alerts dropped, unnamed routes).
- Five new `ModeSymbolsTest` cases for the card markers — including the two places a symbol stands for
  more than one leg: an interline chain marked by an alert on any of its legs, and a merged run of
  walks keeping the loudest alert its members brought (which is why collapsing consecutive street
  symbols is now a merge rather than a filter).
- `Otp2PlanDecodeTest` extended for the new field.
- Full unit suite green; `obaGoogle` + `obaMaplibre` compile clean under `-PwarningsAsErrors=true`;
  androidTest sources compile; spotless clean.

Device-verified on a Pixel 7 Pro against the live Link suspension.

## Known gap

The card marks only the symbols it draws. An alert on a leg the summary abbreviates away — one under
the negligible-distance threshold, or a car leg the app ships no art for — appears only in the banner,
which lists everything. Hanging it on a neighbouring symbol would point the rider at the wrong leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added service alerts to trip-planning results, including affected routes, severity indicators, expandable details, descriptions, and links.
  - Trip and leg symbols now display alerts, showing the highest applicable severity across connected journeys.
  - Added localized accessibility announcements for alert severity and detail controls.
  - Standardized metric and imperial unit handling across trip results, directions, and region views.
  - Improved arrivals alert styling with consistent severity-based presentation.

- **Tests**
  - Added coverage for alert decoding, grouping, severity handling, accessibility, units, and visual indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
