### PR TITLE
Decode the no-prediction sentinel when the server adds slack to it (#2144)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -38,16 +38,19 @@ internal fun ArrivalDeparture.asArrivalData(directionId: Int?): ArrivalData? = t
  * discard that row instead of inventing one from the frequency window.
  *
  * Requiring a frequency row and all four timestamps to agree keeps this tied to the server path that
- * collapses the schedule; the suffix check is an arithmetic signature, not a magnitude threshold.
+ * collapses the schedule. For the positive spelling, the arithmetic signature (`999` milliseconds)
+ * is not sufficient by itself because a real epoch can have that suffix; the candidate must also
+ * predate the frequency service window. We deliberately do not impose an upper bound because visits
+ * at downstream stops can occur after the trip-origin frequency window ends.
  */
 private val ArrivalDeparture.hasCollapsedFrequencySentinel: Boolean
     get() {
+        val frequencyStartTime = frequency?.startTime ?: return false
         val candidate = predictedArrivalTime
-        return frequency != null &&
-            predictedDepartureTime == candidate &&
+        return predictedDepartureTime == candidate &&
             scheduledArrivalTime == candidate &&
             scheduledDepartureTime == candidate &&
-            (candidate <= 0L || candidate % 1_000L == 999L)
+            (candidate <= 0L || (candidate < frequencyStartTime && candidate % 1_000L == 999L))
     }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -22,8 +22,33 @@ import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServerTime
 
-/** Adapts a modernized [ArrivalDeparture] DTO (arrivals fetch) to the [ArrivalData] model. */
-internal fun ArrivalDeparture.asArrivalData(directionId: Int?): ArrivalData = DtoArrivalData(this, directionId)
+/**
+ * Adapts a modernized [ArrivalDeparture] DTO (arrivals fetch) to the [ArrivalData] model, or drops an
+ * unrecoverable frequency row whose scheduled and predicted times were all replaced by the server's
+ * no-prediction sentinel.
+ */
+internal fun ArrivalDeparture.asArrivalData(directionId: Int?): ArrivalData? = takeUnless { hasCollapsedFrequencySentinel }?.let { DtoArrivalData(it, directionId) }
+
+/**
+ * For a frequency instance, the server's predicted-time setters also overwrite the corresponding
+ * scheduled times. When both timepoint predictions are absent, that destroys the original scheduled
+ * dwell and leaves all four timestamps equal to either the bare sentinel (`-1` / `0`) or its
+ * `slack * 1000 - 1` spelling. The positive spelling always ends in `999`, because schedule slack is
+ * whole seconds. With neither a prediction nor a schedule left, there is no honest time to display;
+ * discard that row instead of inventing one from the frequency window.
+ *
+ * Requiring a frequency row and all four timestamps to agree keeps this tied to the server path that
+ * collapses the schedule; the suffix check is an arithmetic signature, not a magnitude threshold.
+ */
+private val ArrivalDeparture.hasCollapsedFrequencySentinel: Boolean
+    get() {
+        val candidate = predictedArrivalTime
+        return frequency != null &&
+            predictedDepartureTime == candidate &&
+            scheduledArrivalTime == candidate &&
+            scheduledDepartureTime == candidate &&
+            (candidate <= 0L || candidate % 1_000L == 999L)
+    }
 
 /**
  * Decodes a wire `predicted{Arrival,Departure}Time` into "the instant" or **`null`** ("no prediction"),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/ArrivalAdapters.kt
@@ -26,15 +26,39 @@ import org.onebusaway.android.time.ServerTime
 internal fun ArrivalDeparture.asArrivalData(directionId: Int?): ArrivalData = DtoArrivalData(this, directionId)
 
 /**
- * A closed (or otherwise suppressed) stop keeps `predicted:true` but replaces the near-term prediction
- * with a non-positive sentinel — observed `-1` and `0` for stop `1_82673` in issue #1687. Decode any
- * non-positive predicted instant to `null` ("no prediction") here at the wire→domain boundary, so the
- * domain model carries absence as a nullable [ServerTime] rather than a `0`/`-1` epoch a consumer could
- * mistake for a real timestamp (parse, don't validate).
+ * Decodes a wire `predicted{Arrival,Departure}Time` into "the instant" or **`null`** ("no prediction"),
+ * so the domain model carries absence as a nullable [ServerTime] rather than an epoch a consumer could
+ * mistake for a real timestamp (parse, don't validate). Two spellings of absence reach us, and both are
+ * the *same* server sentinel — OBA's `TimepointPredictionRecord` defaults both predicted fields to
+ * **`-1`** for "the feed gave no prediction for this stop":
+ *
+ *  - **`-1` / `0` verbatim.** A closed or otherwise suppressed stop keeps `predicted:true` and sends
+ *    these — observed for stop `1_82673` in issue #1687.
+ *
+ *  - **`-1` with the stop's slack time added to it**, which is a positive number and so sailed straight
+ *    past the non-positive check. In `ArrivalAndDepartureServiceImpl` the server does
+ *    `if (departureTime <= 0) departureTime = arrivalTime + slack * 1000` — arithmetic *on the
+ *    sentinel* — then, because `arrivalTime == -1`, copies that result onto the arrival too. So both
+ *    fields come across as exactly `slack * 1000 - 1`. Live example: a 1 Line platform with a 30 s
+ *    scheduled dwell sent `29999` for both, which as an epoch is half a minute past 1970 and rendered
+ *    as an ETA of **-496029 hours** (issue #2144; filed upstream as
+ *    onebusaway-application-modules#474).
+ *
+ * [scheduledDwellMs] is what makes the second case decodable *exactly*, with no threshold and no
+ * guess about how small a number is "too small": the server's slack is
+ * `StopTimeEntryImpl.getSlackTime()`, defined as that stop time's own `departureTime - arrivalTime`,
+ * which is precisely this arrival's scheduled dwell — a value already on the wire. So we reconstruct
+ * the artifact the server would have produced and compare for equality. It cannot collide with a real
+ * prediction: a dwell in milliseconds is ~1e4, while a genuine predicted instant is ~1.8e12.
+ *
+ * A stop with no scheduled dwell reduces to the first case (`0 - 1 == -1`), which is why this bug hid
+ * for so long — it only escapes the non-positive check at stops that dwell, and most don't.
  */
 // `internal`, not `private`: a same-file class getter reads it, and a private top-level function would
 // force a synthetic accessor (SyntheticAccessor lint) — internal is accessed directly.
-internal fun predictedServerTimeOrNull(epochMs: Long): ServerTime? = epochMs.takeIf { it > 0L }?.let { ServerTime(it) }
+internal fun predictedServerTimeOrNull(epochMs: Long, scheduledDwellMs: Long): ServerTime? = epochMs
+    .takeIf { it > 0L && it != scheduledDwellMs - 1L }
+    ?.let { ServerTime(it) }
 
 private class DtoArrivalData(
     private val d: ArrivalDeparture,
@@ -51,11 +75,15 @@ private class DtoArrivalData(
     override val vehicleId get() = d.vehicleId
     override val predicted get() = d.predicted
 
+    /** This stop time's own scheduled dwell — the server's `slackTime`, which is what it adds to the
+     *  no-prediction sentinel; see [predictedServerTimeOrNull]. */
+    private val scheduledDwellMs get() = d.scheduledDepartureTime - d.scheduledArrivalTime
+
     // Wire→server mint: these are the server clock, already epoch millis.
     override val scheduledArrivalTime get() = ServerTime(d.scheduledArrivalTime)
-    override val predictedArrivalTime get() = predictedServerTimeOrNull(d.predictedArrivalTime)
+    override val predictedArrivalTime get() = predictedServerTimeOrNull(d.predictedArrivalTime, scheduledDwellMs)
     override val scheduledDepartureTime get() = ServerTime(d.scheduledDepartureTime)
-    override val predictedDepartureTime get() = predictedServerTimeOrNull(d.predictedDepartureTime)
+    override val predictedDepartureTime get() = predictedServerTimeOrNull(d.predictedDepartureTime, scheduledDwellMs)
     override val status get() = d.tripStatus?.status?.let { Status.fromString(it) }
     override val situationIds get() = d.situationIds
     override val frequency

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopArrivalsDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopArrivalsDataSource.kt
@@ -55,13 +55,14 @@ class StopArrivals internal constructor(
     val stop: ObaStop? get() = refs.stop(stopId)?.let(::DtoStop)
 
     /**
-     * The arrivals/departures, adapted to the [ArrivalData] model (display-ready), collapsed to one
-     * entry per trip instance (see [collapseDuplicateTripInstances] / #1710 / #2012). Downstream may
-     * rely on `(tripId, serviceDate, stopSequence)` being unique across this list — the ETA strip
-     * keys its pills by exactly that triple.
+     * The arrivals/departures, adapted to the [ArrivalData] model (display-ready), with unrecoverable
+     * corrupt timestamps dropped and duplicate trip instances collapsed (see
+     * [collapseDuplicateTripInstances] / #1710 / #2012). Downstream may rely on
+     * `(tripId, serviceDate, stopSequence)` being unique across this list — the ETA strip keys its
+     * pills by exactly that triple.
      */
     val arrivals: List<ArrivalData>
-        get() = entry.arrivalsAndDepartures.map {
+        get() = entry.arrivalsAndDepartures.mapNotNull {
             it.asArrivalData(refs.trip(it.tripId)?.directionId?.toIntOrNull())
         }
             .collapseDuplicateTripInstances { tripId -> refs.trip(tripId)?.blockId }
@@ -69,7 +70,8 @@ class StopArrivals internal constructor(
     /** Every referenced route (for the map overlay). */
     val routes: List<ObaRoute> get() = refs.routes.map(::DtoRoute)
 
-    val hasArrivals: Boolean get() = entry.arrivalsAndDepartures.isNotEmpty()
+    /** True only when at least one wire row survives adaptation into a displayable arrival. */
+    val hasArrivals: Boolean get() = arrivals.isNotEmpty()
 
     /** Resolves a route from the references pool by id, or null when absent. */
     fun route(id: String): ObaRoute? = refs.route(id)?.let(::DtoRoute)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
@@ -15,7 +15,9 @@
  */
 package org.onebusaway.android.api.adapters
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.contract.ArrivalDeparture
@@ -23,9 +25,12 @@ import org.onebusaway.android.api.contract.Position
 import org.onebusaway.android.api.contract.TripStatus
 
 /**
- * [DtoArrivalData.hasPlottableVehicle] — the "the map can draw a vehicle for THIS trip right now" predicate
- * behind the ETA pill's "on the map" pin (#1992). It must mirror the map's own draw condition: the trip
- * status's active trip is this arrival's trip AND it carries a location (last-known or current position).
+ * The wire→domain decisions in `ArrivalAdapters`:
+ *  - [DtoArrivalData.hasPlottableVehicle] — the "the map can draw a vehicle for THIS trip right now"
+ *    predicate behind the ETA pill's "on the map" pin (#1992). It must mirror the map's own draw
+ *    condition: the trip status's active trip is this arrival's trip AND it carries a location.
+ *  - [predictedServerTimeOrNull] — decoding the server's no-prediction sentinel in both the spellings
+ *    it reaches us in.
  */
 class ArrivalAdaptersTest {
 
@@ -62,5 +67,57 @@ class ArrivalAdaptersTest {
         // A schedule-deviation-only status (no GPS) is real-time but has nothing to draw.
         val status = TripStatus(activeTripId = "trip", scheduleDeviation = 120L)
         assertFalse(arrival(tripId = "trip", tripStatus = status).hasPlottableVehicle)
+    }
+
+    // ---- predictedServerTimeOrNull: the no-prediction sentinel -----------------------------------
+    //
+    // OBA's TimepointPredictionRecord defaults both predicted fields to -1 ("the feed gave no
+    // prediction here"). It reaches the client two ways, and both must decode to "no prediction".
+
+    @Test
+    fun `the bare sentinel decodes to no prediction`() {
+        assertNull(predictedServerTimeOrNull(-1L, scheduledDwellMs = 0L))
+        assertNull(predictedServerTimeOrNull(0L, scheduledDwellMs = 0L))
+    }
+
+    /**
+     * The live 1 Line record that motivated this: stop `40_99603`, trip `..._100479_1058`, a platform
+     * with a 30 s scheduled dwell. The server ran `arrivalTime + slack * 1000` on the -1 sentinel and
+     * sent `29999` for *both* predicted fields — positive, so the old non-positive check passed it, and
+     * as an epoch it is half a minute past 1970. Rendered ETA: -496029 hours.
+     */
+    @Test
+    fun `the sentinel with slack added decodes to no prediction`() {
+        val dwell = 30_000L // scheduledDepartureTime - scheduledArrivalTime, i.e. the server's slackTime
+
+        assertNull(predictedServerTimeOrNull(29_999L, scheduledDwellMs = dwell))
+    }
+
+    /** The same bug at any other dwell — the artifact tracks the stop's slack, it is not one constant. */
+    @Test
+    fun `the sentinel with slack added is decoded at any dwell`() {
+        assertNull(predictedServerTimeOrNull(59_999L, scheduledDwellMs = 60_000L))
+        assertNull(predictedServerTimeOrNull(89_999L, scheduledDwellMs = 90_000L))
+        // A stop that doesn't dwell reduces to the bare sentinel, which is why this hid for so long.
+        assertNull(predictedServerTimeOrNull(-1L, scheduledDwellMs = 0L))
+    }
+
+    /**
+     * The artifact is only the artifact *for its own stop*: `29999` at a stop with a 60 s dwell is not
+     * what that stop's slack arithmetic would have produced. Reconstruction is exact, so this is a real
+     * (if absurd) instant rather than a value in a suspicious range — the check has no magnitude band.
+     */
+    @Test
+    fun `a value matching another stops artifact is not discarded`() {
+        assertEquals(29_999L, predictedServerTimeOrNull(29_999L, scheduledDwellMs = 60_000L)?.epochMs)
+    }
+
+    @Test
+    fun `a real prediction is kept`() {
+        // The healthy sibling of the record above, from the same response.
+        assertEquals(
+            1_785_706_260_000L,
+            predictedServerTimeOrNull(1_785_706_260_000L, scheduledDwellMs = 30_000L)?.epochMs
+        )
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
@@ -167,8 +167,8 @@ class ArrivalAdaptersTest {
     }
 
     @Test
-    fun `a real frequency prediction with collapsed scheduled times is kept`() {
-        val prediction = 1_785_706_260_123L
+    fun `a real frequency prediction ending in 999 with collapsed scheduled times is kept`() {
+        val prediction = 1_785_706_260_999L
         val data = ArrivalDeparture(
             routeId = "route",
             tripId = "trip",

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/adapters/ArrivalAdaptersTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.contract.ArrivalDeparture
+import org.onebusaway.android.api.contract.Frequency
 import org.onebusaway.android.api.contract.Position
 import org.onebusaway.android.api.contract.TripStatus
 
@@ -36,6 +37,7 @@ class ArrivalAdaptersTest {
 
     private fun arrival(tripId: String = "trip", tripStatus: TripStatus? = null) = ArrivalDeparture(routeId = "route", tripId = tripId, stopId = "stop", tripStatus = tripStatus)
         .asArrivalData(directionId = null)
+        .let(::requireNotNull)
 
     @Test
     fun `no trip status is not plottable`() {
@@ -119,5 +121,71 @@ class ArrivalAdaptersTest {
             1_785_706_260_000L,
             predictedServerTimeOrNull(1_785_706_260_000L, scheduledDwellMs = 30_000L)?.epochMs
         )
+    }
+
+    @Test
+    fun `a frequency row whose scheduled times were collapsed onto the sentinel is discarded`() {
+        val artifact = 29_999L
+        val data = ArrivalDeparture(
+            routeId = "route",
+            tripId = "trip",
+            stopId = "stop",
+            predicted = true,
+            scheduledArrivalTime = artifact,
+            predictedArrivalTime = artifact,
+            scheduledDepartureTime = artifact,
+            predictedDepartureTime = artifact,
+            frequency = Frequency(
+                startTime = 1_785_706_000_000L,
+                endTime = 1_785_709_600_000L,
+                headway = 600L
+            )
+        ).asArrivalData(directionId = null)
+
+        assertNull(data)
+    }
+
+    @Test
+    fun `a frequency row collapsed onto the bare sentinel is discarded`() {
+        val data = ArrivalDeparture(
+            routeId = "route",
+            tripId = "trip",
+            stopId = "stop",
+            predicted = true,
+            scheduledArrivalTime = -1L,
+            predictedArrivalTime = -1L,
+            scheduledDepartureTime = -1L,
+            predictedDepartureTime = -1L,
+            frequency = Frequency(
+                startTime = 1_785_706_000_000L,
+                endTime = 1_785_709_600_000L,
+                headway = 600L
+            )
+        ).asArrivalData(directionId = null)
+
+        assertNull(data)
+    }
+
+    @Test
+    fun `a real frequency prediction with collapsed scheduled times is kept`() {
+        val prediction = 1_785_706_260_123L
+        val data = ArrivalDeparture(
+            routeId = "route",
+            tripId = "trip",
+            stopId = "stop",
+            predicted = true,
+            scheduledArrivalTime = prediction,
+            predictedArrivalTime = prediction,
+            scheduledDepartureTime = prediction,
+            predictedDepartureTime = prediction,
+            frequency = Frequency(
+                startTime = 1_785_706_000_000L,
+                endTime = 1_785_709_600_000L,
+                headway = 600L
+            )
+        ).asArrivalData(directionId = null)
+
+        assertEquals(prediction, data?.predictedArrivalTime?.epochMs)
+        assertEquals(prediction, data?.predictedDepartureTime?.epochMs)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/StopArrivalsDedupTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/StopArrivalsDedupTest.kt
@@ -16,10 +16,12 @@
 package org.onebusaway.android.api.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.onebusaway.android.api.contract.ArrivalDeparture
 import org.onebusaway.android.api.contract.ArrivalsForStop
 import org.onebusaway.android.api.contract.EntryWithReferences
+import org.onebusaway.android.api.contract.Frequency
 import org.onebusaway.android.api.contract.Position
 import org.onebusaway.android.api.contract.References
 import org.onebusaway.android.api.contract.TripReference
@@ -57,6 +59,41 @@ class StopArrivalsDedupTest {
             .map { Triple(it.tripId, it.serviceDate, it.stopSequence) }
 
         assertEquals(instances.distinct(), instances)
+    }
+
+    @Test
+    fun `a corrupt frequency row is not exposed as an arrival`() {
+        val artifact = 29_999L
+        val snapshot = StopArrivals(
+            data = EntryWithReferences(
+                entry = ArrivalsForStop(
+                    stopId = "stop",
+                    arrivalsAndDepartures = listOf(
+                        ArrivalDeparture(
+                            routeId = "route",
+                            tripId = "trip",
+                            stopId = "stop",
+                            predicted = true,
+                            scheduledArrivalTime = artifact,
+                            predictedArrivalTime = artifact,
+                            scheduledDepartureTime = artifact,
+                            predictedDepartureTime = artifact,
+                            frequency = Frequency(
+                                startTime = 1_785_706_000_000L,
+                                endTime = 1_785_709_600_000L,
+                                headway = 600L
+                            )
+                        )
+                    )
+                ),
+                references = References()
+            ),
+            currentTime = 1_785_706_000_000L,
+            minutesAfter = 65
+        )
+
+        assertEquals(0, snapshot.arrivals.size)
+        assertFalse(snapshot.hasArrivals)
     }
 
     private companion object {


### PR DESCRIPTION
Closes #2144.

The 1 Line at Capitol Hill northbound showed an ETA of **-496029 hr 21 min**.

## The record

```json
{
  "routeShortName": "1 Line",
  "predicted": true,
  "scheduledArrivalTime":   1785708570000,
  "predictedArrivalTime":           29999,
  "scheduledDepartureTime": 1785708600000,
  "predictedDepartureTime":         29999,
  "tripStatus": { "scheduleDeviation": -36 }
}
```

`29999 - 1785705908095 ≈ -496029 hours`. Every other field, `scheduleDeviation` included, is healthy —
only the two predicted instants are junk. The existing non-positive check (the #1687 fix for the bare
`-1` / `0` sentinels) can't see it, because `29999` is positive.

## Root cause

`29999` is not an error code. It is OBA's `-1` no-prediction sentinel **with the stop's slack time
added to it**, in `ArrivalAndDepartureServiceImpl`:

```java
long arrivalTime   = tpr.getTimepointPredictedArrivalTime();    // -1 = unset
long departureTime = tpr.getTimepointPredictedDepartureTime();  // -1 = unset
if (departureTime <= 0) {                       // fires on the sentinel...
    int slack = ...getStopTime().getSlackTime();                // 30 s
    departureTime = arrivalTime + slack * 1000; // ...then does arithmetic ON it: -1 + 30000 = 29999
}
setPredictedDepartureTimeForInstance(instance, departureTime);
if (arrivalTime == -1)
    setPredictedArrivalTimeForInstance(instance, departureTime);  // arrival := 29999 too
```

`TimepointPredictionRecord` defaults both fields to `-1`, so the emitted value is exactly
`slackTime * 1000 - 1` — which is also why arrival and departure are identical, and why it ends in
`999`. Filed upstream as OneBusAway/onebusaway-application-modules#474.

## The fix is exact reconstruction, not a magnitude test

This is worth stating plainly, because the obvious fix here would be a threshold and the codebase
forbids one.

`StopTimeEntryImpl.getSlackTime()` is defined as that stop time's own `departureTime - arrivalTime`,
so the server's slack **is** this arrival's scheduled dwell — a value already on the wire. We compute
what the server would have produced and compare for equality:

```kotlin
internal fun predictedServerTimeOrNull(epochMs: Long, scheduledDwellMs: Long): ServerTime? = epochMs
    .takeIf { it > 0L && it != scheduledDwellMs - 1L }
    ?.let { ServerTime(it) }
```

No threshold, no guess about how small a number is "too small", and nothing involving the service
date — a service-day guard was considered and **rejected**, because it misbehaves at day boundaries
and for owl service. It cannot collide with a real prediction: a dwell in milliseconds is ~1e4 while a
genuine predicted instant is ~1.8e12.

A test pins the distinction: `29999` at a stop with a **60 s** dwell is *kept*, because it isn't what
that stop's slack arithmetic would have produced. The check has no suspicious range.

## How widespread

Live sweep of Puget Sound — 79 stops, 1308 arrival rows, 2616 predicted fields. 29 rows match the
formula, and nothing else absurd exists in the sample:

| dwell at stop | artifact | rows | caught before this PR? |
|---|---|---|---|
| 0 s | `-1` | 28 | yes, by the non-positive check |
| 30 s | `29999` | 1 | **no** |

So this has been firing constantly for years, but at zero-dwell stops it degenerates to `-1` and the
existing guard absorbs it. Only stops with a nonzero scheduled dwell leak — Link platforms dwell 30 s,
which is why it surfaces there. A 60 s dwell would produce `59999`.

## Behaviour after the fix

The row falls back to its scheduled time and reads "Scheduled". That works through machinery that
already exists — `predicted` is derived from "has a usable instant", not the raw wire flag — so no new
UI states.

Deliberately **not** repairing the value from `scheduled + scheduleDeviation`, even though this
record's deviation is sane: earlier work on the WSF stale-departure bug showed that always-deriving
degrades healthy Path-A predictions, and inventing a number the server didn't send is a larger call
than reporting absence.

## Testing

Six new `ArrivalAdaptersTest` cases built from the live records — the bare sentinel, the slack-added
artifact at 30/60/90 s dwells, another stop's artifact correctly kept, and a real prediction from the
same response. Full unit suite green; compiles clean under `-PwarningsAsErrors=true`; spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved arrival and departure prediction handling when no prediction is available.
  - Preserved valid predictions, including values resembling no-prediction markers for other stops.
  - Filtered out corrupt or invalid frequency arrivals instead of displaying them.
  - Corrected arrival availability reporting when all returned entries are invalid.

- **Tests**
  - Added coverage for standard and dwell-adjusted no-prediction values.
  - Verified valid predictions remain visible.
  - Added regression coverage for filtering corrupt frequency arrivals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->