### PR TITLE
Keep the map controls above the directions drawer (#2155)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -673,15 +673,21 @@ fun HomeScreen(
                                 }
                             }
 
-                            // Lift the FABs above the whole collapsed sheet peek; the target changes only on settle
-                            // and MapChrome animates it. Local here since the screen holds the live SheetState. Only
-                            // while the sheet is shown at peek — a hidden sheet also rests at PartiallyExpanded now.
-                            val fabInsetTarget =
-                                if (sheetShown && sheetState.currentValue == SheetValue.PartiallyExpanded) {
-                                    collapsedPeekDp
+                            // Lift the FABs above whichever sheet is resting over the map — the collapsed arrivals
+                            // peek, or in directions the results drawer (whose settled height the map inset above
+                            // already tracks). The target changes only on settle and MapChrome animates it. Local
+                            // here since the screen holds the live SheetState. The arrivals term counts only while
+                            // that sheet is shown at peek — a hidden sheet also rests at PartiallyExpanded now.
+                            val fabInsetTarget = mapControlsBottomInset(
+                                arrivalsPeek = collapsedPeekDp,
+                                arrivalsAtPeek = sheetShown &&
+                                    sheetState.currentValue == SheetValue.PartiallyExpanded,
+                                directionsSheet = if (showResultsSheet) {
+                                    with(density) { directionsSheetHeightPx.toDp() }
                                 } else {
                                     0.dp
                                 }
+                            )
                             Box(Modifier.fillMaxSize()) {
                                 // The map, with the chrome drawn over it: weather/donation/route-header/survey. The
                                 // list "tabs" are now their own NavHost destinations, so HOME is always the map.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -15,6 +15,9 @@
  */
 package org.onebusaway.android.ui.home
 
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
 /**
  * Pure decision logic for the arrivals bottom sheet, lifted out of [HomeScreen]'s `LaunchedEffect`
  * /`BackHandler` so the parity-sensitive behavior (the part that can't be exercised in a JVM test
@@ -48,6 +51,26 @@ internal fun focusBannerTopEdge(
     is CurrentFocus.Directions -> directionsFormBottomPx
     CurrentFocus.None, is CurrentFocus.BikeStation -> 0
 }
+
+/**
+ * How far to lift the map's floating controls (my-location, zoom, layers) off the bottom edge so they
+ * stay in the visible map band above whichever bottom sheet is resting over it.
+ *
+ * [arrivalsPeek] is the collapsed arrivals peek, counted only while the arrivals sheet rests *at* that
+ * peek ([arrivalsAtPeek]) — an expanded arrivals sheet covers the controls outright, so lifting to it
+ * would only park them behind a full-height panel. [directionsSheet] is the directions results drawer's
+ * settled height, or zero when that drawer isn't shown; it always counts, because the drawer rests at a
+ * fraction of the window and the controls belong above it in either of its two positions (#2155).
+ *
+ * The two sheets are mutually exclusive today — directions focus is not stop focus, so [shouldShowSheet]
+ * keeps the arrivals sheet hidden for the whole of directions mode — but taking the larger clears either
+ * one without depending on that.
+ */
+internal fun mapControlsBottomInset(
+    arrivalsPeek: Dp,
+    arrivalsAtPeek: Boolean,
+    directionsSheet: Dp
+): Dp = maxOf(if (arrivalsAtPeek) arrivalsPeek else 0.dp, directionsSheet)
 
 /** The drag-handle toggle target: a full sheet collapses to peek; anything else expands to full. */
 internal fun toggleSheetTarget(current: ArrivalsSheetState): ArrivalsSheetState = if (current == ArrivalsSheetState.Expanded) ArrivalsSheetState.Collapsed else ArrivalsSheetState.Expanded

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.home
 
+import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -59,6 +60,53 @@ class HomeSheetLogicTest {
         assertEquals(
             180,
             focusBannerTopEdge(CurrentFocus.Directions(), 240, directionsFormBottomPx = 180)
+        )
+    }
+
+    // --- mapControlsBottomInset ---
+
+    @Test
+    fun `the map controls sit at the bottom edge with no sheet over the map`() {
+        assertEquals(
+            0.dp,
+            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = false, directionsSheet = 0.dp)
+        )
+    }
+
+    @Test
+    fun `a peeking arrivals sheet lifts the map controls, an expanded one does not`() {
+        assertEquals(
+            200.dp,
+            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = true, directionsSheet = 0.dp)
+        )
+        assertEquals(
+            0.dp,
+            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = false, directionsSheet = 0.dp)
+        )
+    }
+
+    @Test
+    fun `the directions drawer lifts the map controls in both of its resting positions`() {
+        // Expanded (a fraction of the window) and collapsed to its handle-only peek.
+        assertEquals(
+            320.dp,
+            mapControlsBottomInset(arrivalsPeek = 0.dp, arrivalsAtPeek = false, directionsSheet = 320.dp)
+        )
+        assertEquals(
+            48.dp,
+            mapControlsBottomInset(arrivalsPeek = 0.dp, arrivalsAtPeek = false, directionsSheet = 48.dp)
+        )
+    }
+
+    @Test
+    fun `with both sheets reporting a height the controls clear the taller one`() {
+        assertEquals(
+            320.dp,
+            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = true, directionsSheet = 320.dp)
+        )
+        assertEquals(
+            200.dp,
+            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = true, directionsSheet = 48.dp)
         )
     }
 


### PR DESCRIPTION
Fixes #2155.

## The bug

The map's floating controls lifted only for the arrivals sheet's collapsed peek:

```kotlin
if (sheetShown && sheetState.currentValue == SheetValue.PartiallyExpanded) collapsedPeekDp else 0.dp
```

In directions mode the arrivals sheet is hidden — `shouldShowSheet` requires stop focus, and directions focus isn't that — so the lift target was `0` while the directions results drawer rested over 40% of the window. Since that drawer draws after `MapFeature` in the scaffold body, the my-location FAB (and the zoom pill / layers FAB beside it) ended up underneath it.

## The fix

The drawer already measures its settled height and publishes it as the map camera's bottom inset (`directionsSheetHeightPx` → `setDirectionsResultsInset`). The FAB lift now reads that same value, so it costs no new measurement and tracks the drawer through both of its resting positions — the expanded fraction and the handle-only peek.

The decision moved into a pure function so it's unit-testable rather than trapped in the composable:

- `HomeSheetLogic.kt` — `mapControlsBottomInset(arrivalsPeek, arrivalsAtPeek, directionsSheet)`, taking the larger of the two sheet heights. They're mutually exclusive today, but `max` clears either one without depending on that.
- `HomeScreen.kt` — call site, replacing the inline conditional.

The `arrivalsAtPeek` term keeps the existing behaviour that an *expanded* arrivals sheet contributes no lift — it covers the controls outright, so lifting to it would only park them behind a full-height panel. The directions drawer always counts, because it never covers the whole window.

The FAB stays tappable where it lands: `DirectionsResultsSheet` is a sheet-only host with a transparent, empty body (M3 builds its scaffold root from a plain `Box`, not a touch-intercepting `Surface`), so the region above the drawer doesn't intercept touches.

## Testing

- `HomeSheetLogicTest` — 4 new decision-table cases: no sheet, arrivals peek vs. expanded, the drawer in both resting positions, and both sheets reporting a height.
- `compileObaGoogleDebugKotlin` and the unit tests pass under `-PwarningsAsErrors=true`; `spotlessCheck` clean.
- Device-verified on a Pixel 7 Pro: in directions mode the controls sit in the map band above the drawer and settle back down when it collapses to its handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map control positioning when arrivals or directions panels are open.
  * Prevented controls from being obscured by partially expanded arrivals or directions results.

* **Tests**
  * Added coverage for map inset behavior across sheet visibility, positions, and overlapping panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->