### PR TITLE
Resolve a planned leg's stop against its route's own stops (#2170)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopsForRouteRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopsForRouteRepository.kt
@@ -72,12 +72,8 @@ interface StopsForRouteRepository {
     suspend fun routeMap(routeId: String): Result<RouteMapData?>
 
     /**
-     * Every OBA stop id the route serves — the whole references pool, not only the ids a direction
-     * group happens to list. This is the authoritative answer to "which OBA stop is this?" for a
-     * planned transit leg, whose stops OTP names in a different id space (see
-     * [org.onebusaway.android.directions.OtpObaIdResolver]). [Result.failure] on IO / HTTP / non-OK
-     * code **and** when there is no endpoint to contact — a caller that can't get the route's stops
-     * cannot name one of them, so there is nothing to degrade to.
+     * Every stop id the route serves — the whole references pool, not only the ids a direction group
+     * happens to list. Same failure contract as [routeStopGroups].
      */
     suspend fun routeStopIds(routeId: String): Result<List<String>>
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopsForRouteRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/StopsForRouteRepository.kt
@@ -51,6 +51,7 @@ import org.onebusaway.android.util.runCatchingCancellable
  * - [routeStopGroups] — the per-direction stop list (route info + a focused stop's trips).
  * - [routeMap] — the full route map: stops tagged with direction membership, selectable directions,
  *   and decoded shapes (the route overlay).
+ * - [routeStopIds] — just the ids of every stop the route serves.
  *
  * The wire DTO stays encapsulated here; callers only ever see the model projections.
  */
@@ -69,6 +70,16 @@ interface StopsForRouteRepository {
      * IO / HTTP / non-OK code, matching the legacy `MapDataSource.routeMap`.
      */
     suspend fun routeMap(routeId: String): Result<RouteMapData?>
+
+    /**
+     * Every OBA stop id the route serves — the whole references pool, not only the ids a direction
+     * group happens to list. This is the authoritative answer to "which OBA stop is this?" for a
+     * planned transit leg, whose stops OTP names in a different id space (see
+     * [org.onebusaway.android.directions.OtpObaIdResolver]). [Result.failure] on IO / HTTP / non-OK
+     * code **and** when there is no endpoint to contact — a caller that can't get the route's stops
+     * cannot name one of them, so there is nothing to degrade to.
+     */
+    suspend fun routeStopIds(routeId: String): Result<List<String>>
 }
 
 /**
@@ -113,6 +124,10 @@ class DefaultStopsForRouteRepository internal constructor(
         // runCatchingCancellable rethrows a CancellationException (raised by withContext if the caller is
         // cancelled mid-decode) rather than reporting the abandoned work as a failure.
         return runCatchingCancellable { withContext(Dispatchers.Default) { fetched.toRouteMapData(routeId) } }
+    }
+
+    override suspend fun routeStopIds(routeId: String): Result<List<String>> = entry(routeId).mapCatching { fetched ->
+        fetched?.references?.stops?.map { it.id } ?: throw noEndpoint()
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
@@ -23,7 +23,15 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.onebusaway.android.api.data.AgenciesDataSource
 import org.onebusaway.android.api.data.StopsForRouteRepository
+import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.models.AgencyContact
+
+/** The OBA ids one planned transit leg resolves to; null anywhere OBA can't name the entity. */
+data class ResolvedLegIds(
+    val routeId: String?,
+    val fromStopId: String?,
+    val toStopId: String?
+)
 
 /**
  * Resolves an OTP transit leg's GTFS ids onto the OBA ids the where-API expects, so a planned trip's
@@ -49,7 +57,13 @@ import org.onebusaway.android.models.AgencyContact
  * `kcm:23561` in OTP is `1_23561` in OBA, and `40_23561` does not exist. A single route can even span
  * two OBA agencies' stops (KCM route `1_102558` calls at both `1_*` and `29_*` stops). So a stop is
  * resolved against the route's **actual** OBA stop list rather than by guessing its prefix — see
- * [obaStopId].
+ * [resolveLegs].
+ *
+ * That makes this path network-bound where it used to be pure string work: resolving an itinerary costs
+ * one stops-for-route fetch per distinct transit route, and it is the *cold* one — the drawer's route
+ * focus and the route map read the same shared cache, but only after the rider taps a leg, which cannot
+ * happen until this has returned. [resolveLegs] therefore fetches an itinerary's routes in one
+ * concurrent round rather than one serial round trip per leg.
  *
  * This is the client-side stand-in for an authoritative OTP-agency → OBA-agency map in the regions
  * directory: when that field lands it becomes the resolution/override source in place of the
@@ -71,30 +85,39 @@ class OtpObaIdResolver @Inject constructor(
     }
 
     /**
-     * The OBA stop id for a stop called at on an OTP transit leg travelling [obaRouteId], or null when
-     * the route's stops can't be reached or none of them is this stop.
+     * The OBA ids for each of [legs], index-aligned to it — a non-transit leg, or one whose route or
+     * stops can't be reached, yields nulls rather than being dropped.
      *
-     * The GTFS entity id is the same on both sides; only the OBA agency prefix has to be found, and the
-     * one place it is *stated* rather than guessed is the route's own OBA stop list. So this looks the
-     * entity up there, using OBA's id contract (`{agencyId}_{entityId}`, split at the first `_` — see
-     * `AgencyAndId.convertFromString`) to compare. It goes through the shared, cached
-     * [StopsForRouteRepository], which the drawer's route focus and the route map already fetch for the
-     * very same routes, so a planned leg normally resolves off a cache hit.
+     * Resolving the whole itinerary at once rather than one entity at a time is what lets each route's
+     * stops be fetched once, concurrently, and indexed once; it also means a leg's stop ids can only
+     * ever be looked up on that leg's own route.
      */
-    suspend fun obaStopId(stopGtfsId: String?, obaRouteId: String?): String? {
-        val entity = gtfsEntitySuffix(stopGtfsId) ?: return null
-        val routeId = obaRouteId ?: return null
-        val stopIds = stopsForRoute.routeStopIds(routeId).getOrNull() ?: return null
-        return stopIds.firstOrNull { it.substringAfter('_', missingDelimiterValue = "") == entity }
+    suspend fun resolveLegs(legs: List<TripLeg>): List<ResolvedLegIds> = coroutineScope {
+        val routeIds = legs.map { obaRouteId(it.routeId, it.agencyId, it.agencyName) }
+        val stopsByRoute = routeIds.filterNotNull().distinct()
+            .map { routeId -> async { routeId to stopIndex(routeId) } }
+            .awaitAll().toMap()
+        legs.mapIndexed { i, leg ->
+            val stops = routeIds[i]?.let { stopsByRoute[it] }.orEmpty()
+            ResolvedLegIds(
+                routeId = routeIds[i],
+                fromStopId = gtfsEntitySuffix(leg.from.stopId)?.let(stops::get),
+                toStopId = gtfsEntitySuffix(leg.to.stopId)?.let(stops::get)
+            )
+        }
     }
 
     /**
-     * Warms the route stop lists [obaStopId] resolves against, so an itinerary's legs pay for one
-     * round of concurrent fetches rather than one serial fetch each while the drawer shows Loading.
+     * A route's stops keyed by GTFS entity id, empty when they can't be reached. The entity id is the
+     * same on both sides; only the OBA agency prefix has to be found, and the one place it is *stated*
+     * rather than guessed is this list. Keyed by splitting each OBA id at its **first** `_`, which is
+     * OBA's own id contract (`AgencyAndId.convertFromString`, server-side — the rule is not implemented
+     * in this repo), so an entity id containing underscores survives intact.
      */
-    suspend fun prefetchRouteStops(obaRouteIds: Collection<String>): Unit = coroutineScope {
-        obaRouteIds.distinct().map { async { stopsForRoute.routeStopIds(it) } }.awaitAll()
-    }
+    private suspend fun stopIndex(obaRouteId: String): Map<String, String> = stopsForRoute.routeStopIds(obaRouteId)
+        .getOrNull()
+        .orEmpty()
+        .associateBy { it.substringAfter('_', missingDelimiterValue = "") }
 
     /**
      * The OBA agency id for an OTP agency: the gtfsId suffix when it names a covered agency, else the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
@@ -34,8 +34,14 @@ import org.onebusaway.android.models.AgencyContact
  * the agency prefix is remapped. For a **route** the OBA agency id is **derived** from the OTP agency
  * gtfsId's suffix and then **verified** against the region's agencies-with-coverage; where the derived
  * value isn't a covered agency — feeds whose GTFS `agency_id` diverges from OBA's (verified for Puget
- * Sound: Intercity is `19:0` in OTP but agency `19` in OBA; Skagit uses a UUID agency id) — it falls
- * back to matching the OTP agency **name** against the covered agencies.
+ * Sound: Intercity is `19:0` in OTP but agency `19` in OBA) — it falls back to matching the OTP agency
+ * **name** against the covered agencies. Some OTP agencies are in neither: Puget Sound's graph plans on
+ * Skagit and Whatcom, which OBA does not cover at all, and those correctly resolve to null.
+ *
+ * Membership is all the derived suffix is checked for, not identity — a feed whose GTFS `agency_id`
+ * collided with a *different* OBA agency's id would resolve silently to the wrong agency. That does not
+ * happen in Puget Sound today (every derived hit's OBA name equals the OTP agency name), but nothing
+ * here enforces it; the regions-directory mapping below is the real fix.
  *
  * A **stop** does not get that prefix, because a route's agency does not own the stops it calls at
  * (#2170). Verified against the live Puget Sound deployments: ST route 522 is `kcm:100232` under agency

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
@@ -112,12 +112,17 @@ class OtpObaIdResolver @Inject constructor(
      * same on both sides; only the OBA agency prefix has to be found, and the one place it is *stated*
      * rather than guessed is this list. Keyed by splitting each OBA id at its **first** `_`, which is
      * OBA's own id contract (`AgencyAndId.convertFromString`, server-side — the rule is not implemented
-     * in this repo), so an entity id containing underscores survives intact.
+     * in this repo), so an entity id containing underscores survives intact. A suffix that names more
+     * than one of the route's stops (two agencies' stops sharing an entity id) is ambiguous and dropped
+     * rather than picking one arbitrarily — the caller degrades exactly as it does for an unreachable
+     * stop.
      */
     private suspend fun stopIndex(obaRouteId: String): Map<String, String> = stopsForRoute.routeStopIds(obaRouteId)
         .getOrNull()
         .orEmpty()
-        .associateBy { it.substringAfter('_', missingDelimiterValue = "") }
+        .groupBy { it.substringAfter('_', missingDelimiterValue = "") }
+        .mapNotNull { (suffix, ids) -> ids.singleOrNull()?.let { suffix to it } }
+        .toMap()
 
     /**
      * The OBA agency id for an OTP agency: the gtfsId suffix when it names a covered agency, else the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/OtpObaIdResolver.kt
@@ -16,9 +16,13 @@
 package org.onebusaway.android.directions
 
 import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.onebusaway.android.api.data.AgenciesDataSource
+import org.onebusaway.android.api.data.StopsForRouteRepository
 import org.onebusaway.android.models.AgencyContact
 
 /**
@@ -27,11 +31,19 @@ import org.onebusaway.android.models.AgencyContact
  *
  * OTP2 ids are `{feedId}:{entityId}` and agency ids `{feedId}:{obaAgencyId}`; OBA ids are
  * `{obaAgencyId}_{entityId}`. The **entity id** (route/stop number) is identical on both sides, so only
- * the agency prefix is remapped. The OBA agency id is **derived** from the OTP agency gtfsId's suffix
- * and then **verified** against the region's agencies-with-coverage; where the derived value isn't a
- * covered agency — feeds whose GTFS `agency_id` diverges from OBA's (verified for Puget Sound:
- * Intercity is `19:0` in OTP but agency `19` in OBA; Skagit uses a UUID agency id) — it falls back to
- * matching the OTP agency **name** against the covered agencies.
+ * the agency prefix is remapped. For a **route** the OBA agency id is **derived** from the OTP agency
+ * gtfsId's suffix and then **verified** against the region's agencies-with-coverage; where the derived
+ * value isn't a covered agency — feeds whose GTFS `agency_id` diverges from OBA's (verified for Puget
+ * Sound: Intercity is `19:0` in OTP but agency `19` in OBA; Skagit uses a UUID agency id) — it falls
+ * back to matching the OTP agency **name** against the covered agencies.
+ *
+ * A **stop** does not get that prefix, because a route's agency does not own the stops it calls at
+ * (#2170). Verified against the live Puget Sound deployments: ST route 522 is `kcm:100232` under agency
+ * `kcm:40` in OTP and `40_100232` in OBA, yet every stop it serves is a King County Metro stop —
+ * `kcm:23561` in OTP is `1_23561` in OBA, and `40_23561` does not exist. A single route can even span
+ * two OBA agencies' stops (KCM route `1_102558` calls at both `1_*` and `29_*` stops). So a stop is
+ * resolved against the route's **actual** OBA stop list rather than by guessing its prefix — see
+ * [obaStopId].
  *
  * This is the client-side stand-in for an authoritative OTP-agency → OBA-agency map in the regions
  * directory: when that field lands it becomes the resolution/override source in place of the
@@ -39,24 +51,43 @@ import org.onebusaway.android.models.AgencyContact
  * degrade (e.g. to plain leg framing) rather than issuing a request that would 404 / return null.
  */
 class OtpObaIdResolver @Inject constructor(
-    private val agenciesDataSource: AgenciesDataSource
+    private val agenciesDataSource: AgenciesDataSource,
+    private val stopsForRoute: StopsForRouteRepository
 ) {
     private val mutex = Mutex()
     private var cachedAgencies: List<AgencyContact>? = null
 
     /** The OBA route id for an OTP transit leg's route, or null when the agency can't be resolved. */
-    suspend fun obaRouteId(routeGtfsId: String?, agencyGtfsId: String?, agencyName: String?): String? = obaId(routeGtfsId, agencyGtfsId, agencyName)
-
-    /**
-     * The OBA stop id for a stop reached on an OTP transit leg. The stop is namespaced under the leg's
-     * route agency (that's the agency serving it here), so it takes the same resolved agency prefix.
-     */
-    suspend fun obaStopId(stopGtfsId: String?, agencyGtfsId: String?, agencyName: String?): String? = obaId(stopGtfsId, agencyGtfsId, agencyName)
-
-    private suspend fun obaId(entityGtfsId: String?, agencyGtfsId: String?, agencyName: String?): String? {
-        val entity = gtfsEntitySuffix(entityGtfsId) ?: return null
+    suspend fun obaRouteId(routeGtfsId: String?, agencyGtfsId: String?, agencyName: String?): String? {
+        val entity = gtfsEntitySuffix(routeGtfsId) ?: return null
         val agency = resolveAgency(agencyGtfsId, agencyName) ?: return null
         return "${agency}_$entity"
+    }
+
+    /**
+     * The OBA stop id for a stop called at on an OTP transit leg travelling [obaRouteId], or null when
+     * the route's stops can't be reached or none of them is this stop.
+     *
+     * The GTFS entity id is the same on both sides; only the OBA agency prefix has to be found, and the
+     * one place it is *stated* rather than guessed is the route's own OBA stop list. So this looks the
+     * entity up there, using OBA's id contract (`{agencyId}_{entityId}`, split at the first `_` — see
+     * `AgencyAndId.convertFromString`) to compare. It goes through the shared, cached
+     * [StopsForRouteRepository], which the drawer's route focus and the route map already fetch for the
+     * very same routes, so a planned leg normally resolves off a cache hit.
+     */
+    suspend fun obaStopId(stopGtfsId: String?, obaRouteId: String?): String? {
+        val entity = gtfsEntitySuffix(stopGtfsId) ?: return null
+        val routeId = obaRouteId ?: return null
+        val stopIds = stopsForRoute.routeStopIds(routeId).getOrNull() ?: return null
+        return stopIds.firstOrNull { it.substringAfter('_', missingDelimiterValue = "") == entity }
+    }
+
+    /**
+     * Warms the route stop lists [obaStopId] resolves against, so an itinerary's legs pay for one
+     * round of concurrent fetches rather than one serial fetch each while the drawer shows Loading.
+     */
+    suspend fun prefetchRouteStops(obaRouteIds: Collection<String>): Unit = coroutineScope {
+        obaRouteIds.distinct().map { async { stopsForRoute.routeStopIds(it) } }.awaitAll()
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -112,12 +112,9 @@ class DefaultTripResultsRepository @Inject constructor(
         substitutable: List<List<InterchangeableRoute>>
     ): List<RouteLegRef?> {
         val refs = MutableList<RouteLegRef?>(legs.size) { null }
-        // Each leg's OBA route id, resolved once up front: every stop below is resolved *against* its
-        // leg's route (a route's agency doesn't own its stops — #2170), so the route id is needed before
-        // any stop is. Warming the route stop lists here lets the itinerary's legs share one round of
-        // concurrent fetches instead of blocking on one each.
-        val obaRouteIds = legs.map { otpObaIdResolver.obaRouteId(it.routeId, it.agencyId, it.agencyName) }
-        otpObaIdResolver.prefetchRouteStops(obaRouteIds.filterNotNull())
+        // Every OBA id this itinerary needs, resolved in one network round (#2170) and index-aligned to
+        // `legs`, so each leg's stops can only be named on that leg's own route.
+        val ids = otpObaIdResolver.resolveLegs(legs)
         for (chain in Interlines.chains(legs)) {
             val leader = legs[chain.leaderIndex]
             val transitions = chain.transitionLegIndices.associateWith { j ->
@@ -125,7 +122,7 @@ class DefaultTripResultsRepository @Inject constructor(
                     badge = legs[j].shortNameBadge(),
                     routeDisplayName = legs[j].routeDisplayName(),
                     headsign = legs[j].headsign,
-                    stop = legs[j].from.resolveStop(obaRouteIds[j])
+                    stop = legs[j].from.toStopRef(ids[j].fromStopId)
                 )
             }
             // The ride's legs beyond the leader — each continued onto on the same vehicle, boarding at
@@ -133,10 +130,9 @@ class DefaultTripResultsRepository @Inject constructor(
             // matches — a self-interline) and shows the shared vehicle across them (#2000). A leg whose
             // route can't be resolved to an OBA id is dropped (it can't be loaded), same as the leader.
             val extraSegments = ((chain.leaderIndex + 1)..chain.alightIndex).mapNotNull { j ->
-                val routeId = obaRouteIds[j] ?: return@mapNotNull null
                 RouteFocusSegment(
-                    routeId = routeId,
-                    anchorStopId = otpObaIdResolver.obaStopId(legs[j].from.stopId, routeId),
+                    routeId = ids[j].routeId ?: return@mapNotNull null,
+                    anchorStopId = ids[j].fromStopId,
                     directionHeadsign = legs[j].headsign
                 )
             }
@@ -150,15 +146,15 @@ class DefaultTripResultsRepository @Inject constructor(
             val riddenSpans = (chain.leaderIndex..chain.alightIndex).map { j ->
                 RiddenSpan(
                     points = legs[j].legGeometry?.decodedPoints().orEmpty(),
-                    routeId = obaRouteIds[j],
+                    routeId = ids[j].routeId,
                     startsCutover = j in chain.transitionLegIndices
                 )
             }
             refs[chain.leaderIndex] = RouteLegRef(
-                routeId = obaRouteIds[chain.leaderIndex],
+                routeId = ids[chain.leaderIndex].routeId,
                 headsign = leader.headsign,
-                board = leader.from.resolveStop(obaRouteIds[chain.leaderIndex]),
-                alight = legs[chain.alightIndex].to.resolveStop(obaRouteIds[chain.alightIndex]),
+                board = leader.from.toStopRef(ids[chain.leaderIndex].fromStopId),
+                alight = legs[chain.alightIndex].to.toStopRef(ids[chain.alightIndex].toStopId),
                 interlineTransitions = transitions,
                 extraSegments = extraSegments,
                 riddenSpans = riddenSpans,
@@ -183,12 +179,11 @@ class DefaultTripResultsRepository @Inject constructor(
     }
 
     /**
-     * The stop as the drawer/map refer to it — its OBA id resolved against [obaRouteId], the route the
-     * leg calls there on (#2170). The name/code/point stand on their own, so a stop whose OBA id can't
-     * be resolved is still labelled and framed; it just gets no arrivals board.
+     * The stop as the drawer/map refer to it. The name/code/point stand on their own, so a stop whose
+     * OBA id couldn't be resolved is still labelled and framed; it just gets no arrivals board.
      */
-    private suspend fun TripPlace.resolveStop(obaRouteId: String?) = RouteStopRef(
-        stopId = otpObaIdResolver.obaStopId(stopId, obaRouteId),
+    private fun TripPlace.toStopRef(obaStopId: String?) = RouteStopRef(
+        stopId = obaStopId,
         stopCode = stopCode,
         name = name,
         point = geoPointOrNull(lat, lon)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -112,6 +112,12 @@ class DefaultTripResultsRepository @Inject constructor(
         substitutable: List<List<InterchangeableRoute>>
     ): List<RouteLegRef?> {
         val refs = MutableList<RouteLegRef?>(legs.size) { null }
+        // Each leg's OBA route id, resolved once up front: every stop below is resolved *against* its
+        // leg's route (a route's agency doesn't own its stops — #2170), so the route id is needed before
+        // any stop is. Warming the route stop lists here lets the itinerary's legs share one round of
+        // concurrent fetches instead of blocking on one each.
+        val obaRouteIds = legs.map { otpObaIdResolver.obaRouteId(it.routeId, it.agencyId, it.agencyName) }
+        otpObaIdResolver.prefetchRouteStops(obaRouteIds.filterNotNull())
         for (chain in Interlines.chains(legs)) {
             val leader = legs[chain.leaderIndex]
             val transitions = chain.transitionLegIndices.associateWith { j ->
@@ -119,7 +125,7 @@ class DefaultTripResultsRepository @Inject constructor(
                     badge = legs[j].shortNameBadge(),
                     routeDisplayName = legs[j].routeDisplayName(),
                     headsign = legs[j].headsign,
-                    stop = legs[j].from.resolveStop(legs[j])
+                    stop = legs[j].from.resolveStop(obaRouteIds[j])
                 )
             }
             // The ride's legs beyond the leader — each continued onto on the same vehicle, boarding at
@@ -127,11 +133,10 @@ class DefaultTripResultsRepository @Inject constructor(
             // matches — a self-interline) and shows the shared vehicle across them (#2000). A leg whose
             // route can't be resolved to an OBA id is dropped (it can't be loaded), same as the leader.
             val extraSegments = ((chain.leaderIndex + 1)..chain.alightIndex).mapNotNull { j ->
-                val routeId = otpObaIdResolver.obaRouteId(legs[j].routeId, legs[j].agencyId, legs[j].agencyName)
-                    ?: return@mapNotNull null
+                val routeId = obaRouteIds[j] ?: return@mapNotNull null
                 RouteFocusSegment(
                     routeId = routeId,
-                    anchorStopId = otpObaIdResolver.obaStopId(legs[j].from.stopId, legs[j].agencyId, legs[j].agencyName),
+                    anchorStopId = otpObaIdResolver.obaStopId(legs[j].from.stopId, routeId),
                     directionHeadsign = legs[j].headsign
                 )
             }
@@ -145,15 +150,15 @@ class DefaultTripResultsRepository @Inject constructor(
             val riddenSpans = (chain.leaderIndex..chain.alightIndex).map { j ->
                 RiddenSpan(
                     points = legs[j].legGeometry?.decodedPoints().orEmpty(),
-                    routeId = otpObaIdResolver.obaRouteId(legs[j].routeId, legs[j].agencyId, legs[j].agencyName),
+                    routeId = obaRouteIds[j],
                     startsCutover = j in chain.transitionLegIndices
                 )
             }
             refs[chain.leaderIndex] = RouteLegRef(
-                routeId = otpObaIdResolver.obaRouteId(leader.routeId, leader.agencyId, leader.agencyName),
+                routeId = obaRouteIds[chain.leaderIndex],
                 headsign = leader.headsign,
-                board = leader.from.resolveStop(leader),
-                alight = legs[chain.alightIndex].to.resolveStop(legs[chain.alightIndex]),
+                board = leader.from.resolveStop(obaRouteIds[chain.leaderIndex]),
+                alight = legs[chain.alightIndex].to.resolveStop(obaRouteIds[chain.alightIndex]),
                 interlineTransitions = transitions,
                 extraSegments = extraSegments,
                 riddenSpans = riddenSpans,
@@ -177,8 +182,13 @@ class DefaultTripResultsRepository @Inject constructor(
         )
     }
 
-    private suspend fun TripPlace.resolveStop(leg: TripLeg) = RouteStopRef(
-        stopId = otpObaIdResolver.obaStopId(stopId, leg.agencyId, leg.agencyName),
+    /**
+     * The stop as the drawer/map refer to it — its OBA id resolved against [obaRouteId], the route the
+     * leg calls there on (#2170). The name/code/point stand on their own, so a stop whose OBA id can't
+     * be resolved is still labelled and framed; it just gets no arrivals board.
+     */
+    private suspend fun TripPlace.resolveStop(obaRouteId: String?) = RouteStopRef(
+        stopId = otpObaIdResolver.obaStopId(stopId, obaRouteId),
         stopCode = stopCode,
         name = name,
         point = geoPointOrNull(lat, lon)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/StopsForRouteRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/StopsForRouteRepositoryTest.kt
@@ -90,13 +90,25 @@ class StopsForRouteRepositoryTest {
     }
 
     @Test
+    fun `stop ids come from the references pool and share the same fetch`() = runTest {
+        val fake = FakeFetch().apply { results["r"] = Result.success(entryWith(listOf("1_a", "29_b"))) }
+        val repository = DefaultStopsForRouteRepository(backgroundScope, fetch = fake::get)
+
+        repository.routeMap("r")
+
+        assertEquals(listOf("1_a", "29_b"), repository.routeStopIds("r").getOrThrow())
+        assertEquals(listOf("r"), fake.calls)
+    }
+
+    @Test
     fun `no endpoint yields null map but a stop-list failure`() = runTest {
         val fake = FakeFetch() // default success(null) = no endpoint
         val repository = DefaultStopsForRouteRepository(backgroundScope, fetch = fake::get)
 
-        // The map treats "no region" as nothing-to-show; the stop list treats it as an error to surface.
+        // The map treats "no region" as nothing-to-show; the stop lists treat it as an error to surface.
         assertNull(repository.routeMap("r").getOrThrow())
         assertTrue(repository.routeStopGroups("r").isFailure)
+        assertTrue(repository.routeStopIds("r").isFailure)
     }
 
     // Not covered here: an unexpected crash *inside* the fetch block (the fetch lambda throwing rather

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2026 Open Transit Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.onebusaway.android.directions
 
 import kotlinx.coroutines.test.runTest
@@ -21,9 +6,10 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.api.data.AgenciesDataSource
 import org.onebusaway.android.api.data.StopsForRouteRepository
+import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.models.AgencyContact
-import org.onebusaway.android.models.RouteMapData
-import org.onebusaway.android.models.RouteStopGroup
+import org.onebusaway.android.testing.FakeStopsForRouteRepository
 
 /**
  * JVM tests for [OtpObaIdResolver]'s derive → verify → name-fallback route resolution and its
@@ -32,33 +18,19 @@ import org.onebusaway.android.models.RouteStopGroup
  */
 class OtpObaIdResolverTest {
 
-    // The region's covered OBA agencies (id + name), verbatim from Puget Sound's
-    // agencies-with-coverage (checked 2026-08-04). Note 97 is Everett Transit: Skagit and Whatcom are
-    // in the OTP graph but are NOT covered OBA agencies, which is why they resolve to null below.
+    // The covered OBA agencies a test asserts on, with the ids/names Puget Sound's
+    // agencies-with-coverage reports (checked 2026-08-04). Note 97 is Everett Transit — Skagit and
+    // Whatcom are in the OTP graph but are NOT covered OBA agencies, hence the null case below.
     private val coverage = listOf(
         agency("1", "Metro Transit"),
-        agency("3", "Pierce Transit"),
         agency("19", "Intercity Transit"),
-        agency("23", "City of Seattle"),
-        agency("29", "Community Transit"),
         agency("40", "Sound Transit"),
         agency("97", "Everett Transit")
     )
 
-    /** Stops-for-route stub: the OBA stop ids each route serves, or a failure for an unstubbed route. */
-    private class RouteStops(private val stops: Map<String, List<String>>) : StopsForRouteRepository {
-        val calls = mutableListOf<String>()
-        override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = Result.success(emptyList())
-        override suspend fun routeMap(routeId: String): Result<RouteMapData?> = Result.success(null)
-        override suspend fun routeStopIds(routeId: String): Result<List<String>> {
-            calls += routeId
-            return stops[routeId]?.let { Result.success(it) } ?: Result.failure(IllegalStateException("offline"))
-        }
-    }
-
     private fun resolver(
         agencies: Result<List<AgencyContact>> = Result.success(coverage),
-        routeStops: StopsForRouteRepository = RouteStops(emptyMap())
+        routeStops: StopsForRouteRepository = FakeStopsForRouteRepository()
     ) = OtpObaIdResolver(
         object : AgenciesDataSource {
             override suspend fun getAgencies() = agencies
@@ -68,9 +40,22 @@ class OtpObaIdResolverTest {
 
     private fun agency(id: String, name: String) = AgencyContact(id = id, name = name, email = null, url = null, phone = null)
 
+    private fun routeStops(vararg stops: Pair<String, List<String>>) = FakeStopsForRouteRepository(stopIds = mutableMapOf(*stops))
+
+    /** A transit leg on [routeGtfsId] under [agencyGtfsId], boarding at [from] and alighting at [to]. */
+    private fun leg(routeGtfsId: String, agencyGtfsId: String, agencyName: String, from: String? = null, to: String? = null) = TripLeg(
+        routeId = routeGtfsId,
+        agencyId = agencyGtfsId,
+        agencyName = agencyName,
+        from = TripPlace(stopId = from),
+        to = TripPlace(stopId = to)
+    )
+
     @Test
     fun derivedAgencySuffix_whenCovered() = runTest {
-        // kcm:1 → suffix "1" is a covered agency → OBA route 1_102574.
+        // kcm:1 → suffix "1" is a covered agency → OBA route 1_102574. The feed prefix carries no
+        // weight of its own: Sound Transit is published under four Puget Sound feeds (kcm, Pierce,
+        // CommTrans, and its own "40"), all suffixed :40, and every one resolves to OBA agency 40.
         assertEquals(
             "1_102574",
             resolver().obaRouteId("kcm:102574", agencyGtfsId = "kcm:1", agencyName = "Metro Transit")
@@ -78,66 +63,85 @@ class OtpObaIdResolverTest {
     }
 
     @Test
-    fun stopIsNamedByTheRouteItIsServedOn() = runTest {
-        val routeStops = RouteStops(mapOf("1_102574" to listOf("1_13580", "1_13585")))
-        assertEquals("1_13585", resolver(routeStops = routeStops).obaStopId("kcm:13585", "1_102574"))
-    }
-
-    @Test
     fun stopDoesNotTakeItsRouteAgencyPrefix() = runTest {
         // #2170: ST 522 is agency 40 in both OTP (kcm:40) and OBA (40_100232), but every stop it calls
         // at is a Metro stop — 40_23561 does not exist. The route's own stop list is what says so.
-        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561", "1_38567")))
-        assertEquals("1_23561", resolver(routeStops = routeStops).obaStopId("kcm:23561", "40_100232"))
+        val stops = routeStops("40_100232" to listOf("1_23561", "1_76305"))
+        val ids = resolver(routeStops = stops).resolveLegs(
+            listOf(leg("kcm:100232", "kcm:40", "Sound Transit", from = "kcm:23561", to = "kcm:76305"))
+        )
+
+        assertEquals(ResolvedLegIds("40_100232", "1_23561", "1_76305"), ids.single())
     }
 
     @Test
     fun stopIsFoundWhenARouteSpansTwoAgenciesStops() = runTest {
         // KCM 931 calls at both Metro (1_*) and Community Transit (29_*) stops, so no single prefix
-        // could have been guessed for the leg at all.
-        val routeStops = RouteStops(mapOf("1_102558" to listOf("1_75995", "29_2229")))
-        val resolver = resolver(routeStops = routeStops)
-        assertEquals("29_2229", resolver.obaStopId("CommTrans:2229", "1_102558"))
-        assertEquals("1_75995", resolver.obaStopId("kcm:75995", "1_102558"))
+        // could have been guessed for the leg at all. Its board stop even comes from another OTP feed.
+        val stops = routeStops("1_102558" to listOf("1_75995", "29_2229"))
+        val ids = resolver(routeStops = stops).resolveLegs(
+            listOf(leg("kcm:102558", "kcm:1", "Metro Transit", from = "CommTrans:2229", to = "kcm:75995"))
+        )
+
+        assertEquals(ResolvedLegIds("1_102558", "29_2229", "1_75995"), ids.single())
     }
 
     @Test
     fun stopEntityIdKeepsItsOwnUnderscores() = runTest {
-        // OBA splits an id at its *first* underscore (AgencyAndId.convertFromString), so an entity id
-        // containing one still matches.
-        val routeStops = RouteStops(mapOf("40_TLINE" to listOf("40_T05_T1")))
-        assertEquals("40_T05_T1", resolver(routeStops = routeStops).obaStopId("40:T05_T1", "40_TLINE"))
+        // OBA ids split at their *first* underscore, so an entity id containing one still matches.
+        val stops = routeStops("40_TLINE" to listOf("40_T05_T1"))
+        val ids = resolver(routeStops = stops).resolveLegs(
+            listOf(leg("40:TLINE", "40:40", "Sound Transit", from = "40:T05_T1"))
+        )
+
+        assertEquals("40_T05_T1", ids.single().fromStopId)
     }
 
     @Test
-    fun stopUnresolvable_whenTheRouteDoesNotServeIt() = runTest {
-        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561")))
-        assertNull(resolver(routeStops = routeStops).obaStopId("kcm:99999", "40_100232"))
+    fun stopUnresolvable_whenTheRouteDoesNotServeItOrCannotBeReached() = runTest {
+        // Nothing to fall back on in either case: guessing the prefix is exactly the bug (#2170), so
+        // callers degrade instead. "40_100479" is unstubbed, i.e. the stops-for-route fetch failed.
+        val stops = routeStops("40_100232" to listOf("1_23561"))
+        val ids = resolver(routeStops = stops).resolveLegs(
+            listOf(
+                leg("kcm:100232", "kcm:40", "Sound Transit", from = "kcm:99999"),
+                leg("40:100479", "40:40", "Sound Transit", from = "40:99")
+            )
+        )
+
+        assertEquals(listOf(null, null), ids.map { it.fromStopId })
+        // The routes themselves still resolve — only their stops are unreachable.
+        assertEquals(listOf("40_100232", "40_100479"), ids.map { it.routeId })
     }
 
     @Test
-    fun stopUnresolvable_whenTheRouteStopsCannotBeFetched() = runTest {
-        // Nothing to fall back on: guessing the prefix is exactly the bug. Callers degrade instead.
-        assertNull(resolver().obaStopId("kcm:23561", "40_100232"))
+    fun nonTransitLegResolvesToNothingAndCostsNoFetch() = runTest {
+        val stops = routeStops()
+        val ids = resolver(routeStops = stops).resolveLegs(listOf(TripLeg()))
+
+        assertEquals(ResolvedLegIds(null, null, null), ids.single())
+        assertEquals(emptyList<String>(), stops.stopIdCalls)
     }
 
     @Test
-    fun stopUnresolvable_whenTheRouteItselfIsUnresolvable() = runTest {
-        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561")))
-        assertNull(resolver(routeStops = routeStops).obaStopId("kcm:23561", null))
-        // No point asking for a route we can't name.
-        assertEquals(emptyList<String>(), routeStops.calls)
-    }
+    fun eachRouteIsFetchedOnceForTheWholeItinerary() = runTest {
+        // Three legs, two distinct routes — the shared route's stops are fetched once, and both legs
+        // read their own ends out of it.
+        val stops = routeStops(
+            "40_100232" to listOf("1_23561", "1_76305"),
+            "1_102558" to listOf("29_2229", "1_75995")
+        )
+        val ids = resolver(routeStops = stops).resolveLegs(
+            listOf(
+                leg("kcm:100232", "kcm:40", "Sound Transit", from = "kcm:23561", to = "kcm:76305"),
+                leg("kcm:102558", "kcm:1", "Metro Transit", from = "CommTrans:2229", to = "kcm:75995"),
+                leg("kcm:100232", "kcm:40", "Sound Transit", from = "kcm:76305", to = "kcm:23561")
+            )
+        )
 
-    @Test
-    fun prefetchWarmsEachRouteOnce() = runTest {
-        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561"), "1_102558" to listOf("29_2229")))
-        val resolver = resolver(routeStops = routeStops)
-
-        resolver.prefetchRouteStops(listOf("40_100232", "1_102558", "40_100232"))
-
-        assertEquals(setOf("40_100232", "1_102558"), routeStops.calls.toSet())
-        assertEquals(2, routeStops.calls.size)
+        assertEquals(listOf("1_23561", "29_2229", "1_76305"), ids.map { it.fromStopId })
+        assertEquals(setOf("40_100232", "1_102558"), stops.stopIdCalls.toSet())
+        assertEquals(2, stops.stopIdCalls.size)
     }
 
     @Test
@@ -170,14 +174,6 @@ class OtpObaIdResolverTest {
                 agencyName = "Skagit Transit"
             )
         )
-    }
-
-    @Test
-    fun derivedSuffixWins_evenWhereAnotherFeedSharesTheAgency() = runTest {
-        // Sound Transit is published under four OTP feeds (kcm, Pierce, CommTrans, and its own "40"),
-        // all suffixed :40 — every one resolves to the single OBA agency 40.
-        assertEquals("40_560", resolver().obaRouteId("Pierce:560", agencyGtfsId = "Pierce:40", agencyName = "Sound Transit"))
-        assertEquals("40_515", resolver().obaRouteId("CommTrans:515", agencyGtfsId = "CommTrans:40", agencyName = "Sound Transit"))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
@@ -87,6 +87,18 @@ class OtpObaIdResolverTest {
     }
 
     @Test
+    fun stopUnresolvable_whenTwoAgenciesShareTheSameEntityId() = runTest {
+        // Two of the route's stops split to the same suffix ("123") under different agencies — nothing
+        // says which one the leg's board stop actually is, so it's dropped rather than picking one.
+        val stops = routeStops("40_100232" to listOf("1_123", "29_123"))
+        val ids = resolver(routeStops = stops).resolveLegs(
+            listOf(leg("kcm:100232", "kcm:40", "Sound Transit", from = "kcm:123"))
+        )
+
+        assertNull(ids.single().fromStopId)
+    }
+
+    @Test
     fun stopEntityIdKeepsItsOwnUnderscores() = runTest {
         // OBA ids split at their *first* underscore, so an entity id containing one still matches.
         val stops = routeStops("40_TLINE" to listOf("40_T05_T1"))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
@@ -20,11 +20,15 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.onebusaway.android.api.data.AgenciesDataSource
+import org.onebusaway.android.api.data.StopsForRouteRepository
 import org.onebusaway.android.models.AgencyContact
+import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.models.RouteStopGroup
 
 /**
- * JVM tests for [OtpObaIdResolver]'s derive → verify → name-fallback resolution, over Puget-Sound-shaped
- * agency data (verified against the live OTP/OBA deployments).
+ * JVM tests for [OtpObaIdResolver]'s derive → verify → name-fallback route resolution and its
+ * resolve-against-the-route's-own-stops stop resolution (#2170), over Puget-Sound-shaped data (verified
+ * against the live OTP/OBA deployments).
  */
 class OtpObaIdResolverTest {
 
@@ -36,9 +40,26 @@ class OtpObaIdResolverTest {
         agency("97", "Skagit Transit")
     )
 
-    private fun resolver(agencies: Result<List<AgencyContact>> = Result.success(coverage)) = OtpObaIdResolver(object : AgenciesDataSource {
-        override suspend fun getAgencies() = agencies
-    })
+    /** Stops-for-route stub: the OBA stop ids each route serves, or a failure for an unstubbed route. */
+    private class RouteStops(private val stops: Map<String, List<String>>) : StopsForRouteRepository {
+        val calls = mutableListOf<String>()
+        override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = Result.success(emptyList())
+        override suspend fun routeMap(routeId: String): Result<RouteMapData?> = Result.success(null)
+        override suspend fun routeStopIds(routeId: String): Result<List<String>> {
+            calls += routeId
+            return stops[routeId]?.let { Result.success(it) } ?: Result.failure(IllegalStateException("offline"))
+        }
+    }
+
+    private fun resolver(
+        agencies: Result<List<AgencyContact>> = Result.success(coverage),
+        routeStops: StopsForRouteRepository = RouteStops(emptyMap())
+    ) = OtpObaIdResolver(
+        object : AgenciesDataSource {
+            override suspend fun getAgencies() = agencies
+        },
+        routeStops
+    )
 
     private fun agency(id: String, name: String) = AgencyContact(id = id, name = name, email = null, url = null, phone = null)
 
@@ -52,11 +73,66 @@ class OtpObaIdResolverTest {
     }
 
     @Test
-    fun stopTakesTheSameAgencyPrefix() = runTest {
-        assertEquals(
-            "1_13585",
-            resolver().obaStopId("kcm:13585", agencyGtfsId = "kcm:1", agencyName = "Metro Transit")
-        )
+    fun stopIsNamedByTheRouteItIsServedOn() = runTest {
+        val routeStops = RouteStops(mapOf("1_102574" to listOf("1_13580", "1_13585")))
+        assertEquals("1_13585", resolver(routeStops = routeStops).obaStopId("kcm:13585", "1_102574"))
+    }
+
+    @Test
+    fun stopDoesNotTakeItsRouteAgencyPrefix() = runTest {
+        // #2170: ST 522 is agency 40 in both OTP (kcm:40) and OBA (40_100232), but every stop it calls
+        // at is a Metro stop — 40_23561 does not exist. The route's own stop list is what says so.
+        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561", "1_38567")))
+        assertEquals("1_23561", resolver(routeStops = routeStops).obaStopId("kcm:23561", "40_100232"))
+    }
+
+    @Test
+    fun stopIsFoundWhenARouteSpansTwoAgenciesStops() = runTest {
+        // KCM 931 calls at both Metro (1_*) and Community Transit (29_*) stops, so no single prefix
+        // could have been guessed for the leg at all.
+        val routeStops = RouteStops(mapOf("1_102558" to listOf("1_75995", "29_2229")))
+        val resolver = resolver(routeStops = routeStops)
+        assertEquals("29_2229", resolver.obaStopId("CommTrans:2229", "1_102558"))
+        assertEquals("1_75995", resolver.obaStopId("kcm:75995", "1_102558"))
+    }
+
+    @Test
+    fun stopEntityIdKeepsItsOwnUnderscores() = runTest {
+        // OBA splits an id at its *first* underscore (AgencyAndId.convertFromString), so an entity id
+        // containing one still matches.
+        val routeStops = RouteStops(mapOf("40_TLINE" to listOf("40_T05_T1")))
+        assertEquals("40_T05_T1", resolver(routeStops = routeStops).obaStopId("40:T05_T1", "40_TLINE"))
+    }
+
+    @Test
+    fun stopUnresolvable_whenTheRouteDoesNotServeIt() = runTest {
+        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561")))
+        assertNull(resolver(routeStops = routeStops).obaStopId("kcm:99999", "40_100232"))
+    }
+
+    @Test
+    fun stopUnresolvable_whenTheRouteStopsCannotBeFetched() = runTest {
+        // Nothing to fall back on: guessing the prefix is exactly the bug. Callers degrade instead.
+        assertNull(resolver().obaStopId("kcm:23561", "40_100232"))
+    }
+
+    @Test
+    fun stopUnresolvable_whenTheRouteItselfIsUnresolvable() = runTest {
+        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561")))
+        assertNull(resolver(routeStops = routeStops).obaStopId("kcm:23561", null))
+        // No point asking for a route we can't name.
+        assertEquals(emptyList<String>(), routeStops.calls)
+    }
+
+    @Test
+    fun prefetchWarmsEachRouteOnce() = runTest {
+        val routeStops = RouteStops(mapOf("40_100232" to listOf("1_23561"), "1_102558" to listOf("29_2229")))
+        val resolver = resolver(routeStops = routeStops)
+
+        resolver.prefetchRouteStops(listOf("40_100232", "1_102558", "40_100232"))
+
+        assertEquals(setOf("40_100232", "1_102558"), routeStops.calls.toSet())
+        assertEquals(2, routeStops.calls.size)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/OtpObaIdResolverTest.kt
@@ -32,12 +32,17 @@ import org.onebusaway.android.models.RouteStopGroup
  */
 class OtpObaIdResolverTest {
 
-    // The region's covered OBA agencies (id + name), as agencies-with-coverage would report them.
+    // The region's covered OBA agencies (id + name), verbatim from Puget Sound's
+    // agencies-with-coverage (checked 2026-08-04). Note 97 is Everett Transit: Skagit and Whatcom are
+    // in the OTP graph but are NOT covered OBA agencies, which is why they resolve to null below.
     private val coverage = listOf(
         agency("1", "Metro Transit"),
-        agency("40", "Sound Transit"),
+        agency("3", "Pierce Transit"),
         agency("19", "Intercity Transit"),
-        agency("97", "Skagit Transit")
+        agency("23", "City of Seattle"),
+        agency("29", "Community Transit"),
+        agency("40", "Sound Transit"),
+        agency("97", "Everett Transit")
     )
 
     /** Stops-for-route stub: the OBA stop ids each route serves, or a failure for an unstubbed route. */
@@ -154,16 +159,25 @@ class OtpObaIdResolverTest {
     }
 
     @Test
-    fun nameFallback_forUuidAgencyId() = runTest {
-        // Skagit uses a UUID agency id in OTP; only the name resolves it to OBA agency "97".
-        assertEquals(
-            "97_42",
+    fun unresolvable_forAnAgencyTheRegionDoesNotCover() = runTest {
+        // Skagit is in the Puget Sound OTP graph (with a UUID agency id, so nothing is derivable from
+        // it) but is not a covered OBA agency, so neither rule can name it. OTP will happily plan a leg
+        // on it; the drawer degrades rather than inventing an id.
+        assertNull(
             resolver().obaRouteId(
                 "Skagit:42",
                 agencyGtfsId = "Skagit:e0e4541a-2714-487b-b30c-f5c6cb4a310f",
                 agencyName = "Skagit Transit"
             )
         )
+    }
+
+    @Test
+    fun derivedSuffixWins_evenWhereAnotherFeedSharesTheAgency() = runTest {
+        // Sound Transit is published under four OTP feeds (kcm, Pierce, CommTrans, and its own "40"),
+        // all suffixed :40 — every one resolves to the single OBA agency 40.
+        assertEquals("40_560", resolver().obaRouteId("Pierce:560", agencyGtfsId = "Pierce:40", agencyName = "Sound Transit"))
+        assertEquals("40_515", resolver().obaRouteId("CommTrans:515", agencyGtfsId = "CommTrans:40", agencyName = "Sound Transit"))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusedTripRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusedTripRepositoryTest.kt
@@ -49,6 +49,7 @@ class FocusedTripRepositoryTest {
         val catalogs = mutableMapOf<String, Result<List<RouteStopGroup>>>()
         override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = catalogs[routeId] ?: Result.success(emptyList())
         override suspend fun routeMap(routeId: String): Result<RouteMapData?> = Result.success(null)
+        override suspend fun routeStopIds(routeId: String): Result<List<String>> = Result.success(emptyList())
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusedTripRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/FocusedTripRepositoryTest.kt
@@ -11,15 +11,14 @@ import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
-import org.onebusaway.android.api.data.StopsForRouteRepository
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaTripSchedule
-import org.onebusaway.android.models.RouteMapData
 import org.onebusaway.android.models.RouteStopGroup
 import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.models.TripRouteInfo
+import org.onebusaway.android.testing.FakeStopsForRouteRepository
 import org.onebusaway.android.util.Polyline
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -45,13 +44,6 @@ class FocusedTripRepositoryTest {
         override suspend fun resolveNeighborTrip(tripId: String): TripRouteInfo? = null
     }
 
-    private class RouteStops : StopsForRouteRepository {
-        val catalogs = mutableMapOf<String, Result<List<RouteStopGroup>>>()
-        override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = catalogs[routeId] ?: Result.success(emptyList())
-        override suspend fun routeMap(routeId: String): Result<RouteMapData?> = Result.success(null)
-        override suspend fun routeStopIds(routeId: String): Result<List<String>> = Result.success(emptyList())
-    }
-
     @Test
     fun `stops are the exact trip schedule subset rather than every route stop`() = runTest {
         val observations = Observations().apply {
@@ -59,8 +51,8 @@ class FocusedTripRepositoryTest {
                 arrayOf(StopTimeData("a"), StopTimeData("c"))
             )
         }
-        val routes = RouteStops().apply {
-            catalogs["route"] = Result.success(
+        val routes = FakeStopsForRouteRepository().apply {
+            stopGroups["route"] = Result.success(
                 listOf(RouteStopGroup("outbound", listOf(stop("a"), stop("b"), stop("c"))))
             )
         }
@@ -79,7 +71,7 @@ class FocusedTripRepositoryTest {
             shapes["shared"] = Polyline(emptyList())
             shapes["missing"] = null
         }
-        val repository = DefaultFocusedTripRepository(observations, RouteStops(), backgroundScope)
+        val repository = DefaultFocusedTripRepository(observations, FakeStopsForRouteRepository(), backgroundScope)
 
         val result = repository.getGeometry(
             setOf(
@@ -103,8 +95,8 @@ class FocusedTripRepositoryTest {
             scheduleFailures += "failed"
             schedules["good"] = TripScheduleData(arrayOf(StopTimeData("served")))
         }
-        val routes = RouteStops().apply {
-            catalogs["route"] = Result.success(listOf(RouteStopGroup(null, listOf(stop("served")))))
+        val routes = FakeStopsForRouteRepository().apply {
+            stopGroups["route"] = Result.success(listOf(RouteStopGroup(null, listOf(stop("served")))))
         }
         val loggedFailures = mutableListOf<String>()
         val repository = DefaultFocusedTripRepository(
@@ -134,7 +126,7 @@ class FocusedTripRepositoryTest {
         // no TTL). So a later focus on the same shape re-queries ensureShape — cheap in production,
         // where the polyline is already cached there — rather than memoizing decoded points here.
         val observations = Observations().apply { shapes["shared"] = Polyline(emptyList()) }
-        val repository = DefaultFocusedTripRepository(observations, RouteStops(), backgroundScope)
+        val repository = DefaultFocusedTripRepository(observations, FakeStopsForRouteRepository(), backgroundScope)
 
         repository.getGeometry(setOf(FocusedTrip("older-trip", "route", "shared", null)))
         repository.getGeometry(setOf(FocusedTrip("newer-trip", "route", "shared", null)))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakeStopsForRouteRepository.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakeStopsForRouteRepository.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.testing
 
+import java.util.concurrent.CopyOnWriteArrayList
 import org.onebusaway.android.api.data.StopsForRouteRepository
 import org.onebusaway.android.models.RouteMapData
 import org.onebusaway.android.models.RouteStopGroup
@@ -34,8 +35,12 @@ class FakeStopsForRouteRepository(
     val routeMaps: MutableMap<String, Result<RouteMapData?>> = mutableMapOf()
 ) : StopsForRouteRepository {
 
-    /** Route ids passed to [routeStopIds], in call order — for asserting fetches are not repeated. */
-    val stopIdCalls = mutableListOf<String>()
+    /**
+     * Route ids passed to [routeStopIds], in call order — for asserting fetches are not repeated.
+     * Concurrent-safe because callers fan out over a route list (`OtpObaIdResolver.resolveLegs`), so a
+     * test running on a multi-threaded dispatcher would otherwise race on the append and lose entries.
+     */
+    val stopIdCalls: MutableList<String> = CopyOnWriteArrayList()
 
     override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = stopGroups[routeId] ?: Result.failure(IllegalStateException("no stop groups stubbed for $routeId"))
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakeStopsForRouteRepository.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakeStopsForRouteRepository.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.testing
+
+import org.onebusaway.android.api.data.StopsForRouteRepository
+import org.onebusaway.android.models.RouteMapData
+import org.onebusaway.android.models.RouteStopGroup
+
+/**
+ * Shared stub for [StopsForRouteRepository]: stub the projection a test cares about via [stopGroups] /
+ * [stopIds], and leave the rest. One stub rather than one per test class so a new method on the
+ * interface costs one edit here, and so the two suites can't drift on what an unstubbed route does.
+ *
+ * An unstubbed route is deliberately a **failure**, not an empty success — every projection's contract
+ * distinguishes "the route has no such data" from "the route couldn't be reached", and a test that
+ * forgets to stub should see the latter rather than silently exercising the empty path.
+ */
+class FakeStopsForRouteRepository(
+    val stopGroups: MutableMap<String, Result<List<RouteStopGroup>>> = mutableMapOf(),
+    val stopIds: MutableMap<String, List<String>> = mutableMapOf()
+) : StopsForRouteRepository {
+
+    /** Route ids passed to [routeStopIds], in call order — for asserting fetches are not repeated. */
+    val stopIdCalls = mutableListOf<String>()
+
+    override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = stopGroups[routeId] ?: Result.success(emptyList())
+
+    override suspend fun routeMap(routeId: String): Result<RouteMapData?> = Result.success(null)
+
+    override suspend fun routeStopIds(routeId: String): Result<List<String>> {
+        stopIdCalls += routeId
+        return stopIds[routeId]?.let { Result.success(it) } ?: Result.failure(IllegalStateException("no stops stubbed for $routeId"))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakeStopsForRouteRepository.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/FakeStopsForRouteRepository.kt
@@ -30,15 +30,16 @@ import org.onebusaway.android.models.RouteStopGroup
  */
 class FakeStopsForRouteRepository(
     val stopGroups: MutableMap<String, Result<List<RouteStopGroup>>> = mutableMapOf(),
-    val stopIds: MutableMap<String, List<String>> = mutableMapOf()
+    val stopIds: MutableMap<String, List<String>> = mutableMapOf(),
+    val routeMaps: MutableMap<String, Result<RouteMapData?>> = mutableMapOf()
 ) : StopsForRouteRepository {
 
     /** Route ids passed to [routeStopIds], in call order — for asserting fetches are not repeated. */
     val stopIdCalls = mutableListOf<String>()
 
-    override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = stopGroups[routeId] ?: Result.success(emptyList())
+    override suspend fun routeStopGroups(routeId: String): Result<List<RouteStopGroup>> = stopGroups[routeId] ?: Result.failure(IllegalStateException("no stop groups stubbed for $routeId"))
 
-    override suspend fun routeMap(routeId: String): Result<RouteMapData?> = Result.success(null)
+    override suspend fun routeMap(routeId: String): Result<RouteMapData?> = routeMaps[routeId] ?: Result.failure(IllegalStateException("no route map stubbed for $routeId"))
 
     override suspend fun routeStopIds(routeId: String): Result<List<String>> {
         stopIdCalls += routeId


### PR DESCRIPTION
Fixes #2170.

## The bug

The ETA strip was **totally absent** on a Sound Transit 522 leg in the directions drawer — not even the "No upcoming arrivals" text, which is reserved for a stop that *was* looked up and had nothing.

The stop id the drawer asked OBA for did not exist, so arrivals came back as an error and `DirectionStopEtaStrip` returned early on anything that isn't `Content`.

## Root cause

`OtpObaIdResolver` mapped an OTP stop onto OBA by stamping the **leg route's** agency prefix onto the GTFS entity id, on the premise documented in its own KDoc: *"the stop is namespaced under the leg's route agency (that's the agency serving it here)"*.

That premise is false — **a route's agency does not own the stops it calls at.** Verified against the live Puget Sound deployments:

| | OTP | OBA |
|---|---|---|
| ST 522 route | `kcm:100232`, agency `kcm:40` | `40_100232` ✅ |
| its board stop | `kcm:23561` | `1_23561` — the app asked for `40_23561` → **404** |

Not unique to 522, just most visible there:

- Both Seattle streetcars have the same shape (OTP agency `kcm:23`, all `1_*` stops).
- One route can span **two** OBA agencies' stops — KCM 931 (`1_102558`) calls at both `1_*` and `29_*` — so no single prefix could ever have been right for the leg regardless. Its board stop even comes from a different OTP feed than its route (`CommTrans:2229` → `29_2229`).
- Wrong prefixes aren't always a clean 404: `40_620` and `1_620` are both real stops in different agencies, so the guess can silently name *someone else's* stop.

## Fix

Resolve the stop where its OBA agency is **stated** rather than guessed — the route's own OBA stop list.

- New `StopsForRouteRepository.routeStopIds` projection, off the **existing** cached/coalesced fetch (no new wire call shape).
- `OtpObaIdResolver.resolveLegs(legs)` returns each leg's route + end-stop ids in one pass, fetching the itinerary's distinct routes in one concurrent round and indexing each route's stops by entity id once. Matching uses OBA's id contract (split at the first `_`), so an entity id containing underscores survives.
- Route id resolution is **unchanged** — it was always correct.
- A stop that can't be resolved yields `null` and the caller degrades (stop still labelled and framed, just no arrivals board). Deliberately **no** fallback to the synthesized id: that fallback is the bug.

## ⚠️ Heuristic sign-off (CLAUDE.md)

Per *"No unsanctioned heuristics"*, reworking a pre-existing heuristic re-opens its sign-off. **Please review this paragraph specifically.**

This change **shrinks** the reverse-engineered rule's blast radius from two entity kinds to one: stops no longer go through it at all. What remains is `resolveAgency` for **routes** — derive the OBA agency from the OTP agency gtfsId suffix, verify it against agencies-with-coverage, else fall back to name matching.

The residual gap, now documented at the site: **membership is all the derived suffix is checked for, not identity.** A feed whose GTFS `agency_id` collided with a *different* OBA agency's id would resolve silently to the wrong agency. I simulated all 15 OTP agencies in the live Puget Sound graph — every derived hit's OBA name equals the OTP agency name, so it doesn't bite today, but nothing enforces it. Cheap hardening if wanted: require that name agreement before trusting the derived suffix. Left out as beyond this issue's scope.

The real fix remains an authoritative OTP-agency → OBA-agency map in the regions directory; when that lands, `resolveLegs` needs no change at all.

## Drive-by correction

The resolver's KDoc and its test both claimed OBA agency `97` is Skagit Transit, name-matched from OTP's UUID agency id — cited as the *justification* for the name-fallback rule. Live `agencies-with-coverage` says 97 is **Everett Transit**, and Skagit isn't a covered OBA agency at all. The test asserted `97_42` for a route that correctly resolves to `null`. Replaced with the real coverage list and the true behaviour (Skagit and Whatcom are in the OTP graph, not in OBA coverage → `null`).

## Cost of the change

This path is now network-bound where it used to be pure string work: one stops-for-route fetch per distinct transit route in the selected itinerary.

Worth being explicit that it is the **cold** fetch. The trip log builds before any leg can be tapped, so this warms the shared cache for the route focus that follows, never the reverse. That's why `resolveLegs` fans out concurrently — `SingleFlight` only coalesces *concurrent* callers, so a serial loop would have paid one round trip per leg.

The fetch includes polylines (the shared cache's superset). Measured gzipped, shapes are up to ~70% of the response — Link 1 Line is 9,965 B with vs 2,962 B without. Deliberately not split: a polyline-free variant would key a second cache entry per route and force a full re-fetch the instant the rider taps that leg, breaking the "each route fetched once, both projections from that one fetch" invariant the class is built around.

## Verification

- **Device-verified** on a Pixel 7 Pro: the 522 leg now shows its ETA strip.
- Data-level end-to-end: `arrivals-and-departures-for-stop/1_23561` lists route `40_100232` with headsigns "Bothell"/"Woodinville" — exactly what the strip's route-id + headsign matcher selects on.
- New JVM coverage for the 522 case, the two-agency route, cross-feed board stops, entity ids containing underscores, non-transit legs, each unresolvable path, and one-fetch-per-route.
- Compiles clean under `-PwarningsAsErrors=true`; unit tests and androidTest compile pass; Spotless applied.

## Notes for review

The third commit is a `/simplify` pass. It replaced a parallel `obaRouteIds` array (threaded into seven call sites, including cross-index pairings nothing checked) and a separate `prefetchRouteStops` — a public API whose result was discarded and which a caller could silently forget — with the single `resolveLegs` call. It also promotes the duplicated `StopsForRouteRepository` test stub to `testing/FakeStopsForRouteRepository`; the interface change had already forced a mechanical edit in the other copy, and the two had diverged on what an unstubbed route returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Trip itinerary processing now resolves route stops in batches, reducing repeated lookups.
  * Improved stop matching across routes and agencies, including stop IDs containing underscores.
  * Trip results preserve stop display information even when an arrivals-board identifier cannot be resolved.
* **Bug Fixes**
  * Corrected route stop identification to use stops actually served by each route.
  * Improved handling of unresolved routes, stops, and non-transit legs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->