### PR TITLE
Show the bikeshare provider in directions rows (#2150)

### DIFF
--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -58,6 +58,15 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
+        <!--
+            The bikeshare operators the directions rows can hand a rider to (#2150). Declared one by
+            one rather than as a launcher-intent query, which would make every app on the device
+            visible to us: this app needs to know about exactly these, and only to answer "is it
+            installed, or does the rider need the store?". Must stay in step with the catalog in
+            RentalPickups.kt — an operator missing here still opens, but always via the Play Store.
+        -->
+        <package android:name="com.limebike" />
+        <package android:name="co.bird.android" />
     </queries>
 
     <application

--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -11,9 +11,35 @@ fragment PlaceFields on Place {
     lat
     lon
     stop { gtfsId code }
-    rentalVehicle { vehicleId name }
+    # A vehicle-rental endpoint, in the two shapes OTP has for one: a free-floating vehicle, or a
+    # docked station. Both carry the same rental facts, so the adapter maps them onto one domain type
+    # (`TripVehicleRental`) and only `stationName` says which shape it came from.
+    #
+    # `rentalNetwork.networkId` is the operator, read straight off the field OTP publishes for it —
+    # never parsed out of the `network:id` prefix on `vehicleId`/`stationId` (#2138). `rentalUris` is
+    # the operator's own deep link to *this* vehicle/station; it is null on every vehicle the Puget
+    # Sound deployment serves today (checked against the live server on 2026-08-03 across all 13,396
+    # rental vehicles of both its networks), so the app must treat it as an operator capability rather
+    # than something a rental leg comes with — see `RentalOperators`.
+    #
+    # `RentalVehicle.name` is deliberately not selected: OTP fills it from the GBFS vehicle type, and
+    # every Lime and Bird vehicle in that deployment is named the literal string "Default vehicle
+    # type". `vehicleType` carries the fact that name was standing in for, in a form the app can
+    # actually word ("E-bike"), and `Place.name` above already carries whatever OTP called the place.
+    rentalVehicle {
+        vehicleId
+        rentalNetwork { networkId url }
+        rentalUris { android web }
+        vehicleType { formFactor propulsionType }
+        fuel { range }
+    }
     vehicleParking { vehicleParkingId name }
-    vehicleRentalStation { stationId name }
+    vehicleRentalStation {
+        stationId
+        name
+        rentalNetwork { networkId url }
+        rentalUris { android web }
+    }
 }
 
 # RouteFields is the planned leg's route. AlternativeRouteFields is the deliberately smaller set an

--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -28,8 +28,8 @@ fragment PlaceFields on Place {
     # actually word ("E-bike"), and `Place.name` above already carries whatever OTP called the place.
     rentalVehicle {
         vehicleId
-        rentalNetwork { networkId url }
-        rentalUris { android web }
+        rentalNetwork { ...RentalNetworkFields }
+        rentalUris { ...RentalUriFields }
         vehicleType { formFactor propulsionType }
         fuel { range }
     }
@@ -37,9 +37,25 @@ fragment PlaceFields on Place {
     vehicleRentalStation {
         stationId
         name
-        rentalNetwork { networkId url }
-        rentalUris { android web }
+        rentalNetwork { ...RentalNetworkFields }
+        rentalUris { ...RentalUriFields }
     }
+}
+
+# The rental facts a vehicle and a station state identically — OTP types both endpoints' network and
+# URIs the same way (`VehicleRentalNetwork!` / `VehicleRentalUris`), so these are named fragments
+# rather than the same selection inlined under each, for the reason PlaceFields itself gives above:
+# Apollo generates one type instead of two structurally-identical ones, and the adapter maps them with
+# one function rather than two copies. (They hang off the two concrete types rather than their
+# `RentalPlace` union, which — being a union — has no fields of its own to select.)
+fragment RentalNetworkFields on VehicleRentalNetwork {
+    networkId
+    url
+}
+
+fragment RentalUriFields on VehicleRentalUris {
+    android
+    web
 }
 
 # RouteFields is the planned leg's route. AlternativeRouteFields is the deliberately smaller set an

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -21,6 +21,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toKotlinDuration
 import org.onebusaway.android.api.graphql.PlanQuery
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
+import org.onebusaway.android.directions.model.RentalFormFactor
+import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripAbsoluteDirection
 import org.onebusaway.android.directions.model.TripAlert
 import org.onebusaway.android.directions.model.TripAlertSeverity
@@ -32,6 +34,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripRelativeDirection
 import org.onebusaway.android.directions.model.TripStep
+import org.onebusaway.android.directions.model.TripVehicleRental
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.time.ServerTime
 
@@ -169,7 +172,34 @@ private fun PlaceFields.toTripPlace(): TripPlace = TripPlace(
         hasRental = rentalVehicle != null || vehicleRentalStation != null,
         hasParking = vehicleParking != null
     ),
-    bikeShareId = rentalVehicle?.vehicleId ?: vehicleRentalStation?.stationId
+    rental = rentalVehicle?.toTripVehicleRental() ?: vehicleRentalStation?.toTripVehicleRental()
+)
+
+/** A free-floating rental vehicle: no dock to send the rider to, so `isStation` stays false. */
+private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental = TripVehicleRental(
+    id = vehicleId,
+    networkId = rentalNetwork.networkId,
+    networkUrl = rentalNetwork.url?.ifBlank { null },
+    androidUri = rentalUris?.android?.ifBlank { null },
+    webUri = rentalUris?.web?.ifBlank { null },
+    formFactor = vehicleType?.formFactor?.rawValue.toEnum<RentalFormFactor>(),
+    propulsion = vehicleType?.propulsionType?.rawValue.toEnum<RentalPropulsion>(),
+    rangeMeters = fuel?.range
+)
+
+/**
+ * A docked rental station. It publishes no vehicle type — the dock holds whatever the operator left
+ * in it — so [TripVehicleRental.formFactor]/[TripVehicleRental.propulsion] stay null and the drawer
+ * words the leg by its own travel mode instead.
+ */
+private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleRental = TripVehicleRental(
+    id = stationId,
+    isStation = true,
+    stationName = name.ifBlank { null },
+    networkId = rentalNetwork.networkId,
+    networkUrl = rentalNetwork.url?.ifBlank { null },
+    androidUri = rentalUris?.android?.ifBlank { null },
+    webUri = rentalUris?.web?.ifBlank { null }
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -202,7 +202,8 @@ private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleR
 /**
  * The rental facts both endpoint shapes state identically, mapped once: OTP types their network and
  * URIs the same way, and the shared Plan.graphql fragments hand this the same generated types from
- * either. Blank→null on every URL, the same normalization the route names get above.
+ * either. Every URL is normalized by [absoluteUriOrNull], which subsumes the blank→null the route
+ * names get above.
  */
 private fun toTripVehicleRental(
     id: String?,
@@ -216,13 +217,31 @@ private fun toTripVehicleRental(
     id = id,
     stationName = stationName,
     networkId = network.networkId,
-    networkUrl = network.url?.ifBlank { null },
-    androidUri = uris?.android?.ifBlank { null },
-    webUri = uris?.web?.ifBlank { null },
+    networkUrl = network.url.absoluteUriOrNull(),
+    androidUri = uris?.android.absoluteUriOrNull(),
+    webUri = uris?.web.absoluteUriOrNull(),
     formFactor = formFactor,
     propulsion = propulsion,
     rangeMeters = rangeMeters
 )
+
+/**
+ * A feed-published URI the app could actually open, or null — blank, or naming no scheme.
+ *
+ * `Uri.parse` turns `lime.example/ride/abc` into a perfectly good *relative* URI that nothing on the
+ * device can view, so an `ACTION_VIEW` on one is a dead tap (or a toast) under a chip that promised
+ * to open the operator. Dropping it here instead leaves the rental's remaining links to be offered in
+ * their own right, and makes [TripVehicleRental]'s three URLs absolute-or-absent for every reader.
+ *
+ * The check is the wire format's own grammar rather than a guess at the string's shape: RFC 3986 §3.1
+ * defines a scheme as an ASCII letter followed by letters, digits, `+`, `-` or `.`, then a colon —
+ * which is exactly what Android dispatches an intent on. (The sibling iOS app guards the same field
+ * the same way, for the same reason: there, a scheme-less `URL(string:)` is non-nil too.)
+ */
+private fun String?.absoluteUriOrNull(): String? = this?.takeIf { URI_SCHEME.containsMatchIn(it) }
+
+/** RFC 3986 §3.1: `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"`. */
+private val URI_SCHEME = Regex("""^[a-zA-Z][a-zA-Z0-9+.\-]*:""")
 
 /**
  * OTP2's `Place.stop`/`rentalVehicle`/`vehicleParking`/`vehicleRentalStation` are populated

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -21,6 +21,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toKotlinDuration
 import org.onebusaway.android.api.graphql.PlanQuery
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
+import org.onebusaway.android.api.graphql.fragment.RentalNetworkFields
+import org.onebusaway.android.api.graphql.fragment.RentalUriFields
 import org.onebusaway.android.directions.model.RentalFormFactor
 import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripAbsoluteDirection
@@ -176,12 +178,10 @@ private fun PlaceFields.toTripPlace(): TripPlace = TripPlace(
 )
 
 /** A free-floating rental vehicle: no dock, so no `stationName` to walk the rider to. */
-private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental = TripVehicleRental(
+private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental = toTripVehicleRental(
     id = vehicleId,
-    networkId = rentalNetwork.networkId,
-    networkUrl = rentalNetwork.url?.ifBlank { null },
-    androidUri = rentalUris?.android?.ifBlank { null },
-    webUri = rentalUris?.web?.ifBlank { null },
+    network = rentalNetwork.rentalNetworkFields,
+    uris = rentalUris?.rentalUriFields,
     formFactor = vehicleType?.formFactor?.rawValue.toEnum<RentalFormFactor>(),
     propulsion = vehicleType?.propulsionType?.rawValue.toEnum<RentalPropulsion>(),
     rangeMeters = fuel?.range
@@ -192,13 +192,36 @@ private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental =
  * in it — so [TripVehicleRental.formFactor]/[TripVehicleRental.propulsion] stay null and the drawer
  * words the leg by its own travel mode instead.
  */
-private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleRental = TripVehicleRental(
+private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleRental = toTripVehicleRental(
     id = stationId,
-    stationName = name.ifBlank { null },
-    networkId = rentalNetwork.networkId,
-    networkUrl = rentalNetwork.url?.ifBlank { null },
-    androidUri = rentalUris?.android?.ifBlank { null },
-    webUri = rentalUris?.web?.ifBlank { null }
+    network = rentalNetwork.rentalNetworkFields,
+    uris = rentalUris?.rentalUriFields,
+    stationName = name.ifBlank { null }
+)
+
+/**
+ * The rental facts both endpoint shapes state identically, mapped once: OTP types their network and
+ * URIs the same way, and the shared Plan.graphql fragments hand this the same generated types from
+ * either. Blank→null on every URL, the same normalization the route names get above.
+ */
+private fun toTripVehicleRental(
+    id: String?,
+    network: RentalNetworkFields,
+    uris: RentalUriFields?,
+    stationName: String? = null,
+    formFactor: RentalFormFactor? = null,
+    propulsion: RentalPropulsion? = null,
+    rangeMeters: Int? = null
+): TripVehicleRental = TripVehicleRental(
+    id = id,
+    stationName = stationName,
+    networkId = network.networkId,
+    networkUrl = network.url?.ifBlank { null },
+    androidUri = uris?.android?.ifBlank { null },
+    webUri = uris?.web?.ifBlank { null },
+    formFactor = formFactor,
+    propulsion = propulsion,
+    rangeMeters = rangeMeters
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -175,7 +175,7 @@ private fun PlaceFields.toTripPlace(): TripPlace = TripPlace(
     rental = rentalVehicle?.toTripVehicleRental() ?: vehicleRentalStation?.toTripVehicleRental()
 )
 
-/** A free-floating rental vehicle: no dock to send the rider to, so `isStation` stays false. */
+/** A free-floating rental vehicle: no dock, so no `stationName` to walk the rider to. */
 private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental = TripVehicleRental(
     id = vehicleId,
     networkId = rentalNetwork.networkId,
@@ -194,7 +194,6 @@ private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental =
  */
 private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleRental = TripVehicleRental(
     id = stationId,
-    isStation = true,
     stationName = name.ifBlank { null },
     networkId = rentalNetwork.networkId,
     networkUrl = rentalNetwork.url?.ifBlank { null },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
@@ -29,6 +29,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripRelativeDirection
 import org.onebusaway.android.directions.model.TripStep
+import org.onebusaway.android.directions.model.TripVehicleRental
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.time.ServerTime
 
@@ -95,7 +96,10 @@ fun OtpPlaceDto.toTripPlace(): TripPlace = TripPlace(
     lat = lat,
     lon = lon,
     vertexType = vertexType.toEnum<TripVertexType>(),
-    bikeShareId = bikeShareId
+    // OTP1's `/plan` carries the rental *id* and nothing else — no network, no vehicle type, no
+    // rental URI — so the rental this mints can only identify the vehicle/dock to the map's bike
+    // layer, and the directions drawer draws the plain bike row it always did (#2150).
+    rental = bikeShareId?.let { TripVehicleRental(id = it) }
 )
 
 fun OtpWalkStepDto.toTripStep(): TripStep = TripStep(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -181,8 +181,60 @@ data class TripPlace(
     val lat: Double? = null,
     val lon: Double? = null,
     val vertexType: TripVertexType? = null,
-    val bikeShareId: String? = null
+    // The rented vehicle (or its dock) this place *is*, when the place is a vehicle-rental endpoint —
+    // null everywhere else. Replaces the bare `bikeShareId` this used to carry: the id alone can only
+    // filter the map's bike layer, while a rider being sent to a shared bike also needs to know whose
+    // it is and how to unlock it (#2150).
+    val rental: TripVehicleRental? = null
 )
+
+/**
+ * A vehicle-rental endpoint of a leg — the shared bike/scooter the rider picks up, or the dock they
+ * pick it up from (#2150). OTP models the two separately (`Place.rentalVehicle` vs.
+ * `Place.vehicleRentalStation`) but publishes the same rental facts on both, so they land on one type
+ * here and [isStation] says which it was.
+ *
+ * Every field is what the *feed* stated, carried unjudged:
+ *  - [isStation] is which of OTP's two shapes this came from, stated rather than inferred from
+ *    [stationName]: whether the rider is looking for a dock is an instruction, and a station that
+ *    published a blank name must not turn into "dockless" on the way through.
+ *  - [id] is OTP's network-qualified `network:id`, the identity the map's bike layer filters on. It is
+ *    not shown to the rider: the ids the live Puget Sound networks publish are UUIDs, which no rider
+ *    can match against a bike in front of them.
+ *  - [networkId] is the operator, from OTP's own `rentalNetwork.networkId` — a GBFS `system_id` like
+ *    `lime_seattle`, not a brand name. Turning it into one is presentation, and lives in
+ *    `RentalOperators` (the UI layer), not here.
+ *  - [androidUri]/[webUri] are the operator's deep links to *this* vehicle or station
+ *    (`rentalUris.android`/`.web`), and [networkUrl] the operator's own system URL. All three are null
+ *    on every vehicle the live OTP2 deployment serves today, which is exactly why they are carried
+ *    rather than assumed: a feed that does publish them lets the app hand the rider straight to the
+ *    bike they were routed onto.
+ *  - [rangeMeters] is `fuel.range` — how far the vehicle can still travel on its current charge,
+ *    documented by the schema as meters.
+ *
+ * OTP1 populates only [id] (its `bikeShareId`): that API carries no rental metadata at all, so a leg
+ * planned on an OTP1 region has a rental with nothing to say about its operator, and the drawer draws
+ * the plain bike row it always did.
+ */
+@Serializable
+data class TripVehicleRental(
+    val id: String? = null,
+    val isStation: Boolean = false,
+    val stationName: String? = null,
+    val networkId: String? = null,
+    val networkUrl: String? = null,
+    val androidUri: String? = null,
+    val webUri: String? = null,
+    val formFactor: RentalFormFactor? = null,
+    val propulsion: RentalPropulsion? = null,
+    val rangeMeters: Int? = null
+)
+
+/** Mirrors OTP2's `FormFactor` wire vocabulary exactly (which mirrors GBFS's `vehicle_type`). */
+enum class RentalFormFactor { BICYCLE, CAR, CARGO_BICYCLE, MOPED, OTHER, SCOOTER, SCOOTER_SEATED, SCOOTER_STANDING }
+
+/** Mirrors OTP2's `PropulsionType` wire vocabulary exactly (which mirrors GBFS's `propulsion_type`). */
+enum class RentalPropulsion { COMBUSTION, COMBUSTION_DIESEL, ELECTRIC, ELECTRIC_ASSIST, HUMAN, HYBRID, HYDROGEN_FUEL_CELL, PLUG_IN_HYBRID }
 
 @Serializable
 data class TripStep(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -192,12 +192,10 @@ data class TripPlace(
  * A vehicle-rental endpoint of a leg — the shared bike/scooter the rider picks up, or the dock they
  * pick it up from (#2150). OTP models the two separately (`Place.rentalVehicle` vs.
  * `Place.vehicleRentalStation`) but publishes the same rental facts on both, so they land on one type
- * here and [isStation] says which it was.
+ * here, and [stationName] is what the rider can act on: the dock to walk to, when the pickup is one
+ * that published a name.
  *
  * Every field is what the *feed* stated, carried unjudged:
- *  - [isStation] is which of OTP's two shapes this came from, stated rather than inferred from
- *    [stationName]: whether the rider is looking for a dock is an instruction, and a station that
- *    published a blank name must not turn into "dockless" on the way through.
  *  - [id] is OTP's network-qualified `network:id`, the identity the map's bike layer filters on. It is
  *    not shown to the rider: the ids the live Puget Sound networks publish are UUIDs, which no rider
  *    can match against a bike in front of them.
@@ -219,7 +217,6 @@ data class TripPlace(
 @Serializable
 data class TripVehicleRental(
     val id: String? = null,
-    val isStation: Boolean = false,
     val stationName: String? = null,
     val networkId: String? = null,
     val networkUrl: String? = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -206,7 +206,9 @@ data class TripPlace(
  *    (`rentalUris.android`/`.web`), and [networkUrl] the operator's own system URL. All three are null
  *    on every vehicle the live OTP2 deployment serves today, which is exactly why they are carried
  *    rather than assumed: a feed that does publish them lets the app hand the rider straight to the
- *    bike they were routed onto.
+ *    bike they were routed onto. All three are **absolute or absent** — a feed value naming no scheme
+ *    is dropped at the wire boundary, since nothing on the device can open one (see
+ *    `Otp2PlanAdapters.absoluteUriOrNull`), so a reader may open what it finds here.
  *  - [rangeMeters] is `fuel.range` — how far the vehicle can still travel on its current charge,
  *    documented by the schema as meters.
  *

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -270,10 +270,10 @@ class DirectionsMapController(private val host: MapHost) {
             for (leg in itinerary.legs) {
                 if (leg.mode == TripMode.BICYCLE) {
                     if (leg.from.vertexType == TripVertexType.BIKESHARE) {
-                        leg.from.bikeShareId?.let { ids.add(it) }
+                        leg.from.rental?.id?.let { ids.add(it) }
                     }
                     if (leg.to.vertexType == TripVertexType.BIKESHARE) {
-                        leg.to.bikeShareId?.let { ids.add(it) }
+                        leg.to.rental?.id?.let { ids.add(it) }
                     }
                 }
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -162,6 +162,11 @@ private val CHEVRON_LEAN_ALLOWANCE = ROUTE_BADGE_HEIGHT * JOIN_LEAN_RATIO / 2
  * [leadingIcon] puts a glyph inside the chip, ahead of the name — the mode the route is ridden on, which
  * a route number alone never says. [leadingIconDescription] labels it for TalkBack; the mode is real
  * information, not decoration, so it is worth announcing.
+ *
+ * [trailingIcon] does the same after the name, for a glyph that qualifies the chip rather than the thing
+ * it names — the bikeshare operator chip marks itself as a way *out* of the app with an open-in-new arrow
+ * (#2150). Left unlabelled by default: what such a chip does is said by its own click label, and
+ * announcing the arrow separately would only repeat it.
  */
 @Composable
 fun RouteBadgeChip(
@@ -171,7 +176,9 @@ fun RouteBadgeChip(
     scale: Float = 1f,
     maxWidth: Dp = Dp.Unspecified,
     leadingIcon: Int? = null,
-    leadingIconDescription: String? = null
+    leadingIconDescription: String? = null,
+    trailingIcon: Int? = null,
+    trailingIconDescription: String? = null
 ) {
     val (container, content) = rememberRouteBadgeColors(routeColor)
     Surface(
@@ -190,7 +197,9 @@ fun RouteBadgeChip(
             scale = scale,
             horizontalPadding = 3.dp * scale,
             leadingIcon = leadingIcon,
-            leadingIconDescription = leadingIconDescription
+            leadingIconDescription = leadingIconDescription,
+            trailingIcon = trailingIcon,
+            trailingIconDescription = trailingIconDescription
         )
     }
 }
@@ -205,7 +214,9 @@ private fun BadgeContent(
     horizontalPadding: Dp,
     leadingIcon: Int?,
     leadingIconDescription: String?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    trailingIcon: Int? = null,
+    trailingIconDescription: String? = null
 ) {
     val base = MaterialTheme.typography.labelMedium
     // Scale every text metric together — the line box with the glyphs (labelMedium's 16sp line height
@@ -240,8 +251,19 @@ private fun BadgeContent(
             fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
+            // Weighted so the name yields the room the trailing glyph needs and ellipsizes into what
+            // is left, rather than pushing the glyph out of a chip capped by `maxWidth`.
+            modifier = if (trailingIcon != null) Modifier.weight(1f, fill = false) else Modifier,
             color = contentColor
         )
+        if (trailingIcon != null) {
+            Icon(
+                painter = painterResource(trailingIcon),
+                contentDescription = trailingIconDescription,
+                tint = contentColor,
+                modifier = Modifier.size(BADGE_ICON_SIZE * scale)
+            )
+        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -163,10 +163,11 @@ private val CHEVRON_LEAN_ALLOWANCE = ROUTE_BADGE_HEIGHT * JOIN_LEAN_RATIO / 2
  * a route number alone never says. [leadingIconDescription] labels it for TalkBack; the mode is real
  * information, not decoration, so it is worth announcing.
  *
- * [trailingIcon] does the same after the name, for a glyph that qualifies the chip rather than the thing
- * it names — the bikeshare operator chip marks itself as a way *out* of the app with an open-in-new arrow
- * (#2150). Left unlabelled by default: what such a chip does is said by its own click label, and
- * announcing the arrow separately would only repeat it.
+ * [trailingIcon] puts one after the name instead, for a glyph that qualifies the chip rather than the
+ * thing it names — the bikeshare operator chip marks itself as a way *out* of the app with an
+ * open-in-new arrow (#2150). It takes no description, unlike the leading one: such a glyph says what
+ * the chip *does*, which is already the chip's own click label, so announcing it again would only
+ * repeat that.
  */
 @Composable
 fun RouteBadgeChip(
@@ -177,8 +178,7 @@ fun RouteBadgeChip(
     maxWidth: Dp = Dp.Unspecified,
     leadingIcon: Int? = null,
     leadingIconDescription: String? = null,
-    trailingIcon: Int? = null,
-    trailingIconDescription: String? = null
+    trailingIcon: Int? = null
 ) {
     val (container, content) = rememberRouteBadgeColors(routeColor)
     Surface(
@@ -198,8 +198,7 @@ fun RouteBadgeChip(
             horizontalPadding = 3.dp * scale,
             leadingIcon = leadingIcon,
             leadingIconDescription = leadingIconDescription,
-            trailingIcon = trailingIcon,
-            trailingIconDescription = trailingIconDescription
+            trailingIcon = trailingIcon
         )
     }
 }
@@ -215,8 +214,7 @@ private fun BadgeContent(
     leadingIcon: Int?,
     leadingIconDescription: String?,
     modifier: Modifier = Modifier,
-    trailingIcon: Int? = null,
-    trailingIconDescription: String? = null
+    trailingIcon: Int? = null
 ) {
     val base = MaterialTheme.typography.labelMedium
     // Scale every text metric together — the line box with the glyphs (labelMedium's 16sp line height
@@ -259,7 +257,7 @@ private fun BadgeContent(
         if (trailingIcon != null) {
             Icon(
                 painter = painterResource(trailingIcon),
-                contentDescription = trailingIconDescription,
+                contentDescription = null,
                 tint = contentColor,
                 modifier = Modifier.size(BADGE_ICON_SIZE * scale)
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -41,8 +41,6 @@ data class RentalPickup(
     val vehicle: RentalVehicleKind?,
     /** The dock's name, when the rider is picking up from one that published a name. */
     val stationName: String?,
-    /** True when there is no dock to look for — the vehicle is standing on the street. */
-    val isDockless: Boolean,
     /** How far the vehicle can still travel on its charge, in meters, when the feed says. */
     val rangeMeters: Int?,
     /** Where the row's action sends the rider, or null when there is nowhere to send them. */
@@ -136,7 +134,6 @@ internal fun rentalPickup(rental: TripVehicleRental?): RentalPickup? {
         operator = RentalOperators.of(networkId),
         vehicle = rental.vehicleKind(),
         stationName = rental.stationName,
-        isDockless = !rental.isStation,
         rangeMeters = rental.rangeMeters,
         link = links.firstOrNull(),
         // The first one that can't fail for want of an app to handle a custom scheme, and never the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -48,7 +48,7 @@ data class RentalPickup(
     /**
      * Where to send them instead when nothing on the device handles [link] — the rider who was offered
      * a `lime://` deep link and hasn't got Lime installed. Null when [link] is all there is, and never
-     * itself a [RentalLink.Deep]: a second custom-scheme URI would fail the same way the first did.
+     * itself a link that could fail the same way (see [RentalLink.Deep.mayNeedTheirApp]).
      */
     val fallback: RentalLink? = null
 )
@@ -81,8 +81,16 @@ data class RentalOperator(
  */
 sealed interface RentalLink {
 
-    /** The operator's own deep link to this vehicle/dock (`rentalUris.android`, else `.web`). */
-    data class Deep(val uri: String) : RentalLink
+    /**
+     * The operator's own deep link to this vehicle/dock (`rentalUris.android`, else `.web`).
+     *
+     * [mayNeedTheirApp] tells the two apart where it matters, which is whether following the link can
+     * fail: an Android URI is free to wear a scheme only the operator's own app answers (`lime://…`),
+     * so a device without that app handles nothing, while `rentalUris.web` is an http(s) URL by GBFS's
+     * definition and a browser always answers it. Only the former needs a [RentalPickup.fallback] —
+     * and only the latter can *be* one.
+     */
+    data class Deep(val uri: String, val mayNeedTheirApp: Boolean) : RentalLink
 
     /** The operator's Android app, by package — launched if installed, else its store page. */
     data class OperatorApp(val packageName: String) : RentalLink
@@ -137,17 +145,20 @@ internal fun rentalPickup(rental: TripVehicleRental?): RentalPickup? {
         stationName = rental.stationName,
         rangeMeters = rental.rangeMeters,
         link = links.firstOrNull(),
-        // The first one that can't fail for want of an app to handle a custom scheme, and never the
-        // primary itself — so a row with only a deep link has no fallback rather than a retry of it.
-        fallback = links.drop(1).firstOrNull { it !is RentalLink.Deep }
+        // The first one that can't fail for want of an app to answer a custom scheme, and never the
+        // primary itself — so a row whose only link is one of those has no fallback rather than a
+        // retry of it.
+        fallback = links.drop(1).firstOrNull { !(it is RentalLink.Deep && it.mayNeedTheirApp) }
     )
 }
 
 /**
  * Every action this rental offers, most specific first: the operator's deep link to this very vehicle,
  * then their app, then their site. The Android URI leads the web one because it is what the operator
- * published *for* an Android handoff (the pattern Google's micromobility deep links document); the
- * catalog's app package comes next because opening the app the rider already has beats a web page; and
+ * published *for* an Android handoff (the pattern Google's micromobility deep links document) — and the
+ * web one follows it rather than being dropped, since it names the same vehicle and, being an ordinary
+ * URL, is the one thing that still works on a device the Android URI's scheme means nothing to. The
+ * catalog's app package comes next because opening the app the rider already has beats a web page, and
  * the feed's own `rentalNetwork.url` outranks the catalog's site because it came from the operator.
  *
  * Empty when nothing at all is known — an unknown network with no URIs, which is every network the app
@@ -156,8 +167,8 @@ internal fun rentalPickup(rental: TripVehicleRental?): RentalPickup? {
 private fun TripVehicleRental.links(networkId: String): List<RentalLink> {
     val known = RentalOperators.known(networkId)
     return listOfNotNull(
-        androidUri?.let { RentalLink.Deep(it) },
-        webUri?.let { RentalLink.Deep(it) },
+        androidUri?.let { RentalLink.Deep(it, mayNeedTheirApp = true) },
+        webUri?.let { RentalLink.Deep(it, mayNeedTheirApp = false) },
         known?.appPackage?.let { RentalLink.OperatorApp(it) },
         networkUrl?.let { RentalLink.Web(it) },
         known?.webUrl?.let { RentalLink.Web(it) }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.onebusaway.android.directions.model.RentalFormFactor
+import org.onebusaway.android.directions.model.RentalPropulsion
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripVehicleRental
+
+/**
+ * Turns a leg's [TripVehicleRental] into what the directions row actually shows about it (#2150) — who
+ * the bike belongs to, what kind of vehicle it is, whether there's a dock to find it at, and where the
+ * tap that says "unlock it" should send the rider.
+ *
+ * Pure (no `Context`, no `android.graphics`), like [ModeSymbols] and [TripLogBuilder] beside it, so
+ * `RentalPickupsTest` covers the operator lookup and the link ordering directly. Strings and colours
+ * are resolved by the renderer from the enums/ARGB ints this hands it.
+ */
+
+/**
+ * A rented vehicle as a directions row presents it. Built only when there is something to say — see
+ * [rentalPickup]; a bikeshare leg the wire told us nothing about (the OTP1 path) draws the plain bike
+ * row it always did rather than an empty chip.
+ */
+data class RentalPickup(
+    val operator: RentalOperator,
+    /** The vehicle, or null when the feed didn't say — a dock publishes no type; it holds what it holds. */
+    val vehicle: RentalVehicleKind?,
+    /** The dock's name, when the rider is picking up from one that published a name. */
+    val stationName: String?,
+    /** True when there is no dock to look for — the vehicle is standing on the street. */
+    val isDockless: Boolean,
+    /** How far the vehicle can still travel on its charge, in meters, when the feed says. */
+    val rangeMeters: Int?,
+    /** Where the row's action sends the rider, or null when there is nowhere to send them. */
+    val link: RentalLink?,
+    /**
+     * Where to send them instead when nothing on the device handles [link] — the rider who was offered
+     * a `lime://` deep link and hasn't got Lime installed. Null when [link] is all there is, and never
+     * itself a [RentalLink.Deep]: a second custom-scheme URI would fail the same way the first did.
+     */
+    val fallback: RentalLink? = null
+)
+
+/**
+ * The operator of a rental network, as the row names it: [displayName] on a [brandColor] chip.
+ *
+ * OTP publishes neither of those — [RentalOperator.networkId] (a GBFS `system_id` like `lime_seattle`)
+ * is the *only* operator fact on the wire, and GBFS 2.x has no brand fields at all. So a known
+ * operator's name and colour come from [RentalOperators]' catalog, and an unknown one falls back to
+ * wearing its raw network id on a neutral chip: an honest "some network called `foo_bar`" beats
+ * inventing a brand for it.
+ */
+data class RentalOperator(
+    val networkId: String,
+    val displayName: String,
+    /** ARGB, or null to let the chip take the app's neutral tint (see `RouteBadgeChip`). */
+    val brandColor: Int?,
+    /** True when this operator came out of the catalog rather than the network-id fallback. */
+    val isKnown: Boolean
+)
+
+/**
+ * Where a rental row's action button goes, in the order [rentalPickup] prefers them.
+ *
+ * [Deep] is the only one that names the *exact* vehicle the rider was routed onto; the others merely
+ * open the operator, which is why the row words them differently ("Open in Lime" vs. "Rent with
+ * Lime"). Nothing here claims a reservation was made — see #2138 for why that's a separate milestone.
+ */
+sealed interface RentalLink {
+
+    /** The operator's own deep link to this vehicle/dock (`rentalUris.android`, else `.web`). */
+    data class Deep(val uri: String) : RentalLink
+
+    /** The operator's Android app, by package — launched if installed, else its store page. */
+    data class OperatorApp(val packageName: String) : RentalLink
+
+    /** The operator's site: `rentalNetwork.url` when the feed publishes one, else the catalog's. */
+    data class Web(val url: String) : RentalLink
+}
+
+/**
+ * The vehicle a rental leg is ridden on, narrowed from GBFS's form factor × propulsion to the words the
+ * row can actually say. "Electric" is [RentalPropulsion.ELECTRIC] or [RentalPropulsion.ELECTRIC_ASSIST]
+ * and nothing else — an explicit reading of the wire vocabulary (throttle mode and pedal-assist), not a
+ * guess about what a bike with a battery is called.
+ *
+ * [RentalFormFactor.OTHER] deliberately has no entry: the feed is saying it *isn't* one of these, so the
+ * row says nothing about the vehicle rather than picking the nearest word.
+ */
+enum class RentalVehicleKind { BIKE, EBIKE, CARGO_BIKE, ELECTRIC_CARGO_BIKE, SCOOTER, ESCOOTER, MOPED, CAR }
+
+/**
+ * What this leg's rental row shows, or null when the leg isn't a rental or the wire said nothing worth
+ * drawing.
+ *
+ * Either endpoint's rental counts, and the pickup wins when both do: a docked trip starts and ends at a
+ * station, a dockless one may start at a vehicle and end nowhere in particular, and it is where the
+ * rider *gets* the bike that decides whether they're looking for a dock. That mirrors
+ * [streetMode][org.onebusaway.android.ui.tripresults.streetMode], which reads the same two endpoints to
+ * decide the leg is a rental at all, so a leg cannot be a bikeshare leg with no rental to show or the
+ * other way round.
+ */
+internal fun TripLeg.rentalPickup(): RentalPickup? = if (streetMode() == StreetMode.BIKESHARE) {
+    rentalPickup(from.rental ?: to.rental)
+} else {
+    // Notably the walk *to* the bike, whose `to` is the rental vehicle: the rider is told whose bike
+    // it is on the row where they ride it, once, rather than on both legs that touch it.
+    null
+}
+
+/**
+ * The presentable form of [rental], or null when it names no network — which is the OTP1 path, whose
+ * rental holds an opaque id and nothing else. Everything the row draws hangs off the operator, so a
+ * chip reading "unknown network" with no link under it and no vehicle beside it would be worse than
+ * the plain bike row the leg already had. OTP2 always states the network (`VehicleRentalNetwork
+ * .networkId` is non-null in the pinned schema), so this drops nothing that path can produce.
+ */
+internal fun rentalPickup(rental: TripVehicleRental?): RentalPickup? {
+    val networkId = rental?.networkId?.ifBlank { null } ?: return null
+    val links = rental.links(networkId)
+    return RentalPickup(
+        operator = RentalOperators.of(networkId),
+        vehicle = rental.vehicleKind(),
+        stationName = rental.stationName,
+        isDockless = !rental.isStation,
+        rangeMeters = rental.rangeMeters,
+        link = links.firstOrNull(),
+        // The first one that can't fail for want of an app to handle a custom scheme, and never the
+        // primary itself — so a row with only a deep link has no fallback rather than a retry of it.
+        fallback = links.drop(1).firstOrNull { it !is RentalLink.Deep }
+    )
+}
+
+/**
+ * Every action this rental offers, most specific first: the operator's deep link to this very vehicle,
+ * then their app, then their site. The Android URI leads the web one because it is what the operator
+ * published *for* an Android handoff (the pattern Google's micromobility deep links document); the
+ * catalog's app package comes next because opening the app the rider already has beats a web page; and
+ * the feed's own `rentalNetwork.url` outranks the catalog's site because it came from the operator.
+ *
+ * Empty when nothing at all is known — an unknown network with no URIs, which is every network the app
+ * has no catalog entry for until its feed starts publishing rental URIs.
+ */
+private fun TripVehicleRental.links(networkId: String): List<RentalLink> {
+    val known = RentalOperators.known(networkId)
+    return listOfNotNull(
+        androidUri?.let { RentalLink.Deep(it) },
+        webUri?.let { RentalLink.Deep(it) },
+        known?.appPackage?.let { RentalLink.OperatorApp(it) },
+        networkUrl?.let { RentalLink.Web(it) },
+        known?.webUrl?.let { RentalLink.Web(it) }
+    )
+}
+
+/** The vehicle's kind, or null when the feed named no form factor (or named [RentalFormFactor.OTHER]). */
+private fun TripVehicleRental.vehicleKind(): RentalVehicleKind? {
+    val electric = propulsion == RentalPropulsion.ELECTRIC || propulsion == RentalPropulsion.ELECTRIC_ASSIST
+    return when (formFactor) {
+        RentalFormFactor.BICYCLE -> if (electric) RentalVehicleKind.EBIKE else RentalVehicleKind.BIKE
+        RentalFormFactor.CARGO_BICYCLE ->
+            if (electric) RentalVehicleKind.ELECTRIC_CARGO_BIKE else RentalVehicleKind.CARGO_BIKE
+        // GBFS splits kick scooters three ways (seated/standing/the pre-3.0 catch-all); the rider is
+        // renting a scooter in all three, and the seat isn't what the row is for.
+        RentalFormFactor.SCOOTER, RentalFormFactor.SCOOTER_SEATED, RentalFormFactor.SCOOTER_STANDING ->
+            if (electric) RentalVehicleKind.ESCOOTER else RentalVehicleKind.SCOOTER
+        RentalFormFactor.MOPED -> RentalVehicleKind.MOPED
+        RentalFormFactor.CAR -> RentalVehicleKind.CAR
+        RentalFormFactor.OTHER, null -> null
+    }
+}
+
+/**
+ * The catalog of rental operators the app can name — every fact in it sourced, because none of them is
+ * on the wire (see [RentalOperator]).
+ *
+ * Keyed by **exact** GBFS `system_id`, never by prefix: `lime_seattle` is Lime, but no rule says a
+ * network id starting "lime" is, and a wrong brand on a rider's screen is worse than a plain id. That
+ * means one entry per city an operator runs in, which is the honest cost of a directory that publishes
+ * no brand — and adding one is a line.
+ *
+ * The entries below are the complete set of networks reachable from this app today: Puget Sound is the
+ * only region publishing an `otpBaseGraphqlUrl` (checked against the live regions directory,
+ * 2026-08-03), and its OTP serves exactly these two networks (13,395 `lime_seattle` vehicles and one
+ * `bird-seattle-washington`, from the deployment's own `rentalVehicles` query the same day).
+ */
+object RentalOperators {
+
+    /** A catalog entry — see [RentalOperators] for where each field comes from. */
+    data class KnownOperator(
+        val displayName: String,
+        val brandColor: Int,
+        /**
+         * The operator's Android app. Must also be listed in the manifest's `<queries>` block, or
+         * Android 11+ package visibility hides it from `getLaunchIntentForPackage` and the app the
+         * rider has installed looks absent — see `ExternalIntents.openRentalApp`.
+         */
+        val appPackage: String?,
+        val webUrl: String?
+    )
+
+    private val CATALOG = mapOf(
+        // Name: the network's own GBFS system_information `attribution_organization_name` ("Lime").
+        // Colour: sampled from Lime's Play Store icon, which is 3872 px of #00DD00 on white.
+        // Package: play.google.com/store/apps/details?id=com.limebike is "Lime - #RideGreen".
+        "lime_seattle" to KnownOperator("Lime", 0xFF00DD00.toInt(), "com.limebike", "https://www.li.me/"),
+        // Name: shortened from the network's GBFS `operator` ("Bird Rides, Inc."), which is the legal
+        // entity rather than what the app is called; its own store listing is "Bird — Ride Electric".
+        // Colour: sampled from that listing's icon (#26CCF0 over 14020 px of it).
+        // Package: the network's GBFS `rental_apps.android.store_uri` names co.bird.android itself.
+        "bird-seattle-washington" to KnownOperator("Bird", 0xFF26CCF0.toInt(), "co.bird.android", "https://www.bird.co/")
+    )
+
+    /** The catalog entry for [networkId], or null when the app has never heard of it. */
+    fun known(networkId: String): KnownOperator? = CATALOG[networkId]
+
+    /**
+     * How to present [networkId] — the catalog entry when there is one, else the id itself on a neutral
+     * chip.
+     */
+    fun of(networkId: String): RentalOperator {
+        val known = known(networkId)
+        return RentalOperator(
+            networkId = networkId,
+            displayName = known?.displayName ?: networkId,
+            brandColor = known?.brandColor,
+            isKnown = known != null
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -205,6 +205,14 @@ private fun TripVehicleRental.vehicleKind(): RentalVehicleKind? {
  * only region publishing an `otpBaseGraphqlUrl` (checked against the live regions directory,
  * 2026-08-03), and its OTP serves exactly these two networks (13,395 `lime_seattle` vehicles and one
  * `bird-seattle-washington`, from the deployment's own `rentalVehicles` query the same day).
+ *
+ * The brand colours — the one fact here with no published source at all, sampled from each operator's
+ * own store icon — were signed off on 2026-08-03 (#2156) rather than dropped for a neutral chip, since
+ * naming the operator a rider can *recognise* is what #2150 is for. They are meant to be temporary in
+ * this form: the intended home is a brand registry shared across the OBA implementations, at which
+ * point [KnownOperator.brandColor] becomes a lookup into it rather than a hex kept here. (The sibling
+ * iOS app made the other choice and paints every rental surface one app-owned purple — worth knowing
+ * before anyone re-opens this.)
  */
 object RentalOperators {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -63,12 +63,13 @@ data class RentalPickup(
  * inventing a brand for it.
  */
 data class RentalOperator(
-    val networkId: String,
     val displayName: String,
-    /** ARGB, or null to let the chip take the app's neutral tint (see `RouteBadgeChip`). */
-    val brandColor: Int?,
-    /** True when this operator came out of the catalog rather than the network-id fallback. */
-    val isKnown: Boolean
+    /**
+     * ARGB, or null to let the chip take the app's neutral tint (see `RouteBadgeChip`) — which is also
+     * how a caller tells a catalogued operator from one wearing its raw network id, since every catalog
+     * entry states a colour.
+     */
+    val brandColor: Int?
 )
 
 /**
@@ -203,7 +204,7 @@ object RentalOperators {
         /**
          * The operator's Android app. Must also be listed in the manifest's `<queries>` block, or
          * Android 11+ package visibility hides it from `getLaunchIntentForPackage` and the app the
-         * rider has installed looks absent — see `ExternalIntents.openRentalApp`.
+         * rider has installed looks absent — see `ExternalIntents.openAppOrStoreListing`.
          */
         val appPackage: String?,
         val webUrl: String?
@@ -230,11 +231,6 @@ object RentalOperators {
      */
     fun of(networkId: String): RentalOperator {
         val known = known(networkId)
-        return RentalOperator(
-            networkId = networkId,
-            displayName = known?.displayName ?: networkId,
-            brandColor = known?.brandColor,
-            isKnown = known != null
-        )
+        return RentalOperator(displayName = known?.displayName ?: networkId, brandColor = known?.brandColor)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -135,6 +135,9 @@ object TripLogBuilder {
         durationMinutes = leg.duration.inWholeMinutes,
         distanceMeters = leg.distance,
         isTransfer = isTransfer,
+        // The shared bike/scooter this leg is ridden on, when it is one (#2150) — null on a plain walk
+        // or the rider's own bike, and read from the same two endpoints [streetMode] reads.
+        rental = leg.rentalPickup(),
         // The generator emits one sub-direction per leg.step (in order), so the localized instruction and
         // the structured step distance line up by index.
         steps = walk.subDirections.orEmpty().mapIndexed { i, sub ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1723,7 +1723,9 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
             // enlargement would buy the arrow room by taking it from the name.
             maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH * RENTAL_OPERATOR_CHIP_SCALE,
             trailingIcon = R.drawable.ic_open_in_new.takeIf { link != null },
-            modifier = Modifier.semantics { contentDescription = described }
+            // Merged, so the chip is one node reading "Lime rental" rather than that description and
+            // the bare brand name inside it announced as two.
+            modifier = Modifier.semantics(mergeDescendants = true) { contentDescription = described }
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -96,6 +97,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontFamily
@@ -139,6 +141,7 @@ import org.onebusaway.android.ui.compose.unitsAreMetric
 import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.ui.tripplan.TripPlanParams
 import org.onebusaway.android.util.DisplayFormat
+import org.onebusaway.android.util.ExternalIntents
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.parseObaHexColor
 
@@ -1615,9 +1618,128 @@ private fun ColumnScope.WalkHeaderContent(entry: TripLogEntry.Walk) {
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
+    entry.rental?.let { RentalContent(it) }
     // A walk gets its alerts under its header for the same reason a ride does — a closed dock or a
     // blocked path is about this stretch of the trip, not the trip as a whole.
     LegAlerts(entry.alerts)
+}
+
+/**
+ * What the rider needs to know about the shared bike they're being sent to (#2150): whose it is, what
+ * it is, where to find it, and how to unlock it. Before this the leg said only "Bike", which told a
+ * rider standing over an unfamiliar scooter nothing about which app opens it.
+ *
+ * Everything here is drawn from what the feed actually said, and each part is omitted rather than
+ * guessed when it didn't: an operator the app has no catalog entry for wears its raw network id (see
+ * [RentalOperators]), a dock that published no name draws no pickup line at all, and a network with
+ * neither a rental URI nor a catalog entry gets no button rather than one going somewhere approximate.
+ *
+ * The vehicle id is deliberately not shown. The ids the live networks publish are UUIDs — nothing a
+ * rider can match against the bike in front of them — so drawing one would be noise that reads like an
+ * instruction.
+ */
+@Composable
+private fun ColumnScope.RentalContent(rental: RentalPickup) {
+    val context = LocalContext.current
+    val metric = unitsAreMetric()
+    Row(
+        modifier = Modifier.padding(top = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        val name = rental.operator.displayName
+        val described = stringResource(R.string.trip_plan_rental_operator_description, name)
+        RouteBadgeChip(
+            shortName = name,
+            routeColor = rental.operator.brandColor,
+            // A brand name is a word, not a route number: capped so a long one ellipsizes inside the
+            // chip instead of pushing the vehicle beside it off the row.
+            maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH,
+            modifier = Modifier.semantics { contentDescription = described }
+        )
+        val details = listOfNotNull(
+            rental.vehicle?.let { stringResource(rentalVehicleRes(it)) },
+            rental.rangeMeters?.let {
+                stringResource(
+                    R.string.trip_plan_rental_range,
+                    ConversionUtils.getFormattedDistance(it.toDouble(), context, metric)
+                )
+            }
+        )
+        if (details.isNotEmpty()) {
+            Text(
+                text = details.joinToString(" · "),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+    // Where to find it: the dock by name, or the fact that there isn't one. A docked station that
+    // published no name says neither — "dockless" would send the rider looking for the wrong thing.
+    val pickup = when {
+        rental.stationName != null -> stringResource(R.string.trip_plan_rental_pick_up_at, rental.stationName)
+        rental.isDockless -> stringResource(R.string.trip_plan_rental_dockless)
+        else -> null
+    }
+    pickup?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    rental.link?.let { link ->
+        TextButton(
+            onClick = { openRental(context, link, rental.fallback) },
+            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+            modifier = Modifier.padding(top = 2.dp)
+        ) {
+            Text(
+                // Only a link to *this* vehicle may say "open it"; the rest merely open the operator,
+                // and the rider still has to find the bike themselves. Nothing here claims the vehicle
+                // was reserved — see #2138 for what an actual handoff would take.
+                text = stringResource(
+                    if (link is RentalLink.Deep) {
+                        R.string.trip_plan_rental_open_in
+                    } else {
+                        R.string.trip_plan_rental_rent_with
+                    },
+                    rental.operator.displayName
+                ),
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}
+
+/** How wide the operator chip may get before its name ellipsizes — about a dozen characters. */
+private val RENTAL_OPERATOR_CHIP_MAX_WIDTH = 96.dp
+
+/**
+ * Hands the rider over: the operator's own link, and — when the device has nothing that handles a
+ * custom-scheme deep link — whatever [fallback] the pickup kept for exactly that (see
+ * [RentalPickup.fallback]).
+ */
+private fun openRental(context: Context, link: RentalLink, fallback: RentalLink?) {
+    when (link) {
+        is RentalLink.Deep -> if (!ExternalIntents.openRentalDeepLink(context, link.uri)) {
+            fallback?.let { openRental(context, it, fallback = null) }
+        }
+        is RentalLink.OperatorApp -> ExternalIntents.openRentalApp(context, link.packageName)
+        is RentalLink.Web -> ExternalIntents.goToUrl(context, link.url)
+    }
+}
+
+/** What to call the rented vehicle — total over [RentalVehicleKind], so a new kind needs its word. */
+private fun rentalVehicleRes(kind: RentalVehicleKind): Int = when (kind) {
+    RentalVehicleKind.BIKE -> R.string.trip_plan_rental_bike
+    RentalVehicleKind.EBIKE -> R.string.trip_plan_rental_ebike
+    RentalVehicleKind.CARGO_BIKE -> R.string.trip_plan_rental_cargo_bike
+    RentalVehicleKind.ELECTRIC_CARGO_BIKE -> R.string.trip_plan_rental_electric_cargo_bike
+    RentalVehicleKind.SCOOTER -> R.string.trip_plan_rental_scooter
+    RentalVehicleKind.ESCOOTER -> R.string.trip_plan_rental_escooter
+    RentalVehicleKind.MOPED -> R.string.trip_plan_rental_moped
+    RentalVehicleKind.CAR -> R.string.trip_plan_rental_car
 }
 
 /**
@@ -2231,12 +2353,12 @@ private fun TripResultsErrorPreview() {
 // isolation, not a defect.
 
 /**
- * Renders [entry] alone, [expanded] or not. The row callbacks are no-ops (nothing is tappable in a
- * static preview) and the ETA strip is empty — it needs a live arrivals session, which is exactly the
+ * Renders [entry] — a ride or an on-street leg — alone, [expanded] or not. The row callbacks are
+ * no-ops (nothing is tappable in a static preview) and the ETA strip is empty — it needs a live arrivals session, which is exactly the
  * host dependency previewing one leg is meant to escape.
  */
 @Composable
-private fun TransitLegPreviewFrame(entry: TripLogEntry.Transit, expanded: Boolean = false) {
+private fun LegPreviewFrame(entry: TripLogEntry, expanded: Boolean = false) {
     CompositionLocalProvider(LocalUnitsAreMetric provides false) {
         ObaTheme {
             Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
@@ -2263,14 +2385,14 @@ private fun TransitLegPreviewFrame(entry: TripLogEntry.Transit, expanded: Boolea
 @Composable
 private fun TransitLegPreview() {
     // Board header, "N stops" meta + realtime chip, board stop — the ride's stops stay folded away.
-    TransitLegPreviewFrame(previewTransitLeg())
+    LegPreviewFrame(previewTransitLeg())
 }
 
 @Preview(showBackground = true, widthDp = 400, heightDp = 340, name = "Transit leg · expanded")
 @Composable
 private fun TransitLegExpandedPreview() {
     // What the chevron reveals: every intermediate stop, on the ride's own coloured spine.
-    TransitLegPreviewFrame(previewTransitLeg(), expanded = true)
+    LegPreviewFrame(previewTransitLeg(), expanded = true)
 }
 
 @Preview(showBackground = true, widthDp = 400, heightDp = 300, name = "Transit leg · service alert")
@@ -2278,7 +2400,7 @@ private fun TransitLegExpandedPreview() {
 private fun TransitLegAlertPreview() {
     // The #2143 placement at leg scale: the banner sits under the route header and above "Get on at",
     // which is the adjacency the whole change is about.
-    TransitLegPreviewFrame(previewTransitLeg(alerts = listOf(PREVIEW_BUS_ALERT)))
+    LegPreviewFrame(previewTransitLeg(alerts = listOf(PREVIEW_BUS_ALERT)))
 }
 
 @Preview(showBackground = true, widthDp = 400, heightDp = 360, name = "Transit leg · two alerts")
@@ -2286,14 +2408,14 @@ private fun TransitLegAlertPreview() {
 private fun TransitLegTwoAlertsPreview() {
     // Loudest first, and two tinted cards stacked — the case where the leg header risks being crowded
     // off the top of the row.
-    TransitLegPreviewFrame(previewTransitLeg(alerts = listOf(PREVIEW_FERRY_ALERT, PREVIEW_BUS_ALERT)))
+    LegPreviewFrame(previewTransitLeg(alerts = listOf(PREVIEW_FERRY_ALERT, PREVIEW_BUS_ALERT)))
 }
 
 @Preview(showBackground = true, widthDp = 400, name = "Transit leg · whichever comes first")
 @Composable
 private fun TransitLegInterchangeablePreview() {
     // An interchangeable pair (#2010): one joined roundel plus the caption that says to board either.
-    TransitLegPreviewFrame(
+    LegPreviewFrame(
         previewTransitLeg(
             routeShortName = "1 Line",
             routeDisplayName = null,
@@ -2310,7 +2432,7 @@ private fun TransitLegInterchangeablePreview() {
 private fun TransitLegInterlinePreview() {
     // A stay-aboard route change (#2000/#2071). The seam row shows whether or not the leg is expanded —
     // it instructs the rider rather than merely annotating the ride — so this one stays collapsed.
-    TransitLegPreviewFrame(
+    LegPreviewFrame(
         previewTransitLeg(rideEvents = listOf(PREVIEW_RIDE_STOPS.first(), PREVIEW_INTERLINE_SEAM))
     )
 }
@@ -2320,5 +2442,64 @@ private fun TransitLegInterlinePreview() {
 private fun TransitLegNoShortNamePreview() {
     // No short name to badge, so the row leads with the long name and the boat glyph rides the spine —
     // and with no GTFS colour, the whole leg falls back to one neutral hue rather than three.
-    TransitLegPreviewFrame(previewFerryLeg())
+    LegPreviewFrame(previewFerryLeg())
+}
+
+// ---- bikeshare-leg previews ----------------------------------------------------------------------
+
+/** A rented-vehicle leg, ridden on [rental] — the shape a bikeshare itinerary's middle leg takes. */
+private fun previewRentalLeg(rental: RentalPickup) = TripLogEntry.Walk(
+    mode = StreetMode.BIKESHARE,
+    durationMinutes = 12,
+    distanceMeters = 3380.0,
+    isTransfer = false,
+    steps = emptyList(),
+    rental = rental
+)
+
+@Preview(showBackground = true, widthDp = 400, name = "Bikeshare leg · known operator")
+@Preview(
+    showBackground = true,
+    widthDp = 400,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "Bikeshare leg · known operator, dark"
+)
+@Composable
+private fun BikeshareLegPreview() {
+    // What a Puget Sound rider actually gets today: a catalogued operator on its brand colour, an
+    // electric-assist bicycle with its remaining range, no dock to look for, and — the feed publishing
+    // no rental URI — a button that opens the operator rather than claiming to unlock this bike. Drawn
+    // in both themes because a saturated brand colour is exactly what the chip's tinting has to tame.
+    LegPreviewFrame(
+        previewRentalLeg(
+            RentalPickup(
+                operator = RentalOperators.of("lime_seattle"),
+                vehicle = RentalVehicleKind.EBIKE,
+                stationName = null,
+                isDockless = true,
+                rangeMeters = 43356,
+                link = RentalLink.OperatorApp("com.limebike"),
+                fallback = RentalLink.Web("https://www.li.me/")
+            )
+        )
+    )
+}
+
+@Preview(showBackground = true, widthDp = 400, name = "Bikeshare leg · docked, unknown operator")
+@Composable
+private fun BikeshareLegDockedPreview() {
+    // The other end of the range: a network the catalog has never heard of, wearing its raw id on a
+    // neutral chip, with a dock to name and nothing to link to. Nothing here is invented for it.
+    LegPreviewFrame(
+        previewRentalLeg(
+            RentalPickup(
+                operator = RentalOperators.of("some_city_bikes"),
+                vehicle = null,
+                stationName = "Pine St & 3rd Ave",
+                isDockless = false,
+                rangeMeters = null,
+                link = null
+            )
+        )
+    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1702,9 +1702,11 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
         RouteBadgeChip(
             shortName = name,
             routeColor = rental.operator.brandColor,
+            scale = RENTAL_OPERATOR_CHIP_SCALE,
             // A brand name is a word, not a route number: capped so a long one ellipsizes inside the
-            // chip instead of pushing the vehicle beside it off the row.
-            maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH,
+            // chip instead of pushing the vehicle beside it off the row. Scaled with the chip, or the
+            // enlargement would buy the arrow room by taking it from the name.
+            maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH * RENTAL_OPERATOR_CHIP_SCALE,
             trailingIcon = R.drawable.ic_open_in_new.takeIf { link != null },
             modifier = modifier.semantics { contentDescription = described }
         )
@@ -1727,7 +1729,14 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
     }
 }
 
-/** How wide the operator chip may get before its name ellipsizes — about a dozen characters. */
+/**
+ * How much bigger the operator chip is than a route roundel. It is the leg's brand *and* its only tap
+ * target, and it carries a glyph beside the name, so it is drawn above roundel size — the same 1.5×
+ * the directions board badge uses, rather than a size of its own.
+ */
+private const val RENTAL_OPERATOR_CHIP_SCALE = 1.5f
+
+/** How wide the operator chip may get before its name ellipsizes, at scale 1 — a dozen characters. */
 private val RENTAL_OPERATOR_CHIP_MAX_WIDTH = 96.dp
 
 /**
@@ -2369,16 +2378,25 @@ private fun TripResultsErrorPreview() {
 
 /**
  * Renders [entry] — a ride or an on-street leg — alone, [expanded] or not. The row callbacks are
- * no-ops (nothing is tappable in a static preview) and the ETA strip is empty — it needs a live arrivals session, which is exactly the
- * host dependency previewing one leg is meant to escape.
+ * no-ops (nothing is tappable in a static preview) and the ETA strip is empty — it needs a live
+ * arrivals session, which is exactly the host dependency previewing one leg is meant to escape.
  */
 @Composable
 private fun LegPreviewFrame(entry: TripLogEntry, expanded: Boolean = false) {
+    LegsPreviewFrame(listOf(entry), if (expanded) setOf(0) else emptySet())
+}
+
+/**
+ * The same, for a short run of consecutive legs — where what's being looked at is how a leg sits
+ * against its neighbours (spacing, the spine's colour flip at each node) rather than the leg alone.
+ */
+@Composable
+private fun LegsPreviewFrame(entries: List<TripLogEntry>, expanded: Set<Int> = emptySet()) {
     CompositionLocalProvider(LocalUnitsAreMetric provides false) {
         ObaTheme {
             Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
                 Column {
-                    rememberLogRows(listOf(entry), if (expanded) setOf(0) else emptySet()).forEach { row ->
+                    rememberLogRows(entries, expanded).forEach { row ->
                         key(row.key) {
                             LogRow(
                                 model = row,
@@ -2483,8 +2501,8 @@ private fun previewRentalLeg(rental: RentalPickup) = TripLogEntry.Walk(
 private fun BikeshareLegPreview() {
     // What a Puget Sound rider actually gets today: a catalogued operator on its brand colour, an
     // electric-assist bicycle with its remaining range, no dock to look for, and — the feed publishing
-    // no rental URI — a button that opens the operator rather than claiming to unlock this bike. Drawn
-    // in both themes because a saturated brand colour is exactly what the chip's tinting has to tame.
+    // no rental URI — a chip that opens the operator rather than claiming to unlock this bike. Drawn in
+    // both themes because a saturated brand colour is exactly what the chip's tinting has to tame.
     LegPreviewFrame(
         previewRentalLeg(
             RentalPickup(
@@ -2497,6 +2515,51 @@ private fun BikeshareLegPreview() {
             )
         )
     )
+}
+
+/** The walk that fetches the bike, the ride, and the walk from where it's left. */
+private fun previewBikeshareItinerary() = listOf(
+    TripLogEntry.Terminal(kind = TerminalKind.START, time = ServerTime(0L), place = "3rd Ave & Pike St"),
+    TripLogEntry.Walk(
+        mode = StreetMode.WALK,
+        durationMinutes = 3,
+        distanceMeters = 210.0,
+        isTransfer = false,
+        steps = listOf(LogStep("Head north on 3rd Ave", distanceMeters = 210.0))
+    ),
+    previewRentalLeg(
+        RentalPickup(
+            operator = RentalOperators.of("lime_seattle"),
+            vehicle = RentalVehicleKind.EBIKE,
+            stationName = null,
+            rangeMeters = 43356,
+            link = RentalLink.OperatorApp("com.limebike"),
+            fallback = RentalLink.Web("https://www.li.me/")
+        )
+    ),
+    TripLogEntry.Walk(
+        mode = StreetMode.WALK,
+        durationMinutes = 2,
+        distanceMeters = 140.0,
+        isTransfer = false,
+        steps = listOf(LogStep("Head west on Denny Way", distanceMeters = 140.0))
+    ),
+    TripLogEntry.Terminal(kind = TerminalKind.ARRIVE, time = ServerTime(17 * 60_000L), place = "Seattle Center")
+)
+
+@Preview(showBackground = true, widthDp = 400, heightDp = 420, name = "Bikeshare itinerary · walk, ride, walk")
+@Preview(
+    showBackground = true,
+    widthDp = 400,
+    heightDp = 420,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "Bikeshare itinerary · walk, ride, walk, dark"
+)
+@Composable
+private fun BikeshareItineraryPreview() {
+    // The ride between its neighbours — where the operator chip has to hold its own against the walk
+    // rows above and below it without swamping them.
+    LegsPreviewFrame(previewBikeshareItinerary())
 }
 
 @Preview(showBackground = true, widthDp = 400, name = "Bikeshare leg · docked, unknown operator")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -56,7 +56,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -1594,10 +1594,14 @@ private fun ColumnScope.TerminalContent(entry: TripLogEntry.Terminal) {
 private fun streetActionRes(mode: StreetMode, isTransfer: Boolean): Int = when (mode) {
     StreetMode.WALK ->
         if (isTransfer) R.string.trip_plan_walk_transfer else R.string.step_by_step_non_transit_mode_walk_action
-    // A rented bike is still ridden: the verb is the same as for the rider's own bike, and only the
-    // glyph (and the map's dock markers) say where it came from.
-    StreetMode.BIKE, StreetMode.BIKESHARE ->
+    StreetMode.BIKE ->
         if (isTransfer) R.string.trip_plan_bike_transfer else R.string.step_by_step_non_transit_mode_bicycle_action
+    // A shared bike is a different act from riding your own — you have to find it and rent it first —
+    // so the leg is titled by what the rider is doing rather than by the vehicle they end up on. It's
+    // the same word the option card's glyph is announced with ([StreetMetric.BIKESHARE]), so the card
+    // and the row that expands from it name the leg alike.
+    StreetMode.BIKESHARE ->
+        if (isTransfer) R.string.trip_plan_bikeshare_transfer else R.string.transit_directions_bikeshare_label
     StreetMode.CAR ->
         if (isTransfer) R.string.trip_plan_car_transfer else R.string.step_by_step_non_transit_mode_car_action
 }
@@ -1629,10 +1633,15 @@ private fun ColumnScope.WalkHeaderContent(entry: TripLogEntry.Walk) {
  * it is, where to find it, and how to unlock it. Before this the leg said only "Bike", which told a
  * rider standing over an unfamiliar scooter nothing about which app opens it.
  *
- * Everything here is drawn from what the feed actually said, and each part is omitted rather than
- * guessed when it didn't: an operator the app has no catalog entry for wears its raw network id (see
- * [RentalOperators]), a dock that published no name draws no pickup line at all, and a network with
- * neither a rental URI nor a catalog entry gets no button rather than one going somewhere approximate.
+ * The operator's chip is also the way over to them: it wears an open-in-new arrow and is the row's
+ * only external affordance, so the brand the rider is looking for and the thing they tap are one
+ * object rather than a chip with a button repeating its name underneath. A network with neither a
+ * rental URI nor a catalog entry has nowhere to send anyone, and its chip is a plain label — no arrow,
+ * no tap — rather than one going somewhere approximate.
+ *
+ * Everything else is drawn from what the feed actually said, and omitted rather than guessed when it
+ * didn't: an operator the app has no catalog entry for wears its raw network id (see
+ * [RentalOperators]), and a pickup with no named dock draws no pickup line.
  *
  * The vehicle id is deliberately not shown. The ids the live networks publish are UUIDs — nothing a
  * rider can match against the bike in front of them — so drawing one would be noise that reads like an
@@ -1647,16 +1656,7 @@ private fun ColumnScope.RentalContent(rental: RentalPickup) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        val name = rental.operator.displayName
-        val described = stringResource(R.string.trip_plan_rental_operator_description, name)
-        RouteBadgeChip(
-            shortName = name,
-            routeColor = rental.operator.brandColor,
-            // A brand name is a word, not a route number: capped so a long one ellipsizes inside the
-            // chip instead of pushing the vehicle beside it off the row.
-            maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH,
-            modifier = Modifier.semantics { contentDescription = described }
-        )
+        OperatorChip(rental) { link -> openRental(context, link, rental.fallback) }
         val details = listOfNotNull(
             rental.vehicle?.let { stringResource(rentalVehicleRes(it)) },
             rental.rangeMeters?.let {
@@ -1674,40 +1674,55 @@ private fun ColumnScope.RentalContent(rental: RentalPickup) {
             )
         }
     }
-    // Where to find it: the dock by name, or the fact that there isn't one. A docked station that
-    // published no name says neither — "dockless" would send the rider looking for the wrong thing.
-    val pickup = when {
-        rental.stationName != null -> stringResource(R.string.trip_plan_rental_pick_up_at, rental.stationName)
-        rental.isDockless -> stringResource(R.string.trip_plan_rental_dockless)
-        else -> null
-    }
-    pickup?.let {
+    rental.stationName?.let {
         Text(
-            text = it,
+            text = stringResource(R.string.trip_plan_rental_pick_up_at, it),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
-    rental.link?.let { link ->
-        TextButton(
-            onClick = { openRental(context, link, rental.fallback) },
-            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-            modifier = Modifier.padding(top = 2.dp)
+}
+
+/**
+ * The operator on its brand colour — and, when there is somewhere to send the rider, the tap that
+ * takes them there.
+ *
+ * The chip itself is roundel-sized, which is well under a comfortable touch target, so the tappable
+ * form reserves the interactive minimum around it ([minimumInteractiveComponentSize]) rather than
+ * leaving a rider to hit an 18dp mark. Only [RentalLink.Deep] names the exact vehicle they were routed
+ * onto, so only it is announced as opening it; the rest merely open the operator, and none of it
+ * claims a reservation was made (see #2138).
+ */
+@Composable
+private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
+    val name = rental.operator.displayName
+    val described = stringResource(R.string.trip_plan_rental_operator_description, name)
+    val link = rental.link
+    val chip = @Composable { modifier: Modifier ->
+        RouteBadgeChip(
+            shortName = name,
+            routeColor = rental.operator.brandColor,
+            // A brand name is a word, not a route number: capped so a long one ellipsizes inside the
+            // chip instead of pushing the vehicle beside it off the row.
+            maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH,
+            trailingIcon = R.drawable.ic_open_in_new.takeIf { link != null },
+            modifier = modifier.semantics { contentDescription = described }
+        )
+    }
+    if (link == null) {
+        chip(Modifier)
+    } else {
+        val openLabel = stringResource(
+            if (link is RentalLink.Deep) R.string.trip_plan_rental_open_in else R.string.trip_plan_rental_rent_with,
+            name
+        )
+        Box(
+            modifier = Modifier
+                .minimumInteractiveComponentSize()
+                .clickable(onClickLabel = openLabel) { onOpen(link) },
+            contentAlignment = Alignment.Center
         ) {
-            Text(
-                // Only a link to *this* vehicle may say "open it"; the rest merely open the operator,
-                // and the rider still has to find the bike themselves. Nothing here claims the vehicle
-                // was reserved — see #2138 for what an actual handoff would take.
-                text = stringResource(
-                    if (link is RentalLink.Deep) {
-                        R.string.trip_plan_rental_open_in
-                    } else {
-                        R.string.trip_plan_rental_rent_with
-                    },
-                    rental.operator.displayName
-                ),
-                style = MaterialTheme.typography.labelLarge
-            )
+            chip(Modifier)
         }
     }
 }
@@ -2476,7 +2491,6 @@ private fun BikeshareLegPreview() {
                 operator = RentalOperators.of("lime_seattle"),
                 vehicle = RentalVehicleKind.EBIKE,
                 stationName = null,
-                isDockless = true,
                 rangeMeters = 43356,
                 link = RentalLink.OperatorApp("com.limebike"),
                 fallback = RentalLink.Web("https://www.li.me/")
@@ -2496,7 +2510,6 @@ private fun BikeshareLegDockedPreview() {
                 operator = RentalOperators.of("some_city_bikes"),
                 vehicle = null,
                 stationName = "Pine St & 3rd Ave",
-                isDockless = false,
                 rangeMeters = null,
                 link = null
             )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -1652,9 +1651,8 @@ private fun ColumnScope.RentalContent(rental: RentalPickup) {
     val context = LocalContext.current
     val metric = unitsAreMetric()
     Row(
-        modifier = Modifier.padding(top = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         OperatorChip(rental) { link -> openRental(context, link, rental.fallback) }
         val details = listOfNotNull(
@@ -1687,11 +1685,14 @@ private fun ColumnScope.RentalContent(rental: RentalPickup) {
  * The operator on its brand colour — and, when there is somewhere to send the rider, the tap that
  * takes them there.
  *
- * The chip itself is roundel-sized, which is well under a comfortable touch target, so the tappable
- * form reserves the interactive minimum around it ([minimumInteractiveComponentSize]) rather than
- * leaving a rider to hit an 18dp mark. Only [RentalLink.Deep] names the exact vehicle they were routed
- * onto, so only it is announced as opening it; the rest merely open the operator, and none of it
- * claims a reservation was made (see #2138).
+ * The tap area is the chip plus [RENTAL_OPERATOR_CHIP_TAP_PADDING], which lands short of the 48dp
+ * interactive minimum — deliberately: reserving the full minimum around a chip this size padded the
+ * row by a dozen dp above and below and made the leg read as three loosely-spaced blocks rather than
+ * one. The chip is drawn at [RENTAL_OPERATOR_CHIP_SCALE] partly to keep what is left a comfortable
+ * mark, and it is never the only way on — the row it sits in is itself a tap target.
+ *
+ * Only [RentalLink.Deep] names the exact vehicle the rider was routed onto, so only it is announced as
+ * opening it; the rest merely open the operator, and none of it claims a reservation was made (#2138).
  */
 @Composable
 private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
@@ -1705,11 +1706,12 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
         )
     }
     Box(
-        modifier = if (link == null) {
-            Modifier
-        } else {
-            Modifier.minimumInteractiveComponentSize().clickable(onClickLabel = openLabel) { onOpen(link) }
-        },
+        // Padding *after* clickable, so the breathing room around the chip is part of what the rider
+        // can hit rather than a dead margin outside it.
+        modifier = when (link) {
+            null -> Modifier
+            else -> Modifier.clickable(onClickLabel = openLabel) { onOpen(link) }
+        }.padding(vertical = RENTAL_OPERATOR_CHIP_TAP_PADDING),
         contentAlignment = Alignment.Center
     ) {
         RouteBadgeChip(
@@ -1732,6 +1734,9 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
  * the directions board badge uses, rather than a size of its own.
  */
 private const val RENTAL_OPERATOR_CHIP_SCALE = 1.5f
+
+/** The breathing room above and below the operator chip, which is also part of its tap area. */
+private val RENTAL_OPERATOR_CHIP_TAP_PADDING = 3.dp
 
 /** How wide the operator chip may get before its name ellipsizes, at scale 1 — a dozen characters. */
 private val RENTAL_OPERATOR_CHIP_MAX_WIDTH = 96.dp

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1652,7 +1652,7 @@ private fun ColumnScope.RentalContent(rental: RentalPickup) {
     val metric = unitsAreMetric()
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(2.dp)
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         OperatorChip(rental) { link -> openRental(context, link, rental.fallback) }
         val details = listOfNotNull(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1698,7 +1698,20 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
     val name = rental.operator.displayName
     val described = stringResource(R.string.trip_plan_rental_operator_description, name)
     val link = rental.link
-    val chip = @Composable { modifier: Modifier ->
+    val openLabel = link?.let {
+        stringResource(
+            if (it is RentalLink.Deep) R.string.trip_plan_rental_open_in else R.string.trip_plan_rental_rent_with,
+            name
+        )
+    }
+    Box(
+        modifier = if (link == null) {
+            Modifier
+        } else {
+            Modifier.minimumInteractiveComponentSize().clickable(onClickLabel = openLabel) { onOpen(link) }
+        },
+        contentAlignment = Alignment.Center
+    ) {
         RouteBadgeChip(
             shortName = name,
             routeColor = rental.operator.brandColor,
@@ -1708,24 +1721,8 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
             // enlargement would buy the arrow room by taking it from the name.
             maxWidth = RENTAL_OPERATOR_CHIP_MAX_WIDTH * RENTAL_OPERATOR_CHIP_SCALE,
             trailingIcon = R.drawable.ic_open_in_new.takeIf { link != null },
-            modifier = modifier.semantics { contentDescription = described }
+            modifier = Modifier.semantics { contentDescription = described }
         )
-    }
-    if (link == null) {
-        chip(Modifier)
-    } else {
-        val openLabel = stringResource(
-            if (link is RentalLink.Deep) R.string.trip_plan_rental_open_in else R.string.trip_plan_rental_rent_with,
-            name
-        )
-        Box(
-            modifier = Modifier
-                .minimumInteractiveComponentSize()
-                .clickable(onClickLabel = openLabel) { onOpen(link) },
-            contentAlignment = Alignment.Center
-        ) {
-            chip(Modifier)
-        }
     }
 }
 
@@ -1746,10 +1743,10 @@ private val RENTAL_OPERATOR_CHIP_MAX_WIDTH = 96.dp
  */
 private fun openRental(context: Context, link: RentalLink, fallback: RentalLink?) {
     when (link) {
-        is RentalLink.Deep -> if (!ExternalIntents.openRentalDeepLink(context, link.uri)) {
+        is RentalLink.Deep -> if (!ExternalIntents.openFeedUri(context, link.uri)) {
             fallback?.let { openRental(context, it, fallback = null) }
         }
-        is RentalLink.OperatorApp -> ExternalIntents.openRentalApp(context, link.packageName)
+        is RentalLink.OperatorApp -> ExternalIntents.openAppOrStoreListing(context, link.packageName)
         is RentalLink.Web -> ExternalIntents.goToUrl(context, link.url)
     }
 }
@@ -2480,6 +2477,17 @@ private fun TransitLegNoShortNamePreview() {
 
 // ---- bikeshare-leg previews ----------------------------------------------------------------------
 
+/** The pickup a Puget Sound rider actually gets today: a catalogued operator, an e-bike, no dock. */
+private fun previewLimePickup() = RentalPickup(
+    operator = RentalOperators.of("lime_seattle"),
+    vehicle = RentalVehicleKind.EBIKE,
+    stationName = null,
+    rangeMeters = 43356,
+    // No live network publishes a rental URI, so the chip opens the operator rather than this vehicle.
+    link = RentalLink.OperatorApp("com.limebike"),
+    fallback = RentalLink.Web("https://www.li.me/")
+)
+
 /** A rented-vehicle leg, ridden on [rental] — the shape a bikeshare itinerary's middle leg takes. */
 private fun previewRentalLeg(rental: RentalPickup) = TripLogEntry.Walk(
     mode = StreetMode.BIKESHARE,
@@ -2503,18 +2511,7 @@ private fun BikeshareLegPreview() {
     // electric-assist bicycle with its remaining range, no dock to look for, and — the feed publishing
     // no rental URI — a chip that opens the operator rather than claiming to unlock this bike. Drawn in
     // both themes because a saturated brand colour is exactly what the chip's tinting has to tame.
-    LegPreviewFrame(
-        previewRentalLeg(
-            RentalPickup(
-                operator = RentalOperators.of("lime_seattle"),
-                vehicle = RentalVehicleKind.EBIKE,
-                stationName = null,
-                rangeMeters = 43356,
-                link = RentalLink.OperatorApp("com.limebike"),
-                fallback = RentalLink.Web("https://www.li.me/")
-            )
-        )
-    )
+    LegPreviewFrame(previewRentalLeg(previewLimePickup()))
 }
 
 /** The walk that fetches the bike, the ride, and the walk from where it's left. */
@@ -2527,16 +2524,7 @@ private fun previewBikeshareItinerary() = listOf(
         isTransfer = false,
         steps = listOf(LogStep("Head north on 3rd Ave", distanceMeters = 210.0))
     ),
-    previewRentalLeg(
-        RentalPickup(
-            operator = RentalOperators.of("lime_seattle"),
-            vehicle = RentalVehicleKind.EBIKE,
-            stationName = null,
-            rangeMeters = 43356,
-            link = RentalLink.OperatorApp("com.limebike"),
-            fallback = RentalLink.Web("https://www.li.me/")
-        )
-    ),
+    previewRentalLeg(previewLimePickup()),
     TripLogEntry.Walk(
         mode = StreetMode.WALK,
         durationMinutes = 2,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -170,6 +170,10 @@ sealed interface TripLogEntry {
      * Tapping the leg frames [legPoints] (or, with no geometry, recentres on [focusPoint]).
      *
      * Named `Walk` because walking is overwhelmingly the case; [mode] carries the rest.
+     *
+     * [rental] is the shared vehicle a [StreetMode.BIKESHARE] leg is ridden on (#2150) — whose it is,
+     * what kind it is, and how to unlock it. Null on every other leg, and on a bikeshare leg the wire
+     * said nothing about (see [rentalPickup]).
      */
     data class Walk(
         val mode: StreetMode,
@@ -177,6 +181,7 @@ sealed interface TripLogEntry {
         val distanceMeters: Double,
         val isTransfer: Boolean,
         val steps: List<LogStep>,
+        val rental: RentalPickup? = null,
         val legPoints: List<GeoPoint> = emptyList(),
         val focusPoint: GeoPoint? = null,
         val legIndices: Set<Int> = emptySet(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -27,6 +27,7 @@ import android.net.Uri
 import android.os.Build
 import android.text.TextUtils
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.core.net.toUri
 import com.google.android.gms.common.GoogleApiAvailability
 import org.onebusaway.android.R
@@ -134,36 +135,39 @@ object ExternalIntents {
     }
 
     /**
-     * Hands the rider to a rental operator's app (#2150): its launcher activity when it's installed,
-     * else its Play Store page so they can get it.
+     * Hands the user to another app: its launcher activity when it's installed, else its Google Play
+     * listing so they can get it. Returns whether the installed app was opened — the difference
+     * callers report to analytics ("opened it" vs. "sent them to download it").
      *
-     * The package has to be declared in the manifest's `<queries>` block for the installed case to be
-     * reachable at all — without it, Android 11+ package visibility makes `getLaunchIntentForPackage`
-     * return null for an app that is right there. The store fallback keeps that a degradation rather
-     * than a dead end, but a catalog entry whose package isn't declared silently never opens the app;
-     * see `RentalOperators.KnownOperator.appPackage`.
+     * Android 11+ package visibility applies: a package the manifest's `<queries>` block doesn't
+     * declare is invisible to [PackageManager.getLaunchIntentForPackage] however installed it is, and
+     * always takes the store path. The store fallback makes that a degradation rather than a dead end,
+     * so an undeclared package is a quiet miss — see the bikeshare operators' packages there, which
+     * must stay in step with `RentalOperators`' catalog.
      */
-    fun openRentalApp(context: Context, packageName: String) {
+    fun openAppOrStoreListing(context: Context, packageName: String): Boolean {
         val launch = context.packageManager.getLaunchIntentForPackage(packageName)
         if (launch != null) {
             try {
-                context.startActivity(launch)
-                return
+                context.startActivity(launch.addCategory(Intent.CATEGORY_LAUNCHER))
+                return true
             } catch (e: ActivityNotFoundException) {
                 // Uninstalled/disabled between the resolve and the launch — fall through to the store.
             }
         }
-        goToUrl(context, "https://play.google.com/store/apps/details?id=$packageName")
+        goToUrl(context, context.getString(R.string.google_play_listing_prefix, packageName))
+        return false
     }
 
     /**
-     * Opens an operator-supplied rental deep link, reporting whether anything handled it.
+     * Opens a URI published by a transit feed — a rental operator's deep link to one vehicle (#2150) —
+     * reporting whether anything on the device handled it.
      *
-     * Unlike [goToUrl] this doesn't toast on failure: the URI comes from a transit feed rather than
-     * from the rider, and "no app for `lime://…`" is the app's problem to fall back from, not an error
-     * to put in front of them.
+     * Unlike [goToUrl] this doesn't toast on failure: the URI came from a feed rather than from the
+     * user, and "no app for `lime://…`" is the caller's cue to fall back, not an error to put in front
+     * of them.
      */
-    fun openRentalDeepLink(context: Context, uri: String): Boolean = try {
+    fun openFeedUri(context: Context, uri: String): Boolean = try {
         context.startActivity(Intent(Intent.ACTION_VIEW, uri.toUri()))
         true
     } catch (e: ActivityNotFoundException) {
@@ -412,29 +416,8 @@ object ExternalIntents {
      * @param region region to launch a payment Intent for
      */
     fun startPaymentIntent(activity: Activity, region: Region) {
-        val manager = activity.packageManager
-        val paymentAndroidAppId = region.paymentAndroidAppId.orEmpty()
-        var intent = manager.getLaunchIntentForPackage(paymentAndroidAppId)
-        if (intent != null) {
-            // Launch installed app
-            intent.addCategory(Intent.CATEGORY_LAUNCHER)
-            activity.startActivity(intent)
-            AnalyticsEntryPoint.get(activity).reportUiEvent(
-                PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                activity.getString(R.string.analytics_label_button_fare_payment),
-                activity.getString(R.string.analytics_label_open_app)
-            )
-        } else {
-            // Go to Play Store listing to download app
-            intent = Intent(Intent.ACTION_VIEW)
-            intent.setData(activity.getString(R.string.google_play_listing_prefix, paymentAndroidAppId).toUri())
-            activity.startActivity(intent)
-            AnalyticsEntryPoint.get(activity).reportUiEvent(
-                PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                activity.getString(R.string.analytics_label_button_fare_payment),
-                activity.getString(R.string.analytics_label_download_app)
-            )
-        }
+        val opened = openAppOrStoreListing(activity, region.paymentAndroidAppId.orEmpty())
+        reportAppHandoff(activity, R.string.analytics_label_button_fare_payment, opened)
     }
 
     /**
@@ -444,27 +427,16 @@ object ExternalIntents {
      * @param context context to launch the fare payment app or Google Play store from
      */
     fun launchTampaHoprApp(context: Context) {
-        val manager = context.packageManager
-        var intent = manager.getLaunchIntentForPackage(context.getString(R.string.hopr_android_app_id))
-        if (intent != null) {
-            // Launch installed app
-            intent.addCategory(Intent.CATEGORY_LAUNCHER)
-            context.startActivity(intent)
-            AnalyticsEntryPoint.get(context).reportUiEvent(
-                PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                context.getString(R.string.analytics_label_button_bike_share),
-                context.getString(R.string.analytics_label_open_app)
-            )
-        } else {
-            // Go to Play Store listing to download app
-            intent = Intent(Intent.ACTION_VIEW)
-            intent.setData(context.getString(R.string.google_play_listing_prefix, context.getString(R.string.hopr_android_app_id)).toUri())
-            context.startActivity(intent)
-            AnalyticsEntryPoint.get(context).reportUiEvent(
-                PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
-                context.getString(R.string.analytics_label_button_bike_share),
-                context.getString(R.string.analytics_label_download_app)
-            )
-        }
+        val opened = openAppOrStoreListing(context, context.getString(R.string.hopr_android_app_id))
+        reportAppHandoff(context, R.string.analytics_label_button_bike_share, opened)
+    }
+
+    /** Reports a hand-off to another app: which button sent the user, and whether it opened or downloaded. */
+    private fun reportAppHandoff(context: Context, @StringRes buttonLabel: Int, opened: Boolean) {
+        AnalyticsEntryPoint.get(context).reportUiEvent(
+            PlausibleAnalytics.REPORT_FARE_PAYMENT_EVENT_URL,
+            context.getString(buttonLabel),
+            context.getString(if (opened) R.string.analytics_label_open_app else R.string.analytics_label_download_app)
+        )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -151,7 +151,7 @@ object ExternalIntents {
             try {
                 context.startActivity(launch.addCategory(Intent.CATEGORY_LAUNCHER))
                 return true
-            } catch (e: ActivityNotFoundException) {
+            } catch (_: ActivityNotFoundException) {
                 // Uninstalled/disabled between the resolve and the launch — fall through to the store.
             }
         }
@@ -170,7 +170,7 @@ object ExternalIntents {
     fun openFeedUri(context: Context, uri: String): Boolean = try {
         context.startActivity(Intent(Intent.ACTION_VIEW, uri.toUri()))
         true
-    } catch (e: ActivityNotFoundException) {
+    } catch (_: ActivityNotFoundException) {
         false
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -382,7 +382,8 @@ object ExternalIntents {
      * payment-app warning the user hasn't opted out of, returns that region so the caller can show
      * the warning dialog and then call [startPaymentIntent]; otherwise launches the payment
      * intent directly (installed app, else the Google Play listing) and returns null. Returns null
-     * when there is no current region (e.g. a custom API URL is set).
+     * when there is no current region (e.g. a custom API URL is set), or when the region names no
+     * payment app.
      * @param activity activity to launch the fare payment app or Google Play store from
      * @return the region whose payment warning must be shown first, or null if already handled
      */
@@ -390,6 +391,14 @@ object ExternalIntents {
         val region = RegionEntryPoint.get(activity).currentRegion()
         if (region == null) {
             // If a custom API URL is set (i.e., no region), then no op
+            return null
+        }
+        // No app to launch: no warning dialog either, or the rider confirms one and nothing happens.
+        // The drawer gates its Pay Fare row on this same field (NavItemsRepository.payFareAvailable),
+        // but re-pulls the gate only when the region *id* changes, so a directory refresh that empties
+        // the field on the same region leaves the row drawn. Emptiness is judged exactly as that gate
+        // judges it, so the two cannot disagree about which regions can pay a fare.
+        if (region.paymentAndroidAppId.isNullOrEmpty()) {
             return null
         }
 
@@ -411,12 +420,16 @@ object ExternalIntents {
 
     /**
      * Launches the payment app for the provided region if it's already installed, and if not
-     * directs the user to the listing in Google Play where it can be downloaded
+     * directs the user to the listing in Google Play where it can be downloaded. A region naming no
+     * payment app launches nothing: an empty package id resolves to no launcher and would send the
+     * rider to a Play listing for a package called "" (see [payFareOrWarningRegion], which stops that
+     * region a step earlier — this is the entry the warning dialog's confirm path calls directly).
      * @param activity Activity to use to launch the Intent
      * @param region region to launch a payment Intent for
      */
     fun startPaymentIntent(activity: Activity, region: Region) {
-        val opened = openAppOrStoreListing(activity, region.paymentAndroidAppId.orEmpty())
+        val appId = region.paymentAndroidAppId?.ifEmpty { null } ?: return
+        val opened = openAppOrStoreListing(activity, appId)
         reportAppHandoff(activity, R.string.analytics_label_button_fare_payment, opened)
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -133,6 +133,43 @@ object ExternalIntents {
         return match?.activityInfo?.packageName
     }
 
+    /**
+     * Hands the rider to a rental operator's app (#2150): its launcher activity when it's installed,
+     * else its Play Store page so they can get it.
+     *
+     * The package has to be declared in the manifest's `<queries>` block for the installed case to be
+     * reachable at all — without it, Android 11+ package visibility makes `getLaunchIntentForPackage`
+     * return null for an app that is right there. The store fallback keeps that a degradation rather
+     * than a dead end, but a catalog entry whose package isn't declared silently never opens the app;
+     * see `RentalOperators.KnownOperator.appPackage`.
+     */
+    fun openRentalApp(context: Context, packageName: String) {
+        val launch = context.packageManager.getLaunchIntentForPackage(packageName)
+        if (launch != null) {
+            try {
+                context.startActivity(launch)
+                return
+            } catch (e: ActivityNotFoundException) {
+                // Uninstalled/disabled between the resolve and the launch — fall through to the store.
+            }
+        }
+        goToUrl(context, "https://play.google.com/store/apps/details?id=$packageName")
+    }
+
+    /**
+     * Opens an operator-supplied rental deep link, reporting whether anything handled it.
+     *
+     * Unlike [goToUrl] this doesn't toast on failure: the URI comes from a transit feed rather than
+     * from the rider, and "no app for `lime://…`" is the app's problem to fall back from, not an error
+     * to put in front of them.
+     */
+    fun openRentalDeepLink(context: Context, uri: String): Boolean = try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, uri.toUri()))
+        true
+    } catch (e: ActivityNotFoundException) {
+        false
+    }
+
     fun goToPhoneDialer(context: Context, url: String) {
         val intent = Intent(Intent.ACTION_DIAL)
         intent.setData(url.toUri())

--- a/onebusaway-android/src/main/res/drawable/ic_open_in_new.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_open_in_new.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <!--
+      Material Symbols `open_in_new` — the arrow leaving a frame, the conventional mark for "this
+      hands you to somewhere outside the app". Drawn on the bikeshare operator's chip, where it says
+      the chip is the way over to the operator rather than a label (#2150).
+
+      autoMirrored because the arrow points the way a reader leaves the row; the app is LTR-only
+      today (see ic_arrow_right), so declaring it costs nothing and keeps it right if that changes.
+    -->
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z"/>
+</vector>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1015,6 +1015,9 @@
          phrasing stays a translator's call. -->
     <string name="trip_plan_walk_transfer">Walk to transfer</string>
     <string name="trip_plan_bike_transfer">Bike to transfer</string>
+    <!-- A shared bike, as opposed to the rider's own: the leg is named for the act (finding and
+         renting one), which is what makes it different from riding the bike you brought. -->
+    <string name="trip_plan_bikeshare_transfer">Bikeshare to transfer</string>
     <string name="trip_plan_car_transfer">Drive to transfer</string>
     <!-- The rented vehicle a bikeshare leg is ridden on, in the trip-log directions. "E-" is the
          electric form of each: the feed states the propulsion, so the two are never guessed apart. -->
@@ -1026,15 +1029,14 @@
     <string name="trip_plan_rental_escooter">E-scooter</string>
     <string name="trip_plan_rental_moped">Moped</string>
     <string name="trip_plan_rental_car">Car</string>
-    <!-- Where the rider picks the rented vehicle up: a named dock, or nowhere in particular -->
-    <!-- %1$s is the rental station's name, e.g. "Pick up at Pine St &amp; 3rd Ave" -->
+    <!-- The dock the rider picks the rented vehicle up from. %1$s is the rental station's name,
+         e.g. "Pick up at Pine St &amp; 3rd Ave". A free-floating vehicle has no dock and no line. -->
     <string name="trip_plan_rental_pick_up_at">Pick up at %1$s</string>
-    <string name="trip_plan_rental_dockless">Dockless</string>
     <!-- How far the vehicle can still travel on its charge. %1$s is an already-formatted distance. -->
     <string name="trip_plan_rental_range">%1$s of range left</string>
-    <!-- The action that hands the rider to the rental operator. The first is used only when the
-         operator published a link to this exact vehicle; the second merely opens the operator. %1$s is
-         the operator's name, e.g. "Lime". -->
+    <!-- What tapping the operator's chip does, announced as its click label. The first is used only
+         when the operator published a link to this exact vehicle; the second merely opens the
+         operator. %1$s is the operator's name, e.g. "Lime". -->
     <string name="trip_plan_rental_open_in">Open in %1$s</string>
     <string name="trip_plan_rental_rent_with">Rent with %1$s</string>
     <!-- Announced for the chip naming the rental operator. %1$s is the operator's name. -->

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1016,6 +1016,29 @@
     <string name="trip_plan_walk_transfer">Walk to transfer</string>
     <string name="trip_plan_bike_transfer">Bike to transfer</string>
     <string name="trip_plan_car_transfer">Drive to transfer</string>
+    <!-- The rented vehicle a bikeshare leg is ridden on, in the trip-log directions. "E-" is the
+         electric form of each: the feed states the propulsion, so the two are never guessed apart. -->
+    <string name="trip_plan_rental_bike">Bike</string>
+    <string name="trip_plan_rental_ebike">E-bike</string>
+    <string name="trip_plan_rental_cargo_bike">Cargo bike</string>
+    <string name="trip_plan_rental_electric_cargo_bike">Electric cargo bike</string>
+    <string name="trip_plan_rental_scooter">Scooter</string>
+    <string name="trip_plan_rental_escooter">E-scooter</string>
+    <string name="trip_plan_rental_moped">Moped</string>
+    <string name="trip_plan_rental_car">Car</string>
+    <!-- Where the rider picks the rented vehicle up: a named dock, or nowhere in particular -->
+    <!-- %1$s is the rental station's name, e.g. "Pick up at Pine St &amp; 3rd Ave" -->
+    <string name="trip_plan_rental_pick_up_at">Pick up at %1$s</string>
+    <string name="trip_plan_rental_dockless">Dockless</string>
+    <!-- How far the vehicle can still travel on its charge. %1$s is an already-formatted distance. -->
+    <string name="trip_plan_rental_range">%1$s of range left</string>
+    <!-- The action that hands the rider to the rental operator. The first is used only when the
+         operator published a link to this exact vehicle; the second merely opens the operator. %1$s is
+         the operator's name, e.g. "Lime". -->
+    <string name="trip_plan_rental_open_in">Open in %1$s</string>
+    <string name="trip_plan_rental_rent_with">Rent with %1$s</string>
+    <!-- Announced for the chip naming the rental operator. %1$s is the operator's name. -->
+    <string name="trip_plan_rental_operator_description">Operated by %1$s</string>
     <!-- A leg's elapsed duration in the trip-log's narrow time column. Abbreviated units, kept inside
          the format string (rather than appended in code) so spacing and word order stay translatable.
          Keep the two forms spaced alike — they share one column. -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -27,6 +27,8 @@ import org.onebusaway.android.api.adapters.toTripItineraries
 import org.onebusaway.android.api.graphql.PlanQuery
 import org.onebusaway.android.api.graphql.fragment.AlternativeRouteFields
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
+import org.onebusaway.android.api.graphql.fragment.RentalNetworkFields
+import org.onebusaway.android.api.graphql.fragment.RentalUriFields
 import org.onebusaway.android.api.graphql.fragment.RouteFields
 import org.onebusaway.android.api.graphql.type.AbsoluteDirection
 import org.onebusaway.android.api.graphql.type.AlertSeverityLevelType
@@ -327,7 +329,10 @@ class Otp2PlanDecodeTest {
                 vehicleRentalStation = PlaceFields.VehicleRentalStation(
                     stationId = "seattle_bikes:42",
                     name = "Pine St & 3rd Ave",
-                    rentalNetwork = PlaceFields.RentalNetwork1(networkId = "seattle_bikes", url = null),
+                    rentalNetwork = PlaceFields.RentalNetwork1(
+                        __typename = "VehicleRentalNetwork",
+                        rentalNetworkFields = network("seattle_bikes")
+                    ),
                     rentalUris = null
                 )
             )
@@ -416,10 +421,16 @@ class Otp2PlanDecodeTest {
      */
     private fun rentalVehicle(): PlaceFields.RentalVehicle = PlaceFields.RentalVehicle(
         vehicleId = "lime_seattle:bs_9",
-        rentalNetwork = PlaceFields.RentalNetwork(networkId = "lime_seattle", url = "https://www.li.me/"),
+        rentalNetwork = PlaceFields.RentalNetwork(
+            __typename = "VehicleRentalNetwork",
+            rentalNetworkFields = network("lime_seattle", url = "https://www.li.me/")
+        ),
         rentalUris = PlaceFields.RentalUris(
-            android = "lime://vehicle/bs_9",
-            web = "https://lime.example/vehicle/bs_9"
+            __typename = "VehicleRentalUris",
+            rentalUriFields = RentalUriFields(
+                android = "lime://vehicle/bs_9",
+                web = "https://lime.example/vehicle/bs_9"
+            )
         ),
         vehicleType = PlaceFields.VehicleType(
             formFactor = FormFactor.BICYCLE,
@@ -427,6 +438,9 @@ class Otp2PlanDecodeTest {
         ),
         fuel = PlaceFields.Fuel(range = 43356)
     )
+
+    /** The network fragment both rental shapes carry — see the RentalNetworkFields fragment in Plan.graphql. */
+    private fun network(networkId: String, url: String? = null) = RentalNetworkFields(networkId = networkId, url = url)
 
     /** Builds a [RouteFields] fixture (the fragment shared by the planned leg's route and each
      *  alternative leg's — see Plan.graphql). */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -313,9 +313,8 @@ class Otp2PlanDecodeTest {
     }
 
     /**
-     * A docked pickup — OTP's other rental shape. The dock is stated as such (`isStation`) rather
-     * than inferred from its name, so a station whose feed published a blank one can't read as a
-     * loose bike standing on the street.
+     * A docked pickup — OTP's other rental shape. Both shapes land on one domain type, and the
+     * station's name is what survives of the difference: it is the dock the row sends the rider to.
      */
     @Test
     fun mapsARentalStationPickup() {
@@ -337,7 +336,6 @@ class Otp2PlanDecodeTest {
         assertEquals(TripVertexType.BIKESHARE, data.toTripItineraries()[0].legs[0].from.vertexType)
         assertEquals("seattle_bikes:42", rental.id)
         assertEquals("seattle_bikes", rental.networkId)
-        assertTrue(rental.isStation)
         assertEquals("Pine St & 3rd Ave", rental.stationName)
         // A dock publishes no vehicle type — it holds whatever the operator left in it.
         assertNull(rental.formFactor)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -347,6 +347,53 @@ class Otp2PlanDecodeTest {
         assertNull(rental.androidUri)
     }
 
+    /**
+     * A feed URL naming no scheme is dropped rather than carried: `Uri.parse` would make a relative
+     * URI of it that nothing on the device can view, so it would reach the rider as a chip promising
+     * to open the operator and then doing nothing. The rental's other links stand on their own.
+     */
+    @Test
+    fun dropsAFeedUrlThatNamesNoScheme() {
+        val data = planDataWithSingleLeg(
+            mode = Mode.BICYCLE,
+            fromPlace = place(
+                name = "Bike",
+                lat = 47.61,
+                lon = -122.33,
+                rentalVehicle = rentalVehicle(
+                    networkUrl = "www.li.me",
+                    androidUri = "lime.example/vehicle/bs_9",
+                    webUri = "  "
+                )
+            )
+        )
+        val rental = data.toTripItineraries()[0].legs[0].from.rental!!
+        assertNull(rental.networkUrl)
+        assertNull(rental.androidUri)
+        assertNull(rental.webUri)
+        // Everything that isn't a URL is untouched — one bad field costs only itself.
+        assertEquals("lime_seattle", rental.networkId)
+        assertEquals(43356, rental.rangeMeters)
+    }
+
+    /** A scheme is the whole test: an operator's own is as openable as `https`, and as welcome. */
+    @Test
+    fun keepsAnyUriThatNamesAScheme() {
+        val data = planDataWithSingleLeg(
+            mode = Mode.BICYCLE,
+            fromPlace = place(
+                name = "Bike",
+                lat = 47.61,
+                lon = -122.33,
+                rentalVehicle = rentalVehicle(androidUri = "lime-bike+v2://vehicle/bs_9")
+            )
+        )
+        assertEquals(
+            "lime-bike+v2://vehicle/bs_9",
+            data.toTripItineraries()[0].legs[0].from.rental!!.androidUri
+        )
+    }
+
     private fun planDataWithSingleLeg(
         mode: Mode,
         itineraryStart: String? = "2026-07-11T10:00:00-07:00",
@@ -419,18 +466,19 @@ class Otp2PlanDecodeTest {
      * except for the rental URIs and network URL, which that deployment publishes on nothing at all
      * and which are here precisely because the app has to carry them the day an operator does.
      */
-    private fun rentalVehicle(): PlaceFields.RentalVehicle = PlaceFields.RentalVehicle(
+    private fun rentalVehicle(
+        networkUrl: String? = "https://www.li.me/",
+        androidUri: String? = "lime://vehicle/bs_9",
+        webUri: String? = "https://lime.example/vehicle/bs_9"
+    ): PlaceFields.RentalVehicle = PlaceFields.RentalVehicle(
         vehicleId = "lime_seattle:bs_9",
         rentalNetwork = PlaceFields.RentalNetwork(
             __typename = "VehicleRentalNetwork",
-            rentalNetworkFields = network("lime_seattle", url = "https://www.li.me/")
+            rentalNetworkFields = network("lime_seattle", url = networkUrl)
         ),
         rentalUris = PlaceFields.RentalUris(
             __typename = "VehicleRentalUris",
-            rentalUriFields = RentalUriFields(
-                android = "lime://vehicle/bs_9",
-                web = "https://lime.example/vehicle/bs_9"
-            )
+            rentalUriFields = RentalUriFields(android = androidUri, web = webUri)
         ),
         vehicleType = PlaceFields.VehicleType(
             formFactor = FormFactor.BICYCLE,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -30,8 +30,12 @@ import org.onebusaway.android.api.graphql.fragment.PlaceFields
 import org.onebusaway.android.api.graphql.fragment.RouteFields
 import org.onebusaway.android.api.graphql.type.AbsoluteDirection
 import org.onebusaway.android.api.graphql.type.AlertSeverityLevelType
+import org.onebusaway.android.api.graphql.type.FormFactor
 import org.onebusaway.android.api.graphql.type.Mode
+import org.onebusaway.android.api.graphql.type.PropulsionType
 import org.onebusaway.android.api.graphql.type.RelativeDirection
+import org.onebusaway.android.directions.model.RentalFormFactor
+import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripAlertSeverity
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripRelativeDirection
@@ -104,7 +108,7 @@ class Otp2PlanDecodeTest {
                     name = "Stop A",
                     lat = 47.61,
                     lon = -122.31,
-                    rentalVehicle = PlaceFields.RentalVehicle(vehicleId = "bs_9", name = "Bike 9")
+                    rentalVehicle = rentalVehicle()
                 )
             ),
             to = to(place(name = "Stop B", lat = 47.62, lon = -122.32)),
@@ -212,7 +216,21 @@ class Otp2PlanDecodeTest {
         assertEquals(iso("2026-07-11T10:02:30-07:00"), bus.startTime)
         assertEquals(30.seconds, bus.departureDelay)
         assertEquals(TripVertexType.BIKESHARE, bus.from.vertexType)
-        assertEquals("bs_9", bus.from.bikeShareId)
+        // The whole rental record, not just its id (#2150): who the vehicle belongs to, what it is,
+        // and the operator's own link to it — each straight off the field OTP publishes for it. The
+        // network is read from `rentalNetwork.networkId`, never parsed off the `network:id` prefix
+        // the vehicle id wears.
+        val rental = bus.from.rental!!
+        assertEquals("lime_seattle:bs_9", rental.id)
+        assertEquals("lime_seattle", rental.networkId)
+        assertEquals("https://www.li.me/", rental.networkUrl)
+        assertEquals("lime://vehicle/bs_9", rental.androidUri)
+        assertEquals("https://lime.example/vehicle/bs_9", rental.webUri)
+        assertEquals(RentalFormFactor.BICYCLE, rental.formFactor)
+        assertEquals(RentalPropulsion.ELECTRIC_ASSIST, rental.propulsion)
+        assertEquals(43356, rental.rangeMeters)
+        // A free-floating vehicle has no dock, and that absence is how the domain says so.
+        assertNull(rental.stationName)
         // OTP2's `stopCalls` include the boarding and alighting calls (1_1001 / 1_1002 here), but
         // `TripLeg.stop` carries only the stops *in between* — what the drawer counts as "N stops
         // in between" and what the reminder plan walks — so the two endpoints are dropped.
@@ -294,10 +312,43 @@ class Otp2PlanDecodeTest {
         assertNull(data.toTripItineraries()[0].legs[0].stop)
     }
 
+    /**
+     * A docked pickup — OTP's other rental shape. The dock is stated as such (`isStation`) rather
+     * than inferred from its name, so a station whose feed published a blank one can't read as a
+     * loose bike standing on the street.
+     */
+    @Test
+    fun mapsARentalStationPickup() {
+        val data = planDataWithSingleLeg(
+            mode = Mode.BICYCLE,
+            fromPlace = place(
+                name = "Pine St & 3rd Ave",
+                lat = 47.61,
+                lon = -122.33,
+                vehicleRentalStation = PlaceFields.VehicleRentalStation(
+                    stationId = "seattle_bikes:42",
+                    name = "Pine St & 3rd Ave",
+                    rentalNetwork = PlaceFields.RentalNetwork1(networkId = "seattle_bikes", url = null),
+                    rentalUris = null
+                )
+            )
+        )
+        val rental = data.toTripItineraries()[0].legs[0].from.rental!!
+        assertEquals(TripVertexType.BIKESHARE, data.toTripItineraries()[0].legs[0].from.vertexType)
+        assertEquals("seattle_bikes:42", rental.id)
+        assertEquals("seattle_bikes", rental.networkId)
+        assertTrue(rental.isStation)
+        assertEquals("Pine St & 3rd Ave", rental.stationName)
+        // A dock publishes no vehicle type — it holds whatever the operator left in it.
+        assertNull(rental.formFactor)
+        assertNull(rental.androidUri)
+    }
+
     private fun planDataWithSingleLeg(
         mode: Mode,
         itineraryStart: String? = "2026-07-11T10:00:00-07:00",
-        stopCalls: List<PlanQuery.StopCall> = emptyList()
+        stopCalls: List<PlanQuery.StopCall> = emptyList(),
+        fromPlace: PlaceFields = place(name = "X", lat = 1.0, lon = 2.0)
     ): PlanQuery.Data {
         val leg = PlanQuery.Leg(
             mode = mode,
@@ -307,7 +358,7 @@ class Otp2PlanDecodeTest {
             interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:01:00-07:00", estimated = null),
-            from = from(place(name = "X", lat = 1.0, lon = 2.0)),
+            from = from(fromPlace),
             to = to(place(name = "Y", lat = 3.0, lon = 4.0)),
             route = null,
             trip = null,
@@ -358,6 +409,26 @@ class Otp2PlanDecodeTest {
         vehicleParking: PlaceFields.VehicleParking? = null,
         vehicleRentalStation: PlaceFields.VehicleRentalStation? = null
     ): PlaceFields = PlaceFields(name, lat, lon, stop, rentalVehicle, vehicleParking, vehicleRentalStation)
+
+    /**
+     * A free-floating rental vehicle, shaped like the ones the live Puget Sound OTP2 deployment
+     * returns (a `network:uuid` id, a network id of `lime_seattle`, an electric-assist bicycle) —
+     * except for the rental URIs and network URL, which that deployment publishes on nothing at all
+     * and which are here precisely because the app has to carry them the day an operator does.
+     */
+    private fun rentalVehicle(): PlaceFields.RentalVehicle = PlaceFields.RentalVehicle(
+        vehicleId = "lime_seattle:bs_9",
+        rentalNetwork = PlaceFields.RentalNetwork(networkId = "lime_seattle", url = "https://www.li.me/"),
+        rentalUris = PlaceFields.RentalUris(
+            android = "lime://vehicle/bs_9",
+            web = "https://lime.example/vehicle/bs_9"
+        ),
+        vehicleType = PlaceFields.VehicleType(
+            formFactor = FormFactor.BICYCLE,
+            propulsionType = PropulsionType.ELECTRIC_ASSIST
+        ),
+        fuel = PlaceFields.Fuel(range = 43356)
+    )
 
     /** Builds a [RouteFields] fixture (the fragment shared by the planned leg's route and each
      *  alternative leg's — see Plan.graphql). */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/OtpPlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/OtpPlanDecodeTest.kt
@@ -135,7 +135,9 @@ class OtpPlanDecodeTest {
         val busFrom = bus.from
         val intermediateStops = bus.intermediateStops!!
         assertEquals(TripVertexType.BIKESHARE, busFrom.vertexType)
-        assertEquals("bs_9", busFrom.bikeShareId)
+        // OTP1 carries only the rental id — no network, no vehicle type, no rental URI (#2150).
+        assertEquals("bs_9", busFrom.rental?.id)
+        assertNull(busFrom.rental?.networkId)
         assertEquals(1, intermediateStops.size)
         assertEquals("Stop Mid", intermediateStops[0].name)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.TripVehicleRental
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
@@ -31,7 +32,7 @@ import org.onebusaway.android.util.routeBadgeChipColor
 @SuppressLint("RestrictedApi") // Hct, Material's vendored color-science util; see AdjacencyRouteColors.kt.
 class ItineraryLegStyleTest {
 
-    private val bikeShareDock = TripPlace(vertexType = TripVertexType.BIKESHARE, bikeShareId = "dock-1")
+    private val bikeShareDock = TripPlace(vertexType = TripVertexType.BIKESHARE, rental = TripVehicleRental(id = "dock-1"))
 
     @Test
     fun `a bicycle leg from a rental dock is bikeshare, from anywhere else own-bike`() {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.directions.model.RentalFormFactor
+import org.onebusaway.android.directions.model.RentalPropulsion
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripMode
+import org.onebusaway.android.directions.model.TripPlace
+import org.onebusaway.android.directions.model.TripVehicleRental
+import org.onebusaway.android.directions.model.TripVertexType
+
+/**
+ * What a bikeshare directions row is allowed to say about the vehicle it sends a rider to (#2150):
+ * which operator names it, which vehicle word it earns, and — the part with real consequences — which
+ * link the "unlock it" tap follows.
+ */
+class RentalPickupsTest {
+
+    @Test
+    fun `a catalogued network is named and coloured, an unknown one wears its id`() {
+        val lime = RentalOperators.of("lime_seattle")
+        assertEquals("Lime", lime.displayName)
+        assertEquals(0xFF00DD00.toInt(), lime.brandColor)
+        assertTrue(lime.isKnown)
+
+        // The honest fallback: no invented brand, no colour asserting one, just what OTP said.
+        val unknown = RentalOperators.of("some_city_bikes")
+        assertEquals("some_city_bikes", unknown.displayName)
+        assertNull(unknown.brandColor)
+        assertFalse(unknown.isKnown)
+    }
+
+    @Test
+    fun `the catalog matches network ids exactly, never by prefix`() {
+        // `lime_seattle` is Lime; nothing says a network id merely *starting* "lime" is, and a wrong
+        // brand on a rider's screen is worse than a plain id.
+        assertNull(RentalOperators.known("lime_portland"))
+        assertNull(RentalOperators.known("lime"))
+        assertNull(RentalOperators.known("limelight_bikes"))
+        assertFalse(RentalOperators.of("lime_portland").isKnown)
+    }
+
+    @Test
+    fun `propulsion decides the vehicle word, form factor decides the vehicle`() {
+        assertEquals(RentalVehicleKind.EBIKE, kindOf(RentalFormFactor.BICYCLE, RentalPropulsion.ELECTRIC_ASSIST))
+        assertEquals(RentalVehicleKind.BIKE, kindOf(RentalFormFactor.BICYCLE, RentalPropulsion.HUMAN))
+        assertEquals(RentalVehicleKind.ESCOOTER, kindOf(RentalFormFactor.SCOOTER, RentalPropulsion.ELECTRIC))
+        // GBFS splits kick scooters three ways; the rider is renting a scooter in all of them.
+        assertEquals(
+            RentalVehicleKind.ESCOOTER,
+            kindOf(RentalFormFactor.SCOOTER_STANDING, RentalPropulsion.ELECTRIC)
+        )
+        assertEquals(RentalVehicleKind.SCOOTER, kindOf(RentalFormFactor.SCOOTER_SEATED, RentalPropulsion.HUMAN))
+        assertEquals(
+            RentalVehicleKind.ELECTRIC_CARGO_BIKE,
+            kindOf(RentalFormFactor.CARGO_BICYCLE, RentalPropulsion.ELECTRIC)
+        )
+        // A combustion moped is a moped; only ELECTRIC/ELECTRIC_ASSIST earn the "e-" word, and only
+        // where the app has one to say.
+        assertEquals(RentalVehicleKind.MOPED, kindOf(RentalFormFactor.MOPED, RentalPropulsion.COMBUSTION))
+        // OTHER is the feed saying it *isn't* one of these — so the row says nothing about it.
+        assertNull(kindOf(RentalFormFactor.OTHER, RentalPropulsion.ELECTRIC))
+        assertNull(kindOf(null, null))
+    }
+
+    @Test
+    fun `an operator deep link wins, and keeps a fallback for a device that cannot follow it`() {
+        val pickup = rentalPickup(
+            rental(
+                networkId = "lime_seattle",
+                androidUri = "lime://vehicle/abc",
+                webUri = "https://lime.example/abc"
+            )
+        )!!
+        assertEquals(RentalLink.Deep("lime://vehicle/abc"), pickup.link)
+        // The rider without the Lime app installed: a second custom-scheme URI would fail the same
+        // way, so the fallback is the operator's app (store page if absent), never another deep link.
+        assertEquals(RentalLink.OperatorApp("com.limebike"), pickup.fallback)
+    }
+
+    @Test
+    fun `without rental uris a catalogued operator still has somewhere to send the rider`() {
+        // Every vehicle the live Puget Sound deployment serves is this case: no rentalUris at all.
+        val pickup = rentalPickup(rental(networkId = "lime_seattle"))!!
+        assertEquals(RentalLink.OperatorApp("com.limebike"), pickup.link)
+        assertEquals(RentalLink.Web("https://www.li.me/"), pickup.fallback)
+    }
+
+    @Test
+    fun `an uncatalogued network offers only what its own feed published`() {
+        val withUrl = rentalPickup(rental(networkId = "some_city_bikes", networkUrl = "https://bikes.example"))!!
+        assertEquals(RentalLink.Web("https://bikes.example"), withUrl.link)
+        assertNull(withUrl.fallback)
+
+        // Nothing published and nothing catalogued: no button rather than one going somewhere
+        // approximate.
+        assertNull(rentalPickup(rental(networkId = "some_city_bikes"))!!.link)
+    }
+
+    @Test
+    fun `a station pickup names its dock, a free-floating one says there is none`() {
+        val docked = rentalPickup(
+            rental(networkId = "some_city_bikes", isStation = true, stationName = "Pine St & 3rd Ave")
+        )!!
+        assertEquals("Pine St & 3rd Ave", docked.stationName)
+        assertFalse(docked.isDockless)
+
+        val loose = rentalPickup(rental(networkId = "lime_seattle"))!!
+        assertNull(loose.stationName)
+        assertTrue(loose.isDockless)
+
+        // A dock that published no name is still a dock: the row draws no pickup line rather than
+        // telling the rider there is nothing to look for.
+        val unnamed = rentalPickup(rental(networkId = "some_city_bikes", isStation = true))!!
+        assertNull(unnamed.stationName)
+        assertFalse(unnamed.isDockless)
+    }
+
+    @Test
+    fun `a rental the wire said nothing about draws no rental block`() {
+        // The OTP1 path: an id and nothing else. A chip naming an unknown network, with no link under
+        // it and no vehicle beside it, would be worse than the plain bike row the leg already had.
+        assertNull(rentalPickup(TripVehicleRental(id = "bs_9")))
+        assertNull(rentalPickup(TripVehicleRental(id = "bs_9", networkId = "  ")))
+        // Everything the row draws hangs off the operator, so even a named dock isn't enough on its
+        // own — and OTP2, which always states the network, never produces one.
+        assertNull(rentalPickup(TripVehicleRental(id = "bs_9", isStation = true, stationName = "Dock")))
+        assertNull(rentalPickup(null))
+    }
+
+    @Test
+    fun `the pickup endpoint wins over the drop-off one`() {
+        val leg = TripLeg(
+            mode = TripMode.BICYCLE,
+            from = place(rental(networkId = "lime_seattle")),
+            to = place(rental(networkId = "some_city_bikes", isStation = true, stationName = "Dock"))
+        )
+        // Where the rider *gets* the bike decides whose it is and whether they're hunting for a dock.
+        assertEquals("Lime", leg.rentalPickup()?.operator?.displayName)
+        assertNull(leg.rentalPickup()?.stationName)
+    }
+
+    @Test
+    fun `a leg that returns a dockless bike to a station still reports the station`() {
+        // OTP puts the station on `to` when the ride ends at a dock and started at a loose vehicle
+        // with no rental record of its own; the row then has the dock to name.
+        val leg = TripLeg(
+            mode = TripMode.BICYCLE,
+            from = TripPlace(name = "Origin"),
+            to = place(rental(networkId = "some_city_bikes", isStation = true, stationName = "Dock"))
+        )
+        assertEquals("Dock", leg.rentalPickup()?.stationName)
+    }
+
+    @Test
+    fun `a plain walk or an own-bike leg has no rental`() {
+        assertNull(TripLeg(mode = TripMode.WALK, from = TripPlace(name = "Origin")).rentalPickup())
+        assertNull(TripLeg(mode = TripMode.BICYCLE, from = TripPlace(name = "Home")).rentalPickup())
+    }
+
+    @Test
+    fun `the walk to the bike is not itself a rental row`() {
+        // Its `to` *is* the rental vehicle — OTP ends the approach walk there — but the rider is told
+        // whose bike it is on the row where they ride it, once, not on both legs that touch it.
+        val walk = TripLeg(
+            mode = TripMode.WALK,
+            from = TripPlace(name = "Origin"),
+            to = place(rental(networkId = "lime_seattle"))
+        )
+        assertNull(walk.rentalPickup())
+    }
+
+    @Test
+    fun `range and vehicle carry through to the row`() {
+        val pickup = rentalPickup(
+            rental(
+                networkId = "lime_seattle",
+                formFactor = RentalFormFactor.BICYCLE,
+                propulsion = RentalPropulsion.ELECTRIC_ASSIST,
+                rangeMeters = 43356
+            )
+        )!!
+        assertEquals(RentalVehicleKind.EBIKE, pickup.vehicle)
+        assertEquals(43356, pickup.rangeMeters)
+    }
+
+    private fun kindOf(formFactor: RentalFormFactor?, propulsion: RentalPropulsion?): RentalVehicleKind? = rentalPickup(
+        rental(networkId = "some_city_bikes", formFactor = formFactor, propulsion = propulsion)
+    )?.vehicle
+
+    private fun rental(
+        networkId: String? = null,
+        networkUrl: String? = null,
+        androidUri: String? = null,
+        webUri: String? = null,
+        isStation: Boolean = false,
+        stationName: String? = null,
+        formFactor: RentalFormFactor? = null,
+        propulsion: RentalPropulsion? = null,
+        rangeMeters: Int? = null
+    ) = TripVehicleRental(
+        id = "$networkId:abc",
+        isStation = isStation,
+        stationName = stationName,
+        networkId = networkId,
+        networkUrl = networkUrl,
+        androidUri = androidUri,
+        webUri = webUri,
+        formFactor = formFactor,
+        propulsion = propulsion,
+        rangeMeters = rangeMeters
+    )
+
+    private fun place(rental: TripVehicleRental) = TripPlace(vertexType = TripVertexType.BIKESHARE, rental = rental)
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
@@ -117,22 +117,12 @@ class RentalPickupsTest {
     }
 
     @Test
-    fun `a station pickup names its dock, a free-floating one says there is none`() {
-        val docked = rentalPickup(
-            rental(networkId = "some_city_bikes", isStation = true, stationName = "Pine St & 3rd Ave")
-        )!!
+    fun `a station pickup names its dock`() {
+        val docked = rentalPickup(rental(networkId = "some_city_bikes", stationName = "Pine St & 3rd Ave"))!!
         assertEquals("Pine St & 3rd Ave", docked.stationName)
-        assertFalse(docked.isDockless)
-
-        val loose = rentalPickup(rental(networkId = "lime_seattle"))!!
-        assertNull(loose.stationName)
-        assertTrue(loose.isDockless)
-
-        // A dock that published no name is still a dock: the row draws no pickup line rather than
-        // telling the rider there is nothing to look for.
-        val unnamed = rentalPickup(rental(networkId = "some_city_bikes", isStation = true))!!
-        assertNull(unnamed.stationName)
-        assertFalse(unnamed.isDockless)
+        // Nothing to walk to on a free-floating vehicle, and the row says nothing rather than
+        // inventing a place.
+        assertNull(rentalPickup(rental(networkId = "lime_seattle"))!!.stationName)
     }
 
     @Test
@@ -143,7 +133,7 @@ class RentalPickupsTest {
         assertNull(rentalPickup(TripVehicleRental(id = "bs_9", networkId = "  ")))
         // Everything the row draws hangs off the operator, so even a named dock isn't enough on its
         // own — and OTP2, which always states the network, never produces one.
-        assertNull(rentalPickup(TripVehicleRental(id = "bs_9", isStation = true, stationName = "Dock")))
+        assertNull(rentalPickup(TripVehicleRental(id = "bs_9", stationName = "Dock")))
         assertNull(rentalPickup(null))
     }
 
@@ -152,7 +142,7 @@ class RentalPickupsTest {
         val leg = TripLeg(
             mode = TripMode.BICYCLE,
             from = place(rental(networkId = "lime_seattle")),
-            to = place(rental(networkId = "some_city_bikes", isStation = true, stationName = "Dock"))
+            to = place(rental(networkId = "some_city_bikes", stationName = "Dock"))
         )
         // Where the rider *gets* the bike decides whose it is and whether they're hunting for a dock.
         assertEquals("Lime", leg.rentalPickup()?.operator?.displayName)
@@ -166,7 +156,7 @@ class RentalPickupsTest {
         val leg = TripLeg(
             mode = TripMode.BICYCLE,
             from = TripPlace(name = "Origin"),
-            to = place(rental(networkId = "some_city_bikes", isStation = true, stationName = "Dock"))
+            to = place(rental(networkId = "some_city_bikes", stationName = "Dock"))
         )
         assertEquals("Dock", leg.rentalPickup()?.stationName)
     }
@@ -212,14 +202,12 @@ class RentalPickupsTest {
         networkUrl: String? = null,
         androidUri: String? = null,
         webUri: String? = null,
-        isStation: Boolean = false,
         stationName: String? = null,
         formFactor: RentalFormFactor? = null,
         propulsion: RentalPropulsion? = null,
         rangeMeters: Int? = null
     ) = TripVehicleRental(
         id = "$networkId:abc",
-        isStation = isStation,
         stationName = stationName,
         networkId = networkId,
         networkUrl = networkUrl,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
@@ -90,10 +90,28 @@ class RentalPickupsTest {
                 webUri = "https://lime.example/abc"
             )
         )!!
-        assertEquals(RentalLink.Deep("lime://vehicle/abc"), pickup.link)
-        // The rider without the Lime app installed: a second custom-scheme URI would fail the same
-        // way, so the fallback is the operator's app (store page if absent), never another deep link.
+        assertEquals(RentalLink.Deep("lime://vehicle/abc", mayNeedTheirApp = true), pickup.link)
+        // The rider without the Lime app installed: the web URI names the same vehicle and a browser
+        // always opens it, so it is the fallback rather than the operator's app.
+        assertEquals(RentalLink.Deep("https://lime.example/abc", mayNeedTheirApp = false), pickup.fallback)
+    }
+
+    @Test
+    fun `a deep link with no web one beside it falls back past every other custom scheme`() {
+        // Nothing else in the list can be one, so this is really the fallback filter's floor: an
+        // Android URI the device can't answer must not fall back to another URI it can't answer.
+        val pickup = rentalPickup(rental(networkId = "lime_seattle", androidUri = "lime://vehicle/abc"))!!
+        assertEquals(RentalLink.Deep("lime://vehicle/abc", mayNeedTheirApp = true), pickup.link)
         assertEquals(RentalLink.OperatorApp("com.limebike"), pickup.fallback)
+    }
+
+    @Test
+    fun `a network publishing only a web uri leaves the rider a link that cannot fail`() {
+        // The uncatalogued case, where the primary is all there is: it must be the http(s) one, since
+        // a chip whose only action is a scheme nothing answers does nothing at all when tapped.
+        val pickup = rentalPickup(rental(networkId = "some_city_bikes", webUri = "https://bikes.example/v/7"))!!
+        assertEquals(RentalLink.Deep("https://bikes.example/v/7", mayNeedTheirApp = false), pickup.link)
+        assertNull(pickup.fallback)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -40,13 +39,11 @@ class RentalPickupsTest {
         val lime = RentalOperators.of("lime_seattle")
         assertEquals("Lime", lime.displayName)
         assertEquals(0xFF00DD00.toInt(), lime.brandColor)
-        assertTrue(lime.isKnown)
 
         // The honest fallback: no invented brand, no colour asserting one, just what OTP said.
         val unknown = RentalOperators.of("some_city_bikes")
         assertEquals("some_city_bikes", unknown.displayName)
         assertNull(unknown.brandColor)
-        assertFalse(unknown.isKnown)
     }
 
     @Test
@@ -56,7 +53,9 @@ class RentalPickupsTest {
         assertNull(RentalOperators.known("lime_portland"))
         assertNull(RentalOperators.known("lime"))
         assertNull(RentalOperators.known("limelight_bikes"))
-        assertFalse(RentalOperators.of("lime_portland").isKnown)
+        // ...so it presents as its own id, on no brand's colour.
+        assertEquals("lime_portland", RentalOperators.of("lime_portland").displayName)
+        assertNull(RentalOperators.of("lime_portland").brandColor)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -23,11 +23,14 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.Direction
+import org.onebusaway.android.directions.model.RentalFormFactor
+import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripStep
+import org.onebusaway.android.directions.model.TripVehicleRental
 import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
@@ -216,6 +219,40 @@ class TripLogBuilderTest {
                     to = walkLeg.to.copy(vertexType = TripVertexType.BIKESHARE)
                 )
             )
+        )
+    }
+
+    @Test
+    fun bikeshareLegCarriesItsRental_soTheRowCanNameTheOperator() {
+        // Without this the leg says only "Bike", which tells a rider standing over an unfamiliar
+        // scooter nothing about whose it is or which app unlocks it (#2150).
+        val leg = walkLeg.copy(
+            mode = TripMode.BICYCLE,
+            from = walkLeg.from.copy(
+                vertexType = TripVertexType.BIKESHARE,
+                rental = TripVehicleRental(
+                    id = "lime_seattle:abc",
+                    networkId = "lime_seattle",
+                    formFactor = RentalFormFactor.BICYCLE,
+                    propulsion = RentalPropulsion.ELECTRIC_ASSIST
+                )
+            )
+        )
+        val rental = TripLogBuilder
+            .build(listOf(leg), listOf(walkDir), listOf(null))
+            .filterIsInstance<TripLogEntry.Walk>()
+            .single()
+            .rental!!
+        assertEquals("Lime", rental.operator.displayName)
+        assertEquals(RentalVehicleKind.EBIKE, rental.vehicle)
+
+        // The rider's own bike is nobody's rental, however the leg is otherwise shaped.
+        assertNull(
+            TripLogBuilder
+                .build(listOf(walkLeg.copy(mode = TripMode.BICYCLE)), listOf(walkDir), listOf(null))
+                .filterIsInstance<TripLogEntry.Walk>()
+                .single()
+                .rental
         )
     }
 


### PR DESCRIPTION
Fixes #2150.

A bikeshare leg said "Bike" and nothing else. A rider standing over an unfamiliar scooter learned nothing from it: not whose it is, not what kind of vehicle they were routed onto, not which app unlocks it. The app had the leg's rental endpoint all along and threw everything but its id away at the wire.

The leg now reads:

```
Bikeshare
2.1 mi
▐Lime ↗▌  E-bike · 27 mi of range left
```

## What's carried

* **`Plan.graphql`** asks each rental endpoint for its network, rental URIs, vehicle type and battery range. The network is read from `rentalNetwork.networkId`, never parsed off the `network:id` prefix the vehicle id wears (#2138). Selections a vehicle and a station state identically ride as shared fragments, so Apollo generates one type instead of two and the adapter maps them with one function.
* It **stops** asking for `RentalVehicle.name`: OTP fills it from the GBFS vehicle type, and it is the literal string "Default vehicle type" on all 13,396 rental vehicles the live Puget Sound deployment serves.
* **`TripPlace.rental`** replaces the bare `bikeShareId` — one `TripVehicleRental` for both of OTP's rental shapes. OTP1 mints one holding only the id (that API carries no rental metadata at all), and such a leg draws the plain bike row it always did.
* **`RentalPickups.kt`** turns that into what the row shows, and holds the operator catalog.

## What the row does, and what it won't claim

The operator chip is the tap: it wears an open-in-new arrow and hands the rider over. Only a link OTP published to *that exact vehicle* is announced as "Open in Lime"; anything else merely opens the operator ("Rent with Lime"). Nothing claims a reservation was made — that is #2138's milestone.

The vehicle id is deliberately **not** drawn. Both live networks publish UUIDs, which no rider can match against a bike in front of them.

A network with neither a rental URI nor a catalog entry draws a plain chip wearing its raw network id: no arrow, no tap, rather than a button going somewhere approximate.

## 🚩 Human call on the operator catalog — made

OTP publishes no operator name and GBFS 2.x no brand fields, so the catalog in `RentalPickups.kt` is **app-authored data**, and its two entries are the only part of this PR not taken from the wire. Sourcing, all checked 2026-08-03 against live endpoints:

| Fact | Source |
|---|---|
| "Lime" | the network's own GBFS `system_information.attribution_organization_name` |
| "Bird" | shortened from its GBFS `operator`, "Bird Rides, Inc." (its store listing is "Bird — Ride Electric") |
| `com.limebike` | its Play Store listing, "Lime - #RideGreen" |
| `co.bird.android` | named by the network's own GBFS `rental_apps.android.store_uri` |
| `#00DD00` / `#26CCF0` | **sampled from each operator's own Play Store icon** — no feed or spec publishes a brand colour |

**Signed off 2026-08-03: the sampled colours stay.** They were the weakest-sourced facts here, and the sibling iOS app is a live counter-example — it paints every rental surface one app-owned `rentalPurple` and carries no per-operator colour at all. Brand recognition is what #2150 is for, so they stay until a **brand colour registry shared across OBA implementations** replaces per-app sampling; the catalog's colours become lookups into it when it exists. The keying is **exact system id, never prefix**: `lime_seattle` is Lime, but nothing says a network merely starting "lime" is, and a wrong brand on a rider's screen is worse than a plain id. That means one entry per city an operator runs in — the honest cost of a directory that publishes no brand. Entries are one line each.

These two are the complete set reachable from the app today: Puget Sound is the only region publishing an `otpBaseGraphqlUrl`, and its OTP serves exactly these networks (13,395 `lime_seattle` vehicles and one `bird-seattle-washington`).

**No live network publishes a rental URI**, on any vehicle of either network — so the deep-link path is wired and unit-tested but never lights up today. In practice the chip opens the operator's app, or its store page.

The catalog's package names must stay in step with the manifest's `<queries>` block (Android 11+ package visibility); both ends say so. An undeclared package is a quiet degradation to the store path, not a break.

## Along the way

`ExternalIntents` already had "launch an app by package, else its Play Store listing" twice — `startPaymentIntent` and, for a bikeshare operator's app, `launchTampaHoprApp`. Rather than add a third copy, all three now call one `openAppOrStoreListing`.

## Verification

* The regenerated query was run against the live Puget Sound OTP2 server: same rental fields, no errors.
* New JVM tests cover the operator lookup (including that it does *not* prefix-match), the vehicle-kind mapping, link ordering and its fallback, station vs. free-floating pickup, and the OTP1 path drawing nothing. Both rental shapes are covered in `Otp2PlanDecodeTest`.
* Compile (both flavors, `-PwarningsAsErrors=true`), full JVM unit suite, androidTest compile and `spotlessCheck` all pass.
* Exercised on a device (Pixel 7 Pro, Puget Sound).
* Previews: `Bikeshare leg · known operator` (light + dark), `Bikeshare itinerary · walk, ride, walk`, and `Bikeshare leg · docked, unknown operator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed bikeshare information to trip directions, including operator, vehicle type, pickup station, and estimated range.
  * Added links to open supported rental apps or websites, with store fallback when needed.
  * Added branded support for Lime and Bird rentals, while retaining useful details for unknown operators.
  * Improved bikeshare transfer labels, accessibility descriptions, and rental app handoffs.
  * Added support for trailing icons in route badges.
* **Bug Fixes**
  * Improved rental station and vehicle detection across supported trip-plan formats.
  * Improved external app and payment-link fallback behavior.
* **Tests**
  * Expanded coverage for rental mapping, display details, operator links, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
