### PR TITLE
Synthesize a rental deep link when the feed publishes none (#2158)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/RentalDeepLinksTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/RentalDeepLinksTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.time.WallTime
+
+/**
+ * Covers the assembly of the rental link the app builds itself (#2158) — the `android.net.Uri` step
+ * `RentalPickupsTest` (a pure JVM test over the link's *components*) can't reach, since `Uri` is stubbed
+ * off-device.
+ *
+ * What's at risk here is what components buy over a format string: that a vehicle id carrying a query
+ * delimiter stays one parameter, and that the timestamp goes out in the unit the operator publishes.
+ */
+@RunWith(AndroidJUnit4::class)
+class RentalDeepLinksTest {
+
+    // Method names are camelCase, not the backtick-with-spaces style the JVM unit tests use: these get
+    // dexed, and D8 rejects spaces in a SimpleName below DEX version 040.
+
+    private val lime = RentalOperators.known("lime_seattle")!!.vehicleUri!!
+
+    @Test
+    fun limeVehicleUri_isTheShapeLimePublishes() {
+        assertEquals(
+            "limebike://map?selected_vehicle_id=abc123&generated_at=1785807940",
+            RentalDeepLinks.vehicleUri(
+                RentalLink.Synthesized(lime, "abc123"),
+                WallTime(1785807940_000L)
+            ).toString()
+        )
+    }
+
+    @Test
+    fun timestamp_isEpochSecondsAndTruncates() {
+        // Epoch seconds, not millis: the stamp is a whole second, and the sub-second remainder is
+        // dropped rather than rounded — a timestamp the operator reads as "the future" is worse than
+        // one it reads as a moment ago.
+        assertEquals(
+            "1785807940",
+            RentalDeepLinks.vehicleUri(RentalLink.Synthesized(lime, "abc123"), WallTime(1785807940_999L))
+                .getQueryParameter("generated_at")
+        )
+    }
+
+    @Test
+    fun vehicleIdCarryingQueryDelimiters_staysOneParameter() {
+        // The whole reason the link is held as components: interpolating this id into the template by
+        // hand would hand Lime a `selected_vehicle_id` of "a" plus two parameters we never wrote.
+        val uri = RentalDeepLinks.vehicleUri(RentalLink.Synthesized(lime, "a&b=c"), WallTime(0L))
+        assertEquals("a&b=c", uri.getQueryParameter("selected_vehicle_id"))
+        assertEquals(setOf("selected_vehicle_id", "generated_at"), uri.queryParameterNames)
+    }
+
+    @Test
+    fun operatorWithNoTimestampParam_getsNoTimestamp() {
+        val uri = RentalDeepLinks.vehicleUri(
+            RentalLink.Synthesized(lime.copy(timestampParam = null), "abc123"),
+            WallTime(1785807940_000L)
+        )
+        assertEquals("limebike://map?selected_vehicle_id=abc123", uri.toString())
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -23,6 +23,7 @@ import org.onebusaway.android.api.graphql.PlanQuery
 import org.onebusaway.android.api.graphql.fragment.PlaceFields
 import org.onebusaway.android.api.graphql.fragment.RentalNetworkFields
 import org.onebusaway.android.api.graphql.fragment.RentalUriFields
+import org.onebusaway.android.directions.model.RentalEndpointKind
 import org.onebusaway.android.directions.model.RentalFormFactor
 import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripAbsoluteDirection
@@ -180,6 +181,7 @@ private fun PlaceFields.toTripPlace(): TripPlace = TripPlace(
 /** A free-floating rental vehicle: no dock, so no `stationName` to walk the rider to. */
 private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental = toTripVehicleRental(
     id = vehicleId,
+    kind = RentalEndpointKind.VEHICLE,
     network = rentalNetwork.rentalNetworkFields,
     uris = rentalUris?.rentalUriFields,
     formFactor = vehicleType?.formFactor?.rawValue.toEnum<RentalFormFactor>(),
@@ -194,6 +196,7 @@ private fun PlaceFields.RentalVehicle.toTripVehicleRental(): TripVehicleRental =
  */
 private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleRental = toTripVehicleRental(
     id = stationId,
+    kind = RentalEndpointKind.STATION,
     network = rentalNetwork.rentalNetworkFields,
     uris = rentalUris?.rentalUriFields,
     stationName = name.ifBlank { null }
@@ -207,6 +210,7 @@ private fun PlaceFields.VehicleRentalStation.toTripVehicleRental(): TripVehicleR
  */
 private fun toTripVehicleRental(
     id: String?,
+    kind: RentalEndpointKind,
     network: RentalNetworkFields,
     uris: RentalUriFields?,
     stationName: String? = null,
@@ -215,6 +219,7 @@ private fun toTripVehicleRental(
     rangeMeters: Int? = null
 ): TripVehicleRental = TripVehicleRental(
     id = id,
+    kind = kind,
     stationName = stationName,
     networkId = network.networkId,
     networkUrl = network.url.absoluteUriOrNull(),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -196,6 +196,10 @@ data class TripPlace(
  * that published a name.
  *
  * Every field is what the *feed* stated, carried unjudged:
+ *  - [kind] is which of those two shapes OTP populated, recorded because merging them here would
+ *    otherwise lose it — and [id] means a different thing in each (a `vehicleId`, or a `stationId`).
+ *    Read it, never [stationName], to tell a loose vehicle from a dock: a station that published no
+ *    name is still a station. Null only on the OTP1 path, which states neither.
  *  - [id] is OTP's network-qualified `network:id`, the identity the map's bike layer filters on. It is
  *    not shown to the rider: the ids the live Puget Sound networks publish are UUIDs, which no rider
  *    can match against a bike in front of them.
@@ -219,6 +223,7 @@ data class TripPlace(
 @Serializable
 data class TripVehicleRental(
     val id: String? = null,
+    val kind: RentalEndpointKind? = null,
     val stationName: String? = null,
     val networkId: String? = null,
     val networkUrl: String? = null,
@@ -228,6 +233,17 @@ data class TripVehicleRental(
     val propulsion: RentalPropulsion? = null,
     val rangeMeters: Int? = null
 )
+
+/**
+ * Which rental endpoint a [TripVehicleRental] describes: a free-floating vehicle
+ * (`Place.rentalVehicle`) or a dock (`Place.vehicleRentalStation`).
+ *
+ * Structural, from which field OTP populated — not read off the values, which cannot tell them apart:
+ * both carry an id, and a dock may publish no name. It decides what [TripVehicleRental.id] identifies,
+ * which is why a link that names a *vehicle* to the operator's app (#2158) is built for one and never
+ * the other.
+ */
+enum class RentalEndpointKind { VEHICLE, STATION }
 
 /** Mirrors OTP2's `FormFactor` wire vocabulary exactly (which mirrors GBFS's `vehicle_type`). */
 enum class RentalFormFactor { BICYCLE, CAR, CARGO_BICYCLE, MOPED, OTHER, SCOOTER, SCOOTER_SEATED, SCOOTER_STANDING }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalDeepLinks.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import android.net.Uri
+import java.util.concurrent.TimeUnit
+import org.onebusaway.android.time.WallTime
+
+/**
+ * Assembles the URI a [RentalLink.Synthesized] stands for (#2158) — the one Android-dependent step of
+ * the link the app builds itself, kept out of `RentalPickups` so that file stays pure and JVM-tested.
+ * Covered by the instrumented `RentalDeepLinksTest`, since `android.net.Uri` is stubbed off-device.
+ */
+object RentalDeepLinks {
+
+    /**
+     * [link] as the URI to hand `ACTION_VIEW`, stamped at [now].
+     *
+     * Built out of components, which is the point of holding them: `appendQueryParameter` escapes each
+     * value, and a value carrying `&` or `=` (a vehicle id is the operator's string, not ours) becomes
+     * one parameter rather than three. Interpolating the same template by hand escapes nothing, and the
+     * mistake is invisible until the day an operator issues an id with a delimiter in it.
+     *
+     * [now] is a parameter, not a clock read here: it belongs to the moment the rider tapped, and the
+     * caller is the only one that knows when that was (see `RentalVehicleUriTemplate.timestampParam` for
+     * why a stamp from when the row was drawn is the wrong one). Epoch seconds is the unit the operator
+     * publishes these in — the conversion is here, at the boundary, so `WallTime` stays unit-free.
+     */
+    fun vehicleUri(link: RentalLink.Synthesized, now: WallTime): Uri {
+        val template = link.template
+        val builder = Uri.Builder()
+            .scheme(template.scheme)
+            .authority(template.host)
+            .appendQueryParameter(template.vehicleIdParam, link.vehicleId)
+        template.timestampParam?.let {
+            builder.appendQueryParameter(it, TimeUnit.MILLISECONDS.toSeconds(now.epochMs).toString())
+        }
+        return builder.build()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import org.onebusaway.android.directions.model.RentalEndpointKind
 import org.onebusaway.android.directions.model.RentalFormFactor
 import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripLeg
@@ -48,7 +49,7 @@ data class RentalPickup(
     /**
      * Where to send them instead when nothing on the device handles [link] — the rider who was offered
      * a `lime://` deep link and hasn't got Lime installed. Null when [link] is all there is, and never
-     * itself a link that could fail the same way (see [RentalLink.Deep.mayNeedTheirApp]).
+     * itself a link that could fail the same way (see [RentalLink.mayNeedTheirApp]).
      */
     val fallback: RentalLink? = null
 )
@@ -75,11 +76,22 @@ data class RentalOperator(
 /**
  * Where a rental row's action button goes, in the order [rentalPickup] prefers them.
  *
- * [Deep] is the only one that names the *exact* vehicle the rider was routed onto; the others merely
- * open the operator, which is why the row words them differently ("Open in Lime" vs. "Rent with
- * Lime"). Nothing here claims a reservation was made — see #2138 for why that's a separate milestone.
+ * [namesTheVehicle] splits them in the way the rider can feel: [Deep] and [Synthesized] open the
+ * operator's app *on the vehicle they were routed onto*, the others merely open the operator, and the
+ * row words the two differently ("Open in Lime" vs. "Rent with Lime"). Nothing here claims a
+ * reservation was made — see #2138 for why that's a separate milestone.
  */
 sealed interface RentalLink {
+
+    /**
+     * Whether following this can find nothing on the device that handles it — a custom scheme only the
+     * operator's own app answers. Those are the links that need a [RentalPickup.fallback], and the ones
+     * that can never *be* one.
+     */
+    val mayNeedTheirApp: Boolean
+
+    /** Whether this opens on the vehicle the rider was routed onto, rather than on the operator. */
+    val namesTheVehicle: Boolean
 
     /**
      * The operator's own deep link to this vehicle/dock (`rentalUris.android`, else `.web`).
@@ -90,14 +102,63 @@ sealed interface RentalLink {
      * definition and a browser always answers it. Only the former needs a [RentalPickup.fallback] —
      * and only the latter can *be* one.
      */
-    data class Deep(val uri: String, val mayNeedTheirApp: Boolean) : RentalLink
+    data class Deep(val uri: String, override val mayNeedTheirApp: Boolean) : RentalLink {
+        override val namesTheVehicle: Boolean get() = true
+    }
+
+    /**
+     * The link the *app* builds to this vehicle, for the operator that publishes none (#2158) — see
+     * [RentalVehicleUriTemplate] for what is known about the shape and what isn't.
+     *
+     * Held as components rather than a built URI for two reasons. It is assembled with `Uri.Builder`
+     * (`RentalDeepLinks`), which this file — pure, JVM-tested — has no business calling; and the
+     * template may stamp the moment of the tap, which a URI built when the row was drawn would get
+     * wrong by however long the sheet sat open.
+     */
+    data class Synthesized(
+        val template: RentalVehicleUriTemplate,
+        /** The operator's own id for the vehicle: OTP's `network:id`, with the network stripped off. */
+        val vehicleId: String
+    ) : RentalLink {
+        override val mayNeedTheirApp: Boolean get() = true
+        override val namesTheVehicle: Boolean get() = true
+    }
 
     /** The operator's Android app, by package — launched if installed, else its store page. */
-    data class OperatorApp(val packageName: String) : RentalLink
+    data class OperatorApp(val packageName: String) : RentalLink {
+        override val mayNeedTheirApp: Boolean get() = false
+        override val namesTheVehicle: Boolean get() = false
+    }
 
     /** The operator's site: `rentalNetwork.url` when the feed publishes one, else the catalog's. */
-    data class Web(val url: String) : RentalLink
+    data class Web(val url: String) : RentalLink {
+        override val mayNeedTheirApp: Boolean get() = false
+        override val namesTheVehicle: Boolean get() = false
+    }
 }
+
+/**
+ * The shape of an operator's own "show me this vehicle" URI, for building one the feed didn't publish
+ * (#2158). Components, never a format string: percent-encoding a query *value* does not escape the `&`
+ * and `=` that separate it from the next one, so a template interpolated by hand is a URI the operator's
+ * app reads as extra parameters. `Uri.Builder` cannot express that mistake.
+ *
+ * Only an operator whose *Android* URI shape is sourced gets one — see [RentalOperators] for each
+ * operator's evidence, and for the one step of it that is still an assumption.
+ */
+data class RentalVehicleUriTemplate(
+    val scheme: String,
+    val host: String,
+    /** The query parameter naming the vehicle. */
+    val vehicleIdParam: String,
+    /**
+     * The query parameter carrying when the link was built, in epoch **seconds**, or null for an
+     * operator whose links carry no such stamp. Its presence is what makes the URI worth re-building at
+     * the moment of the tap: a stamp minted when the row was drawn is stale by the time a rider who
+     * left the sheet open comes back to it, and it is the operator's app that decides what stale means.
+     */
+    val timestampParam: String?
+)
 
 /**
  * The vehicle a rental leg is ridden on, narrowed from GBFS's form factor × propulsion to the words the
@@ -148,7 +209,7 @@ internal fun rentalPickup(rental: TripVehicleRental?): RentalPickup? {
         // The first one that can't fail for want of an app to answer a custom scheme, and never the
         // primary itself — so a row whose only link is one of those has no fallback rather than a
         // retry of it.
-        fallback = links.drop(1).firstOrNull { !(it is RentalLink.Deep && it.mayNeedTheirApp) }
+        fallback = links.drop(1).firstOrNull { !it.mayNeedTheirApp }
     )
 }
 
@@ -161,6 +222,13 @@ internal fun rentalPickup(rental: TripVehicleRental?): RentalPickup? {
  * catalog's app package comes next because opening the app the rider already has beats a web page, and
  * the feed's own `rentalNetwork.url` outranks the catalog's site because it came from the operator.
  *
+ * The link the app builds itself (#2158) sits between them: below both feed-published URIs, which came
+ * from the operator and say what the operator meant, and above the plain app launch, which drops the
+ * rider on a map they must find their own bike on again. That is the whole of its worth — it is the app
+ * launch, aimed. What that rank costs when the aim is *off* is not nothing, which is the open question
+ * on this: see [RentalOperators.LIME_VEHICLE_URI] for what the operator's app did with an id it didn't
+ * recognise.
+ *
  * Empty when nothing at all is known — an unknown network with no URIs, which is every network the app
  * has no catalog entry for until its feed starts publishing rental URIs.
  */
@@ -169,11 +237,38 @@ private fun TripVehicleRental.links(networkId: String): List<RentalLink> {
     return listOfNotNull(
         androidUri?.let { RentalLink.Deep(it, mayNeedTheirApp = true) },
         webUri?.let { RentalLink.Deep(it, mayNeedTheirApp = false) },
+        synthesizedLink(known),
         known?.appPackage?.let { RentalLink.OperatorApp(it) },
         networkUrl?.let { RentalLink.Web(it) },
         known?.webUrl?.let { RentalLink.Web(it) }
     )
 }
+
+/**
+ * The link the app builds to this vehicle from [known]'s URI shape, or null when it can't build one
+ * that means anything: an operator with no sourced shape, an endpoint that is a **dock** (whose [id] is
+ * a station id, which no `selected_vehicle_id` will ever match), or an id with nothing left after the
+ * network is stripped off it.
+ *
+ * Each of those is a fall-through, never a substitution — the rental's remaining links are offered in
+ * their own right, so the worst case is the behaviour that shipped in #2156.
+ */
+private fun TripVehicleRental.synthesizedLink(known: RentalOperators.KnownOperator?): RentalLink.Synthesized? {
+    val template = known?.vehicleUri ?: return null
+    if (kind != RentalEndpointKind.VEHICLE) return null
+    return rawVehicleId()?.let { RentalLink.Synthesized(template, it) }
+}
+
+/**
+ * The operator's own id for this vehicle: OTP qualifies it as `network:id`, and the operator's links
+ * name the bare GBFS id. Everything through the **first** colon goes, which is the join OTP made — the
+ * feed's own id is free to contain more of them. An id with no colon at all is passed through as it
+ * stands rather than emptied.
+ *
+ * Null when nothing is left, so the caller drops to a link that needs no id instead of building one
+ * with an empty parameter.
+ */
+private fun TripVehicleRental.rawVehicleId(): String? = id?.substringAfter(':')?.ifBlank { null }
 
 /** The vehicle's kind, or null when the feed named no form factor (or named [RentalFormFactor.OTHER]). */
 private fun TripVehicleRental.vehicleKind(): RentalVehicleKind? {
@@ -213,6 +308,11 @@ private fun TripVehicleRental.vehicleKind(): RentalVehicleKind? {
  * point [KnownOperator.brandColor] becomes a lookup into it rather than a hex kept here. (The sibling
  * iOS app made the other choice and paints every rental surface one app-owned purple — worth knowing
  * before anyone re-opens this.)
+ *
+ * [KnownOperator.vehicleUri] is the other fact here that isn't simply looked up (#2158) — the URI shape
+ * that lets a row open the operator's app *on the vehicle*, for the operator that publishes no such link
+ * itself. Each entry states its evidence; [LIME_VEHICLE_URI] states the step of it that a maintainer has
+ * to accept rather than check.
  */
 object RentalOperators {
 
@@ -226,19 +326,83 @@ object RentalOperators {
          * rider has installed looks absent — see `ExternalIntents.openAppOrStoreListing`.
          */
         val appPackage: String?,
-        val webUrl: String?
+        val webUrl: String?,
+        /**
+         * How this operator's app is asked to show one vehicle, when the feed publishes no link of its
+         * own (#2158) — null for an operator whose Android URI shape isn't sourced, or that has no such
+         * link to build. Sourced per entry below; the rule is that an unsourced shape means **no
+         * synthesis**, never a plausible-looking guess.
+         */
+        val vehicleUri: RentalVehicleUriTemplate? = null
+    )
+
+    /**
+     * Lime's "show me this vehicle" URI, in Lime's own words.
+     *
+     * Not reverse-engineered: Lime *publishes* this shape, in the GBFS feeds of the cities where it
+     * turns rental URIs on. On 2026-08-03 every one of the 7,097 vehicles in
+     * `data.lime.bike/api/partners/v1/gbfs/washington_dc/free_bike_status` carried
+     * `rental_uris.android` = `limebike://map?selected_vehicle_id=<id>&generated_at=<seconds>`, byte for
+     * byte the same as its `.ios` sibling — which is what settles the two things a synthesized link
+     * would otherwise be guessing at. The scheme is not an iOS-only scheme (Lime ships one app URI for
+     * both platforms, and publishes it under the `android` key itself), and `generated_at` is epoch
+     * **seconds**, read off the published values rather than inferred from their magnitude: they track
+     * the same feed's `last_updated`, which GBFS defines as epoch seconds. Seattle is simply a city
+     * where Lime has not turned the field on — the same feed there publishes no `rental_uris` at all,
+     * for any of its 13k vehicles, which is the hole this fills.
+     *
+     * 🚩 **The step that is not sourced, and the reason this is a human sign-off gate — now with a
+     * device result against it.** The id. Lime's published links carry a short code (`IBO2JSMUXZVUQ`),
+     * *not* the GBFS `bike_id` beside it in the same record (a UUID) — and a UUID is all OTP hands us,
+     * since `vehicleId` is that `bike_id` under its network prefix. So the app fills
+     * `selected_vehicle_id` from the id space the feed identifies vehicles by, which is demonstrably not
+     * the one Lime's own links use.
+     *
+     * Tapped on a Pixel 7 Pro with Lime installed (2026-08-03), a link built this way produced Lime's
+     * **"Resource not found"** error screen — not its map. So the graceful-failure argument this rests
+     * on (`ExternalIntents.openFeedUri` reporting false, the caller falling back) does not cover the
+     * case that actually happens: Lime *claims* the scheme, accepts the URI, and fails inside its own
+     * app, where the fallback chain can no longer see it. On that evidence the rider is left worse off
+     * than the plain app launch `RentalLink.OperatorApp` gives them, which is what a maintainer signing
+     * this off has to weigh. The same URI is what the sibling iOS app emits — its own tests assert only
+     * that the URL is well-formed, so it has never been shown to select a vehicle either (#2158).
+     */
+    private val LIME_VEHICLE_URI = RentalVehicleUriTemplate(
+        scheme = "limebike",
+        host = "map",
+        vehicleIdParam = "selected_vehicle_id",
+        timestampParam = "generated_at"
     )
 
     private val CATALOG = mapOf(
         // Name: the network's own GBFS system_information `attribution_organization_name` ("Lime").
         // Colour: sampled from Lime's Play Store icon, which is 3872 px of #00DD00 on white.
         // Package: play.google.com/store/apps/details?id=com.limebike is "Lime - #RideGreen".
-        "lime_seattle" to KnownOperator("Lime", 0xFF00DD00.toInt(), "com.limebike", "https://www.li.me/"),
+        // Vehicle URI: Lime's own, copied off a Lime feed that publishes them — see LIME_VEHICLE_URI.
+        "lime_seattle" to KnownOperator(
+            displayName = "Lime",
+            brandColor = 0xFF00DD00.toInt(),
+            appPackage = "com.limebike",
+            webUrl = "https://www.li.me/",
+            vehicleUri = LIME_VEHICLE_URI
+        ),
         // Name: shortened from the network's GBFS `operator` ("Bird Rides, Inc."), which is the legal
         // entity rather than what the app is called; its own store listing is "Bird — Ride Electric".
         // Colour: sampled from that listing's icon (#26CCF0 over 14020 px of it).
         // Package: the network's GBFS `rental_apps.android.store_uri` names co.bird.android itself.
-        "bird-seattle-washington" to KnownOperator("Bird", 0xFF26CCF0.toInt(), "co.bird.android", "https://www.bird.co/")
+        //
+        // No vehicle URI, on the operator's own evidence rather than for want of looking: Bird's
+        // `rental_apps` publishes an Android `discovery_uri` of `bird://charger-onboarding` — a link for
+        // people who *charge* scooters, not people who ride one — and nothing that takes a vehicle id.
+        // (The sibling iOS app carries a `bird://` app-launch entry, which is its iOS `discovery_uri`.
+        // Android has no use for one: an app launch is exactly what `appPackage` above does, and it does
+        // it better, since a rider without the app lands on the Play listing instead of nowhere.)
+        "bird-seattle-washington" to KnownOperator(
+            displayName = "Bird",
+            brandColor = 0xFF26CCF0.toInt(),
+            appPackage = "co.bird.android",
+            webUrl = "https://www.bird.co/"
+        )
     )
 
     /** The catalog entry for [networkId], or null when the app has never heard of it. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -120,6 +120,7 @@ import org.onebusaway.android.directions.realtime.TripPlanMonitor
 import org.onebusaway.android.directions.realtime.TripPlanNotifications
 import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.compose.LocalUnitsAreMetric
 import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.ui.compose.components.EtaDurationText
@@ -1691,8 +1692,12 @@ private fun ColumnScope.RentalContent(rental: RentalPickup) {
  * one. The chip is drawn at [RENTAL_OPERATOR_CHIP_SCALE] partly to keep what is left a comfortable
  * mark, and it is never the only way on — the row it sits in is itself a tap target.
  *
- * Only [RentalLink.Deep] names the exact vehicle the rider was routed onto, so only it is announced as
- * opening it; the rest merely open the operator, and none of it claims a reservation was made (#2138).
+ * A link that names the vehicle is announced as opening it; the rest merely open the operator, and none
+ * of it claims a reservation was made (#2138). The link the app builds itself (#2158) is announced the
+ * same way as one the operator published, because what the chip promises is what the tap does — it
+ * opens their app — and it is aimed at this vehicle either way. It is deliberately not hedged into its
+ * own wording: "Open in Lime (maybe on your bike)" is not a sentence, and the rider has no action to
+ * take differently on the answer.
  */
 @Composable
 private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
@@ -1701,7 +1706,7 @@ private fun OperatorChip(rental: RentalPickup, onOpen: (RentalLink) -> Unit) {
     val link = rental.link
     val openLabel = link?.let {
         stringResource(
-            if (it is RentalLink.Deep) R.string.trip_plan_rental_open_in else R.string.trip_plan_rental_rent_with,
+            if (it.namesTheVehicle) R.string.trip_plan_rental_open_in else R.string.trip_plan_rental_rent_with,
             name
         )
     }
@@ -1747,12 +1752,20 @@ private val RENTAL_OPERATOR_CHIP_MAX_WIDTH = 96.dp
  * Hands the rider over: the operator's own link, and — when the device has nothing that handles a
  * custom-scheme deep link — whatever [fallback] the pickup kept for exactly that (see
  * [RentalPickup.fallback]).
+ *
+ * A synthesized link is built *here*, at the tap, rather than when the row was drawn: it stamps the
+ * moment it was made (#2158), and a rider who opened the sheet and came back to it later would
+ * otherwise send the operator's app a stamp from whenever the plan happened to load.
  */
 private fun openRental(context: Context, link: RentalLink, fallback: RentalLink?) {
     when (link) {
         is RentalLink.Deep -> if (!ExternalIntents.openFeedUri(context, link.uri)) {
             fallback?.let { openRental(context, it, fallback = null) }
         }
+        is RentalLink.Synthesized ->
+            if (!ExternalIntents.openFeedUri(context, RentalDeepLinks.vehicleUri(link, WallTime.now()))) {
+                fallback?.let { openRental(context, it, fallback = null) }
+            }
         is RentalLink.OperatorApp -> ExternalIntents.openAppOrStoreListing(context, link.packageName)
         is RentalLink.Web -> ExternalIntents.goToUrl(context, link.url)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -160,19 +160,28 @@ object ExternalIntents {
     }
 
     /**
-     * Opens a URI published by a transit feed — a rental operator's deep link to one vehicle (#2150) —
-     * reporting whether anything on the device handled it.
+     * Opens a rental operator's deep link to one vehicle — the one their feed published (#2150), or the
+     * one the app built to their own published shape (#2158) — reporting whether anything on the device
+     * handled it.
      *
-     * Unlike [goToUrl] this doesn't toast on failure: the URI came from a feed rather than from the
-     * user, and "no app for `lime://…`" is the caller's cue to fall back, not an error to put in front
-     * of them.
+     * Unlike [goToUrl] this doesn't toast on failure: the URI wasn't typed by the user, and "no app for
+     * `limebike://…`" is the caller's cue to fall back, not an error to put in front of them.
+     *
+     * Note what this can and cannot report. It answers "did anything on the device claim the scheme?" —
+     * so a device without the operator's app falls back cleanly. It cannot see the operator's app taking
+     * the URI and then failing on its contents, which is a real outcome for the link the app builds
+     * itself (see `RentalOperators.LIME_VEHICLE_URI`): there the hand-off succeeded, and the rider is
+     * looking at the operator's error screen with no fallback left to run.
      */
-    fun openFeedUri(context: Context, uri: String): Boolean = try {
-        context.startActivity(Intent(Intent.ACTION_VIEW, uri.toUri()))
+    fun openFeedUri(context: Context, uri: Uri): Boolean = try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, uri))
         true
     } catch (_: ActivityNotFoundException) {
         false
     }
+
+    /** [openFeedUri] for a URI the feed published as a string. */
+    fun openFeedUri(context: Context, uri: String): Boolean = openFeedUri(context, uri.toUri())
 
     fun goToPhoneDialer(context: Context, url: String) {
         val intent = Intent(Intent.ACTION_DIAL)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -36,6 +36,7 @@ import org.onebusaway.android.api.graphql.type.FormFactor
 import org.onebusaway.android.api.graphql.type.Mode
 import org.onebusaway.android.api.graphql.type.PropulsionType
 import org.onebusaway.android.api.graphql.type.RelativeDirection
+import org.onebusaway.android.directions.model.RentalEndpointKind
 import org.onebusaway.android.directions.model.RentalFormFactor
 import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripAlertSeverity
@@ -223,6 +224,9 @@ class Otp2PlanDecodeTest {
         // network is read from `rentalNetwork.networkId`, never parsed off the `network:id` prefix
         // the vehicle id wears.
         val rental = bus.from.rental!!
+        // Which of OTP's two rental shapes this came from, recorded rather than re-derived from the
+        // values: it is what says the id names a vehicle (#2158).
+        assertEquals(RentalEndpointKind.VEHICLE, rental.kind)
         assertEquals("lime_seattle:bs_9", rental.id)
         assertEquals("lime_seattle", rental.networkId)
         assertEquals("https://www.li.me/", rental.networkUrl)
@@ -342,6 +346,8 @@ class Otp2PlanDecodeTest {
         assertEquals("seattle_bikes:42", rental.id)
         assertEquals("seattle_bikes", rental.networkId)
         assertEquals("Pine St & 3rd Ave", rental.stationName)
+        // A dock, said structurally — so nothing downstream reads its station id as a vehicle's.
+        assertEquals(RentalEndpointKind.STATION, rental.kind)
         // A dock publishes no vehicle type — it holds whatever the operator left in it.
         assertNull(rental.formFactor)
         assertNull(rental.androidUri)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.directions.model.RentalEndpointKind
 import org.onebusaway.android.directions.model.RentalFormFactor
 import org.onebusaway.android.directions.model.RentalPropulsion
 import org.onebusaway.android.directions.model.TripLeg
@@ -98,8 +99,9 @@ class RentalPickupsTest {
 
     @Test
     fun `a deep link with no web one beside it falls back past every other custom scheme`() {
-        // Nothing else in the list can be one, so this is really the fallback filter's floor: an
-        // Android URI the device can't answer must not fall back to another URI it can't answer.
+        // The fallback filter's floor: an Android URI the device can't answer must not fall back to
+        // another URI it can't answer — including the one the app synthesizes, which sits right behind
+        // this one and would fail for exactly the same reason.
         val pickup = rentalPickup(rental(networkId = "lime_seattle", androidUri = "lime://vehicle/abc"))!!
         assertEquals(RentalLink.Deep("lime://vehicle/abc", mayNeedTheirApp = true), pickup.link)
         assertEquals(RentalLink.OperatorApp("com.limebike"), pickup.fallback)
@@ -115,11 +117,67 @@ class RentalPickupsTest {
     }
 
     @Test
-    fun `without rental uris a catalogued operator still has somewhere to send the rider`() {
-        // Every vehicle the live Puget Sound deployment serves is this case: no rentalUris at all.
+    fun `without rental uris the app builds the operator's own link to the vehicle`() {
+        // Every vehicle the live Puget Sound deployment serves is this case: no rentalUris at all. The
+        // shape is Lime's own, from the cities where it publishes the field (see RentalOperators) —
+        // pinned here so a change to it has to be a deliberate one.
         val pickup = rentalPickup(rental(networkId = "lime_seattle"))!!
+        val link = pickup.link as RentalLink.Synthesized
+        assertEquals("limebike", link.template.scheme)
+        assertEquals("map", link.template.host)
+        assertEquals("selected_vehicle_id", link.template.vehicleIdParam)
+        assertEquals("generated_at", link.template.timestampParam)
+        // The network prefix OTP qualifies the id with is not part of the operator's own id for it.
+        assertEquals("abc", link.vehicleId)
+        // It can fail for want of the app, so it keeps the fallback the plain app launch would have
+        // been — which is also why aiming it costs nothing: a rider without Lime still lands on the
+        // Play listing rather than on a marketing page.
+        assertEquals(RentalLink.OperatorApp("com.limebike"), pickup.fallback)
+    }
+
+    @Test
+    fun `an operator that publishes a link keeps it, however good the one we could build`() {
+        // Ordering: feed-published first, synthesized second. Both name the vehicle, but only one of
+        // them is the operator saying what they meant.
+        val pickup = rentalPickup(rental(networkId = "lime_seattle", androidUri = "limebike://map?x=1"))!!
+        assertEquals(RentalLink.Deep("limebike://map?x=1", mayNeedTheirApp = true), pickup.link)
+    }
+
+    @Test
+    fun `a catalogued operator with no sourced link shape opens its app, not a guess`() {
+        // Bird's own GBFS publishes no Android URI that takes a vehicle id, so nothing is invented for
+        // it: the row opens the app it already knows about (#2158).
+        val pickup = rentalPickup(rental(networkId = "bird-seattle-washington"))!!
+        assertEquals(RentalLink.OperatorApp("co.bird.android"), pickup.link)
+        assertEquals(RentalLink.Web("https://www.bird.co/"), pickup.fallback)
+    }
+
+    @Test
+    fun `a dock gets no vehicle link, however well the operator is known`() {
+        // The id of a station endpoint is a station id; no `selected_vehicle_id` will ever match it, so
+        // the row falls through to the app launch rather than naming a vehicle that isn't one.
+        val pickup = rentalPickup(
+            rental(networkId = "lime_seattle", kind = RentalEndpointKind.STATION, stationName = "Pine St")
+        )!!
         assertEquals(RentalLink.OperatorApp("com.limebike"), pickup.link)
-        assertEquals(RentalLink.Web("https://www.li.me/"), pickup.fallback)
+    }
+
+    @Test
+    fun `an id with nothing under its network prefix builds no link`() {
+        // An empty `selected_vehicle_id` would be a link that names no vehicle while claiming to.
+        assertEquals(
+            RentalLink.OperatorApp("com.limebike"),
+            rentalPickup(rental(networkId = "lime_seattle", id = "lime_seattle:"))!!.link
+        )
+        assertEquals(
+            RentalLink.OperatorApp("com.limebike"),
+            rentalPickup(rental(networkId = "lime_seattle", id = null))!!.link
+        )
+        // An unqualified id is the id: nothing to strip, and it is what the operator would know it by.
+        assertEquals(
+            "solo",
+            (rentalPickup(rental(networkId = "lime_seattle", id = "solo"))!!.link as RentalLink.Synthesized).vehicleId
+        )
     }
 
     @Test
@@ -135,7 +193,13 @@ class RentalPickupsTest {
 
     @Test
     fun `a station pickup names its dock`() {
-        val docked = rentalPickup(rental(networkId = "some_city_bikes", stationName = "Pine St & 3rd Ave"))!!
+        val docked = rentalPickup(
+            rental(
+                networkId = "some_city_bikes",
+                kind = RentalEndpointKind.STATION,
+                stationName = "Pine St & 3rd Ave"
+            )
+        )!!
         assertEquals("Pine St & 3rd Ave", docked.stationName)
         // Nothing to walk to on a free-floating vehicle, and the row says nothing rather than
         // inventing a place.
@@ -159,7 +223,9 @@ class RentalPickupsTest {
         val leg = TripLeg(
             mode = TripMode.BICYCLE,
             from = place(rental(networkId = "lime_seattle")),
-            to = place(rental(networkId = "some_city_bikes", stationName = "Dock"))
+            to = place(
+                rental(networkId = "some_city_bikes", kind = RentalEndpointKind.STATION, stationName = "Dock")
+            )
         )
         // Where the rider *gets* the bike decides whose it is and whether they're hunting for a dock.
         assertEquals("Lime", leg.rentalPickup()?.operator?.displayName)
@@ -173,7 +239,9 @@ class RentalPickupsTest {
         val leg = TripLeg(
             mode = TripMode.BICYCLE,
             from = TripPlace(name = "Origin"),
-            to = place(rental(networkId = "some_city_bikes", stationName = "Dock"))
+            to = place(
+                rental(networkId = "some_city_bikes", kind = RentalEndpointKind.STATION, stationName = "Dock")
+            )
         )
         assertEquals("Dock", leg.rentalPickup()?.stationName)
     }
@@ -222,9 +290,12 @@ class RentalPickupsTest {
         stationName: String? = null,
         formFactor: RentalFormFactor? = null,
         propulsion: RentalPropulsion? = null,
-        rangeMeters: Int? = null
+        rangeMeters: Int? = null,
+        id: String? = "$networkId:abc",
+        kind: RentalEndpointKind = RentalEndpointKind.VEHICLE
     ) = TripVehicleRental(
-        id = "$networkId:abc",
+        id = id,
+        kind = kind,
         stationName = stationName,
         networkId = networkId,
         networkUrl = networkUrl,


### PR DESCRIPTION
Closes #2158 — or argues that it can't be closed this way. **Draft on purpose:** it works end to end, and on the device it makes the tap worse. Opening it so the finding can be taken to the iOS side, which ships the same link.

## What it does

Ports onebusaway-ios' `RentalDeepLink`. When a rental publishes no `rentalUris` — which is all 12,958 vehicles the Puget Sound OTP2 deployment serves — the app builds the operator's own "show me this vehicle" URI from its scheme and the vehicle's id, ranked feed URI > synthesized > operator app > operator site.

- `RentalLink.Synthesized` holds URI **components**, not a string: `Uri.Builder` escapes each query value, so a vehicle id carrying `&` or `=` stays one parameter. It's assembled at the moment of the tap, so `generated_at` isn't a stamp from whenever the sheet happened to load.
- `TripVehicleRental.kind` (VEHICLE/STATION) records which of OTP's two rental shapes an endpoint came from, set at the adapter where OTP states it. A dock's station id can't be sent as a `selected_vehicle_id`, and that's structural rather than inferred from whether a name was published.
- `mayNeedTheirApp` / `namesTheVehicle` moved onto `RentalLink`, so the fallback filter and the chip's wording stop type-testing the variants.

## The sourcing came out better than the issue expected

The issue flagged the scheme as reverse-engineered (ubahnverleih/WoBike) and `generated_at`'s unit as inferred. Both turn out to be **first-party**. Lime publishes `rental_uris.android` in the cities where it turns the field on — on 2026-08-03 all 7,097 vehicles in `data.lime.bike/api/partners/v1/gbfs/washington_dc/free_bike_status` carried:

```
limebike://map?selected_vehicle_id=IBO2JSMUXZVUQ&generated_at=1785807940
```

under the `android` key, byte-identical to `.ios`. So `limebike://` is not an iOS-only scheme, and `generated_at` is epoch seconds read off published values rather than guessed from magnitude. Seattle simply has the field switched off.

**Bird gets no synthesis**, on its own evidence: its GBFS `rental_apps.android.discovery_uri` is `bird://charger-onboarding` — for people who *charge* scooters — and nothing there takes a vehicle id. iOS carries a `bird://` app-launch entry; Android has no use for one, since `OperatorApp("co.bird.android")` already does that and sends a rider without the app to the Play listing instead of nowhere.

## 🚩 Why this is a draft

The id is the one step nothing published can source, and the device says it's wrong.

Lime's own links carry a short code (`IBO2JSMUXZVUQ`). The GBFS `bike_id` beside it in the same record is a UUID — and the UUID is all OTP hands us, since `vehicleId` is that `bike_id` under its network prefix. Tapping a link built from the UUID on a Pixel 7 Pro with Lime installed produced Lime's **"Resource not found"** error screen. Not its map.

That breaks the premise the whole approach rests on, on both platforms. "Failure is graceful" covers the case where *no app claims the scheme* — `ExternalIntents.openFeedUri` returns false and the caller falls back. It does not cover this: Lime claims the scheme, accepts the URI, and fails inside its own app, past the point any fallback can see. On today's evidence a rider is left worse off than with #2156's plain app launch.

## What this means for onebusaway-ios

The URI is byte-identical to what `RentalDeepLink.target(for:)` emits for the same vehicle — same scheme, host, parameter, timestamp unit, same strip-through-the-first-colon on the same OTP `network:id`. iOS reads its rentals from the same OTP2 deployment, so it sends the same UUID.

`RentalDeepLinkTests.swift` is 15 tests, every one of them an assertion about URL *construction* — escaping, ranking, the station case. None can observe what Lime does with the URL. The synthesis has never been shown to select a bike on either platform; what's verified is that the string is well-formed.

Caveat worth stating: the Lime **iOS** app is a different client from the Lime Android app tested here. Near-certainly the same backend lookup, but not proven.

## Options from here

1. Drop Lime's template, keep the mechanism — nothing synthesizes today, ready if an id source appears.
2. Revert to #2156 behaviour and close #2158 as blocked on Lime.
3. Ship as-is if the iOS side has evidence the id space is fine.

## Testing

`compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean, `spotlessCheck` clean, unit suite green. `RentalPickupsTest` covers the ordering, the dock fall-through, the id stripping and Bird's deliberate absence; the new instrumented `RentalDeepLinksTest` covers the `Uri` assembly (delimiters in an id, epoch-seconds truncation) and has **not** been device-run. The behaviour above was verified by hand on a Pixel 7 Pro.
