### PR TITLE
Read OBA JSON as UTF-8 whatever the server's charset says (#2147)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/JsonCharsetInterceptor.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/JsonCharsetInterceptor.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.api.net
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 
@@ -76,7 +77,42 @@ internal fun utf8JsonMediaTypeFor(contentType: MediaType?): MediaType? {
     // No charset stated: OkHttp already reads it as UTF-8, so there is nothing to correct.
     val declared = contentType.charset() ?: return null
     if (declared == Charsets.UTF_8) return null
-    // Rebuilt from type/subtype rather than by string-editing the original, so any other parameter the
-    // server attached is dropped along with the wrong charset rather than carried past this boundary.
-    return "${contentType.type}/${contentType.subtype}; charset=utf-8".toMediaType()
+    // Only the charset is wrong, so only the charset is replaced — every other parameter the server
+    // attached (`profile` on a `+json` type, say) is carried through. OkHttp can look a parameter up by
+    // name but not enumerate them, so the list is re-split off the original header text.
+    val type = "${contentType.type}/${contentType.subtype}"
+    val others = contentType.toString().splitParameters()
+        .filterNot { it.substringBefore('=').trim().equals("charset", ignoreCase = true) }
+    val rebuilt = (listOf(type) + others + "charset=utf-8").joinToString("; ")
+    // The fallback is unreachable for anything OkHttp itself parsed, but a header rebuild must never be
+    // the reason a good response fails: correct the charset alone rather than throw.
+    return rebuilt.toMediaTypeOrNull() ?: "$type; charset=utf-8".toMediaType()
+}
+
+/**
+ * The parameters of a `Content-Type` header, trimmed, with the leading type/subtype dropped.
+ *
+ * Split on the `;` that separate parameters — *not* on one inside a quoted value (RFC 2045 §5.1
+ * `quoted-string`), which is part of the value and must survive the round trip intact.
+ */
+private fun String.splitParameters(): List<String> {
+    val parameters = mutableListOf<String>()
+    val current = StringBuilder()
+    var quoted = false
+    var escaped = false
+    for (c in this) {
+        when {
+            escaped -> escaped = false
+            quoted && c == '\\' -> escaped = true
+            c == '"' -> quoted = !quoted
+            c == ';' && !quoted -> {
+                parameters += current.toString()
+                current.clear()
+                continue
+            }
+        }
+        current.append(c)
+    }
+    parameters += current.toString()
+    return parameters.drop(1).map { it.trim() }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/JsonCharsetInterceptor.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/JsonCharsetInterceptor.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.net
+
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+
+/**
+ * Reads a JSON response body as UTF-8 even when the server's `Content-Type` claims some other charset.
+ *
+ * The OBA "where" API answers every request with **`application/json;charset=ISO-8859-1`** while
+ * emitting UTF-8 bytes. Retrofit's kotlinx-serialization converter decodes through
+ * `ResponseBody.string()`, which believes that header, so every non-ASCII character in the API's text
+ * arrived mojibaked: a service alert reading "What’s happening in Seattle today" (U+2019, wire bytes
+ * `E2 80 99`) reached the screen as `What` + `â` + two unprintable C1 control characters + `s`. The
+ * same corruption applied to every stop name, route name and headsign the region publishes with a
+ * curly quote, an accent, or a dash.
+ *
+ * Overriding a server's stated charset is normally the wrong instinct, so the grounds are worth
+ * stating rather than assumed:
+ *  - **The format defines it.** RFC 8259 §8.1: "JSON text exchanged between systems that are not part
+ *    of a closed ecosystem MUST be encoded using UTF-8." A public transit API is not a closed
+ *    ecosystem, and the `charset` parameter is not even registered for `application/json`.
+ *  - **The bytes agree.** The live Puget Sound API's response decodes cleanly as UTF-8 and yields the
+ *    intended characters; decoded as the ISO-8859-1 it advertises, it yields the mojibake above. So
+ *    this corrects a header that disagrees with its own body — it does not reinterpret the body.
+ *
+ * It is deliberately narrow, so it cannot silently re-encode something that really is Latin-1:
+ *  - only JSON media types (`…/json`, `…/…+json`); an HTML error page keeps whatever it declares,
+ *  - only when a charset is actually stated and is not already UTF-8. A response that states none is
+ *    left alone — OkHttp already defaults those to UTF-8, so touching them would be noise.
+ *
+ * The body is re-wrapped rather than buffered: [okhttp3.ResponseBody.source] hands back the unread
+ * stream, so this re-labels it and streams on.
+ */
+class JsonCharsetInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        val body = response.body
+        val corrected = utf8JsonMediaTypeFor(body.contentType()) ?: return response
+        return response.newBuilder()
+            // Both the header and the body's own media type: the converter reads the latter, while
+            // logging and any other interceptor reads the former, and they must not disagree.
+            .header("Content-Type", corrected.toString())
+            .body(body.source().asResponseBody(corrected, body.contentLength()))
+            .build()
+    }
+}
+
+/**
+ * The UTF-8 media type [contentType] should have declared, or **null** to leave the response untouched
+ * — the whole of [JsonCharsetInterceptor]'s decision, kept pure so `JsonCharsetInterceptorTest` can
+ * cover the cases without a server.
+ */
+internal fun utf8JsonMediaTypeFor(contentType: MediaType?): MediaType? {
+    if (contentType == null) return null
+    // `application/json`, and the `+json` structured-suffix family (`application/problem+json`, …).
+    if (contentType.subtype != "json" && !contentType.subtype.endsWith("+json")) return null
+    // No charset stated: OkHttp already reads it as UTF-8, so there is nothing to correct.
+    val declared = contentType.charset() ?: return null
+    if (declared == Charsets.UTF_8) return null
+    // Rebuilt from type/subtype rather than by string-editing the original, so any other parameter the
+    // server attached is dropped along with the wrong charset rather than carried past this boundary.
+    return "${contentType.type}/${contentType.subtype}; charset=utf-8".toMediaType()
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
@@ -34,6 +34,7 @@ import org.onebusaway.android.api.contract.ReminderWebService
 import org.onebusaway.android.api.contract.SurveyWebService
 import org.onebusaway.android.api.contract.WeatherWebService
 import org.onebusaway.android.api.net.ApiParamsInterceptor
+import org.onebusaway.android.api.net.JsonCharsetInterceptor
 import org.onebusaway.android.api.net.ObaEndpointResolver
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -64,6 +65,8 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(resolver: ObaEndpointResolver): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(ApiParamsInterceptor(resolver))
+        // This is the client that needs it: the OBA API declares `charset=ISO-8859-1` on UTF-8 bytes.
+        .addInterceptor(JsonCharsetInterceptor())
         .apply {
             if (BuildConfig.DEBUG) {
                 addInterceptor(
@@ -145,6 +148,12 @@ object NetworkModule {
 
     /** A plain OkHttp client (debug logging only, no [ApiParamsInterceptor]), optionally [configure]d. */
     private fun plainClient(configure: OkHttpClient.Builder.() -> Unit = {}): OkHttpClient = OkHttpClient.Builder()
+        // Carried by every JSON client, not only the one caught misdeclaring its charset: what
+        // [JsonCharsetInterceptor] states is a property of the *format* (RFC 8259), so a second server
+        // picking up the same misconfiguration is a no-op here rather than a fresh round of mojibake in
+        // region names or trip-planner text. On today's hosts — all of which declare no charset, which
+        // already means UTF-8 — it does nothing at all.
+        .addInterceptor(JsonCharsetInterceptor())
         .apply {
             if (BuildConfig.DEBUG) {
                 addInterceptor(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/net/JsonCharsetInterceptorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/net/JsonCharsetInterceptorTest.kt
@@ -46,6 +46,31 @@ class JsonCharsetInterceptorTest {
     }
 
     /**
+     * The charset is the only thing wrong with the header, so it is the only thing that changes: a
+     * `profile` — the one parameter the `+json` family really does carry — must reach the converter as
+     * the server sent it.
+     */
+    @Test
+    fun keepsTheOtherParametersItWasSentAlongside() {
+        val corrected = utf8JsonMediaTypeFor(
+            """application/vnd.api+json; profile="https://example.com/v1"; charset=ISO-8859-1""".toMediaType()
+        )
+
+        assertEquals(Charsets.UTF_8, corrected?.charset())
+        assertEquals("https://example.com/v1", corrected?.parameter("profile"))
+    }
+
+    /** A `;` inside a quoted parameter value is part of the value, not a separator between parameters. */
+    @Test
+    fun keepsAParameterWhoseQuotedValueContainsASemicolon() {
+        val corrected =
+            utf8JsonMediaTypeFor("""application/json; note="a;b"; charset=ISO-8859-1""".toMediaType())
+
+        assertEquals(Charsets.UTF_8, corrected?.charset())
+        assertEquals("a;b", corrected?.parameter("note"))
+    }
+
+    /**
      * The common shape on every other host this app talks to. OkHttp already reads a charset-less body
      * as UTF-8, so rewriting it would be noise — the response must be passed through untouched.
      */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/net/JsonCharsetInterceptorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/net/JsonCharsetInterceptorTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.net
+
+import okhttp3.MediaType.Companion.toMediaType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** Covers [utf8JsonMediaTypeFor], the whole of [JsonCharsetInterceptor]'s decision. */
+class JsonCharsetInterceptorTest {
+
+    /**
+     * The case that motivated all this: the OBA "where" API's own header, verbatim. Its bytes are
+     * UTF-8, so believing this is what turned "What’s happening in Seattle today" into mojibake.
+     */
+    @Test
+    fun correctsTheObaApisIso88591Claim() {
+        val corrected = utf8JsonMediaTypeFor("application/json;charset=ISO-8859-1".toMediaType())
+
+        assertEquals(Charsets.UTF_8, corrected?.charset())
+        assertEquals("application", corrected?.type)
+        assertEquals("json", corrected?.subtype)
+    }
+
+    /** The `+json` structured-suffix family is JSON too, and equally bound to UTF-8. */
+    @Test
+    fun correctsAStructuredJsonSuffixType() {
+        assertEquals(
+            Charsets.UTF_8,
+            utf8JsonMediaTypeFor("application/problem+json; charset=windows-1252".toMediaType())?.charset()
+        )
+    }
+
+    /**
+     * The common shape on every other host this app talks to. OkHttp already reads a charset-less body
+     * as UTF-8, so rewriting it would be noise — the response must be passed through untouched.
+     */
+    @Test
+    fun leavesAResponseThatStatesNoCharsetAlone() {
+        assertNull(utf8JsonMediaTypeFor("application/json".toMediaType()))
+    }
+
+    @Test
+    fun leavesAResponseAlreadyStatingUtf8Alone() {
+        assertNull(utf8JsonMediaTypeFor("application/json; charset=utf-8".toMediaType()))
+        assertNull(utf8JsonMediaTypeFor("application/json; charset=UTF-8".toMediaType()))
+    }
+
+    /**
+     * The guard that keeps this from being a blanket re-encoding: only JSON is bound to UTF-8 by its
+     * format, so a server's charset on anything else is the server's to state — an error page really
+     * may be Latin-1.
+     */
+    @Test
+    fun leavesNonJsonMediaTypesAlone() {
+        assertNull(utf8JsonMediaTypeFor("text/html; charset=ISO-8859-1".toMediaType()))
+        assertNull(utf8JsonMediaTypeFor("application/octet-stream".toMediaType()))
+        // Not a false match on the `+json` suffix rule.
+        assertNull(utf8JsonMediaTypeFor("application/jsonish; charset=ISO-8859-1".toMediaType()))
+    }
+
+    /** A body with no Content-Type at all: nothing is claimed, so there is nothing to correct. */
+    @Test
+    fun leavesAnAbsentContentTypeAlone() {
+        assertNull(utf8JsonMediaTypeFor(null))
+    }
+
+    /**
+     * The corruption this prevents, spelled out on the exact bytes the live API sends — so the test
+     * names the failure rather than only the header rewrite that avoids it.
+     */
+    @Test
+    fun theWireBytesAreUtf8AndAreMojibakeWhenReadAsLatin1() {
+        val wire = byteArrayOf(0x57, 0x68, 0x61, 0x74, 0xE2.toByte(), 0x80.toByte(), 0x99.toByte(), 0x73)
+
+        assertEquals("What’s", String(wire, Charsets.UTF_8))
+        assertEquals("Whatâs", String(wire, Charsets.ISO_8859_1))
+    }
+}


### PR DESCRIPTION
Closes #2147. Split out of #2145, where it was found — it is an independent defect and stands on its own.

## The bug

The OBA "where" API answers every request with

```
Content-Type: application/json;charset=ISO-8859-1
```

while emitting UTF-8 bytes. Retrofit's kotlinx-serialization converter decodes through
`ResponseBody.string()`, which honours that header, so every non-ASCII character in the API's text
arrived corrupted. The Sound Transit alert running today reads

> What’s happening in Seattle today could affect your travel.

and reached the screen as `What` + `â` + two unprintable C1 control characters + `s`:

```python
>>> b'What\xe2\x80\x99s'.decode('utf-8')        # what the server actually sent
'What’s'
>>> b'What\xe2\x80\x99s'.decode('iso-8859-1')   # what the header made us do
'Whatâ\x80\x99s'
```

Not limited to alerts — the same applies to every stop name, route name and headsign the region
publishes with a curly quote, an accent or a dash.

## The fix, and why overriding a server is defensible here

Corrected at the wire boundary by an interceptor. Overriding a server's stated charset is normally the
wrong instinct, so the grounds are stated at the call site rather than assumed:

- **The format defines it.** RFC 8259 §8.1: *"JSON text exchanged between systems that are not part of
  a closed ecosystem MUST be encoded using UTF-8."* A public transit API is not a closed ecosystem, and
  `charset` is not even a registered parameter for `application/json`.
- **The bytes agree.** The live response decodes cleanly as UTF-8 and yields the intended characters;
  decoded as the ISO-8859-1 it advertises it yields the mojibake above. So this corrects a header that
  disagrees with its own body — it does not reinterpret the body.

Narrow on purpose, so it cannot silently re-encode something that really is Latin-1:

- JSON media types only (`…/json`, `…/…+json`) — an HTML error page keeps whatever it declares;
- only when a charset is actually stated and is not already UTF-8 — a response that states none is left
  alone, since OkHttp already defaults those to UTF-8.

The body is re-wrapped rather than buffered: `ResponseBody.source()` hands back the unread stream, so
the interceptor re-labels it and streams on.

## Scope

It goes on every JSON client rather than only the one caught doing it. The rule is a property of the
*format*, so a second server picking up the same misconfiguration costs nothing here instead of a fresh
round of mojibake in region names or trip-planner text. On today's hosts — regions directory, sidecar,
OTP, all of which declare no charset — it does nothing at all.

## Testing

New `JsonCharsetInterceptorTest` covers the decision function: the OBA header verbatim, the `+json`
suffix family, charset-less and already-UTF-8 responses passed through, non-JSON left alone (including
that `application/jsonish` doesn't false-match the suffix rule), and a missing Content-Type. One test
pins the actual failure on the exact wire bytes rather than only the header rewrite that avoids it.

Full unit suite green; compiles clean under `-PwarningsAsErrors=true`; spotless clean. Device-verified
on a Pixel 7 Pro against the live alert.

Worth also reporting upstream so the server stops mislabelling its own output; this is the client-side
defence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON responses with incorrect character encoding declarations.
  * Prevented garbled text when UTF-8 content is returned with a different charset.
  * Applied consistent encoding handling across API and supplemental service requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->