### PR TITLE
Make the arrivals NOW pill reachable, and share its cutoff (#2177)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripNowPillRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripNowPillRenderTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.arrivals.components.EtaStrip
+import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+
+/**
+ * The NOW pill is reachable (issue #2177).
+ *
+ * It used to be selected by an exact-zero test, so it was on screen for at most the single minute a
+ * departure spent at zero, and a bus that had just pulled out fell through to the numeric branch and
+ * rendered "-1min" — while the trip-tracking notification, showing the same departure, said "Now".
+ * The cutoff is [org.onebusaway.android.time.isEtaNow] now, shared by both surfaces, so this pins
+ * the whole window rather than the one instant.
+ *
+ * Deliberately not `@SmokeTest`: the API-23 floor subset (#1818) keeps one strip render test, and
+ * that stays [EtaStripRenderTest].
+ */
+class EtaStripNowPillRenderTest {
+
+    // Unconfined composition — see createUnconfinedComposeRule (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val now = InstrumentationRegistry.getInstrumentation().targetContext
+        .getString(R.string.stop_info_eta_now)
+
+    /**
+     * Renders one pill per [etaMinutes]. The values are stable for the test's duration: previewArrival
+     * anchors the server "now" at 0 and liveEta floors each side to its own minute, so each pill holds
+     * its exact value for the first 60s.
+     */
+    private fun showStrip(vararg etaMinutes: Long) {
+        composeRule.setContent {
+            Box(Modifier.width(320.dp)) {
+                EtaStrip(
+                    // Distinct trip ids: the strip's LazyRow keys on trip-instance identity and a
+                    // duplicate key throws (see EtaStrip's itemsIndexed).
+                    trips = etaMinutes.mapIndexed { i, eta ->
+                        previewArrival("8", "Rainier Beach", etaMinutes = eta, tripId = "trip_$i")
+                    },
+                    actionsFor = { null },
+                    callbacks = previewRowCallbacks()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun everyDepartureInsideTheNowWindowReadsNow() {
+        // -2 is the far edge of NOW_WINDOW; 1 is the first pill outside it on the upcoming side.
+        showStrip(-2, -1, 0, 1)
+
+        composeRule.onAllNodesWithText(now).assertCountEquals(3)
+        // The regression itself: nothing inside the window fell through to a negative countdown.
+        composeRule.onAllNodesWithText("-", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun aBusThatIsActuallyGoneStillSaysHowLongAgo() {
+        // Past the window the strip goes back to a countdown — the arrivals response keeps departed
+        // trips for a few minutes, and a bus that left four minutes ago is gone, not here.
+        showStrip(-4)
+
+        composeRule.onAllNodesWithText(now).assertCountEquals(0)
+        composeRule.onAllNodesWithText("-4", substring = true).assertCountEquals(1)
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripRenderTest.kt
@@ -50,7 +50,7 @@ class EtaStripRenderTest {
                     // Distinct trip ids per pill: the strip's LazyRow keys on trip-instance identity
                     // and a duplicate key throws (see EtaStrip's itemsIndexed).
                     trips = listOf(
-                        previewArrival("8", "Rainier Beach", etaMinutes = -2, tripId = "trip_1"),
+                        previewArrival("8", "Rainier Beach", etaMinutes = -4, tripId = "trip_1"),
                         previewArrival("8", "Rainier Beach", etaMinutes = 5, tripId = "trip_2"),
                         previewArrival("40", "Northgate", etaMinutes = 12, tripId = "trip_3")
                     ),
@@ -65,11 +65,11 @@ class EtaStripRenderTest {
 
         // Assert on a pill's ETA text, not just any clickable node: the flanking chevron gutters are
         // clickable even when hidden, so a bare hasClickAction() match would pass with zero pills
-        // composed. The recent-past "-2" countdown is the strip's only "-2" — the gutters render only an
+        // composed. The long-gone "-4" countdown is the strip's only "-4" — the gutters render only an
         // icon, and no clock subline contains it — so this uniquely proves the LazyRow built its items.
-        // The value is stable for the test's duration: previewArrival anchors serverNow at 0 and
-        // liveEta divides each side into whole minutes, so the pill reads exactly -2 for the first 60s.
-        composeRule.onNodeWithText("-2", substring = true).assertExists()
+        // It is -4 rather than a just-departed value because inside the NOW window the pill reads "NOW"
+        // and has no number to match on (#2177 — see EtaStripNowPillRenderTest).
+        composeRule.onNodeWithText("-4", substring = true).assertExists()
         // Route identity is inside each pill when the caller supplies it (#2099).
         composeRule.onNodeWithText("40").assertExists()
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/ServerTimeTicker.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/ServerTimeTicker.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.delay
 
 /**
@@ -84,5 +85,29 @@ fun etaMinutes(displayTime: ServerTime, now: ServerTime): Long = displayTime.epo
  * surfaces showing the same arrival come to disagree by one.
  */
 fun untilNextMinute(now: ServerTime): Duration = (MS_PER_MINUTE - now.epochMs % MS_PER_MINUTE).milliseconds
+
+/**
+ * How long past its own time a departure still reads as "NOW" (issue #2177). The bus is at the
+ * stop and the rider is boarding across this window, so it is the answer to the question they are
+ * actually asking; a countdown that reverts to a number the instant it touches zero takes the
+ * confirmation away at the one moment it is being looked at.
+ *
+ * Two minutes rather than "any time in the past" because the arrivals window really does reach
+ * further back than that — the OBA arrivals request keeps recently-departed trips for a few minutes
+ * — and a bus that left five minutes ago is gone, not here. Past this it is honest to say how long
+ * ago it went.
+ */
+val NOW_WINDOW: Duration = 2.minutes
+
+/**
+ * Whether an ETA of [minutes] whole minutes (as [etaMinutes] computes it) reads as "NOW" rather
+ * than as a countdown.
+ *
+ * The single place the cutoff lives, for the same reason [etaMinutes] is the single place the
+ * number does: the ETA strip, the flat arrival row, the starred-stop badge and the trip-tracking
+ * notification all show the *same* departure, and when each restated the cutoff for itself they
+ * disagreed — the shade said "Now" while the arrivals row beside it said "-2min" (#2177).
+ */
+fun isEtaNow(minutes: Long): Boolean = minutes <= 0L && minutes >= -NOW_WINDOW.inWholeMinutes
 
 private const val MS_PER_MINUTE = 60 * 1000L

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tracking/TrackingPolicy.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tracking/TrackingPolicy.kt
@@ -19,6 +19,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import org.onebusaway.android.time.NOW_WINDOW
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.time.etaMinutes
@@ -85,11 +86,12 @@ sealed interface TrackingOutcome {
 }
 
 /**
- * How long a departure stays on the card past its own time. The rider is boarding in this window,
- * and a number that vanishes the instant it hits zero takes the confirmation away at the one moment
- * it is being looked at.
+ * How long a departure stays on the card past its own time: exactly as long as it still reads
+ * "Now" ([NOW_WINDOW]), by definition rather than by coincidence. The card has no rendering for a
+ * departure that has stopped being "Now" — a negative countdown on a Lock Screen is not something
+ * it ever wants to show — so the two windows being one value is what keeps that true.
  */
-val TRACKING_LINGER: Duration = 2.minutes
+val TRACKING_LINGER: Duration = NOW_WINDOW
 
 /**
  * How many departures the card lists. The row's strip can run much longer, but a notification is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tracking/TripTrackingNotifications.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tracking/TripTrackingNotifications.kt
@@ -26,6 +26,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import org.onebusaway.android.R
 import org.onebusaway.android.notifications.NotificationChannels
+import org.onebusaway.android.time.isEtaNow
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.home.FocusedStop
 import org.onebusaway.android.ui.nav.RouteRevealExtras
@@ -324,15 +325,20 @@ class TripTrackingNotifications @Inject constructor(
         // other surface saying "1hr 3min" (#1777). Its parts alternate number/unit, so the trailing
         // unit is the tile's small text and everything before it the value.
         val parts = DisplayFormat.formatEtaParts(context, departure.etaMinutes)
+        val now = isEtaNow(departure.etaMinutes)
         return TrackedMetric(
             value = when {
                 departure.canceled -> context.getString(R.string.trip_tracking_canceled)
-                // A bus still seconds away floors to zero minutes; the arrivals pill renders that "NOW".
-                departure.etaMinutes <= 0 -> context.getString(R.string.trip_tracking_short_now)
+                // A bus still seconds away floors to zero minutes, and one that has just pulled out is
+                // still being boarded — [isEtaNow] is the same cutoff the arrivals pill renders "NOW" at,
+                // shared rather than restated so the shade and the row it was copied from cannot disagree
+                // (#2177). Every departure the card can hold is inside it anyway (see TRACKING_LINGER),
+                // so this is the whole of the card's non-canceled past.
+                now -> context.getString(R.string.trip_tracking_short_now)
                 else -> parts.dropLast(1).joinToString("") { it.text }
             },
             // Only a bare countdown takes a unit; "Now" and "Canceled" are already whole phrases.
-            unit = parts.last().text.takeIf { !departure.canceled && departure.etaMinutes > 0 },
+            unit = parts.last().text.takeIf { !departure.canceled && !now },
             dueAt = DisplayFormat.formatTime(context, departure.displayTime.epochMs)
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -70,6 +70,7 @@ import org.onebusaway.android.models.FrequencyWindow
 import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.isEtaNow
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -553,7 +554,7 @@ private fun EtaContent(
         Modifier
     }
     Row(modifier = rowModifier) {
-        if (eta == 0L) {
+        if (isEtaNow(eta)) {
             Text(
                 text = stringResource(R.string.stop_info_eta_now),
                 fontSize = 30.sp,
@@ -789,7 +790,8 @@ private fun RouteArrivalRowPreview() {
                     isFavorite = true,
                     callbacks = callbacks
                 )
-                // A single-arrival route with a just-departed (recent-past) pill leading.
+                // A single-arrival route led by a just-departed pill — inside the NOW window, so it
+                // renders "NOW" rather than a negative countdown (#2177).
                 RouteArrivalRow(
                     group = RouteRowGroup(
                         listOf(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.isEtaNow
 import org.onebusaway.android.time.rememberLiveServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
@@ -479,12 +480,12 @@ private val PILL_BADGE_MAX_WIDTH = 72.dp
  * dialog, which passes no clicks). [onClick] taps focus that trip's vehicle + stop; [onLongClick]
  * opens the trip menu; [canceled] strikes the text through. [clockTime] is the small "1:10pm"-style
  * clock time shown below the ETA (issue #1786); null omits that line (e.g. the Home legend's
- * illustrative pills, which aren't tied to a real arrival time). The "NOW" pill ([eta] == 0) always
+ * illustrative pills, which aren't tied to a real arrival time). The "NOW" pill ([isEtaNow]) always
  * omits it too — it's a single centered label — so it's shorter by content; the strip levels it back
  * to its neighbours' height with fillMaxHeight (see EtaStrip's ReferencePillHeightFrame / EtaPillWithMenu).
  *
- * Every pill renders at the same size regardless of [eta] — a recent-past (negative-ETA) trip shows
- * its negative countdown in place at the same size as the upcoming ones, not a smaller pill.
+ * Every pill renders at the same size regardless of [eta] — a trip already gone past the NOW window
+ * shows its negative countdown in place at the same size as the upcoming ones, not a smaller pill.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -529,7 +530,7 @@ internal fun EtaPill(
     }
     // Numbers stay bold-sized, only the unit letters shrink (see formatEtaParts for the part shape;
     // etaAnnotatedString for why they render as a single AnnotatedString).
-    val etaParts = if (eta != 0L) DisplayFormat.formatEtaParts(LocalContext.current, eta) else null
+    val etaParts = if (isEtaNow(eta)) null else DisplayFormat.formatEtaParts(LocalContext.current, eta)
     // See tightLineStyle's doc: keyed to each Text's own (dominant) size, so the padding/gap values
     // below are the actual on-screen spacing rather than a guess fighting Android's hidden font padding.
     val baseTextStyle = LocalTextStyle.current
@@ -719,8 +720,11 @@ private fun EtaPillVariantsPreview() {
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.Bottom
             ) {
-                // A recent-past arrival: same size as the upcoming ones — negative ETAs aren't shrunk.
+                // An arrival gone past the NOW window: same size as the upcoming ones — negative ETAs
+                // aren't shrunk.
                 EtaPill(-3, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "2:57pm")
+                // Still inside it, so still NOW — as is 0 (#2177).
+                EtaPill(-1, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "2:59pm")
                 EtaPill(0, colorResource(R.color.stop_info_ontime_fill), predicted = true, clockTime = "3:00pm")
                 EtaPill(5, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "3:05pm")
                 EtaPill(12, colorResource(R.color.stop_info_early_fill), predicted = true, clockTime = "3:12pm")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -46,6 +46,7 @@ import org.onebusaway.android.database.oba.StopListRow
 import org.onebusaway.android.database.oba.StopRecentRow
 import org.onebusaway.android.database.oba.TripDepartureTime
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.isEtaNow
 import org.onebusaway.android.tracking.TrackedRouteKey
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.arrivals.convertArrivals
@@ -401,7 +402,10 @@ private fun List<ArrivalBadge>.flagTracked(tracked: Set<TrackedRouteKey>): List<
 }
 
 private fun ArrivalInfo.toBadge(context: Context, stop: StopListItem): ArrivalBadge {
-    val etaText = if (eta <= 0) {
+    // The same NOW cutoff every other ETA surface uses (#2177). This used to be a bare `eta <= 0`,
+    // which called a bus that left five minutes ago — well within the arrivals response's past
+    // window — "Now"; outside the window it now reports the negative minutes like the pills do.
+    val etaText = if (isEtaNow(eta)) {
         context.getString(R.string.starred_stop_arrival_now)
     } else {
         context.getString(R.string.starred_stop_arrival_min, eta.toInt())

--- a/onebusaway-android/src/test/java/org/onebusaway/android/time/ServerTimeTickerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/time/ServerTimeTickerTest.kt
@@ -18,6 +18,8 @@ package org.onebusaway.android.time
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -25,6 +27,9 @@ import org.junit.Test
  * in the server clock domain used to count ETA pills down between polls (issue #1781). It anchors on
  * a poll's server-clock reading and advances it by elapsed **device** time, so the result is immune to
  * device clock skew (#1612), mirroring `serverNowMs` in `VehicleInfoWindow`.
+ *
+ * Also covers the two shared rules every ETA surface reads off that clock: [etaMinutes]/[untilNextMinute],
+ * the number and when it turns over, and [isEtaNow], the cutoff at which the number gives way to "NOW".
  */
 class ServerTimeTickerTest {
 
@@ -42,6 +47,30 @@ class ServerTimeTickerTest {
         // And it really is the instant the printed number changes.
         assertEquals(5L, etaMinutes(due, elevenPast))
         assertEquals(4L, etaMinutes(due, elevenPast + untilNextMinute(elevenPast)))
+    }
+
+    @Test
+    fun `NOW covers the whole window a departure is still being boarded in`() {
+        // Issue #2177: this used to be an exact-zero test in the ETA pill, so NOW was reachable for at
+        // most the one minute a departure spent at zero and a bus that had just pulled out printed
+        // "-1min" — while the trip-tracking notification, on the same departure, said "Now".
+        assertFalse(isEtaNow(1))
+        assertTrue(isEtaNow(0))
+        assertTrue(isEtaNow(-1))
+        assertTrue(isEtaNow(-2))
+        // Past the window it is a countdown again: the arrivals response reaches further back than
+        // this, and a bus that left three minutes ago is gone rather than here.
+        assertFalse(isEtaNow(-3))
+    }
+
+    @Test
+    fun `the window's far edge is the last minute the tracking card holds a departure`() {
+        // The notification drops a departure once it is past TRACKING_LINGER, and renders every one it
+        // keeps as "Now" — so the two only stay consistent if nothing it can still hold falls outside
+        // the NOW window. Stated as a test because the shade disagreeing with the arrivals row it was
+        // copied from is exactly what #2177 was.
+        assertTrue(isEtaNow(-NOW_WINDOW.inWholeMinutes))
+        assertFalse(isEtaNow(-NOW_WINDOW.inWholeMinutes - 1))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/tracking/TrackingPolicyTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/tracking/TrackingPolicyTest.kt
@@ -24,6 +24,7 @@ import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.time.etaMinutes
+import org.onebusaway.android.time.isEtaNow
 
 /**
  * The rules the tracking notification lives by: which departures a row shows, when it rolls onto the
@@ -77,7 +78,9 @@ class TrackingPolicyTest {
         val outcome = live(match(-TRACKING_LINGER), match(12.minutes))
 
         assertEquals(2, outcome.departures.size)
-        assertTrue(outcome.departures.first().etaMinutes <= 0)
+        // Not merely "still listed": at the far edge of the linger it must still *read* "Now", which is
+        // the only thing the card knows how to say about a departure that has gone (#2177).
+        assertTrue(isEtaNow(outcome.departures.first().etaMinutes))
     }
 
     @Test


### PR DESCRIPTION
Fixes #2177.

## What was wrong

The ETA strip picked its "NOW" pill with an exact-zero test:

```kotlin
val etaParts = if (eta != 0L) DisplayFormat.formatEtaParts(LocalContext.current, eta) else null
```

so NOW was on screen for at most the one minute a departure spent at zero, and a bus that had just pulled out fell through to the numeric branch and printed `-1min`, `-2min`. The trip-tracking notification, rendering the same departures, said "Now" for all of them.

Chasing it turned up **four** restatements of the cutoff, with **three** different answers:

| surface | cutoff | effect |
|---|---|---|
| ETA strip pill | `eta == 0` | NOW unreachable except at exactly 0 |
| flat arrival row (`EtaContent`) | `eta == 0L` | same |
| trip-tracking notification | `<= 0` | correct, but only because `TRACKING_LINGER` bounds it at -2 |
| starred-stop badge (`MyListRepository`) | `<= 0`, unbounded | calls a bus that left five minutes ago "Now" |

## The decision the issue asked for

The issue left open whether NOW should be `eta <= 0` (matching the notification) or whether the strip genuinely wants to show how long ago a bus left. **Both, split at two minutes** — and the split is the notification's own window, not a new number:

- **NOW covers `NOW_WINDOW` = 2 minutes past a departure's own time.** That is the stretch in which the rider is boarding, and it is exactly the range the notification can ever render (its departures are dropped past `TRACKING_LINGER`), so the notification's behaviour is bit-identical to before.
- **Past the window it is a countdown again.** The client sends no `minutesBefore`, so the arrivals response keeps departed trips for the server's default few minutes — a `-5min` pill is a real state, and a bus that left five minutes ago is gone, not here. This is the one behaviour change beyond the fix: the starred-stop badge stops calling those "Now".

`TRACKING_LINGER` becomes `NOW_WINDOW` rather than its own `2.minutes`, by definition instead of by coincidence: the card has no rendering for a departure that has stopped being "Now", so the two windows being one value is what keeps that true.

The cutoff itself is now `isEtaNow`, living next to `etaMinutes` in `org.onebusaway.android.time` for the reason that function gives — it is the one place the rule lives, and all four surfaces call it.

⚠️ **Worth a human eye:** 2 minutes is a product judgement about when a bus stops being "here". It is not newly invented (it is `TRACKING_LINGER`, shipped in #2173, reused rather than duplicated), but this PR extends its reach from the notification to every ETA surface.

## Not in scope

The pill's look once it is on screen — 26sp bold white, no clock subline, `fillMaxHeight` — is deliberate, from #1805 and #1811. Untouched.

## Testing

- **JVM unit** (`ServerTimeTickerTest`): the window `[-2, 0]` and its edges; and that the far edge is the last minute `TRACKING_LINGER` holds a departure, so the shade and the arrivals row cannot drift apart again. `TrackingPolicyTest`'s boarding-moment test now asserts the departure still *reads* "Now", not merely that it is still listed.
- **Device** (`EtaStripNowPillRenderTest`, new): the whole just-left window renders NOW with no negative countdown surviving; a departure at -4 still says how long ago. Not `@SmokeTest` — the API-23 floor subset keeps its one strip test.
- `EtaStripRenderTest`'s recent-past pill moves -2 → -4, since -2 no longer has a number to match on.
- Verified: `compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, `testObaGoogleDebugUnitTest`, `spotlessCheck`, and both strip render tests green on a Pixel 7 Pro (Android 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recently departed arrivals now remain labeled “Now” for up to two minutes, instead of showing negative countdowns.
  * ETA displays, arrival badges, notifications, and trip tracking now use consistent “Now” behavior.
  * Departures beyond the two-minute window continue to show their negative countdown, such as “-4”.
* **Tests**
  * Added coverage for the “Now” window boundaries and negative ETA display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->