### PR TITLE
Refine the transit leg's directions row (#2151)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -32,13 +32,15 @@ import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
 /**
- * Verifies that a ride's interchangeable routes (#2010) reach the rider in both places they're drawn:
- * the itinerary option card's joined roundel at the top, and the ride's own joined badge in the trip
- * log (with its "whichever comes first" caption). A ride with a single route badges only that route and
- * says nothing about alternatives.
+ * Verifies that a ride's interchangeable routes (#2010) reach the rider in both places they're drawn,
+ * in the form each place carries: the itinerary option card joins them into one roundel at the top,
+ * where it has a single line to stand for the whole ride, and the trip log gives each its own line —
+ * roundel, headsign, and the "whichever comes first" caption under them (#2151). A ride with a single
+ * route draws one line and says nothing about alternatives.
  *
  * The on-device counterpart to [org.onebusaway.android.directions.model.InterchangeableRoutesTest]
- * (which decides *which* routes qualify) and `RouteBadgesTest` (which builds the badge).
+ * (which decides *which* routes qualify), `RouteBadgesTest` (which builds the badge) and
+ * `BoardableRoutesTest` (which builds the log's lines).
  */
 class DirectionRowAlternativeRoutesTest {
 
@@ -85,7 +87,6 @@ class DirectionRowAlternativeRoutesTest {
         boardTime = ServerTime(2 * 60_000L),
         exitTime = ServerTime(32 * 60_000L),
         durationMinutes = 30,
-        realtime = RealtimeState.Unknown,
         rideEvents = emptyList(),
         routeLeg = interlinedLegRef,
         legPoints = listOf(boardPoint, alightPoint)
@@ -104,14 +105,27 @@ class DirectionRowAlternativeRoutesTest {
         directions = listOf(ride.copy(routeLeg = routeLeg))
     )
 
-    /** Both roundels — the option card's and the ride's — name each interchangeable route. */
+    /** Both surfaces — the option card's joined roundel and the log's lines — name each route. */
     @Test
     fun interchangeableRoutesAreBadgedInThePickerAndTheLog() {
         composeRule.setContent { TripResultsList(state = state(interlinedLegRef)) }
 
-        // One node per route in each of the two badges: the option card's and the ride's.
+        // One node per route on each surface: the option card's joined roundel, and the log's own line.
         composeRule.onAllNodesWithText("1 Line").assertCountEquals(2)
         composeRule.onAllNodesWithText("2 Line").assertCountEquals(2)
+    }
+
+    /**
+     * Each of the log's lines says where *its* route is headed (#2151). The pair shares the track but
+     * not its destination, which is the thing the joined roundel had nowhere to put — and the reason a
+     * rider offered the choice can make it.
+     */
+    @Test
+    fun eachLineInTheLogNamesItsOwnRoutesHeadsign() {
+        composeRule.setContent { TripResultsList(state = state(interlinedLegRef)) }
+
+        composeRule.onNodeWithText("Downtown Redmond").assertExists()
+        composeRule.onNodeWithText("Federal Way Downtown").assertExists()
     }
 
     /** The ride carries the caption that makes the badge an instruction, not just a label. */
@@ -124,7 +138,7 @@ class DirectionRowAlternativeRoutesTest {
             .assertExists()
     }
 
-    /** A ride the rider can't substitute anything for badges its own route and adds no caption. */
+    /** A ride the rider can't substitute anything for draws one line and adds no caption. */
     @Test
     fun rideWithoutInterchangeableRoutesBadgesOnlyItsOwnRoute() {
         val soloRef = interlinedLegRef.copy(

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -27,7 +27,6 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.components.RouteBadge
-import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.util.GeoPoint
 
@@ -66,14 +65,6 @@ class DirectionRowAlternativeRoutesTest {
                 shortName = "1 Line",
                 routeColor = 0xFF00A651.toInt()
             )
-        ),
-        badge = LegBadge(
-            listOf(
-                RouteBadge("1 Line", 0xFF00A651.toInt()),
-                RouteBadge("2 Line", 0xFF0075C4.toInt())
-            ),
-            TransitMode.RAIL,
-            RouteBadgeJoin.ANY_OF
         )
     )
 
@@ -95,7 +86,15 @@ class DirectionRowAlternativeRoutesTest {
     private fun state(routeLeg: RouteLegRef) = TripResultsUiState.Success(
         options = listOf(
             ItineraryOption(
-                symbols = listOfNotNull(routeLeg.badge).map { ModeSymbol.Transit(it) },
+                symbols = listOf(
+                    ModeSymbol.Transit(
+                        legBadge(
+                            RouteBadge("2 Line", 0xFF0075C4.toInt()),
+                            routeLeg.alternatives.map { RouteBadge(it.shortName, it.routeColor) },
+                            TransitMode.RAIL
+                        )
+                    )
+                ),
                 durationMinutes = 32L,
                 startTime = ServerTime(0L),
                 endTime = ServerTime(32 * 60_000L)
@@ -142,8 +141,7 @@ class DirectionRowAlternativeRoutesTest {
     @Test
     fun rideWithoutInterchangeableRoutesBadgesOnlyItsOwnRoute() {
         val soloRef = interlinedLegRef.copy(
-            alternatives = emptyList(),
-            badge = LegBadge(listOf(RouteBadge("2 Line", 0xFF0075C4.toInt())), TransitMode.RAIL, RouteBadgeJoin.ANY_OF)
+            alternatives = emptyList()
         )
         composeRule.setContent { TripResultsList(state = state(soloRef)) }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -87,7 +87,6 @@ class DirectionRowFocusTest {
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,
-        realtime = RealtimeState.OnTime,
         rideEvents = listOf(RideEvent.Stop(LogStop("Capitol Hill Station", stopMidPoint))),
         routeLeg = routeLeg,
         legPoints = transitLegPoints,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -165,7 +165,7 @@ class DirectionRowFocusTest {
         composeRule.onNodeWithText(midStopName).assertDoesNotExist()
 
         // Tapping the transit header highlights the route but does not reveal the stops (#2040).
-        composeRule.onNodeWithText(transitTitle).performClick()
+        composeRule.onNodeWithText(requireNotNull(transit.headsign)).performClick()
         assertEquals("1_100", captured?.first?.routeId)
         assertEquals(FocusedLeg(transitLegPoints, setOf(1)), captured?.second)
         composeRule.onNodeWithText(midStopName).assertDoesNotExist()

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
@@ -77,8 +77,7 @@ class DirectionRowInterlineBadgeTest {
         headsign = "Rainier Beach",
         board = RouteStopRef("1_500", "500", "3rd Ave & Pine St", boardPoint),
         alight = RouteStopRef("1_600", "600", "Rainier Ave S & S Alaska St", alightPoint),
-        interlineTransitions = mapOf(1 to transition),
-        badge = interlinedBadge
+        interlineTransitions = mapOf(1 to transition)
     )
 
     private val ride = TripLogEntry.Transit(

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
@@ -91,7 +91,6 @@ class DirectionRowInterlineBadgeTest {
         boardTime = ServerTime(2 * 60_000L),
         exitTime = ServerTime(32 * 60_000L),
         durationMinutes = 30,
-        realtime = RealtimeState.Unknown,
         rideEvents = listOf(RideEvent.Transition(transition)),
         routeLeg = interlinedLegRef,
         legPoints = listOf(boardPoint, seamPoint, alightPoint)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -23,6 +23,7 @@ import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
+import org.onebusaway.android.util.ROUTE_NAME_ORDER
 import org.onebusaway.android.util.inInterchangeableOrder
 import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.riddenRouteHue
@@ -96,30 +97,12 @@ internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode
     RouteBadgeJoin.ANY_OF
 )
 
-/**
- * How one boardable route names itself on a directions row: its roundel, and where it is headed.
- *
- * [badge] is null for a route publishing no short name — the row then leads with [name], the fuller
- * name, in the roundel's place. [name] is null whenever [badge] is set: with the roundel there the row
- * doesn't print the long name beside it (#2151), so exactly one of the two identifies the route and
- * the renderer has no rule of its own to apply.
- */
+/** One route/headsign line in a transit leg's board instruction. */
 internal data class BoardableRoute(val badge: RouteBadge?, val name: String?, val headsign: String?)
 
 /**
- * The routes the rider may board this ride on — the planned one, plus everything ruled interchangeable
- * with it (#2010) — each named as a directions row draws it.
- *
- * In the same natural-name order, and under the same by-name deduplication, as the option card's joined
- * roundel ([legBadge]), so the picker and the drawer can't disagree about what the choice is. That the
- * list has more than one entry *is* the choice: the drawer gives each entry its own line and captions
- * them "whichever comes first" (#2151), where the option card joins them into a single chip. A line per
- * route is what lets each say where it is headed — two interchangeable routes share the ride but not
- * their headsigns, and the joined chip had nowhere to put them.
- *
- * The planned route is named by the drawer's narrower roundel rule ([shortNameBadge]) — no roundel for a
- * route publishing no short name — rather than the option cards' [plannedBadge], since these lines are
- * what the drawer draws.
+ * The planned route and its interchangeable alternatives, in natural route-name order. Unlike a joined
+ * badge, these lines keep same-named routes because their headsigns can distinguish them (#2151).
  */
 internal fun TripLogEntry.Transit.boardableRoutes(): List<BoardableRoute> {
     val planned = BoardableRoute(
@@ -128,7 +111,9 @@ internal fun TripLogEntry.Transit.boardableRoutes(): List<BoardableRoute> {
         headsign = headsign
     )
     val alternatives = routeLeg.alternatives.map { BoardableRoute(RouteBadge(it.shortName, it.routeColor), null, it.headsign) }
-    return (listOf(planned) + alternatives).inInterchangeableOrder { it.badge?.shortName ?: it.name.orEmpty() }
+    return (listOf(planned) + alternatives).sortedWith(
+        compareBy(ROUTE_NAME_ORDER) { it.badge?.shortName ?: it.name.orEmpty() }
+    )
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RouteBadges.kt
@@ -97,6 +97,41 @@ internal fun legBadge(planned: RouteBadge?, alternatives: List<RouteBadge>, mode
 )
 
 /**
+ * How one boardable route names itself on a directions row: its roundel, and where it is headed.
+ *
+ * [badge] is null for a route publishing no short name — the row then leads with [name], the fuller
+ * name, in the roundel's place. [name] is null whenever [badge] is set: with the roundel there the row
+ * doesn't print the long name beside it (#2151), so exactly one of the two identifies the route and
+ * the renderer has no rule of its own to apply.
+ */
+internal data class BoardableRoute(val badge: RouteBadge?, val name: String?, val headsign: String?)
+
+/**
+ * The routes the rider may board this ride on — the planned one, plus everything ruled interchangeable
+ * with it (#2010) — each named as a directions row draws it.
+ *
+ * In the same natural-name order, and under the same by-name deduplication, as the option card's joined
+ * roundel ([legBadge]), so the picker and the drawer can't disagree about what the choice is. That the
+ * list has more than one entry *is* the choice: the drawer gives each entry its own line and captions
+ * them "whichever comes first" (#2151), where the option card joins them into a single chip. A line per
+ * route is what lets each say where it is headed — two interchangeable routes share the ride but not
+ * their headsigns, and the joined chip had nowhere to put them.
+ *
+ * The planned route is named by the drawer's narrower roundel rule ([shortNameBadge]) — no roundel for a
+ * route publishing no short name — rather than the option cards' [plannedBadge], since these lines are
+ * what the drawer draws.
+ */
+internal fun TripLogEntry.Transit.boardableRoutes(): List<BoardableRoute> {
+    val planned = BoardableRoute(
+        badge = routeShortName?.let { RouteBadge(it, ridePresentationColor(routeColorHex)) },
+        name = routeDisplayName.takeIf { routeShortName == null },
+        headsign = headsign
+    )
+    val alternatives = routeLeg.alternatives.map { BoardableRoute(RouteBadge(it.shortName, it.routeColor), null, it.headsign) }
+    return (listOf(planned) + alternatives).inInterchangeableOrder { it.badge?.shortName ?: it.name.orEmpty() }
+}
+
+/**
  * The transit leg's roundel as the **directions drawer** draws one: its short name and parsed GTFS
  * color, and *no* badge at all for a route publishing no short name.
  *

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -23,7 +23,6 @@ import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.routeDisplayShortName
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.GeoPoint
-import org.onebusaway.android.util.ScheduleDeviation
 import org.onebusaway.android.util.geoPointOrNull
 
 /**
@@ -158,8 +157,8 @@ object TripLogBuilder {
      * durations, so the ledger's elapsed delta always agrees with the two times printed beside it (the
      * rider is aboard for that whole span, seam dwell included). The continuation's own events append in
      * travel order — its [transition] seam (when it changes route) first, then the stops it passes after
-     * that seam — so the merged ride reads `stops… → "stay aboard for route X" → stops…` and the leg's
-     * "N stops" summary counts the whole chain.
+     * that seam — so the merged ride reads `stops… → "stay aboard for route X" → stops…`, the whole
+     * chain under one header.
      */
     private fun foldIntoLeader(
         entries: MutableList<TripLogEntry>,
@@ -206,7 +205,6 @@ object TripLogBuilder {
             boardTime = leg.startTime,
             exitTime = leg.endTime,
             durationMinutes = leg.duration.inWholeMinutes,
-            realtime = leg.realtimeState(),
             // Only this leg's own stops; a folded chain's later legs append theirs after their seam.
             rideEvents = stopEvents(board),
             routeLeg = routeLeg,
@@ -220,9 +218,7 @@ object TripLogBuilder {
      * A transit leg's intermediate stops: the board direction's sub-directions, in travel order.
      *
      * A stop the generator could label neither by name nor by code is dropped rather than carried as an
-     * empty string — the timeline would otherwise draw a node and a blank line for it. Dropping it here
-     * rather than at the renderer also keeps [TripLogEntry.Transit.stopCount] honest: the "N stops"
-     * summary counts exactly the stops the leg can actually list.
+     * empty string — the timeline would otherwise draw a node and a blank line for it.
      */
     private fun stopEvents(board: Direction): List<RideEvent> = board.subDirections.orEmpty()
         .map { LogStop(it.directionText.str(), it.focusPoint()) }
@@ -239,25 +235,6 @@ object TripLogBuilder {
 
     /** True for a walk leg flanked by transit on both sides — a transfer, vs. a first/last-mile walk. */
     private fun List<TripLeg>.isTransferAt(i: Int): Boolean = getOrNull(i - 1)?.mode?.isTransit == true && getOrNull(i + 1)?.mode?.isTransit == true
-
-    /**
-     * Real-time board state from the leg's [TripLeg.realTime] flag + [TripLeg.departureDelay].
-     *
-     * Which bucket the leg falls in is [ScheduleDeviation]'s call, shared with the arrivals drawer
-     * (#2043); this used to round to the nearest minute and treat only an exact 0 as on time, giving
-     * the trip planner a ±30 s window where the rest of the app had none. The rounded minute count
-     * still supplies the "N min late/early" text — the band decides the bucket, the rounding only
-     * words it, and the band's edges (±90 s) always round to at least 1, so there is no "0 min late".
-     */
-    private fun TripLeg.realtimeState(): RealtimeState {
-        val minutes = ScheduleDeviation.roundedMinutes(departureDelay)
-        return when (ScheduleDeviation.status(realTime, departureDelay)) {
-            ScheduleDeviation.Status.SCHEDULED -> RealtimeState.Unknown
-            ScheduleDeviation.Status.ON_TIME -> RealtimeState.OnTime
-            ScheduleDeviation.Status.DELAYED -> RealtimeState.Late(minutes)
-            ScheduleDeviation.Status.EARLY -> RealtimeState.Early(-minutes)
-        }
-    }
 
     /** The point this direction refers to, or null when the underlying place had no coordinates. */
     private fun Direction.focusPoint(): GeoPoint? = geoPointOrNull(focusLat, focusLon)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -149,7 +149,6 @@ class DefaultTripResultsRepository @Inject constructor(
                     startsCutover = j in chain.transitionLegIndices
                 )
             }
-            val alternatives = substitutable[chain.leaderIndex]
             refs[chain.leaderIndex] = RouteLegRef(
                 routeId = otpObaIdResolver.obaRouteId(leader.routeId, leader.agencyId, leader.agencyName),
                 headsign = leader.headsign,
@@ -158,19 +157,10 @@ class DefaultTripResultsRepository @Inject constructor(
                 interlineTransitions = transitions,
                 extraSegments = extraSegments,
                 riddenSpans = riddenSpans,
-                alternatives = alternatives.map { it.resolve() },
-                // Kept separately from the joined badge: natural-name ordering means the joined form
-                // cannot identify which segment was planned, and same-named routes may collapse to one.
-                // The route-badged ETA strip needs this route's own color even in either case (#2099).
-                plannedBadge = leader.plannedBadge(),
-                // Built here, alongside the option cards' badges, so the drawer renders one rather than
-                // deriving it per row (#2010). The drawer's board row draws only the interchangeable
-                // form; on an interlined ride it names each segment at its own row instead (#2071), so
-                // the "5 > 12" this returns for one of those is drawn on the option card alone. Still
-                // built by the shared [rideBadge] rather than short-cut to the interchangeable case —
-                // that is where the two forms are held apart, invariant check and all, and the card's
-                // badge would otherwise be the only thing keeping it honest.
-                badge = rideBadge(legs, chain, alternatives)
+                alternatives = substitutable[chain.leaderIndex].map { it.resolve() },
+                // Alternatives cannot identify which same-named route was planned; the ETA strip needs
+                // this route's own color (#2099).
+                plannedBadge = leader.plannedBadge()
             )
         }
         return refs

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -94,7 +94,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -122,6 +121,7 @@ import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.LocalUnitsAreMetric
 import org.onebusaway.android.ui.compose.components.AlertSeverity
+import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.EtaDurationText
 import org.onebusaway.android.ui.compose.components.EtaPartsText
 import org.onebusaway.android.ui.compose.components.LoadingContent
@@ -1024,6 +1024,14 @@ private val LOG_EDGE_GAP = 4.dp
 private const val BADGE_SCALE = 1.5f
 
 /**
+ * The gap between a board row's route lines when a ride offers a choice of several (#2151). Barely more
+ * than a hairline: the lines are one instruction ("board whichever of these comes first"), so they need
+ * their roundels prised apart rather than separated — a gap wide enough to read as a list would undo the
+ * caption below them.
+ */
+private val ROUTE_LINE_GAP = 1.5.dp
+
+/**
  * How far the timeline's fixed metrics stretch with the user's font scale, capped at the platform's 2×
  * ceiling so a large text size can't crowd the content off a narrow screen. [TIME_WIDTH] is sized for
  * the default scale, so the ledger's clock time — its primary information — can't clip at an
@@ -1816,8 +1824,7 @@ private fun ColumnScope.BoardContent(
     onFocusPoint: (GeoPoint) -> Unit,
     stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit
 ) {
-    val context = LocalContext.current
-    // The route/headsign/meta block highlights the leg on the map; expanding its steps is the scaffold's
+    // The route/headsign block highlights the leg on the map; expanding its steps is the scaffold's
     // own chevron segment (#2040), not a side effect of this tap. The board stop + ETA strip below is a
     // third, separate tap target that zooms to the stop. Because this control is this inner block rather
     // than the whole row, the scaffold's touch-target floor doesn't reach it — so it carries its own. (Its
@@ -1827,47 +1834,32 @@ private fun ColumnScope.BoardContent(
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
             .clickable(onClick = onFocus)
     ) {
-        // A ride the rider may take on any of several routes badges them all as one joined roundel
-        // ("1 Line/2 Line", #2010). A ride the *vehicle* changes route during does not (#2071): the
-        // drawer draws a row per segment, so the header badges only the route boarded and each route the
-        // vehicle becomes is badged at the seam the rider reaches it at (TransitionContent) — the
-        // header's roundel says what to board, not everything the ride will eventually be called. The
-        // option card above still joins them ("5 > 12", #2049); it has one line for the whole ride.
-        // A route that publishes no short name gets no roundel and leads with its long name — see
-        // routeDisplayShortName.
-        val joined = entry.routeLeg.badge?.takeIf { it.isInterchangeable }
-        SegmentIdentity(
-            title = entry.routeDisplayName?.takeIf { it != entry.routeShortName },
-            headsign = entry.headsign,
-            roundel = when {
-                joined != null -> ({ RouteBadgeChip(joined.routes, scale = BADGE_SCALE, join = joined.join) })
-                entry.routeShortName != null ->
-                    ({ RouteBadgeChip(entry.routeShortName, ridePresentationColor(entry.routeColorHex), scale = BADGE_SCALE) })
-                else -> null
-            }
-        )
-        // What an interchangeable badge means: any of those routes will do, so board the first to
-        // arrive. Their arrivals share one route-badged ETA strip under the board stop (#2010/#2099). A ride that changes
-        // route under the rider carries the opposite instruction — board this one and stay on it — and
-        // gives it in its own row further down the ride (TransitionContent); its badge never reaches
-        // this header, so it cannot pick this caption up.
-        if (joined != null) {
+        // A ride the rider may take on any of several routes gets a line per route (#2151) rather than
+        // the option card's joined "1 Line/2 Line" roundel (#2010) — the drawer has the width for a line
+        // each, and each line can then say where that route is headed, which the joined chip couldn't.
+        // A ride the *vehicle* changes route during is not listed here at all (#2071): the drawer draws
+        // a row per segment, so this header names only the route boarded and each route the vehicle
+        // becomes is named at the seam the rider reaches it at (TransitionContent) — the header says
+        // what to board, not everything the ride will eventually be called.
+        val boardable = entry.boardableRoutes()
+        boardable.forEachIndexed { i, route ->
+            if (i > 0) Spacer(Modifier.height(ROUTE_LINE_GAP))
+            SegmentIdentity(badge = route.badge, name = route.name, headsign = route.headsign)
+        }
+        // What a list of routes means: any of them will do, so board the first to arrive. Their arrivals
+        // share one route-badged ETA strip under the board stop (#2010/#2099). A ride that changes route
+        // under the rider carries the opposite instruction — board this one and stay on it — and gives
+        // it in its own row further down the ride (TransitionContent); its routes never reach this
+        // header, so it cannot pick this caption up.
+        if (boardable.size > 1) {
             Text(
                 text = stringResource(R.string.directions_whichever_comes_first),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                // Set off the lines it captions by a hair, so it reads as their footing rather than as
+                // another line in the list.
+                modifier = Modifier.padding(top = 1.dp)
             )
-        }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            val meta = transitMeta(entry, context)
-            if (meta.isNotEmpty()) {
-                Text(
-                    text = meta,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            RealtimeChip(entry.realtime)
         }
     }
     // Directly under the route header and above the boarding instruction (#2143): the alert is about
@@ -1901,11 +1893,11 @@ private fun ColumnScope.StopContent(stop: LogStop) {
  * A stay-aboard interline (#2000): the vehicle keeps going but its route changes, so the rider is told
  * to stay on board — never to get off and reboard.
  *
- * Laid out as the board row of the ride's *next segment* (#2071) — badge, fuller name, headsign, by the
- * same rules a board row uses — since that is what the seam is: the header above named the route
- * boarded, and this names the route the rider goes on to ride, at the point they reach it. The
- * instruction and the seam stop follow, so a route with no long name reads
- * `[12] / Interlaken Park / Stay on board / At Mount Baker Transit Center`.
+ * Laid out as the board row of the ride's *next segment* (#2071) — roundel and headsign, by the same
+ * rules a board row uses — since that is what the seam is: the header above named the route boarded, and
+ * this names the route the rider goes on to ride, at the point they reach it. The instruction and the
+ * seam stop follow, so a route reads
+ * `[12] → Interlaken Park / Stay on board / At Mount Baker Transit Center`.
  *
  * With nothing at all to name the new route by — no badge, no name, no headsign — the instruction says
  * so itself rather than standing over a blank.
@@ -1913,15 +1905,14 @@ private fun ColumnScope.StopContent(stop: LogStop) {
 @Composable
 private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
     val headsign = transition.headsign?.takeIf { it.isNotEmpty() }
-    val title = transition.routeDisplayName?.takeIf { it != transition.badge?.shortName }
     SegmentIdentity(
-        title = title,
-        headsign = headsign,
-        roundel = transition.badge?.let { badge ->
-            { RouteBadgeChip(badge.shortName, badge.routeColor, scale = BADGE_SCALE) }
-        }
+        badge = transition.badge,
+        // Only ever the stand-in for a missing roundel, as on a board row: a route with a roundel is
+        // named by it alone (#2151).
+        name = transition.routeDisplayName.takeIf { transition.badge == null },
+        headsign = headsign
     )
-    val named = transition.badge != null || title != null || headsign != null
+    val named = transition.badge != null || transition.routeDisplayName != null || headsign != null
     Text(
         text = stringResource(
             if (named) R.string.step_by_step_transit_stay_on_board else R.string.step_by_step_transit_interline_unknown_route
@@ -1940,45 +1931,38 @@ private fun ColumnScope.TransitionContent(transition: InterlineTransition) {
 }
 
 /**
- * How a row names the route the rider is about to be on: its [roundel], the fuller name beside it, and
- * the [headsign] under both.
+ * How a row names one route the rider is about to be on: its roundel and, on the same line, where that
+ * route is headed.
  *
  * One composable rather than two so the ride's segments can't drift apart (#2071). The rider boards a
  * segment at the board row and reaches every later one at a seam row, and those are the same act — a
  * padding or type tweak landing on one of them and not the other would make one ride read as two
- * different kinds of thing.
+ * different kinds of thing. It names exactly one route, so a board row offering several draws it once
+ * per route (#2151).
  *
- * [roundel] is a slot rather than a badge value because the two rows draw genuinely different chips: a
- * board row may draw the joined "1 Line/2 Line" roundel, which is outlined, where a seam always draws
- * the plain single one. Null draws none — and takes its spacing with it — for a route publishing no
- * short name. [title] is null when the name would merely repeat the roundel, and the weight falls to a
- * spacer, so whatever follows is laid out the same either way.
+ * The roundel and the headsign together already say what to board, so the route's long name isn't
+ * printed beside them (#2151); [name] is drawn only in the roundel's place, for a route publishing no
+ * short name — see [BoardableRoute]. The headsign takes the app's shared "heading toward X" treatment
+ * ([DirectionHeadsign], #1823) rather than a setting of its own, so the sign on the bus reads the same
+ * here as on an arrivals row.
  */
 @Composable
-private fun SegmentIdentity(title: String?, headsign: String?, roundel: (@Composable () -> Unit)?) {
+private fun SegmentIdentity(badge: RouteBadge?, name: String?, headsign: String?) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        if (roundel != null) {
-            roundel()
+        if (badge != null) {
+            RouteBadgeChip(badge.shortName, badge.routeColor, scale = BADGE_SCALE)
             Spacer(Modifier.width(8.dp))
-        }
-        if (title != null) {
+        } else if (name != null) {
             Text(
-                text = title,
+                text = name,
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(1f)
+                color = MaterialTheme.colorScheme.onSurface
             )
-        } else {
-            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.width(8.dp))
         }
-    }
-    headsign?.let {
-        Text(
-            text = it,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        // Weighted so a long headsign ellipsizes against the row rather than pushing the roundel off it.
+        headsign?.let { DirectionHeadsign(it, Modifier.weight(1f)) }
     }
 }
 
@@ -2011,37 +1995,6 @@ private fun StopActionLabel(actionRes: Int, stopName: String?, onClick: (() -> U
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(1f)
         )
-    }
-}
-
-/** The on-time / delayed real-time chip; [RealtimeState.Unknown] renders nothing. */
-@Composable
-private fun RealtimeChip(state: RealtimeState) {
-    // labelMedium text over a 14%-alpha tint of itself, so it takes the text tier: the iOS display
-    // colors sit at 2.7-3.2:1 on that tint, which is what the retired trip_realtime_* palette had been
-    // hand-picked to avoid. Read off the state's own [ScheduleDeviation.Status] rather than named here,
-    // so a re-hue of the shared palette can't leave this screen behind. That palette's polarity
-    // contradicted the arrivals drawer: blue meant "early" here and "late" there, in one app (#2043).
-    val text = when (state) {
-        RealtimeState.Unknown -> return
-        RealtimeState.OnTime -> stringResource(R.string.trip_plan_realtime_on_time)
-        is RealtimeState.Late ->
-            pluralStringResource(R.plurals.trip_plan_realtime_late, state.minutes.toInt(), state.minutes.toInt())
-        is RealtimeState.Early ->
-            pluralStringResource(R.plurals.trip_plan_realtime_early, state.minutes.toInt(), state.minutes.toInt())
-    }
-    val color = colorResource(state.status.textColorRes)
-    Spacer(Modifier.width(8.dp))
-    Row(
-        modifier = Modifier
-            .clip(RoundedCornerShape(20.dp))
-            .background(color.copy(alpha = 0.14f))
-            .padding(horizontal = 8.dp, vertical = 2.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(Modifier.size(6.dp).clip(CircleShape).background(color))
-        Spacer(Modifier.width(5.dp))
-        Text(text = text, style = MaterialTheme.typography.labelMedium, color = color)
     }
 }
 
@@ -2083,13 +2036,6 @@ private fun deltaText(minutes: Long, context: Context): String {
 
 /** The walk leg's distance ("0.2 mi"); blank when the leg carries no distance. Its duration is the delta. */
 private fun walkMeta(entry: TripLogEntry.Walk, context: Context, metric: Boolean): String = if (entry.distanceMeters > 0.0) ConversionUtils.getFormattedDistance(entry.distanceMeters, context, metric) else ""
-
-/** The transit leg's stop count ("5 stops"); blank when unknown (e.g. the OTP2 path). Duration is the delta. */
-private fun transitMeta(entry: TripLogEntry.Transit, context: Context): String = if (entry.stopCount > 0) {
-    context.resources.getQuantityString(R.plurals.trip_plan_intermediate_stops, entry.stopCount, entry.stopCount)
-} else {
-    ""
-}
 
 // ---- previews ------------------------------------------------------------------------------------
 //
@@ -2172,9 +2118,9 @@ private fun previewTransitLeg(
     mode: TransitMode = TransitMode.BUS,
     routeColorHex: String? = "1B6EF3",
     headsign: String? = "Rainier Beach",
-    realtime: RealtimeState = RealtimeState.OnTime,
     rideEvents: List<RideEvent> = PREVIEW_RIDE_STOPS,
     badge: LegBadge? = null,
+    alternatives: List<AlternativeRouteRef> = emptyList(),
     alerts: List<TripAlertItem> = emptyList()
 ) = TripLogEntry.Transit(
     routeShortName = routeShortName,
@@ -2186,22 +2132,22 @@ private fun previewTransitLeg(
     boardTime = ServerTime(4 * 60_000L),
     exitTime = ServerTime(20 * 60_000L),
     durationMinutes = 16,
-    realtime = realtime,
     rideEvents = rideEvents,
     routeLeg = RouteLegRef(
         routeId = "1_100",
         headsign = headsign,
         board = RouteStopRef("1_500", "500", "Pine St & 3rd Ave", null),
         alight = RouteStopRef("1_600", "600", "Rainier Ave S & S Alaska St", null),
+        alternatives = alternatives,
         badge = badge
     ),
     alerts = alerts
 )
 
 /**
- * A Washington State Ferries run: no route short name, so no badge — the long name is the row's title
- * and the boat glyph rides the spine. Built off [previewTransitLeg] and then re-timed, since an hour
- * on a boat is the one thing about it that isn't a bus ride's shape.
+ * A Washington State Ferries run: no route short name, so no badge — the long name stands in the
+ * roundel's place and the boat glyph rides the spine. Built off [previewTransitLeg] and then re-timed,
+ * since an hour on a boat is the one thing about it that isn't a bus ride's shape.
  */
 private fun previewFerryLeg(alerts: List<TripAlertItem> = emptyList()) = previewTransitLeg(
     routeShortName = null,
@@ -2209,7 +2155,6 @@ private fun previewFerryLeg(alerts: List<TripAlertItem> = emptyList()) = preview
     mode = TransitMode.FERRY,
     routeColorHex = null,
     headsign = "Bremerton",
-    realtime = RealtimeState.Unknown,
     rideEvents = emptyList(),
     alerts = alerts
 ).copy(
@@ -2421,7 +2366,7 @@ private fun LegsPreviewFrame(entries: List<TripLogEntry>, expanded: Set<Int> = e
 @Preview(showBackground = true, widthDp = 400, name = "Transit leg · collapsed")
 @Composable
 private fun TransitLegPreview() {
-    // Board header, "N stops" meta + realtime chip, board stop — the ride's stops stay folded away.
+    // Board header (roundel + headsign) and board stop — the ride's stops stay folded away.
     LegPreviewFrame(previewTransitLeg())
 }
 
@@ -2451,7 +2396,8 @@ private fun TransitLegTwoAlertsPreview() {
 @Preview(showBackground = true, widthDp = 400, name = "Transit leg · whichever comes first")
 @Composable
 private fun TransitLegInterchangeablePreview() {
-    // An interchangeable pair (#2010): one joined roundel plus the caption that says to board either.
+    // An interchangeable pair (#2010/#2151): a line per route, each with its own headsign — the two
+    // share the track but not where they end up — plus the caption that says to board either.
     LegPreviewFrame(
         previewTransitLeg(
             routeShortName = "1 Line",
@@ -2459,7 +2405,15 @@ private fun TransitLegInterchangeablePreview() {
             mode = TransitMode.RAIL,
             routeColorHex = "00A651",
             headsign = "Angle Lake",
-            badge = PREVIEW_RAIL_PAIR_BADGE
+            badge = PREVIEW_RAIL_PAIR_BADGE,
+            alternatives = listOf(
+                AlternativeRouteRef(
+                    routeId = "40_2LINE",
+                    headsign = "Downtown Redmond",
+                    shortName = "2 Line",
+                    routeColor = 0xFF0075C4.toInt()
+                )
+            )
         )
     )
 }
@@ -2477,7 +2431,7 @@ private fun TransitLegInterlinePreview() {
 @Preview(showBackground = true, widthDp = 400, name = "Transit leg · unnamed route (ferry)")
 @Composable
 private fun TransitLegNoShortNamePreview() {
-    // No short name to badge, so the row leads with the long name and the boat glyph rides the spine —
+    // No short name to badge, so the long name stands in its place and the boat glyph rides the spine —
     // and with no GTFS colour, the whole leg falls back to one neutral hue rather than three.
     LegPreviewFrame(previewFerryLeg())
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1024,14 +1024,6 @@ private val LOG_EDGE_GAP = 4.dp
 private const val BADGE_SCALE = 1.5f
 
 /**
- * The gap between a board row's route lines when a ride offers a choice of several (#2151). Barely more
- * than a hairline: the lines are one instruction ("board whichever of these comes first"), so they need
- * their roundels prised apart rather than separated — a gap wide enough to read as a list would undo the
- * caption below them.
- */
-private val ROUTE_LINE_GAP = 1.5.dp
-
-/**
  * How far the timeline's fixed metrics stretch with the user's font scale, capped at the platform's 2×
  * ceiling so a large text size can't crowd the content off a narrow screen. [TIME_WIDTH] is sized for
  * the default scale, so the ledger's clock time — its primary information — can't clip at an
@@ -1834,30 +1826,17 @@ private fun ColumnScope.BoardContent(
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
             .clickable(onClick = onFocus)
     ) {
-        // A ride the rider may take on any of several routes gets a line per route (#2151) rather than
-        // the option card's joined "1 Line/2 Line" roundel (#2010) — the drawer has the width for a line
-        // each, and each line can then say where that route is headed, which the joined chip couldn't.
-        // A ride the *vehicle* changes route during is not listed here at all (#2071): the drawer draws
-        // a row per segment, so this header names only the route boarded and each route the vehicle
-        // becomes is named at the seam the rider reaches it at (TransitionContent) — the header says
-        // what to board, not everything the ride will eventually be called.
         val boardable = entry.boardableRoutes()
-        boardable.forEachIndexed { i, route ->
-            if (i > 0) Spacer(Modifier.height(ROUTE_LINE_GAP))
-            SegmentIdentity(badge = route.badge, name = route.name, headsign = route.headsign)
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            boardable.forEach { route ->
+                SegmentIdentity(badge = route.badge, name = route.name, headsign = route.headsign)
+            }
         }
-        // What a list of routes means: any of them will do, so board the first to arrive. Their arrivals
-        // share one route-badged ETA strip under the board stop (#2010/#2099). A ride that changes route
-        // under the rider carries the opposite instruction — board this one and stay on it — and gives
-        // it in its own row further down the ride (TransitionContent); its routes never reach this
-        // header, so it cannot pick this caption up.
         if (boardable.size > 1) {
             Text(
                 text = stringResource(R.string.directions_whichever_comes_first),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                // Set off the lines it captions by a hair, so it reads as their footing rather than as
-                // another line in the list.
                 modifier = Modifier.padding(top = 1.dp)
             )
         }
@@ -2119,7 +2098,6 @@ private fun previewTransitLeg(
     routeColorHex: String? = "1B6EF3",
     headsign: String? = "Rainier Beach",
     rideEvents: List<RideEvent> = PREVIEW_RIDE_STOPS,
-    badge: LegBadge? = null,
     alternatives: List<AlternativeRouteRef> = emptyList(),
     alerts: List<TripAlertItem> = emptyList()
 ) = TripLogEntry.Transit(
@@ -2138,8 +2116,7 @@ private fun previewTransitLeg(
         headsign = headsign,
         board = RouteStopRef("1_500", "500", "Pine St & 3rd Ave", null),
         alight = RouteStopRef("1_600", "600", "Rainier Ave S & S Alaska St", null),
-        alternatives = alternatives,
-        badge = badge
+        alternatives = alternatives
     ),
     alerts = alerts
 )
@@ -2244,7 +2221,6 @@ private fun previewDirections(alerted: Boolean = false) = listOf(
     // seam row, which is why the seam sits among the stops rather than before them.
     previewTransitLeg(
         rideEvents = PREVIEW_RIDE_STOPS.take(2) + PREVIEW_INTERLINE_SEAM + PREVIEW_RIDE_STOPS.drop(2),
-        badge = PREVIEW_BUS_CHAIN_BADGE,
         alerts = listOfNotNull(PREVIEW_BUS_ALERT.takeIf { alerted })
     ),
     previewFerryLeg(alerts = listOfNotNull(PREVIEW_FERRY_ALERT.takeIf { alerted })),
@@ -2405,7 +2381,6 @@ private fun TransitLegInterchangeablePreview() {
             mode = TransitMode.RAIL,
             routeColorHex = "00A651",
             headsign = "Angle Lake",
-            badge = PREVIEW_RAIL_PAIR_BADGE,
             alternatives = listOf(
                 AlternativeRouteRef(
                     routeId = "40_2LINE",

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -25,7 +25,6 @@ import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.util.GeoPoint
-import org.onebusaway.android.util.ScheduleDeviation
 
 /**
  * One of the (up to three) itinerary option cards shown above the directions. Carries structured data
@@ -106,18 +105,18 @@ data class LegBadge(
     val mode: TransitMode,
     // Stated at every construction, with no default. It is moot for the single-route badge most rides
     // get — nothing to divide, so no relation to name — but a *joined* badge that forgot to say would
-    // take a default silently, and the join is not merely a divider shape: [isInterchangeable] reads it
-    // to decide whether the drawer tells the rider to board whichever route comes first. Getting that by
-    // omission is a wrong instruction, not a wrong pixel.
+    // take a default silently, and the join is not merely a divider shape: it says which of the two
+    // ways a ride names several routes this badge stands for, and a card promising a choice the rider
+    // doesn't have is a wrong instruction, not a wrong pixel.
     val join: RouteBadgeJoin
 ) {
     /** Whether this ride has more than one route on its badge, i.e. the chip is a joined/multicolor one. */
     val isJoined: Boolean get() = routes.size > 1
 
     /** Whether the badge offers a *choice* of routes — as opposed to naming a ride that becomes another
-     *  route under the rider ([RouteBadgeJoin.THEN]), which is one route to board, not several. The
-     *  drawer's board row draws only this form: the other names routes the rider does not reach until
-     *  later in the ride, and it has a row down there to name each of them at (#2071). */
+     *  route under the rider ([RouteBadgeJoin.THEN]), which is one route to board, not several. Only the
+     *  option cards draw either joined form: the drawer names one route per line, from the ride's own
+     *  routes ([TripLogEntry.Transit.boardableRoutes], #2151) and its seam rows (#2071). */
     val isInterchangeable: Boolean get() = isJoined && join == RouteBadgeJoin.ANY_OF
 
     /** True when the ride names no route at all, and can only be shown as its mode. */
@@ -225,7 +224,6 @@ sealed interface TripLogEntry {
         val boardTime: ServerTime,
         val exitTime: ServerTime,
         val durationMinutes: Long,
-        val realtime: RealtimeState,
         val rideEvents: List<RideEvent>,
         val routeLeg: RouteLegRef,
         val legPoints: List<GeoPoint> = emptyList(),
@@ -239,13 +237,6 @@ sealed interface TripLogEntry {
     ) : TripLogEntry {
         /** This ride as the map's focus target — every leg of a folded chain; see [FocusedLeg]. */
         val focus: FocusedLeg get() = FocusedLeg(legPoints, legIndices)
-
-        /**
-         * How many intermediate stops the ride passes — derived from [rideEvents] rather than stored, so
-         * the "N stops" summary can't disagree with the list the leg expands to (it did when a folded
-         * interline continuation's stops were merged but its count wasn't).
-         */
-        val stopCount: Int get() = rideEvents.count { it is RideEvent.Stop }
     }
 }
 
@@ -362,35 +353,6 @@ data class LogStep(val text: String, val distanceMeters: Double = 0.0, val point
  * the trip-plan model has no per-intermediate-stop timestamp (only the board/exit times are known).
  */
 data class LogStop(val name: String, val point: GeoPoint? = null)
-
-/**
- * The real-time state of a transit board, shown as an on-time / delayed chip. [Unknown] (no real-time
- * data) renders no chip; which of the others applies is [ScheduleDeviation]'s call, shared with the
- * arrivals drawer (#2043); [Late]/[Early] carry the deviation worded in whole minutes.
- *
- * Each case names the [ScheduleDeviation.Status] it displays as, so the chip reads its color off the
- * shared palette instead of re-spelling the state→color mapping — the same coupling that used to let
- * this screen and the arrivals drawer disagree about which hue meant "early".
- */
-sealed interface RealtimeState {
-    val status: ScheduleDeviation.Status
-
-    data object Unknown : RealtimeState {
-        override val status = ScheduleDeviation.Status.SCHEDULED
-    }
-
-    data object OnTime : RealtimeState {
-        override val status = ScheduleDeviation.Status.ON_TIME
-    }
-
-    data class Late(val minutes: Long) : RealtimeState {
-        override val status = ScheduleDeviation.Status.DELAYED
-    }
-
-    data class Early(val minutes: Long) : RealtimeState {
-        override val status = ScheduleDeviation.Status.EARLY
-    }
-}
 
 /**
  * The route/stop identity of a transit leg, carried on its leg card so tapping the leg highlights the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -110,15 +110,6 @@ data class LegBadge(
     // doesn't have is a wrong instruction, not a wrong pixel.
     val join: RouteBadgeJoin
 ) {
-    /** Whether this ride has more than one route on its badge, i.e. the chip is a joined/multicolor one. */
-    val isJoined: Boolean get() = routes.size > 1
-
-    /** Whether the badge offers a *choice* of routes — as opposed to naming a ride that becomes another
-     *  route under the rider ([RouteBadgeJoin.THEN]), which is one route to board, not several. Only the
-     *  option cards draw either joined form: the drawer names one route per line, from the ride's own
-     *  routes ([TripLogEntry.Transit.boardableRoutes], #2151) and its seam rows (#2071). */
-    val isInterchangeable: Boolean get() = isJoined && join == RouteBadgeJoin.ANY_OF
-
     /** True when the ride names no route at all, and can only be shown as its mode. */
     val isUnnamed: Boolean get() = routes.isEmpty()
 }
@@ -364,11 +355,8 @@ data class LogStop(val name: String, val point: GeoPoint? = null)
  * [alternatives] are the interchangeable routes for this leg (#2010) — the board stop interleaves
  * their live arrivals with the planned route's in one ETA strip, badging each pill by route (#2099),
  * so the rider can see which of them comes first.
- * [plannedBadge] identifies the planned route's own segment independently of [badge], whose routes are
- * name-sorted and may deduplicate two distinct routes publishing the same public name.
- * [badge] is the leg's finished roundel (planned route joined by those alternatives), built once by
- * the repository rather than re-derived per row while composing; null where no badge was built at all
- * (fixtures), which is not the same as a badge that found no route to name.
+ * [plannedBadge] identifies the planned route's own segment independently of [alternatives], including
+ * when another route publishes the same public name.
  */
 data class RouteLegRef(
     val routeId: String?,
@@ -394,8 +382,7 @@ data class RouteLegRef(
     // the two can't disagree about where a ride changes route. Empty where no ref was resolved.
     val riddenSpans: List<RiddenSpan> = emptyList(),
     val alternatives: List<AlternativeRouteRef> = emptyList(),
-    val plannedBadge: RouteBadge? = null,
-    val badge: LegBadge? = null
+    val plannedBadge: RouteBadge? = null
 )
 
 /**

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -970,9 +970,9 @@
     <string name="directions_to_here">Directions to here</string>
     <!-- Shown under a transit leg's Board/Alight row when that stop has no upcoming arrivals for the route -->
     <string name="directions_stop_no_arrivals">No upcoming arrivals</string>
-    <!-- Caption beside a transit leg's joined route badge, when several routes go between the same two
-         stops without making the rider late for the rest of the trip (badge reads e.g. "1 Line/2 Line"). -->
-    <string name="directions_whichever_comes_first">whichever comes first</string>
+    <!-- Caption under a transit leg's route lines, when several routes go between the same two stops
+         without making the rider late for the rest of the trip (the lines read e.g. "1 Line" / "2 Line"). -->
+    <string name="directions_whichever_comes_first">Whichever comes first</string>
     <!-- Content description for the rule drawn across a Board row's live ETA strip at the moment the
          plan has the rider reach that stop. %1$s is a clock time, e.g. "3:19pm". -->
     <string name="directions_stop_eta_reach_stop">You get to this stop at %1$s</string>
@@ -1048,22 +1048,6 @@
     <string name="trip_plan_delta_minutes">%1$dmin</string>
     <!-- An hour or more: %1$d is whole hours, %2$d the remaining minutes -->
     <string name="trip_plan_delta_hours_minutes">%1$dh %2$dmin</string>
-    <!-- Real-time status chip on a transit leg's board, in the trip-log directions -->
-    <string name="trip_plan_realtime_on_time">On time</string>
-    <!-- How far a transit leg's departure runs behind / ahead of schedule, e.g. "3 min late" -->
-    <plurals name="trip_plan_realtime_late">
-        <item quantity="one">%1$d min late</item>
-        <item quantity="other">%1$d min late</item>
-    </plurals>
-    <plurals name="trip_plan_realtime_early">
-        <item quantity="one">%1$d min early</item>
-        <item quantity="other">%1$d min early</item>
-    </plurals>
-    <!-- Number of intermediate stops a transit leg passes through, e.g. "5 stops" -->
-    <plurals name="trip_plan_intermediate_stops">
-        <item quantity="one">%1$d stop</item>
-        <item quantity="other">%1$d stops</item>
-    </plurals>
 
 
     <string name="tripplanner_no_server_selected_error">No region selected</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/InterleaveRouteItemsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/InterleaveRouteItemsTest.kt
@@ -18,11 +18,8 @@ package org.onebusaway.android.ui.home.directions
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.ui.compose.components.RouteBadge
-import org.onebusaway.android.ui.compose.components.RouteBadgeJoin
 import org.onebusaway.android.ui.tripresults.AlternativeRouteRef
-import org.onebusaway.android.ui.tripresults.LegBadge
 import org.onebusaway.android.ui.tripresults.RouteLegRef
-import org.onebusaway.android.ui.tripresults.TransitMode
 
 class InterleaveRouteItemsTest {
 
@@ -62,10 +59,7 @@ class InterleaveRouteItemsTest {
             alternatives = listOf(
                 AlternativeRouteRef("1_alternative", "Downtown", alternative.shortName, alternative.routeColor)
             ),
-            plannedBadge = planned,
-            // The joined presentation deduplicates identical public names, so it cannot be used to
-            // recover which route was planned.
-            badge = LegBadge(listOf(alternative), TransitMode.RAIL, RouteBadgeJoin.ANY_OF)
+            plannedBadge = planned
         )
 
         assertEquals(planned, routeLeg.etaPlannedBadge("A Line"))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/BoardableRoutesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/BoardableRoutesTest.kt
@@ -72,18 +72,17 @@ class BoardableRoutesTest {
         )
     }
 
-    /**
-     * Two routes publishing one public name collapse to a single line, exactly as they collapse on the
-     * joined roundel ([legBadge]) — the rider is being offered one name, so a caption promising a choice
-     * between two of it would be nonsense.
-     */
+    /** Same-named routes remain distinct because their headsigns tell the rider which vehicle is which. */
     @Test
-    fun routesSharingAPublicNameCollapseToOneLine() {
+    fun routesSharingAPublicNameKeepTheirHeadsignLines() {
         val routes = ride(shortName = "40", headsign = "Downtown Seattle")
             .withAlternatives(alternative("40", "Northgate"))
             .boardableRoutes()
 
-        assertEquals(listOf("40"), routes.map { it.badge?.shortName })
+        assertEquals(
+            listOf("40" to "Downtown Seattle", "40" to "Northgate"),
+            routes.map { it.badge?.shortName to it.headsign }
+        )
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/BoardableRoutesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/BoardableRoutesTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * JVM tests for the lines a directions board row draws for a ride (#2151): one per route the rider may
+ * board it on, each naming where that route is headed, with "whichever comes first" under them when
+ * there is more than one.
+ *
+ * The list's *size* is the instruction — one line is a ride, two are a choice — so what these pin is
+ * which routes end up on it, in what order, and how a route that names itself unusually lands.
+ *
+ * Every fixture leaves the GTFS colour null: parsing one goes through `android.graphics.Color`, which a
+ * JVM test can't call (`DirectionRowAlternativeRoutesTest` covers the colour on-device), and the colour
+ * is not what decides a line.
+ */
+class BoardableRoutesTest {
+
+    /** The ordinary ride: one line, the route boarded, headed where the leg says. */
+    @Test
+    fun anOrdinaryRideOffersItsOwnRouteAlone() {
+        val routes = ride(shortName = "8", headsign = "Rainier Beach").boardableRoutes()
+
+        assertEquals(1, routes.size)
+        assertEquals("8", routes.single().badge?.shortName)
+        assertEquals("Rainier Beach", routes.single().headsign)
+        assertNull("a badged route is named by its roundel alone", routes.single().name)
+    }
+
+    /**
+     * Interchangeable routes each get a line, in natural name order rather than plan order — the same
+     * order the option card's joined roundel reads in, so the corridor looks the same on both surfaces
+     * whichever of its lines the planner happened to pick.
+     */
+    @Test
+    fun interchangeableRoutesEachGetALineInNaturalOrder() {
+        val routes = ride(shortName = "2 Line", headsign = "Downtown Redmond")
+            .withAlternatives(alternative("1 Line", "Federal Way Downtown"))
+            .boardableRoutes()
+
+        assertEquals(listOf("1 Line", "2 Line"), routes.map { it.badge?.shortName })
+    }
+
+    /** …and each line keeps its *own* headsign: the pair shares the track, not where it ends up. */
+    @Test
+    fun eachLineNamesWhereItsOwnRouteIsHeaded() {
+        val routes = ride(shortName = "2 Line", headsign = "Downtown Redmond")
+            .withAlternatives(alternative("1 Line", "Federal Way Downtown"))
+            .boardableRoutes()
+
+        assertEquals(
+            listOf("1 Line" to "Federal Way Downtown", "2 Line" to "Downtown Redmond"),
+            routes.map { it.badge?.shortName to it.headsign }
+        )
+    }
+
+    /**
+     * Two routes publishing one public name collapse to a single line, exactly as they collapse on the
+     * joined roundel ([legBadge]) — the rider is being offered one name, so a caption promising a choice
+     * between two of it would be nonsense.
+     */
+    @Test
+    fun routesSharingAPublicNameCollapseToOneLine() {
+        val routes = ride(shortName = "40", headsign = "Downtown Seattle")
+            .withAlternatives(alternative("40", "Northgate"))
+            .boardableRoutes()
+
+        assertEquals(listOf("40"), routes.map { it.badge?.shortName })
+    }
+
+    /**
+     * A route publishing no short name has no roundel to draw, so its line leads with the fuller name
+     * instead — the ferry case. It is still the route the rider boards, and must not drop off the list.
+     */
+    @Test
+    fun aRouteWithNoShortNameLeadsWithItsFullerName() {
+        val routes = ride(shortName = null, headsign = "Bremerton", displayName = "Seattle - Bremerton").boardableRoutes()
+
+        assertNull(routes.single().badge)
+        assertEquals("Seattle - Bremerton", routes.single().name)
+        assertEquals("Bremerton", routes.single().headsign)
+    }
+
+    private fun ride(shortName: String?, headsign: String?, displayName: String? = shortName) = TripLogEntry.Transit(
+        routeShortName = shortName,
+        routeDisplayName = displayName,
+        mode = TransitMode.BUS,
+        routeColorHex = null,
+        headsign = headsign,
+        reachStopTime = null,
+        boardTime = ServerTime(0L),
+        exitTime = ServerTime(60_000L),
+        durationMinutes = 1,
+        rideEvents = emptyList(),
+        routeLeg = RouteLegRef(routeId = "1_100", headsign = headsign, board = null, alight = null)
+    )
+
+    private fun TripLogEntry.Transit.withAlternatives(vararg alternatives: AlternativeRouteRef) = copy(routeLeg = routeLeg.copy(alternatives = alternatives.toList()))
+
+    private fun alternative(shortName: String, headsign: String) = AlternativeRouteRef(
+        routeId = "1_$shortName",
+        headsign = headsign,
+        shortName = shortName,
+        routeColor = null
+    )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
@@ -50,7 +50,6 @@ class RideCoveringLegsTest {
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,
-        realtime = RealtimeState.Unknown,
         rideEvents = emptyList(),
         routeLeg = RouteLegRef("1_$shortName", "Downtown", null, null),
         legIndices = legIndices

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RouteBadgesTest.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui.tripresults
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -45,7 +44,7 @@ class RouteBadgesTest {
         )
 
         assertEquals(listOf("1 Line", "2 Line"), badge.routes.map { it.shortName })
-        assertTrue(badge.isInterchangeable)
+        assertEquals(RouteBadgeJoin.ANY_OF, badge.join)
     }
 
     /** …and the mirror-image plan produces the identical badge. */
@@ -74,7 +73,7 @@ class RouteBadgesTest {
         val badge = legBadge(planned = RouteBadge("8", null), alternatives = emptyList(), mode = TransitMode.BUS)
 
         assertEquals(listOf("8"), badge.routes.map { it.shortName })
-        assertFalse(badge.isInterchangeable)
+        assertEquals(RouteBadgeJoin.ANY_OF, badge.join)
     }
 
     /** A route can't appear twice in one badge, however it reached the list. */
@@ -199,9 +198,6 @@ class RouteBadgesTest {
 
         assertEquals(listOf("12", "10"), badge.routes.map { it.shortName })
         assertEquals(RouteBadgeJoin.THEN, badge.join)
-        assertTrue(badge.isJoined)
-        // "Board either one" is the wrong instruction here: there is one vehicle, and it becomes the 10.
-        assertFalse(badge.isInterchangeable)
     }
 
     /** A self-interline is invisible to the rider — same route, same vehicle — so it badges once. */
@@ -210,7 +206,6 @@ class RouteBadgesTest {
         val badge = rideBadgeOf(transitLeg("12"), transitLeg("12", interline = true))
 
         assertEquals(listOf("12"), badge.routes.map { it.shortName })
-        assertFalse(badge.isJoined)
     }
 
     /** A ride with no route change is the leg's own badge: its interchangeable routes, slashed. */
@@ -222,7 +217,6 @@ class RouteBadgesTest {
 
         assertEquals(listOf("1 Line", "2 Line"), badge.routes.map { it.shortName })
         assertEquals(RouteBadgeJoin.ANY_OF, badge.join)
-        assertTrue(badge.isInterchangeable)
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.ui.tripresults
 
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -257,7 +256,7 @@ class TripLogBuilderTest {
     }
 
     @Test
-    fun transitEntry_carriesTimesColorStopsAndRealtime() {
+    fun transitEntry_carriesTimesColorAndStops() {
         val transit = TripLogBuilder
             .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef))
             .filterIsInstance<TripLogEntry.Transit>()
@@ -269,9 +268,7 @@ class TripLogBuilderTest {
         assertEquals(ServerTime(4 * 60_000L), transit.boardTime)
         assertEquals(ServerTime(20 * 60_000L), transit.exitTime)
         assertEquals(16L, transit.durationMinutes)
-        assertEquals(1, transit.stopCount)
         assertEquals("Capitol Hill Station", transit.stopNames().single())
-        assertEquals(RealtimeState.Late(2), transit.realtime)
         assertEquals(transitRef, transit.routeLeg)
     }
 
@@ -325,7 +322,6 @@ class TripLogBuilderTest {
             .single()
 
         assertEquals(listOf("Capitol Hill Station"), transit.stopNames())
-        assertEquals(1, transit.stopCount)
     }
 
     @Test
@@ -389,8 +385,8 @@ class TripLogBuilderTest {
                 }
             }
         )
-        // …and the "N stops" summary counts the whole ride, not just the leader leg's share.
-        assertEquals(2, transit.stopCount)
+        // …so the ride lists the whole chain's stops, not just the leader leg's share.
+        assertEquals(2, transit.stopNames().size)
     }
 
     @Test
@@ -409,7 +405,7 @@ class TripLogBuilderTest {
         ).filterIsInstance<TripLogEntry.Transit>().single()
 
         assertTrue("a self-interline shows no seam row", transit.rideEvents.none { it is RideEvent.Transition })
-        assertEquals(2, transit.stopCount)
+        assertEquals(2, transit.stopNames().size)
     }
 
     /**
@@ -474,59 +470,5 @@ class TripLogBuilderTest {
 
         assertNull(transit.routeShortName)
         assertEquals("Seattle - Bremerton", transit.routeDisplayName)
-    }
-
-    // --- The shared on-time band (#2043) ---------------------------------------------------------
-    //
-    // The trip planner used to round the delay to the nearest minute and call only an exact 0 "on
-    // time", giving it a ±30 s window while the arrivals drawer had none. Both now bucket through
-    // ScheduleDeviation, so the same vehicle can't read on-time in one screen and late in the other.
-
-    /** The realtime state for a transit leg whose departure is [delaySeconds] off schedule. */
-    private fun realtimeStateFor(delaySeconds: Long, realTime: Boolean = true): RealtimeState {
-        val leg = transitLeg.copy(realTime = realTime, departureDelay = delaySeconds.seconds)
-        return TripLogBuilder
-            .build(listOf(leg), listOf(boardDir, alightDir), listOf(transitRef))
-            .filterIsInstance<TripLogEntry.Transit>()
-            .single()
-            .realtime
-    }
-
-    @Test
-    fun deviationJustInsideTheBand_isOnTime() {
-        // Both of these used to round to ±1 minute and render as late/early.
-        assertEquals(RealtimeState.OnTime, realtimeStateFor(89))
-        assertEquals(RealtimeState.OnTime, realtimeStateFor(-89))
-    }
-
-    @Test
-    fun deviationJustOutsideTheBand_isLateOrEarly() {
-        assertEquals(RealtimeState.Late(2), realtimeStateFor(91))
-        assertEquals(RealtimeState.Early(2), realtimeStateFor(-91))
-    }
-
-    /**
-     * The band's edges always round to at least one minute, so a Late/Early chip can never read
-     * "0 min late" — the case the old `minutes == 0L` bucket used to absorb.
-     */
-    @Test
-    fun lateAndEarlyChipsNeverReportZeroMinutes() {
-        for (seconds in longArrayOf(91, 120, 200, -91, -120, -200)) {
-            val state = realtimeStateFor(seconds)
-            val minutes = when (state) {
-                is RealtimeState.Late -> state.minutes
-                is RealtimeState.Early -> state.minutes
-                else -> error("$seconds s must bucket as late or early, was $state")
-            }
-            assertTrue("$seconds s must report at least a minute, was $minutes", minutes >= 1)
-        }
-    }
-
-    /** No real-time data means no chip, whatever the leg's delay field happens to hold. */
-    @Test
-    fun withoutRealtime_isUnknownWhateverTheDeviation() {
-        assertEquals(RealtimeState.Unknown, realtimeStateFor(0, realTime = false))
-        assertEquals(RealtimeState.Unknown, realtimeStateFor(600, realTime = false))
-        assertEquals(RealtimeState.Unknown, realtimeStateFor(-600, realTime = false))
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
@@ -70,7 +70,6 @@ class TripLogRowsTest {
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,
-        realtime = RealtimeState.OnTime,
         rideEvents = events,
         routeLeg = RouteLegRef("1_100", "Rainier Beach", null, null)
     )


### PR DESCRIPTION
Fixes #2151.

Three visual refinements to a transit leg in the directions drawer.

The board row used to lead with the route's long name, drop the headsign to a line of its own underneath, and then spend a third line on "5 stops" and an on-time pill:

```
[  8  ] Route 8
Rainier Beach
5 stops   ● On time
Get on  Pine St & 3rd Ave
[ live ETA strip ]
```

It now says what to board on one line, in the app's own headsign voice:

```
[  8  ] → Rainier Beach
Get on  Pine St & 3rd Ave
[ live ETA strip ]
```

## (1) The "N stops" summary and the lateness pill are gone

The board stop's live ETA strip directly below already says when the vehicle is actually coming, and the ride's stops are one chevron tap away — the two lines said it again, less well, and the pill's `[dot] On time` was the loudest thing on a row whose job is "board the 8".

Removed with them, rather than left unrendered: `RealtimeState`, `TripLogBuilder.realtimeState()`, `TripLogEntry.Transit.stopCount`, and the four string resources. The `ScheduleDeviation` band they bucketed through is untouched and still shared with the arrivals drawer (#2043) — nothing else in the app loses a real-time reading. **Say so if you'd rather the model stayed for a future surface**; it's a clean revert.

## (2) The long name goes, the headsign comes up beside the roundel

The roundel and the headsign together are the whole instruction, so the long name is no longer printed beside them — `[8] Route 8` was the roundel twice.

The headsign now takes the shared `DirectionHeadsign` treatment (arrow + tightened monospace, #1823), so the sign on the bus reads identically here, on an arrivals row, and on the map's route header, instead of being the one place set in plain `bodyMedium`.

A route publishing **no** short name has no roundel to draw, so its fuller name still stands in the roundel's place — that's the WSF ferry case (`Seattle - Bremerton → Bremerton`), and it must not lose its identity to this change. Board rows and stay-aboard seam rows share one composable (`SegmentIdentity`, #2071), so both were re-set together.

## (3) Interchangeable routes get a line each

A ride the rider may take on any of several routes (#2010) drew the option card's joined chip plus a caption:

```
[ 1 Line / 2 Line ]
whichever comes first
```

The joined chip has room for names and nothing else — but the two routes share the *track*, not where they end up, and which is which is exactly what a rider making the choice wants. So the drawer, which has the width for it, gives each route its own line:

```
[ 1 Line ] → Federal Way Downtown
[ 2 Line ] → Downtown Redmond
Whichever comes first
```

The option card above is unchanged and still joins them — it has one line to stand for the whole ride.

The lines come from a new pure `TripLogEntry.Transit.boardableRoutes()`, ordered and deduplicated by the same `inInterchangeableOrder` the card's joined roundel uses, so the picker and the drawer can't disagree about what the choice is. The caption keys off the *line count*, which falls out of that: two routes publishing one public name collapse to a single line **and** drop the caption, rather than offering a choice between "40" and "40".

An interlined ride (#2000) still isn't listed here — it names each route at the seam the rider reaches it at (#2071), and "board whichever comes first" would tell them to board the bus they're already sitting on.

## Tests

* `BoardableRoutesTest` (new, JVM) — ordering, per-route headsigns, the same-public-name collapse, and the no-short-name fallback.
* `DirectionRowAlternativeRoutesTest` — gains an on-device assertion that each line carries its own headsign; its existing badge counts hold, since the log now contributes one node per route where it contributed one joined chip.
* `TripLogBuilderTest` — the realtime-band tests go with the model; the `stopCount` assertions were each redundant with a `stopNames()` assertion beside them and now read through that.

## Verified

`obaGoogle` + `obaMaplibre` compile clean under `-PwarningsAsErrors=true`, unit tests and `spotlessCheck` pass, and the build is installed and exercised on a Pixel 7 Pro. Lint left to CI per the repo's guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip results now display each boardable route and its corresponding headsign on separate lines.
  * Alternative routes are consistently ordered and shown with route badges or full names when needed, including same-named routes separately.
  * Interline transitions use the same route and headsign presentation.

* **Improvements**
  * Removed outdated realtime status and intermediate-stop details from trip headers and logs.
  * Updated route guidance text to clarify when any listed route arrives first.

* **Tests**
  * Added coverage for route ordering, naming, and headsign display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->