### PR TITLE
Prefer communication_period over deprecated active_period for wide alerts

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.kt
@@ -47,22 +47,34 @@ object GtfsAlertsHelper {
             )
 
     /**
-     * These alerts come straight off a raw GTFS-realtime feed, not the OBA API, so
-     * `active_period.start` is POSIX **seconds** per the GTFS-rt spec — a fixed unit, not a
-     * magnitude guess. (The OBA `situation` path is the polymorphic one; its seconds-vs-millis
-     * rule lives in `situationEpochToMillis` and does not apply here.)
+     * These alerts come straight off a raw GTFS-realtime feed, not the OBA API, so a period's
+     * `start` is POSIX **seconds** per the GTFS-rt spec — a fixed unit, not a magnitude guess.
+     * (The OBA `situation` path is the polymorphic one; its seconds-vs-millis rule lives in
+     * `situationEpochToMillis` and does not apply here.)
      *
-     * `active_period` is `[deprecated = true]` as of the proto shipped in
-     * gtfs-realtime-bindings 0.2.0, superseded by `communication_period` / `impact_period`. We
-     * keep reading it because that is the field feeds in the wild actually populate — dropping it
-     * would silence every alert we surface today — so the migration can't be done at the bump.
-     * Tracked by https://github.com/OneBusAway/onebusaway-android/issues/2160.
+     * "Should we show this to the user in the next 24h" maps to `communication_period`, so it's
+     * preferred when a feed populates it. `active_period` is `[deprecated = true]` as of the
+     * proto shipped in gtfs-realtime-bindings 0.2.0, but feeds in the wild still only populate
+     * it, so [activePeriodStartSec] stays as a fallback — dropping it would silence every alert
+     * on those feeds. Tracked by https://github.com/OneBusAway/onebusaway-android/issues/2160.
      */
-    @Suppress("DEPRECATION")
     fun isStartDateWithin24Hours(alert: GtfsRealtime.Alert, nowMs: Long): Boolean {
-        if (alert.activePeriodCount == 0) return false
-        val elapsed = nowMs - alert.getActivePeriod(0).start * MILLIS_PER_SECOND
+        val startSec = communicationPeriodStartSec(alert) ?: activePeriodStartSec(alert) ?: return false
+        val elapsed = nowMs - startSec * MILLIS_PER_SECOND
         return elapsed in 0..DAY_MS
+    }
+
+    private fun communicationPeriodStartSec(alert: GtfsRealtime.Alert): Long? {
+        if (alert.communicationPeriodCount == 0) return null
+        return alert.getCommunicationPeriod(0).start
+    }
+
+    // Fallback for feeds that only populate the deprecated active_period; see the rationale on
+    // isStartDateWithin24Hours. Drop this once communication_period is the only field in the wild.
+    @Suppress("DEPRECATION")
+    private fun activePeriodStartSec(alert: GtfsRealtime.Alert): Long? {
+        if (alert.activePeriodCount == 0) return null
+        return alert.getActivePeriod(0).start
     }
 
     private fun isAlertRead(context: Context, entity: GtfsRealtime.FeedEntity): Boolean = DatabaseEntryPoint.get(context).alertsRepository().isAlertExists(entity.id)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
@@ -81,6 +81,7 @@ class GtfsAlertsHelperTest {
     }
 
     @Test
+    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
     @Suppress("DEPRECATION")
     fun `alert with both fields prefers communication period over active period`() {
         // #2160: communication_period wins when both are populated, even if active_period alone

--- a/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
@@ -63,8 +63,37 @@ class GtfsAlertsHelperTest {
         assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(GtfsRealtime.Alert.newBuilder().build(), nowMs))
     }
 
-    // Mirrors the deprecated-but-still-universal `active_period` read in the helper under test;
-    // see the rationale on [GtfsAlertsHelper.isStartDateWithin24Hours].
+    @Test
+    fun `communication period only alert within 24 hours is surfaced`() {
+        // #2160: a feed that only populates the new field must still be readable, not silenced.
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
+            .build()
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+    }
+
+    @Test
+    fun `communication period only alert outside 24 hours is not surfaced`() {
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
+            .build()
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `alert with both fields prefers communication period over active period`() {
+        // #2160: communication_period wins when both are populated, even if active_period alone
+        // would put the alert outside the 24h window.
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
+            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
+            .build()
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+    }
+
+    // Mirrors the deprecated-but-still-universal `active_period` fallback read in the helper
+    // under test; see the rationale on [GtfsAlertsHelper.isStartDateWithin24Hours].
     @Suppress("DEPRECATION")
     private fun alertStartingAt(startSec: Long): GtfsRealtime.Alert = GtfsRealtime.Alert.newBuilder()
         .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(startSec).build())


### PR DESCRIPTION
## Summary
- `GtfsAlertsHelper.isStartDateWithin24Hours` only read the now-deprecated GTFS-rt `active_period` field, so a feed emitting only `communication_period` / `impact_period` never surfaced any wide alert.
- Now reads `communication_period` first ("should we show this to the user in the next 24h"), falling back to `active_period` for feeds that haven't migrated off it yet.
- The `@Suppress("DEPRECATION")` is now scoped to just the fallback helper (`activePeriodStartSec`) instead of the whole function, so it'll naturally go away if `active_period` support is ever dropped.

Fixes #2160

## Test plan
- [x] `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` — clean, no warnings
- [x] `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests "org.onebusaway.android.widealerts.GtfsAlertsHelperTest"` — all pass, including new communication-period-only and both-fields-present cases
- [x] `./gradlew spotlessCheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service alert timing so alerts using the newer communication period are surfaced correctly within 24 hours.
  * Added fallback support for alerts using the older active period format.
  * Ensured newer timing information takes precedence when both formats are provided.

* **Tests**
  * Added coverage for alerts inside and outside the 24-hour window and for mixed-format alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->