### PR TITLE
Read region-id from the add-region deep link (#2165)

### DIFF
--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -36,8 +36,14 @@ makes it current. Ampersands inside a nested URL must be percent-encoded as `%26
 | `otp-url` | no | `Region.otpBaseUrl` — the trip-planning server |
 | `sidecar-url` | no | `Region.sidecarBaseUrl` |
 | `umami-url` / `umami-id` | no | `Region.umamiAnalytics` |
+| `region-id` | no | `Region.sidecarRegionId` — the id the **sidecar** knows this deployment by |
 
-A custom region behaves like a directory region with three deliberate differences:
+`region-id` is what the sidecar itself emits on the links it generates
+([obacloud#1040](https://github.com/OneBusAway/obacloud/pull/1040)). It is optional on both ends: a link
+without it (or with a value that isn't a number) is accepted unchanged, it just leaves the region unable
+to reach the sidecar's region-scoped endpoints. See "Two ids" below.
+
+A custom region behaves like a directory region with four deliberate differences:
 
 - **It survives regions-directory refreshes.** `RegionDao.replaceAll` deletes only `custom = 0` rows, so
   a refresh can't take the rider's own region with it, and `RegionCache.loadRegions` unions custom
@@ -48,9 +54,35 @@ A custom region behaves like a directory region with three deliberate difference
   auto-selection must not silently undo.
 - **Its id is negative** (counting down from `-2`), so it can't collide with a directory id (those are
   `>= 0`) or with the `-1` "no region" sentinel in the region-id preference. Ids are never reused, so a
-  stale reference resolves to nothing rather than to somebody else's server.
+  stale reference resolves to nothing rather than to somebody else's server. This stays true even when
+  the link supplies `region-id` — see below.
+- **It may carry two ids.** `Region.id` is ours; `Region.sidecarRegionId` is the server's.
 
 Re-sending the same `oba-url` **updates that region in place** rather than adding a duplicate.
+
+#### Two ids
+
+`Region.id` is a primary key we assign, and for a custom region it is a locally-invented negative number
+the sidecar has never heard of. That id is not inert — it is formatted straight into every region-scoped
+sidecar URL (`…/api/v2/regions/{id}/push_registrations`, `…/api/v2/regions/{id}/alarms`, and the v1
+weather / studies / alerts endpoints), so before
+[#2165](https://github.com/OneBusAway/onebusaway-android/issues/2165) a deep-link-added region addressed
+all of them with an id the server would 404. Service-alert push registration and arrival reminders could
+never work for one.
+
+`region-id` fixes that, and is kept as a **separate** field (`Region.sidecarRegionId`) rather than
+adopted as `Region.id`:
+
+- Every sidecar call reads `Region.sidecarId` (`sidecarRegionId ?: id`). A directory region has no
+  override and needs none — our primary key *is* the directory's id.
+- The local id stays negative, so the id-space invariant above survives intact. Adopting the server's id
+  as the primary key would put a custom row back into the directory's space, where the next directory
+  refresh carrying the same id collides with it: `RegionDao.replaceAll` deletes only `custom = 0` rows,
+  so the custom row survives the delete and the directory insert lands on top of it.
+
+This diverges from OneBusAway for iOS ([#1234](https://github.com/OneBusAway/onebusaway-ios/pull/1234)),
+which uses the supplied id directly. The two ids genuinely mean different things — our primary key vs.
+the sidecar's name for the same deployment — and conflating them is what created this bug.
 
 Capability flags (`supportsObaDiscoveryApis`, `supportsObaRealtimeApis`) are set true because
 `RegionUtils.isRegionUsable` requires them — they are *declarations*, not observations: nothing has
@@ -166,6 +198,11 @@ adb shell am start -a android.intent.action.VIEW \
 # Custom region (raises the confirmation dialog; nothing is written until you accept)
 adb shell am start -a android.intent.action.VIEW \
   -d 'onebusaway://add-region?name=Test%20Deployment&oba-url=https://api.example.com' \
+  com.joulespersecond.seattlebusbot
+
+# Custom region naming the sidecar's own id, so its region-scoped endpoints resolve
+adb shell am start -a android.intent.action.VIEW \
+  -d 'onebusaway://add-region?name=Puget%20Sound&oba-url=https://api.pugetsound.onebusaway.org&sidecar-url=https://sidecar.onebusaway.org&region-id=1' \
   com.joulespersecond.seattlebusbot
 
 # Trip (keep the URL single-quoted so the shell doesn't split on &)

--- a/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/12.json
+++ b/onebusaway-android/schemas/org.onebusaway.android.database.AppDatabase/12.json
@@ -1,0 +1,939 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "7e3fb27660fa769dee28e1d050cd25b1",
+    "entities": [
+      {
+        "tableName": "studies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `is_subscribed` INTEGER NOT NULL, PRIMARY KEY(`study_id`))",
+        "fields": [
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_subscribed",
+            "columnName": "is_subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "study_id"
+          ]
+        }
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`survey_id` INTEGER NOT NULL, `study_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `state` INTEGER NOT NULL, PRIMARY KEY(`survey_id`), FOREIGN KEY(`study_id`) REFERENCES `studies`(`study_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "survey_id",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "study_id",
+            "columnName": "study_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "survey_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_surveys_study_id",
+            "unique": false,
+            "columnNames": [
+              "study_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_surveys_study_id` ON `${TABLE_NAME}` (`study_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "studies",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "study_id"
+            ],
+            "referencedColumns": [
+              "study_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT NOT NULL, `name` TEXT NOT NULL, `direction` TEXT NOT NULL, `use_count` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "routes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `short_name` TEXT NOT NULL, `long_name` TEXT, `use_count` INTEGER NOT NULL, `user_name` TEXT, `access_time` INTEGER, `favorite` INTEGER, `url` TEXT, `region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessTime",
+            "columnName": "access_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `route_id` TEXT, `departure` INTEGER NOT NULL, `headsign` TEXT, `name` TEXT NOT NULL, `reminder` INTEGER NOT NULL, `alarm_delete_path` TEXT NOT NULL, `service_date` INTEGER NOT NULL, `stop_sequence` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `vehicle_id` TEXT, PRIMARY KEY(`_id`, `stop_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "route_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "departure",
+            "columnName": "departure",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headsign",
+            "columnName": "headsign",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminder",
+            "columnName": "reminder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alarmDeletePath",
+            "columnName": "alarm_delete_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceDate",
+            "columnName": "service_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopSequence",
+            "columnName": "stop_sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vehicleId",
+            "columnName": "vehicle_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id",
+            "stop_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trip_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trip_id` TEXT NOT NULL, `stop_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `state` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stop_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "service_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `marked_read_time` INTEGER, `hidden` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedReadTime",
+            "columnName": "marked_read_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "regions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `oba_base_url` TEXT NOT NULL, `siri_base_url` TEXT NOT NULL, `lang` TEXT NOT NULL, `contact_email` TEXT NOT NULL, `supports_api_discovery` INTEGER NOT NULL, `supports_api_realtime` INTEGER NOT NULL, `supports_siri_realtime` INTEGER NOT NULL, `twitter_url` TEXT, `experimental` INTEGER, `stop_info_url` TEXT, `otp_base_url` TEXT, `otp_contact_email` TEXT, `supports_otp_bikeshare` INTEGER, `otp_base_graphql_url` TEXT, `supports_otp_graphql_bikeshare` INTEGER, `supports_embedded_social` INTEGER, `payment_android_app_id` TEXT, `payment_warning_title` TEXT, `payment_warning_body` TEXT, `sidecar_base_url` TEXT DEFAULT 'https://onebusaway.co', `plausible_analytics_server_url` TEXT, `umami_analytics_url` TEXT, `umami_analytics_id` TEXT, `custom` INTEGER NOT NULL DEFAULT 0, `sidecar_region_id` INTEGER, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "obaBaseUrl",
+            "columnName": "oba_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siriBaseUrl",
+            "columnName": "siri_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactEmail",
+            "columnName": "contact_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaDiscovery",
+            "columnName": "supports_api_discovery",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsObaRealtime",
+            "columnName": "supports_api_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supportsSiriRealtime",
+            "columnName": "supports_siri_realtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "twitterUrl",
+            "columnName": "twitter_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimental",
+            "columnName": "experimental",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stopInfoUrl",
+            "columnName": "stop_info_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpBaseUrl",
+            "columnName": "otp_base_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "otpContactEmail",
+            "columnName": "otp_contact_email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsOtpBikeshare",
+            "columnName": "supports_otp_bikeshare",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "otpBaseGraphqlUrl",
+            "columnName": "otp_base_graphql_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsOtpGraphqlBikeshare",
+            "columnName": "supports_otp_graphql_bikeshare",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsEmbeddedSocial",
+            "columnName": "supports_embedded_social",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paymentAndroidAppId",
+            "columnName": "payment_android_app_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningTitle",
+            "columnName": "payment_warning_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentWarningBody",
+            "columnName": "payment_warning_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sidecarBaseUrl",
+            "columnName": "sidecar_base_url",
+            "affinity": "TEXT",
+            "defaultValue": "'https://onebusaway.co'"
+          },
+          {
+            "fieldPath": "plausibleAnalyticsServerUrl",
+            "columnName": "plausible_analytics_server_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsUrl",
+            "columnName": "umami_analytics_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umamiAnalyticsId",
+            "columnName": "umami_analytics_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "custom",
+            "columnName": "custom",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sidecarRegionId",
+            "columnName": "sidecar_region_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "region_bounds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `lat` REAL NOT NULL, `lon` REAL NOT NULL, `lat_span` REAL NOT NULL, `lon_span` REAL NOT NULL, FOREIGN KEY(`region_id`) REFERENCES `regions`(`_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "lon",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latSpan",
+            "columnName": "lat_span",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lonSpan",
+            "columnName": "lon_span",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_region_bounds_region_id",
+            "unique": false,
+            "columnNames": [
+              "region_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_region_bounds_region_id` ON `${TABLE_NAME}` (`region_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "regions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "region_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "open311_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `region_id` INTEGER NOT NULL, `jurisdiction` TEXT, `api_key` TEXT NOT NULL, `open311_base_url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jurisdiction",
+            "columnName": "jurisdiction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "api_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "open311_base_url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "nav_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nav_id` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `trip_id` TEXT NOT NULL, `destination_id` TEXT NOT NULL, `before_id` TEXT NOT NULL, `seq_num` INTEGER NOT NULL, `is_active` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navId",
+            "columnName": "nav_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "trip_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationId",
+            "columnName": "destination_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "beforeId",
+            "columnName": "before_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "seq_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "navigation_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` TEXT NOT NULL, `format_version` INTEGER NOT NULL, `plan_json` TEXT NOT NULL, `state_json` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `updated_at_ms` INTEGER NOT NULL, PRIMARY KEY(`session_id`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formatVersion",
+            "columnName": "format_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planJson",
+            "columnName": "plan_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "state_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtMs",
+            "columnName": "updated_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "session_id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_stops",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `code` TEXT, `name` TEXT, `direction` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `location_type` INTEGER NOT NULL, `route_ids` TEXT NOT NULL, `wheelchair_boarding` TEXT, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationType",
+            "columnName": "location_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeIds",
+            "columnName": "route_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wheelchairBoarding",
+            "columnName": "wheelchair_boarding",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_stops_region_id_latitude_longitude",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "latitude",
+              "longitude"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_latitude_longitude` ON `${TABLE_NAME}` (`region_id`, `latitude`, `longitude`)"
+          },
+          {
+            "name": "index_cached_stops_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_stops_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_route_types",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `region_id` INTEGER NOT NULL, `last_seen` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regionId",
+            "columnName": "region_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "last_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_route_types_region_id_last_seen",
+            "unique": false,
+            "columnNames": [
+              "region_id",
+              "last_seen"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_route_types_region_id_last_seen` ON `${TABLE_NAME}` (`region_id`, `last_seen`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7e3fb27660fa769dee28e1d050cd25b1')"
+    ]
+  }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/database/AppDatabaseMigrationTest.kt
@@ -36,7 +36,9 @@ import org.onebusaway.android.SmokeTest
  * `cached_stops.wheelchair_boarding` as NULL for existing rows (#1029); that [MIGRATION_8_9] adds
  * `regions.supports_otp_graphql_bikeshare` as NULL (reading back as false) for existing rows; and that
  * [MIGRATION_9_10] adds `regions.custom` as 0, so every region cached before custom regions existed
- * (#2027) reads back as a directory region and survives no differently than before.
+ * (#2027) reads back as a directory region and survives no differently than before; and that
+ * [MIGRATION_11_12] adds `regions.sidecar_region_id` as NULL, so a cached region keeps addressing the
+ * sidecar by its own `_id` (#2165).
  */
 @SmokeTest // API-23 floor smoke subset (#1818): exercises Room migrations + java.time desugaring
 @RunWith(AndroidJUnit4::class)
@@ -283,6 +285,32 @@ class AppDatabaseMigrationTest {
         db.query("SELECT format_version FROM navigation_sessions WHERE session_id='session'").use { cursor ->
             cursor.moveToFirst()
             assertEquals(1, cursor.getInt(0))
+        }
+        db.close()
+    }
+
+    @Test
+    fun migrate11To12_addsSidecarRegionIdNullForExistingRegions() {
+        helper.createDatabase(TEST_DB, 11).use { db ->
+            // A region cached before the sidecar started naming its own id (#2165) - it is addressed by
+            // its own _id, which is the pre-#2165 behaviour and the right one for a directory region.
+            db.execSQL(
+                "INSERT INTO regions " +
+                    "(_id, name, oba_base_url, siri_base_url, lang, contact_email, " +
+                    "supports_api_discovery, supports_api_realtime, supports_siri_realtime) " +
+                    "VALUES (1, 'Puget Sound', 'https://oba', 'https://siri', 'en_US', 'a@b.c', 1, 1, 1)"
+            )
+        }
+
+        // runMigrationsAndValidate asserts the resulting schema matches the exported 12.json.
+        val db = helper.runMigrationsAndValidate(TEST_DB, 12, true, MIGRATION_11_12)
+
+        db.query("SELECT sidecar_region_id FROM regions WHERE _id = 1").use { c ->
+            c.moveToFirst()
+            assertTrue(
+                "a region cached before #2165 must have NULL sidecar_region_id (addressed by _id)",
+                c.isNull(0)
+            )
         }
         db.close()
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/DatabaseModule.kt
@@ -25,6 +25,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import org.onebusaway.android.database.AppDatabase
 import org.onebusaway.android.database.MIGRATION_10_11
+import org.onebusaway.android.database.MIGRATION_11_12
 import org.onebusaway.android.database.MIGRATION_1_2
 import org.onebusaway.android.database.MIGRATION_2_3
 import org.onebusaway.android.database.MIGRATION_3_4
@@ -77,7 +78,8 @@ object DatabaseModule {
         MIGRATION_7_8,
         MIGRATION_8_9,
         MIGRATION_9_10,
-        MIGRATION_10_11
+        MIGRATION_10_11,
+        MIGRATION_11_12
     ).build()
 
     @Provides

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/AppDatabase.kt
@@ -60,6 +60,10 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
  * server, which the directory publishes separately from the OTP1 `supports_otp_bikeshare` because the
  * two servers genuinely differ. NULL (every existing cached row) reads back as false until the next
  * regions refresh.
+ *
+ * v12 adds `regions.sidecar_region_id` (#2165): the id the sidecar knows a deployment by, when an
+ * `add-region` deep link names one that differs from the row's own `_id`. NULL everywhere else, which
+ * reads back as "address the sidecar by `_id`".
  */
 @Database(
     entities = [
@@ -79,7 +83,7 @@ import org.onebusaway.android.database.widealerts.entity.AlertEntity
         CachedStopRecord::class,
         CachedRouteTypeRecord::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/Migrations.kt
@@ -236,3 +236,18 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
         )
     }
 }
+
+/**
+ * Adds `regions.sidecar_region_id`: the id the sidecar knows a deployment by, when it differs from the
+ * row's own `_id` (#2165). Only a custom region added by an `add-region` link carrying `region-id` ever
+ * has one, so NULL — every existing cached row, and every directory row forever — is exactly right: it
+ * reads back as "address the sidecar by `_id`", which is what the app did before. Purely additive, no
+ * other v12 table/column changes. Verified by AppDatabaseMigrationTest.
+ */
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `regions` ADD COLUMN `sidecar_region_id` INTEGER"
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/ObaEntities.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/database/oba/ObaEntities.kt
@@ -141,7 +141,11 @@ data class RegionRecord(
     // row from the OBA regions directory. It is the flag that keeps the row out of the directory
     // refresh's blast radius: RegionDao.replaceAll deletes only `custom = 0` rows, so a custom region
     // survives every refresh, and custom ids are negative so they can never collide with directory ids.
-    @ColumnInfo(name = "custom", defaultValue = "0") val custom: Int = 0
+    @ColumnInfo(name = "custom", defaultValue = "0") val custom: Int = 0,
+    // The id the sidecar knows this deployment by, when the `add-region` link named one (#2165). NULL
+    // for every directory row, where [id] already *is* the sidecar's id. Deliberately not the primary
+    // key: see the id-space comment in CustomRegions.kt.
+    @ColumnInfo(name = "sidecar_region_id") val sidecarRegionId: Long? = null
 )
 
 @Entity(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/push/PushRegistrationDecision.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/push/PushRegistrationDecision.kt
@@ -178,7 +178,7 @@ fun deriveDesiredRegistration(
         ?.takeIf { it.isNotEmpty() }
     return DesiredRegistration.Wanted(
         PushRegistration(
-            regionId = region.id,
+            regionId = region.sidecarId,
             sidecarBaseUrl = base,
             token = token,
             locale = locale,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/CustomRegions.kt
@@ -28,7 +28,13 @@ data class CustomRegionRequest(
     val otpBaseUrl: String? = null,
     val sidecarBaseUrl: String? = null,
     val umamiAnalyticsUrl: String? = null,
-    val umamiAnalyticsId: String? = null
+    val umamiAnalyticsId: String? = null,
+    /**
+     * The id the sidecar knows this deployment by (`region-id`, #2165) — optional on both ends, so a
+     * link without it behaves exactly as before. Becomes [Region.sidecarRegionId], *not* [Region.id]:
+     * the local id stays negative (see the id-space comment below).
+     */
+    val regionId: Long? = null
 )
 
 /*
@@ -37,6 +43,14 @@ data class CustomRegionRequest(
  *   >= 0   a region from the OBA regions directory (Tampa is 0)
  *   -1     [NO_REGION_ID] — the region-id preference's "no region set" sentinel
  *   <= -2  a user-added custom region (#2027)
+ *
+ * A custom region stays in the negative half even when the `add-region` link names the server's own id
+ * (`region-id`, #2165): that id goes to [Region.sidecarRegionId] instead. Adopting it as [Region.id]
+ * would put a custom row back into the directory's space, where the next directory refresh carrying the
+ * same id collides with it on the primary key — `RegionDao.replaceAll` deletes only `custom = 0` rows,
+ * so the custom row would survive the delete and the insert would land on top of it. The two ids mean
+ * different things (our primary key vs. the sidecar's name for the same deployment), and conflating
+ * them is what created the bug this fixes.
  *
  * Anything reading or writing the region-id preference must go through [NO_REGION_ID] rather than
  * testing the sign: `id < 0` would swallow every custom region, which is exactly the bug that shipped
@@ -102,6 +116,10 @@ internal fun customRegion(id: Long, request: CustomRegionRequest): Region = Regi
     umamiAnalytics = request.umamiAnalyticsUrl?.let {
         Region.UmamiAnalyticsConfig(url = it, id = request.umamiAnalyticsId)
     },
+    // The server's own id for this deployment, when the link named one — kept apart from [id] so the
+    // sidecar is addressed by a name it recognizes without a custom region entering the directory's id
+    // space. Null leaves Region.sidecarId falling back to [id], i.e. the pre-#2165 behaviour.
+    sidecarRegionId = request.regionId,
     // See the KDoc: declared so the region is usable, not observed from the server.
     supportsObaDiscoveryApis = true,
     supportsObaRealtimeApis = true,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
@@ -70,10 +70,29 @@ data class Region(
     // auto-replaces one — the rider chose this server deliberately, so a closer directory region
     // silently taking over would undo that. Custom regions carry no [bounds], so they are also never
     // auto-*selected* (getClosestRegion can't measure a distance to them).
-    val custom: Boolean = false
+    val custom: Boolean = false,
+    // The id the *sidecar* knows this deployment by, when it differs from [id] — set only from the
+    // `add-region` deep link's `region-id` parameter (#2165), null for every directory region. The two
+    // ids genuinely mean different things: [id] is our primary key, and for a custom region it is a
+    // locally-invented negative number the sidecar has never heard of, so addressing the sidecar with it
+    // 404s every push registration and arrival reminder. Kept as a separate field rather than adopting
+    // the server's id as [id] so custom ids stay out of the directory's id space — see the id-space
+    // comment in CustomRegions.kt. Read through [sidecarId], never directly.
+    val sidecarRegionId: Long? = null
 ) {
     val umamiAnalyticsUrl: String? get() = umamiAnalytics?.url
     val umamiAnalyticsId: String? get() = umamiAnalytics?.id
+
+    /**
+     * The region id to address the sidecar with — [sidecarRegionId] when the link supplied one,
+     * otherwise [id]. For a directory region the two are the same value by definition (our primary key
+     * *is* the directory's id); the distinction exists only for custom regions (#2165).
+     *
+     * Every sidecar endpoint that embeds a region id goes through this: alarms and push registrations
+     * (v2, via `sidecarRegionUrl`), and weather, studies and wide alerts (v1, via their `regionID`
+     * placeholders).
+     */
+    val sidecarId: Long get() = sidecarRegionId ?: id
 
     /**
      * Whether this region's trip planning speaks OTP 2.x GraphQL — true exactly when it publishes an

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
@@ -95,6 +95,19 @@ data class Region(
     val sidecarId: Long get() = sidecarRegionId ?: id
 
     /**
+     * The sidecar endpoint this region addresses: the host **and** [sidecarId]. [sidecarId] on its own
+     * does not identify a sidecar — a deep-link-added region carries the id its *own* sidecar knows it
+     * by (#2165), which can equal a directory region's [id] on a completely different host. So anything
+     * keying on "which sidecar am I talking to" — a `distinctUntilChanged` over the region flow, a
+     * fetched-once memo — must compare this pair; keying on the id alone makes such a switch look like
+     * no change at all and leaves the feature showing the previous host's data.
+     *
+     * Call sites that merely *build* a URL don't need it: they read [sidecarBaseUrl] and [sidecarId]
+     * together at the moment of the call, so they can't go stale.
+     */
+    val sidecarTarget: SidecarTarget get() = SidecarTarget(sidecarBaseUrl, sidecarId)
+
+    /**
      * Whether this region's trip planning speaks OTP 2.x GraphQL — true exactly when it publishes an
      * [otpBaseGraphqlUrl]. The single definition of that protocol signal, shared by the request
      * builder's endpoint resolution and the bikeshare capability gate so the two can't disagree about
@@ -126,4 +139,10 @@ data class Region(
     }
 
     data class UmamiAnalyticsConfig(val url: String? = null, val id: String? = null)
+
+    /**
+     * A region-scoped sidecar endpoint: the sidecar host plus the region id that host embeds. The unit
+     * of identity for sidecar-keyed state — see [sidecarTarget].
+     */
+    data class SidecarTarget(val baseUrl: String?, val regionId: Long)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionCache.kt
@@ -108,7 +108,9 @@ class RegionCache @Inject constructor(
      * Re-adding a server already present updates that region in place — matched on the exact
      * [Region.obaBaseUrl], so it keeps its id and stays the same entity to anything holding a reference
      * (the persisted region-id preference, most of all). Otherwise it gets a fresh id from
-     * [nextCustomRegionId]. Deliberately does *not* go through [save], whose `isRegionUsable` filter and
+     * [nextCustomRegionId]. Either way that id is *local* — the sidecar's own id for the deployment, when
+     * the link named one, rides along separately as [Region.sidecarRegionId] (#2165) and never becomes
+     * the row's key. Deliberately does *not* go through [save], whose `isRegionUsable` filter and
      * whole-cache replace are the directory refresh's business.
      */
     suspend fun saveCustom(request: CustomRegionRequest): Region {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionMapper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionMapper.kt
@@ -68,7 +68,8 @@ object RegionMapper {
             sidecarBaseUrl = r.sidecarBaseUrl,
             plausibleAnalyticsServerUrl = r.plausibleAnalyticsServerUrl,
             umamiAnalytics = umami,
-            custom = r.custom > 0
+            custom = r.custom > 0,
+            sidecarRegionId = r.sidecarRegionId
         )
     }
 
@@ -100,7 +101,8 @@ object RegionMapper {
             plausibleAnalyticsServerUrl = region.plausibleAnalyticsServerUrl,
             umamiAnalyticsUrl = region.umamiAnalyticsUrl,
             umamiAnalyticsId = region.umamiAnalyticsId,
-            custom = region.custom.toInt()
+            custom = region.custom.toInt(),
+            sidecarRegionId = region.sidecarRegionId
         ),
         bounds = region.bounds.map {
             RegionBoundRecord(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
 
 /**
@@ -58,16 +59,16 @@ class WeatherViewModel @Inject constructor(
     val state: StateFlow<WeatherUiState> = _state.asStateFlow()
 
     // Guard so the forecast is fetched once per region (not on every region emission).
-    private var fetchedRegionId: Long? = null
+    private var fetchedTarget: Region.SidecarTarget? = null
 
     init {
-        // Self-subscribe to the current region: fetch the forecast once per region id, clear when none.
-        // Keyed on the region id, so weather follows the *region* (not the map viewport — panning out of
-        // range no longer clears it). Replaces the host's MapFeature setRegion push. The id is the
-        // *sidecar's* (#2165) because that is what the weather URL embeds — for every region but a
-        // deep-link-added one it is the same value as Region.id.
+        // Self-subscribe to the current region: fetch the forecast once per sidecar endpoint, clear when
+        // none. Keyed on the region, so weather follows the *region* (not the map viewport — panning out
+        // of range no longer clears it). Replaces the host's MapFeature setRegion push. The key is the
+        // whole Region.sidecarTarget rather than the id alone, because a deep-link-added region's sidecar
+        // id (#2165) can collide with a directory region's on a different host — see sidecarTarget.
         viewModelScope.launch {
-            regionRepo.region.map { it?.sidecarId }.distinctUntilChanged().collect { setRegion(it) }
+            regionRepo.region.map { it?.sidecarTarget }.distinctUntilChanged().collect { setRegion(it) }
         }
         // Observe the hide-weather preference reactively (replaces the on-resume refreshHiddenPref poll).
         // The pref stores "weather enabled" (default true), so hidden = !enabled.
@@ -86,19 +87,19 @@ class WeatherViewModel @Inject constructor(
         }
     }
 
-    /** Fetch the forecast once per region, or clear it when [regionId] is null. */
-    private fun setRegion(regionId: Long?) {
-        if (regionId == null) {
-            fetchedRegionId = null
+    /** Fetch the forecast once per sidecar endpoint, or clear it when [target] is null. */
+    private fun setRegion(target: Region.SidecarTarget?) {
+        if (target == null) {
+            fetchedTarget = null
             _state.update { it.copy(data = null) }
             return
         }
-        if (fetchedRegionId == regionId) {
+        if (fetchedTarget == target) {
             return
         }
-        fetchedRegionId = regionId
+        fetchedTarget = target
         viewModelScope.launch {
-            weatherRepo.currentForecast(regionId).onSuccess { data ->
+            weatherRepo.currentForecast(target.regionId).onSuccess { data ->
                 _state.update { it.copy(data = data) }
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
@@ -63,9 +63,11 @@ class WeatherViewModel @Inject constructor(
     init {
         // Self-subscribe to the current region: fetch the forecast once per region id, clear when none.
         // Keyed on the region id, so weather follows the *region* (not the map viewport — panning out of
-        // range no longer clears it). Replaces the host's MapFeature setRegion push.
+        // range no longer clears it). Replaces the host's MapFeature setRegion push. The id is the
+        // *sidecar's* (#2165) because that is what the weather URL embeds — for every region but a
+        // deep-link-added one it is the same value as Region.id.
         viewModelScope.launch {
-            regionRepo.region.map { it?.id }.distinctUntilChanged().collect { setRegion(it) }
+            regionRepo.region.map { it?.sidecarId }.distinctUntilChanged().collect { setRegion(it) }
         }
         // Observe the hide-weather preference reactively (replaces the on-resume refreshHiddenPref poll).
         // The pref stores "weather enabled" (default true), so hidden = !enabled.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherViewModel.kt
@@ -19,10 +19,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -48,6 +53,7 @@ data class WeatherUiState(
  * `HomeEnvironment.weatherHidden` gate). The NEARBY-tab gate stays in HomeScreen, like the other chrome;
  * the chip's tap (toast the summary) is handled in [WeatherFeature].
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class WeatherViewModel @Inject constructor(
     private val weatherRepo: WeatherRepository,
@@ -58,17 +64,25 @@ class WeatherViewModel @Inject constructor(
     private val _state = MutableStateFlow(WeatherUiState())
     val state: StateFlow<WeatherUiState> = _state.asStateFlow()
 
-    // Guard so the forecast is fetched once per region (not on every region emission).
-    private var fetchedTarget: Region.SidecarTarget? = null
-
     init {
         // Self-subscribe to the current region: fetch the forecast once per sidecar endpoint, clear when
         // none. Keyed on the region, so weather follows the *region* (not the map viewport — panning out
         // of range no longer clears it). Replaces the host's MapFeature setRegion push. The key is the
         // whole Region.sidecarTarget rather than the id alone, because a deep-link-added region's sidecar
         // id (#2165) can collide with a directory region's on a different host — see sidecarTarget.
+        //
+        // flatMapLatest — the shape WideAlertViewModel already uses — is what makes the endpoint the sole
+        // owner of the displayed forecast: switching endpoints cancels the previous one's in-flight fetch,
+        // so a superseded load can neither outlive its endpoint nor land its forecast on top of a newer
+        // one. Each endpoint clears first and then emits its own result, because a forecast belongs to the
+        // sidecar that served it: holding the previous host's temperature on screen while the new host is
+        // still loading (or has failed) is the same "showing the old endpoint's data" bug in slow motion.
         viewModelScope.launch {
-            regionRepo.region.map { it?.sidecarTarget }.distinctUntilChanged().collect { setRegion(it) }
+            regionRepo.region
+                .map { it?.sidecarTarget }
+                .distinctUntilChanged()
+                .flatMapLatest { target -> forecastFor(target) }
+                .collect { data -> _state.update { it.copy(data = data) } }
         }
         // Observe the hide-weather preference reactively (replaces the on-resume refreshHiddenPref poll).
         // The pref stores "weather enabled" (default true), so hidden = !enabled.
@@ -87,21 +101,17 @@ class WeatherViewModel @Inject constructor(
         }
     }
 
-    /** Fetch the forecast once per sidecar endpoint, or clear it when [target] is null. */
-    private fun setRegion(target: Region.SidecarTarget?) {
-        if (target == null) {
-            fetchedTarget = null
-            _state.update { it.copy(data = null) }
-            return
-        }
-        if (fetchedTarget == target) {
-            return
-        }
-        fetchedTarget = target
-        viewModelScope.launch {
-            weatherRepo.currentForecast(target.regionId).onSuccess { data ->
-                _state.update { it.copy(data = data) }
-            }
+    /**
+     * What the chip should show for [target]: nothing at all when there is no region, otherwise a clear
+     * followed by that endpoint's forecast if it arrives. A failed fetch emits only the clear — the chip
+     * goes empty rather than keeping a stale reading from whichever endpoint was current before.
+     */
+    private fun forecastFor(target: Region.SidecarTarget?): Flow<WeatherData?> = if (target == null) {
+        flowOf(null)
+    } else {
+        flow {
+            emit(null)
+            weatherRepo.currentForecast(target.regionId).onSuccess { emit(it) }
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertViewModel.kt
@@ -48,7 +48,9 @@ class WideAlertViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            regionRepo.region.map { it?.id }.distinctUntilChanged().flatMapLatest { regionId ->
+            // The *sidecar's* id for the region (#2165) — it's what the alerts URL embeds, and for
+            // every region but a deep-link-added one it is the same value as Region.id.
+            regionRepo.region.map { it?.sidecarId }.distinctUntilChanged().flatMapLatest { regionId ->
                 if (regionId == null) flowOf(null) else wideAlertsRepo.wideAlerts(regionId.toString())
             }.collect { _wideAlert.value = it }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertViewModel.kt
@@ -48,10 +48,15 @@ class WideAlertViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            // The *sidecar's* id for the region (#2165) — it's what the alerts URL embeds, and for
-            // every region but a deep-link-added one it is the same value as Region.id.
-            regionRepo.region.map { it?.sidecarId }.distinctUntilChanged().flatMapLatest { regionId ->
-                if (regionId == null) flowOf(null) else wideAlertsRepo.wideAlerts(regionId.toString())
+            // Keyed on the whole Region.sidecarTarget — the sidecar host plus the id it embeds (#2165)
+            // — not the id alone, which a deep-link-added region can share with a directory region on a
+            // different host; keying on it alone would make that switch look like no change.
+            regionRepo.region.map { it?.sidecarTarget }.distinctUntilChanged().flatMapLatest { target ->
+                if (target == null) {
+                    flowOf(null)
+                } else {
+                    wideAlertsRepo.wideAlerts(target.regionId.toString())
+                }
             }.collect { _wideAlert.value = it }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ExternalDeepLinks.kt
@@ -73,6 +73,7 @@ object ExternalDeepLinks {
     private const val PARAM_SIDECAR_URL = "sidecar-url"
     private const val PARAM_UMAMI_URL = "umami-url"
     private const val PARAM_UMAMI_ID = "umami-id"
+    private const val PARAM_REGION_ID = "region-id"
 
     /** App links are `https` only — a plaintext link to one of [WEB_HOSTS] is not a deep link. */
     private const val WEB_SCHEME = "https"
@@ -147,6 +148,11 @@ object ExternalDeepLinks {
      *
      * Note this is stricter than the pre-#2027 Android behaviour, where `add-region?oba-url=…` alone set
      * a pair of API-URL preferences. Such a link no longer resolves — see `docs/DEEP_LINKING.md`.
+     *
+     * `region-id` (#2165) is optional on both ends — the sidecar only started emitting it — so a link
+     * without it, or with one that isn't a number, parses exactly as it did before rather than being
+     * rejected: the region is still perfectly usable, it just can't reach the sidecar's region-scoped
+     * endpoints.
      */
     private fun parseAddRegionLink(link: Link): Target? {
         val name = link.params.nonBlank(PARAM_NAME) ?: return null
@@ -158,7 +164,8 @@ object ExternalDeepLinks {
                 otpBaseUrl = link.params.nonBlank(PARAM_OTP_URL),
                 sidecarBaseUrl = link.params.nonBlank(PARAM_SIDECAR_URL),
                 umamiAnalyticsUrl = link.params.nonBlank(PARAM_UMAMI_URL),
-                umamiAnalyticsId = link.params.nonBlank(PARAM_UMAMI_ID)
+                umamiAnalyticsId = link.params.nonBlank(PARAM_UMAMI_ID),
+                regionId = link.params.nonBlank(PARAM_REGION_ID)?.toLongOrNull()
             )
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
@@ -298,7 +298,7 @@ class SurveyViewModel @Inject constructor(
         val base = region.sidecarBaseUrl ?: return null
         return base +
             context.getString(R.string.studies_api_endpoint)
-                .replace("regionID", region.id.toString())
+                .replace("regionID", region.sidecarId.toString())
     }
 
     private fun submitUrl(hero: Boolean): String {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripinfo/TripInfoRepository.kt
@@ -291,7 +291,7 @@ class DefaultTripInfoRepository @Inject constructor(
         val url = sidecarRegionUrl(
             sidecarBaseUrl = base,
             regionsPath = context.getString(R.string.arrivals_reminders_api_endpoint),
-            regionId = region.id,
+            regionId = region.sidecarId,
             resource = "alarms"
         )
         // runCatchingCancellable keeps a cancelled save from being reported to the UI as a save failure.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.kt
@@ -21,11 +21,15 @@ import org.onebusaway.android.util.PreferenceUtils
 class GtfsAlerts @Inject constructor(
     @param:ApplicationContext private val context: Context
 ) {
-    private val fetchedRegions = ConcurrentHashMap.newKeySet<String>()
+    // Fetch-once memo, keyed on the resolved endpoint rather than on [regionId]. The id alone is not a
+    // sidecar identity: a deep-link-added region carries the id its own sidecar knows it by (#2165), so
+    // it can equal a directory region's id on a different host — and keying on it would then suppress
+    // the second region's fetch entirely. The URL embeds both host and id, so it is the honest key.
+    private val fetchedEndpoints = ConcurrentHashMap.newKeySet<String>()
 
     fun fetchAlerts(regionId: String, callback: GtfsAlertCallBack) {
         val pathUrl = getGtfsAlertsUrl(regionId) ?: return
-        if (!fetchedRegions.add(regionId)) {
+        if (!fetchedEndpoints.add(pathUrl)) {
             Log.d(TAG, "Alerts already fetched for region: $regionId")
             return
         }
@@ -54,7 +58,7 @@ class GtfsAlerts @Inject constructor(
                 }
                 processAlerts(feed.entityList, now, callback)
             } catch (error: Exception) {
-                fetchedRegions.remove(regionId)
+                fetchedEndpoints.remove(pathUrl)
                 Log.e(TAG, "Error fetching GTFS alert data for region: $regionId", error)
             }
         }.start()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/push/DeriveDesiredRegistrationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/push/DeriveDesiredRegistrationTest.kt
@@ -66,6 +66,28 @@ class DeriveDesiredRegistrationTest {
     }
 
     @Test
+    fun `a deep-link region registers under the sidecar's id, not its local one`() {
+        // #2165: a custom region's own id is a locally-invented negative number the sidecar has never
+        // heard of, so registering under it POSTs to `/regions/-2/push_registrations` and 404s. When the
+        // link named the server's id, that is the one the URL must carry.
+        val registration = derive(
+            region = sidecarRegion.copy(id = -2L, custom = true, sidecarRegionId = 19L)
+        )
+        assertEquals(
+            DesiredRegistration.Wanted(
+                PushRegistration(
+                    regionId = 19L,
+                    sidecarBaseUrl = "https://sidecar.example.org",
+                    token = "token-a",
+                    locale = "en-US",
+                    description = null
+                )
+            ),
+            registration
+        )
+    }
+
+    @Test
     fun `notifications off is a definitive opt-out regardless of the other inputs`() {
         assertEquals(DesiredRegistration.OptedOut, derive(notificationsEnabled = false))
         // Definitive even while the async inputs are still settling: opting out never waits.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/CustomRegionsTest.kt
@@ -138,6 +138,28 @@ class CustomRegionsTest {
         assertNull(region.umamiAnalytics)
     }
 
+    // --- the sidecar's id for the region (#2165) ---
+
+    @Test
+    fun `the link's region-id addresses the sidecar without entering the directory id space`() {
+        // The whole point of keeping the two apart: the sidecar hears the id it published, while the
+        // primary key stays negative, where a directory refresh carrying region 19 can never land on it.
+        val region = customRegion(FIRST_CUSTOM_REGION_ID, request.copy(regionId = 19L))
+        assertEquals(19L, region.sidecarId)
+        assertEquals(FIRST_CUSTOM_REGION_ID, region.id)
+        assertTrue("the local id must stay out of the directory's space", region.id < NO_REGION_ID)
+    }
+
+    @Test
+    fun `a region with no region-id addresses the sidecar by its own id`() {
+        // The pre-#2165 behaviour, which is also the right one for every directory region: our primary
+        // key *is* the directory's id there, so there is nothing to override.
+        val region = customRegion(FIRST_CUSTOM_REGION_ID, request)
+        assertNull(region.sidecarRegionId)
+        assertEquals(FIRST_CUSTOM_REGION_ID, region.sidecarId)
+        assertEquals(1L, Region(id = 1L).sidecarId)
+    }
+
     @Test
     fun `a custom region has no contact email, so no problem-report address is offered`() {
         // Deliberately not iOS's placeholder example@example.com: ReportTypeRepository offers the

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionMapperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionMapperTest.kt
@@ -152,4 +152,35 @@ class RegionMapperTest {
         assertEquals("juris", back.open311Servers[0].jurisdictionId)
         assertEquals("https://umami", back.umamiAnalytics?.url)
     }
+
+    @Test
+    fun `a custom region's two ids survive the cache separately`() {
+        // #2165: the local primary key and the sidecar's id for the same deployment are distinct facts,
+        // so losing either one in the cache would put the region back to addressing the sidecar with an
+        // id it has never heard of after the next cold start.
+        val original = Region(
+            id = -2L,
+            name = "Deep Link",
+            obaBaseUrl = "https://oba",
+            custom = true,
+            sidecarRegionId = 19L
+        )
+
+        val back = RegionMapper.toRegion(RegionMapper.toEntities(original))
+
+        assertEquals(-2L, back.id)
+        assertEquals(19L, back.sidecarRegionId)
+        assertEquals(19L, back.sidecarId)
+        assertTrue(back.custom)
+    }
+
+    @Test
+    fun `a directory region addresses the sidecar by its own id`() {
+        val back = RegionMapper.toRegion(
+            RegionMapper.toEntities(Region(id = 1L, name = "Puget Sound", obaBaseUrl = "https://oba"))
+        )
+
+        assertNull(back.sidecarRegionId)
+        assertEquals(1L, back.sidecarId)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTest.kt
@@ -15,16 +15,21 @@
  */
 package org.onebusaway.android.region
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Unit tests for [Region.usesOtp2], the single definition of the OTP-protocol signal. Two
- * subsystems now resolve off it — `TripRequestBuilder.otpTarget` (which endpoint a plan is sent to)
- * and `BikeshareAvailability.isTripPlanningEnabled` (which per-server capability flag answers) — so
- * they can't disagree about which server a plan will hit. Pinned directly here rather than only
- * through those consumers.
+ * Unit tests for [Region]'s derived properties — the single definitions that several subsystems
+ * resolve off, pinned directly here rather than only through their consumers.
+ *
+ * [Region.usesOtp2] is the OTP-protocol signal, shared by `TripRequestBuilder.otpTarget` (which
+ * endpoint a plan is sent to) and `BikeshareAvailability.isTripPlanningEnabled` (which per-server
+ * capability flag answers), so the two can't disagree about which server a plan will hit.
+ * [Region.sidecarTarget] is the identity of a region's sidecar endpoint, keying the weather and
+ * wide-alert flows.
  */
 class RegionTest {
 
@@ -46,5 +51,31 @@ class RegionTest {
     @Test
     fun `a published GraphQL endpoint means the region plans over OTP2`() {
         assertTrue(Region(otpBaseGraphqlUrl = "https://otp2.example/otp").usesOtp2)
+    }
+
+    @Test
+    fun `a directory region addresses the sidecar by its own id`() {
+        val region = Region(id = 19, sidecarBaseUrl = "https://a.example.org/")
+        assertEquals(19L, region.sidecarId)
+        assertEquals(Region.SidecarTarget("https://a.example.org/", 19L), region.sidecarTarget)
+    }
+
+    /**
+     * The reason [Region.sidecarTarget] exists: the sidecar id is not unique across regions. A
+     * deep-link-added region carries the id its *own* sidecar knows it by (#2165), which can equal a
+     * directory region's id on a completely different host. Anything keying sidecar-scoped state on the
+     * id alone would read the two as the same endpoint and never refresh on the switch.
+     */
+    @Test
+    fun `two regions can share a sidecar id but never a sidecar target`() {
+        val directory = Region(id = 19, sidecarBaseUrl = "https://a.example.org/")
+        val custom = Region(
+            id = -2,
+            sidecarBaseUrl = "https://b.example.org/",
+            sidecarRegionId = 19,
+            custom = true
+        )
+        assertEquals(directory.sidecarId, custom.sidecarId)
+        assertNotEquals(directory.sidecarTarget, custom.sidecarTarget)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -95,7 +95,9 @@ internal fun region(
     supportsOtpBikeshare: Boolean = false,
     twitterUrl: String? = null,
     otpContactEmail: String? = null,
-    custom: Boolean = false
+    custom: Boolean = false,
+    sidecarBaseUrl: String? = null,
+    sidecarRegionId: Long? = null
 ): Region = Region(
     id = id,
     name = "Region $id",
@@ -121,8 +123,9 @@ internal fun region(
     paymentAndroidAppId = null,
     paymentWarningTitle = null,
     paymentWarningBody = null,
-    sidecarBaseUrl = null,
+    sidecarBaseUrl = sidecarBaseUrl,
     plausibleAnalyticsServerUrl = null,
     umamiAnalytics = null,
-    custom = custom
+    custom = custom,
+    sidecarRegionId = sidecarRegionId
 )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/WeatherViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/WeatherViewModelTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.home
 
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -40,6 +41,27 @@ private class FakeWeatherRepository(var result: Result<WeatherData>) : WeatherRe
 }
 
 /**
+ * A [WeatherRepository] whose fetches stay in flight until the test answers them, so a load can be left
+ * outstanding across a region switch and then completed out of order.
+ */
+private class SuspendingWeatherRepository : WeatherRepository {
+    val requestedRegions = mutableListOf<Long>()
+    private val pending = mutableMapOf<Long, CompletableDeferred<WeatherData>>()
+
+    override suspend fun currentForecast(regionId: Long): Result<WeatherData> {
+        requestedRegions.add(regionId)
+        return Result.success(pendingFor(regionId).await())
+    }
+
+    /** The sidecar for [regionId] answers, whether or not that region is still the current one. */
+    fun answer(regionId: Long, data: WeatherData) {
+        pendingFor(regionId).complete(data)
+    }
+
+    private fun pendingFor(regionId: Long) = pending.getOrPut(regionId) { CompletableDeferred() }
+}
+
+/**
  * Unit tests for [WeatherViewModel]'s region-keyed forecast fetch (migrated from HomeViewModelTest when
  * weather became its own feature module). The hide-weather pref + the NEARBY-tab gate are Application /
  * Compose concerns, verified by equivalence rather than here.
@@ -51,6 +73,7 @@ class WeatherViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val forecast = WeatherData(icon = "clear-day", temperatureF = 70.0, summary = "Clear")
+    private val staleForecast = WeatherData(icon = "rain", temperatureF = 41.0, summary = "Rain")
 
     @Test
     fun `forecast loads when a region is set`() = runTest {
@@ -95,5 +118,77 @@ class WeatherViewModelTest {
         regions.emit(region(2)) // new id: refetch
         advanceUntilIdle()
         assertEquals(listOf(1L, 2L), repo.requestedRegions)
+    }
+
+    @Test
+    fun `a sidecar host change refetches even when the sidecar id is unchanged`() = runTest {
+        val regions = FakeRegionRepository()
+        val repo = FakeWeatherRepository(Result.success(forecast))
+        val vm = WeatherViewModel(repo, regions, FakePreferencesRepository())
+
+        regions.emit(region(1, sidecarBaseUrl = "https://a.example/"))
+        advanceUntilIdle()
+        // A deep-link-added region whose *own* sidecar knows it as 1, on a different host (#2165). Keyed
+        // on the id alone this switch would look like no change and the chip would keep host a's forecast.
+        regions.emit(region(2, sidecarBaseUrl = "https://b.example/", sidecarRegionId = 1))
+        advanceUntilIdle()
+
+        assertEquals(listOf(1L, 1L), repo.requestedRegions)
+        assertEquals(forecast, vm.state.value.data)
+    }
+
+    @Test
+    fun `a superseded fetch cannot land on the region that replaced it`() = runTest {
+        val regions = FakeRegionRepository()
+        val repo = SuspendingWeatherRepository()
+        val vm = WeatherViewModel(repo, regions, FakePreferencesRepository())
+
+        regions.emit(region(1))
+        advanceUntilIdle()
+        regions.emit(region(2)) // region 1's fetch is still outstanding
+        advanceUntilIdle()
+        assertEquals(listOf(1L, 2L), repo.requestedRegions)
+
+        // Region 1's sidecar answers late, after the switch. Its forecast belongs to an endpoint that is
+        // no longer current, so it must not reach the chip.
+        repo.answer(1, staleForecast)
+        advanceUntilIdle()
+        assertNull(vm.state.value.data)
+
+        repo.answer(2, forecast)
+        advanceUntilIdle()
+        assertEquals(forecast, vm.state.value.data)
+    }
+
+    @Test
+    fun `switching regions clears the previous forecast while the new one loads`() = runTest {
+        val regions = FakeRegionRepository()
+        val repo = SuspendingWeatherRepository()
+        val vm = WeatherViewModel(repo, regions, FakePreferencesRepository())
+
+        regions.emit(region(1))
+        repo.answer(1, forecast)
+        advanceUntilIdle()
+        assertEquals(forecast, vm.state.value.data)
+
+        regions.emit(region(2))
+        advanceUntilIdle()
+        assertNull(vm.state.value.data)
+    }
+
+    @Test
+    fun `a fetch failure clears the previous region's forecast rather than keeping it`() = runTest {
+        val regions = FakeRegionRepository()
+        val repo = FakeWeatherRepository(Result.success(forecast))
+        val vm = WeatherViewModel(repo, regions, FakePreferencesRepository())
+
+        regions.emit(region(1))
+        advanceUntilIdle()
+        assertEquals(forecast, vm.state.value.data)
+
+        repo.result = Result.failure(IOException("boom"))
+        regions.emit(region(2))
+        advanceUntilIdle()
+        assertNull(vm.state.value.data)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/WeatherViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/WeatherViewModelTest.kt
@@ -43,22 +43,27 @@ private class FakeWeatherRepository(var result: Result<WeatherData>) : WeatherRe
 /**
  * A [WeatherRepository] whose fetches stay in flight until the test answers them, so a load can be left
  * outstanding across a region switch and then completed out of order.
+ *
+ * Each fetch gets its own response, addressed by the order it was made rather than by region id: the
+ * case most worth testing is two sidecar hosts that know their region by the *same* id (#2165), where
+ * the id names no particular request. Answering a fetch the ViewModel has already cancelled is the point
+ * of the fake, so [answer] deliberately doesn't care whether anyone is still listening.
  */
 private class SuspendingWeatherRepository : WeatherRepository {
     val requestedRegions = mutableListOf<Long>()
-    private val pending = mutableMapOf<Long, CompletableDeferred<WeatherData>>()
+    private val pending = mutableListOf<CompletableDeferred<WeatherData>>()
 
     override suspend fun currentForecast(regionId: Long): Result<WeatherData> {
         requestedRegions.add(regionId)
-        return Result.success(pendingFor(regionId).await())
+        val response = CompletableDeferred<WeatherData>()
+        pending += response
+        return Result.success(response.await())
     }
 
-    /** The sidecar for [regionId] answers, whether or not that region is still the current one. */
-    fun answer(regionId: Long, data: WeatherData) {
-        pendingFor(regionId).complete(data)
+    /** The sidecar answers the [index]th fetch (0-based, in the order the fetches were made). */
+    fun answer(index: Int, data: WeatherData) {
+        pending[index].complete(data)
     }
-
-    private fun pendingFor(regionId: Long) = pending.getOrPut(regionId) { CompletableDeferred() }
 }
 
 /**
@@ -151,11 +156,34 @@ class WeatherViewModelTest {
 
         // Region 1's sidecar answers late, after the switch. Its forecast belongs to an endpoint that is
         // no longer current, so it must not reach the chip.
-        repo.answer(1, staleForecast)
+        repo.answer(0, staleForecast)
         advanceUntilIdle()
         assertNull(vm.state.value.data)
 
-        repo.answer(2, forecast)
+        repo.answer(1, forecast)
+        advanceUntilIdle()
+        assertEquals(forecast, vm.state.value.data)
+    }
+
+    @Test
+    fun `a superseded fetch cannot land when both hosts know the region by the same id`() = runTest {
+        val regions = FakeRegionRepository()
+        val repo = SuspendingWeatherRepository()
+        val vm = WeatherViewModel(repo, regions, FakePreferencesRepository())
+
+        regions.emit(region(1, sidecarBaseUrl = "https://a.example/"))
+        advanceUntilIdle()
+        regions.emit(region(2, sidecarBaseUrl = "https://b.example/", sidecarRegionId = 1))
+        advanceUntilIdle()
+        // Both fetches carry sidecar id 1 (#2165) — only the host differs, so nothing about the id
+        // distinguishes the outstanding fetch from the current one. Ordering is all there is to go on.
+        assertEquals(listOf(1L, 1L), repo.requestedRegions)
+
+        repo.answer(0, staleForecast) // host a answers late
+        advanceUntilIdle()
+        assertNull(vm.state.value.data)
+
+        repo.answer(1, forecast) // host b answers
         advanceUntilIdle()
         assertEquals(forecast, vm.state.value.data)
     }
@@ -167,7 +195,8 @@ class WeatherViewModelTest {
         val vm = WeatherViewModel(repo, regions, FakePreferencesRepository())
 
         regions.emit(region(1))
-        repo.answer(1, forecast)
+        advanceUntilIdle()
+        repo.answer(0, forecast)
         advanceUntilIdle()
         assertEquals(forecast, vm.state.value.data)
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/widealert/WideAlertViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/widealert/WideAlertViewModelTest.kt
@@ -29,7 +29,11 @@ import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.MainDispatcherRule
 
 private class FakeWideAlertsRepository(private val alerts: List<WideAlert>) : WideAlertsRepository {
+    /** The region id of each `wideAlerts` *subscription*, in order — one per stream the VM starts. */
+    val subscriptions = mutableListOf<String>()
+
     override fun wideAlerts(regionId: String): Flow<WideAlert> = flow {
+        subscriptions.add(regionId)
         alerts.forEach { emit(it) }
     }
 }
@@ -57,5 +61,43 @@ class WideAlertViewModelTest {
 
         vm.dismiss()
         assertNull(vm.wideAlert.value)
+    }
+
+    /**
+     * The stream is keyed on the whole [org.onebusaway.android.region.Region.SidecarTarget], not on the
+     * sidecar id alone: a deep-link-added region carries the id its *own* sidecar knows it by (#2165), so
+     * it can equal a directory region's id while pointing at a different host. Keyed on the id alone,
+     * `distinctUntilChanged` swallows the switch and the rider keeps seeing the old host's alert.
+     */
+    @Test
+    fun `switching to a different sidecar host restarts the stream even when the sidecar id matches`() = runTest {
+        val repo = FakeWideAlertsRepository(listOf(WideAlert("Title", "Message", null)))
+        val regions = FakeRegionRepository()
+        WideAlertViewModel(repo, regions)
+
+        regions.emit(region(19, sidecarBaseUrl = "https://a.example.org/"))
+        advanceUntilIdle()
+        regions.emit(
+            region(-2, custom = true, sidecarBaseUrl = "https://b.example.org/", sidecarRegionId = 19)
+        )
+        advanceUntilIdle()
+
+        // Same id on the wire both times — two subscriptions is the whole point.
+        assertEquals(listOf("19", "19"), repo.subscriptions)
+    }
+
+    /** The complement: a re-emission of the *same* endpoint must not restart the stream. */
+    @Test
+    fun `re-emitting the same region does not restart the stream`() = runTest {
+        val repo = FakeWideAlertsRepository(listOf(WideAlert("Title", "Message", null)))
+        val regions = FakeRegionRepository()
+        WideAlertViewModel(repo, regions)
+
+        regions.emit(region(19, sidecarBaseUrl = "https://a.example.org/"))
+        advanceUntilIdle()
+        regions.emit(region(19, sidecarBaseUrl = "https://a.example.org/"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("19"), repo.subscriptions)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/ExternalDeepLinksTest.kt
@@ -109,7 +109,8 @@ class ExternalDeepLinksTest {
                     "otp-url" to "https://otp.example.com",
                     "sidecar-url" to "https://sidecar.example.com",
                     "umami-url" to "https://umami.example.com",
-                    "umami-id" to "abc123"
+                    "umami-id" to "abc123",
+                    "region-id" to "19"
                 )
             ),
             schemes
@@ -122,11 +123,37 @@ class ExternalDeepLinksTest {
                     otpBaseUrl = "https://otp.example.com",
                     sidecarBaseUrl = "https://sidecar.example.com",
                     umamiAnalyticsUrl = "https://umami.example.com",
-                    umamiAnalyticsId = "abc123"
+                    umamiAnalyticsId = "abc123",
+                    regionId = 19L
                 )
             ),
             target
         )
+    }
+
+    @Test
+    fun `add-region without a region-id still parses, carrying none`() {
+        // The sidecar only started emitting `region-id` (#2165) and the parameter is optional on both
+        // ends, so every link written before it must keep working exactly as it did.
+        val target = parse(
+            appLink("add-region", mapOf("name" to "Test", "oba-url" to "https://api.example.com")),
+            schemes
+        )
+        assertNull((target as Target.AddRegion).request.regionId)
+    }
+
+    @Test
+    fun `add-region ignores a region-id that is not a number`() {
+        // Ignored, not rejected: the region is still perfectly usable without a sidecar id, so dropping
+        // the whole link over one unreadable parameter would be the worse failure.
+        val target = parse(
+            appLink(
+                "add-region",
+                mapOf("name" to "Test", "oba-url" to "https://api.example.com", "region-id" to "nineteen")
+            ),
+            schemes
+        )
+        assertNull((target as Target.AddRegion).request.regionId)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2165. Parity with onebusaway-ios#1234, the companion to obacloud#1040 — the sidecar has started emitting a `region-id` parameter on `add-region` links, and neither app read it before. The parameter is optional on both ends, so either side can land first.

## The problem

`ExternalDeepLinks.parseAddRegionLink` recognized `name`, `oba-url`, `otp-url`, `sidecar-url`, `umami-url` and `umami-id`, and nothing else. The region's identifier was then invented locally: `nextCustomRegionId` hands out ids counting down from `-2`.

That id is not inert — it is formatted straight into every region-scoped sidecar URL: `/regions/{id}/push_registrations` (#1957), `/regions/{id}/alarms`, and the v1 weather / studies / wide-alert endpoints. So a region added by deep link addressed all of them with an id the server has never heard of, and service-alert push registration and arrival reminders could never work for one. iOS observed this from the other direction: a live `404` on `/api/v1/regions/1957/alerts.pb` where the region's real id (19) returned `200`.

Invisible until someone actually follows an `add-region` link, which is why it survived #2027/#2030.

## The change

- `CustomRegionRequest.regionId`, parsed from `region-id` in `parseAddRegionLink`.
- `Region.sidecarRegionId: Long?` carries the server's id — null for every directory region — and `Region.sidecarId` (`sidecarRegionId ?: id`) is what the five sidecar call sites now read (`PushRegistrationDecision`, `WeatherViewModel`, `WideAlertViewModel`, `SurveyViewModel`, `TripInfoRepository`).
- Room v11 → v12 adds `regions.sidecar_region_id`, NULL everywhere, which reads back as "address the sidecar by `_id`" — i.e. existing rows keep today's behaviour exactly.
- `docs/DEEP_LINKING.md`: the parameter table, and the "its id is negative" bullet, which stays true for `_id` but is no longer the whole story.

`region-id` is optional on both ends, so a link without it — or with one that isn't a number — parses exactly as it does today rather than being rejected. Such a region is still perfectly usable; it just can't reach the sidecar's region-scoped endpoints.

## Design decision that needs a deliberate sign-off

The issue left the id space as an open question, and this takes **option 2**: keep the local id negative and carry the server's id as a separate field, rather than adopting it as `Region.id` the way iOS did.

The hazard with adopting it: a custom region takes id 19, then a directory refresh arrives carrying directory region 19. `RegionDao.replaceAll` deletes only `custom = 0` rows, so the custom row survives the delete and the directory insert collides with it on the primary key — and `RegionCache.loadRegions` unions custom regions back into every result, so the duplicate reaches the picker.

Keeping them separate preserves the id-space invariant completely at the cost of one field. The two ids genuinely mean different things — our primary key vs. the sidecar's name for the same deployment — and conflating them is what created the bug in the first place. But **it diverges from iOS**, so it deserves an explicit yes rather than being waved through.

## Tests

`ExternalDeepLinksTest` (present / absent / unparseable `region-id`), `CustomRegionsTest`, `RegionMapperTest` (round-trip through the entity), `DeriveDesiredRegistrationTest` (push registration addresses `sidecarId`), and `AppDatabaseMigrationTest` for the 11 → 12 migration.

Compiled clean with `-PwarningsAsErrors=true`; `spotlessCheck` passes. Not yet exercised on a device against a real `add-region` link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `region-id` in custom add-region links.
  * Custom regions can use a server-provided sidecar identifier while retaining their local identifier.
  * Weather, alerts, surveys, trip alarms, and push registrations now use the correct sidecar endpoint.

* **Bug Fixes**
  * Preserved compatibility for existing regions and links without a `region-id`.
  * Invalid `region-id` values are safely ignored.
  * Improved handling when regions share identifiers across different service hosts.
  * Cleared stale weather data and enabled reliable retries after failed requests.

* **Documentation**
  * Documented custom region identifier behavior and deep-link examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->