### PR TITLE
Check every alert period range, on typed server time (#2175)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.kt
@@ -47,7 +47,7 @@ class GtfsAlerts @Inject constructor(
                 // server/device crossing, resolved here at the boundary so the downstream check
                 // stays a pure function of its inputs.
                 val now = if (feed.hasHeader() && feed.header.hasTimestamp()) {
-                    ServerTime(feed.header.timestamp * 1_000L)
+                    GtfsAlertsHelper.serverTimeFromGtfsSeconds(feed.header.timestamp)
                 } else {
                     Log.w(TAG, "GTFS alert feed for region $regionId omitted its timestamp; using the device clock")
                     ServerTime(WallTime.now().epochMs)
@@ -66,7 +66,7 @@ class GtfsAlerts @Inject constructor(
         callback: GtfsAlertCallBack
     ) {
         for (entity in alerts) {
-            if (!GtfsAlertsHelper.isValidEntity(context, entity, now.epochMs)) continue
+            if (!GtfsAlertsHelper.isValidEntity(context, entity, now)) continue
             val alert = entity.alert
             val title = GtfsAlertsHelper.getAlertTitle(alert)
             val description = GtfsAlertsHelper.getAlertDescription(alert)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.kt
@@ -5,6 +5,7 @@ import com.google.transit.realtime.GtfsRealtime
 import java.util.Locale
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 import org.onebusaway.android.app.di.DatabaseEntryPoint
 import org.onebusaway.android.database.widealerts.entity.AlertEntity
 import org.onebusaway.android.time.ServerTime
@@ -38,7 +39,7 @@ object GtfsAlertsHelper {
         now: ServerTime
     ): Boolean = isAgencyWideAlert(entity.alert) &&
         isHighSeverity(entity.alert) &&
-        isStartDateWithin24Hours(entity.alert, now) &&
+        hasRecentlyStartedPeriod(entity.alert, now) &&
         !isAlertRead(context, entity)
 
     private fun isAgencyWideAlert(alert: GtfsRealtime.Alert): Boolean = alert.informedEntityList.any { it.hasAgencyId() }
@@ -50,8 +51,8 @@ object GtfsAlertsHelper {
             )
 
     /**
-     * True when *any* range of the alert's selected period list started within the last 24 hours of
-     * [now] — the feed's own server clock (#1612), so device clock skew can't leak into the window.
+     * True when *any* range of the alert's selected period list started within [RECENT_START_WINDOW]
+     * of [now] — the feed's own server clock (#1612), so device clock skew can't leak into the window.
      *
      * `communication_period` and `active_period` are both `repeated TimeRange`, and the spec treats
      * an alert as applicable during **any** of its configured ranges, so every range is checked
@@ -59,9 +60,9 @@ object GtfsAlertsHelper {
      * is exactly the case index-0-only silently dropped
      * (https://github.com/OneBusAway/onebusaway-android/issues/2175).
      */
-    fun isStartDateWithin24Hours(alert: GtfsRealtime.Alert, now: ServerTime): Boolean = selectedPeriods(alert).any { range ->
+    fun hasRecentlyStartedPeriod(alert: GtfsRealtime.Alert, now: ServerTime): Boolean = selectedPeriods(alert).any { range ->
         // `start` is optional: a range without one begins at "the beginning of time" per the spec,
-        // which is never within the last 24h — so an absent start is a non-match, not an epoch 0.
+        // which is never recent — so an absent start is a non-match, not an epoch 0.
         range.hasStart() && (now - serverTimeFromGtfsSeconds(range.start)) in RECENT_START_WINDOW
     }
 
@@ -70,29 +71,24 @@ object GtfsAlertsHelper {
      *
      * "Should we show this to the user in the next 24h" maps to `communication_period`, so it's
      * preferred when a feed populates it. `active_period` is `[deprecated = true]` as of the proto
-     * shipped in gtfs-realtime-bindings 0.2.0, but feeds in the wild still only populate it, so
-     * [deprecatedActivePeriods] stays as a fallback — dropping it would silence every alert on those
-     * feeds. Tracked by https://github.com/OneBusAway/onebusaway-android/issues/2160.
+     * shipped in gtfs-realtime-bindings 0.2.0, but feeds in the wild still only populate it, so it
+     * stays as the fallback — dropping it would silence every alert on those feeds. That fallback
+     * read is the sole reason for the deprecation suppression here; drop both once
+     * `communication_period` is the only field in the wild.
+     * Tracked by https://github.com/OneBusAway/onebusaway-android/issues/2160.
      */
-    private fun selectedPeriods(alert: GtfsRealtime.Alert): List<GtfsRealtime.TimeRange> = if (alert.communicationPeriodCount > 0) {
-        alert.communicationPeriodList
-    } else {
-        deprecatedActivePeriods(alert)
-    }
-
-    // Fallback for feeds that only populate the deprecated active_period; see the rationale on
-    // selectedPeriods. Drop this once communication_period is the only field in the wild.
     @Suppress("DEPRECATION")
-    private fun deprecatedActivePeriods(alert: GtfsRealtime.Alert): List<GtfsRealtime.TimeRange> = alert.activePeriodList
+    private fun selectedPeriods(alert: GtfsRealtime.Alert): List<GtfsRealtime.TimeRange> = alert.communicationPeriodList.ifEmpty { alert.activePeriodList }
 
     /**
      * Mints a raw GTFS-realtime timestamp into the server clock domain. These alerts come straight
      * off a raw GTFS-realtime feed, not the OBA API, so the wire unit is POSIX **seconds** per the
      * GTFS-rt spec — a fixed unit, not a magnitude guess. (The OBA `situation` path is the
      * polymorphic one; its seconds-vs-millis rule lives in `situationEpochToMillis` and does not
-     * apply here.) This is the one place that conversion happens for this feed.
+     * apply here.) `internal`, like `situationEpochToMillis`, so this stays the one place the
+     * conversion happens for this feed rather than a `* 1_000` anyone can re-derive.
      */
-    fun serverTimeFromGtfsSeconds(epochSec: Long): ServerTime = ServerTime(epochSec * MILLIS_PER_SECOND)
+    internal fun serverTimeFromGtfsSeconds(epochSec: Long): ServerTime = ServerTime(epochSec.seconds.inWholeMilliseconds)
 
     private fun isAlertRead(context: Context, entity: GtfsRealtime.FeedEntity): Boolean = DatabaseEntryPoint.get(context).alertsRepository().isAlertExists(entity.id)
 
@@ -103,7 +99,6 @@ object GtfsAlertsHelper {
     private fun getCurrentAppLanguageCode(): String = Locale.getDefault().language
 
     private const val DEFAULT_LANGUAGE_CODE = "en"
-    private const val MILLIS_PER_SECOND = 1_000L
 
     /** How long ago a period may have started and still count as "just started". */
     private val RECENT_START_WINDOW = Duration.ZERO..24.hours

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlertsHelper.kt
@@ -3,8 +3,11 @@ package org.onebusaway.android.widealerts
 import android.content.Context
 import com.google.transit.realtime.GtfsRealtime
 import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import org.onebusaway.android.app.di.DatabaseEntryPoint
 import org.onebusaway.android.database.widealerts.entity.AlertEntity
+import org.onebusaway.android.time.ServerTime
 
 /** Pure selection helpers and read-state persistence for wide GTFS alerts. */
 object GtfsAlertsHelper {
@@ -32,10 +35,10 @@ object GtfsAlertsHelper {
     fun isValidEntity(
         context: Context,
         entity: GtfsRealtime.FeedEntity,
-        nowMs: Long
+        now: ServerTime
     ): Boolean = isAgencyWideAlert(entity.alert) &&
         isHighSeverity(entity.alert) &&
-        isStartDateWithin24Hours(entity.alert, nowMs) &&
+        isStartDateWithin24Hours(entity.alert, now) &&
         !isAlertRead(context, entity)
 
     private fun isAgencyWideAlert(alert: GtfsRealtime.Alert): Boolean = alert.informedEntityList.any { it.hasAgencyId() }
@@ -47,35 +50,49 @@ object GtfsAlertsHelper {
             )
 
     /**
-     * These alerts come straight off a raw GTFS-realtime feed, not the OBA API, so a period's
-     * `start` is POSIX **seconds** per the GTFS-rt spec — a fixed unit, not a magnitude guess.
-     * (The OBA `situation` path is the polymorphic one; its seconds-vs-millis rule lives in
-     * `situationEpochToMillis` and does not apply here.)
+     * True when *any* range of the alert's selected period list started within the last 24 hours of
+     * [now] — the feed's own server clock (#1612), so device clock skew can't leak into the window.
      *
-     * "Should we show this to the user in the next 24h" maps to `communication_period`, so it's
-     * preferred when a feed populates it. `active_period` is `[deprecated = true]` as of the
-     * proto shipped in gtfs-realtime-bindings 0.2.0, but feeds in the wild still only populate
-     * it, so [activePeriodStartSec] stays as a fallback — dropping it would silence every alert
-     * on those feeds. Tracked by https://github.com/OneBusAway/onebusaway-android/issues/2160.
+     * `communication_period` and `active_period` are both `repeated TimeRange`, and the spec treats
+     * an alert as applicable during **any** of its configured ranges, so every range is checked
+     * rather than index 0: an alert whose first range is stale but whose second opened an hour ago
+     * is exactly the case index-0-only silently dropped
+     * (https://github.com/OneBusAway/onebusaway-android/issues/2175).
      */
-    fun isStartDateWithin24Hours(alert: GtfsRealtime.Alert, nowMs: Long): Boolean {
-        val startSec = communicationPeriodStartSec(alert) ?: activePeriodStartSec(alert) ?: return false
-        val elapsed = nowMs - startSec * MILLIS_PER_SECOND
-        return elapsed in 0..DAY_MS
+    fun isStartDateWithin24Hours(alert: GtfsRealtime.Alert, now: ServerTime): Boolean = selectedPeriods(alert).any { range ->
+        // `start` is optional: a range without one begins at "the beginning of time" per the spec,
+        // which is never within the last 24h — so an absent start is a non-match, not an epoch 0.
+        range.hasStart() && (now - serverTimeFromGtfsSeconds(range.start)) in RECENT_START_WINDOW
     }
 
-    private fun communicationPeriodStartSec(alert: GtfsRealtime.Alert): Long? {
-        if (alert.communicationPeriodCount == 0) return null
-        return alert.getCommunicationPeriod(0).start
+    /**
+     * The period list the "did it start recently" question is answered from.
+     *
+     * "Should we show this to the user in the next 24h" maps to `communication_period`, so it's
+     * preferred when a feed populates it. `active_period` is `[deprecated = true]` as of the proto
+     * shipped in gtfs-realtime-bindings 0.2.0, but feeds in the wild still only populate it, so
+     * [deprecatedActivePeriods] stays as a fallback — dropping it would silence every alert on those
+     * feeds. Tracked by https://github.com/OneBusAway/onebusaway-android/issues/2160.
+     */
+    private fun selectedPeriods(alert: GtfsRealtime.Alert): List<GtfsRealtime.TimeRange> = if (alert.communicationPeriodCount > 0) {
+        alert.communicationPeriodList
+    } else {
+        deprecatedActivePeriods(alert)
     }
 
     // Fallback for feeds that only populate the deprecated active_period; see the rationale on
-    // isStartDateWithin24Hours. Drop this once communication_period is the only field in the wild.
+    // selectedPeriods. Drop this once communication_period is the only field in the wild.
     @Suppress("DEPRECATION")
-    private fun activePeriodStartSec(alert: GtfsRealtime.Alert): Long? {
-        if (alert.activePeriodCount == 0) return null
-        return alert.getActivePeriod(0).start
-    }
+    private fun deprecatedActivePeriods(alert: GtfsRealtime.Alert): List<GtfsRealtime.TimeRange> = alert.activePeriodList
+
+    /**
+     * Mints a raw GTFS-realtime timestamp into the server clock domain. These alerts come straight
+     * off a raw GTFS-realtime feed, not the OBA API, so the wire unit is POSIX **seconds** per the
+     * GTFS-rt spec — a fixed unit, not a magnitude guess. (The OBA `situation` path is the
+     * polymorphic one; its seconds-vs-millis rule lives in `situationEpochToMillis` and does not
+     * apply here.) This is the one place that conversion happens for this feed.
+     */
+    fun serverTimeFromGtfsSeconds(epochSec: Long): ServerTime = ServerTime(epochSec * MILLIS_PER_SECOND)
 
     private fun isAlertRead(context: Context, entity: GtfsRealtime.FeedEntity): Boolean = DatabaseEntryPoint.get(context).alertsRepository().isAlertExists(entity.id)
 
@@ -87,5 +104,7 @@ object GtfsAlertsHelper {
 
     private const val DEFAULT_LANGUAGE_CODE = "en"
     private const val MILLIS_PER_SECOND = 1_000L
-    private const val DAY_MS = 24L * 60L * 60L * 1_000L
+
+    /** How long ago a period may have started and still count as "just started". */
+    private val RECENT_START_WINDOW = Duration.ZERO..24.hours
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
@@ -23,7 +23,7 @@ import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 
 /**
- * Unit tests for the pure, [ServerTime]-driven [GtfsAlertsHelper.isStartDateWithin24Hours]. "Now" is
+ * Unit tests for the pure, [ServerTime]-driven [GtfsAlertsHelper.hasRecentlyStartedPeriod]. "Now" is
  * the feed's server clock (#1612), so these pin the 24h cutoff, the boundary, and the future-start
  * guard against the server time passed in. ([GtfsAlertsHelper.isValidEntity] additionally reads the
  * alerts DB via a Context, so it isn't a pure JVM unit and is out of scope here.)
@@ -37,54 +37,45 @@ class GtfsAlertsHelperTest {
 
     @Test
     fun `start one hour ago is within 24 hours`() {
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec - hourSec), now))
+        assertTrue(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert(activeStartsSec = listOf(nowSec - hourSec)), now))
     }
 
     @Test
     fun `start 25 hours ago is not within 24 hours`() {
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec - 25 * hourSec), now))
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert(activeStartsSec = listOf(nowSec - 25 * hourSec)), now))
     }
 
     @Test
     fun `start exactly 24 hours ago is still within the window`() {
-        val alert = alertStartingAt(nowSec - 24 * hourSec)
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(activeStartsSec = listOf(nowSec - 24 * hourSec))
+        assertTrue(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
         // One millisecond past the boundary is out.
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now + 1.milliseconds))
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now + 1.milliseconds))
     }
 
     @Test
     fun `future-dated start is not within 24 hours`() {
         // Regression guard: a negative elapsed time must not slip past the upper bound.
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec + hourSec), now))
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert(activeStartsSec = listOf(nowSec + hourSec)), now))
     }
 
     @Test
-    fun `alert with no active period does not crash and is not surfaced`() {
-        // active_period is optional in GTFS-RT; getActivePeriod(0) would throw. Must return false, not crash.
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(GtfsRealtime.Alert.newBuilder().build(), now))
+    fun `alert with no periods at all does not crash and is not surfaced`() {
+        // Both period fields are optional in GTFS-RT, so an alert may carry neither. Must return
+        // false, not crash on an empty list.
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert(), now))
     }
 
     @Test
-    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
-    @Suppress("DEPRECATION")
     fun `range with no start is not treated as an epoch-zero start`() {
         // `start` is optional within a TimeRange too: an open-ended range began at "the beginning of
         // time", so it is never a recent start — and must not read as 0, which would also be false
         // but for the wrong reason. Pinned alongside a genuinely recent sibling range.
         val openEnded = GtfsRealtime.TimeRange.newBuilder().setEnd(nowSec + hourSec).build()
-        assertFalse(
-            GtfsAlertsHelper.isStartDateWithin24Hours(
-                GtfsRealtime.Alert.newBuilder().addActivePeriod(openEnded).build(),
-                now
-            )
-        )
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert(activeRanges = listOf(openEnded)), now))
         assertTrue(
-            GtfsAlertsHelper.isStartDateWithin24Hours(
-                GtfsRealtime.Alert.newBuilder()
-                    .addActivePeriod(openEnded)
-                    .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
-                    .build(),
+            GtfsAlertsHelper.hasRecentlyStartedPeriod(
+                alert(activeRanges = listOf(openEnded, rangeStartingAt(nowSec - hourSec))),
                 now
             )
         )
@@ -93,85 +84,79 @@ class GtfsAlertsHelperTest {
     @Test
     fun `communication period only alert within 24 hours is surfaced`() {
         // #2160: a feed that only populates the new field must still be readable, not silenced.
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
-            .build()
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(communicationStartsSec = listOf(nowSec - hourSec))
+        assertTrue(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
     @Test
     fun `communication period only alert outside 24 hours is not surfaced`() {
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
-            .build()
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(communicationStartsSec = listOf(nowSec - 25 * hourSec))
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
     @Test
-    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
-    @Suppress("DEPRECATION")
     fun `alert with both fields prefers communication period over active period`() {
         // #2160: communication_period wins when both are populated, even if active_period alone
         // would put the alert outside the 24h window.
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
-            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
-            .build()
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(
+            communicationStartsSec = listOf(nowSec - hourSec),
+            activeStartsSec = listOf(nowSec - 25 * hourSec)
+        )
+        assertTrue(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
     @Test
-    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
-    @Suppress("DEPRECATION")
     fun `a later active period range within the window is surfaced despite a stale first range`() {
         // #2175: active_period is `repeated`, and the spec makes the alert applicable during any of
         // its ranges — a recurring closure whose first range is weeks old must not be silenced by
         // reading only index 0.
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 30 * 24 * hourSec).build())
-            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 2 * hourSec).build())
-            .build()
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(activeStartsSec = listOf(nowSec - 30 * 24 * hourSec, nowSec - 2 * hourSec))
+        assertTrue(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
     @Test
     fun `a later communication period range within the window is surfaced despite a stale first range`() {
         // #2175: the same repeated-field rule for the preferred communication_period list.
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 30 * 24 * hourSec).build())
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 2 * hourSec).build())
-            .build()
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(communicationStartsSec = listOf(nowSec - 30 * 24 * hourSec, nowSec - 2 * hourSec))
+        assertTrue(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
     @Test
     fun `every range outside the window is still not surfaced`() {
         // The any-match rule widens what's surfaced; it must not surface an alert with no recent
         // range at all — one stale, one future-dated.
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec + hourSec).build())
-            .build()
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(communicationStartsSec = listOf(nowSec - 25 * hourSec, nowSec + hourSec))
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
     @Test
-    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
-    @Suppress("DEPRECATION")
     fun `a recent active period range does not rescue a populated communication period list`() {
         // #2160 precedence holds at the list level: once communication_period is populated it is the
         // authoritative list, and active_period is not consulted for any of its ranges.
-        val alert = GtfsRealtime.Alert.newBuilder()
-            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
-            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
-            .build()
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+        val alert = alert(
+            communicationStartsSec = listOf(nowSec - 25 * hourSec),
+            activeStartsSec = listOf(nowSec - hourSec)
+        )
+        assertFalse(GtfsAlertsHelper.hasRecentlyStartedPeriod(alert, now))
     }
 
-    // Mirrors the deprecated-but-still-universal `active_period` fallback read in the helper
-    // under test; see the rationale on [GtfsAlertsHelper.isStartDateWithin24Hours].
+    private fun rangeStartingAt(startSec: Long): GtfsRealtime.TimeRange = GtfsRealtime.TimeRange.newBuilder().setStart(startSec).build()
+
+    /**
+     * Every alert under test is built here so the `active_period` deprecation suppression has one
+     * home rather than one per test. That field is deprecated in the proto but still the only one
+     * many feeds populate, which is exactly why the helper reads it; see
+     * [GtfsAlertsHelper.hasRecentlyStartedPeriod] and
+     * https://github.com/OneBusAway/onebusaway-android/issues/2160.
+     */
     @Suppress("DEPRECATION")
-    private fun alertStartingAt(startSec: Long): GtfsRealtime.Alert = GtfsRealtime.Alert.newBuilder()
-        .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(startSec).build())
-        .build()
+    private fun alert(
+        communicationStartsSec: List<Long> = emptyList(),
+        activeStartsSec: List<Long> = emptyList(),
+        activeRanges: List<GtfsRealtime.TimeRange> = emptyList()
+    ): GtfsRealtime.Alert = GtfsRealtime.Alert.newBuilder().apply {
+        communicationStartsSec.forEach { addCommunicationPeriod(rangeStartingAt(it)) }
+        activeStartsSec.forEach { addActivePeriod(rangeStartingAt(it)) }
+        activeRanges.forEach { addActivePeriod(it) }
+    }.build()
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/widealerts/GtfsAlertsHelperTest.kt
@@ -16,51 +16,78 @@
 package org.onebusaway.android.widealerts
 
 import com.google.transit.realtime.GtfsRealtime
+import kotlin.time.Duration.Companion.milliseconds
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.time.ServerTime
 
 /**
- * Unit tests for the pure, `nowMs`-driven [GtfsAlertsHelper.isStartDateWithin24Hours]. "Now" is the
- * feed's server clock (#1612), so these pin the 24h cutoff, the boundary, and the future-start guard
- * against the server time passed in. ([GtfsAlertsHelper.isValidEntity] additionally reads the
+ * Unit tests for the pure, [ServerTime]-driven [GtfsAlertsHelper.isStartDateWithin24Hours]. "Now" is
+ * the feed's server clock (#1612), so these pin the 24h cutoff, the boundary, and the future-start
+ * guard against the server time passed in. ([GtfsAlertsHelper.isValidEntity] additionally reads the
  * alerts DB via a Context, so it isn't a pure JVM unit and is out of scope here.)
  */
 class GtfsAlertsHelperTest {
 
-    // A round server "now": epoch seconds 1_700_000_000 expressed in millis.
+    // A round server "now": epoch seconds 1_700_000_000 on the feed's own clock.
     private val nowSec = 1_700_000_000L
-    private val nowMs = nowSec * 1000L
+    private val now = GtfsAlertsHelper.serverTimeFromGtfsSeconds(nowSec)
     private val hourSec = 3_600L
 
     @Test
     fun `start one hour ago is within 24 hours`() {
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec - hourSec), nowMs))
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec - hourSec), now))
     }
 
     @Test
     fun `start 25 hours ago is not within 24 hours`() {
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec - 25 * hourSec), nowMs))
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec - 25 * hourSec), now))
     }
 
     @Test
     fun `start exactly 24 hours ago is still within the window`() {
         val alert = alertStartingAt(nowSec - 24 * hourSec)
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
         // One millisecond past the boundary is out.
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs + 1))
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now + 1.milliseconds))
     }
 
     @Test
     fun `future-dated start is not within 24 hours`() {
         // Regression guard: a negative elapsed time must not slip past the upper bound.
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec + hourSec), nowMs))
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alertStartingAt(nowSec + hourSec), now))
     }
 
     @Test
     fun `alert with no active period does not crash and is not surfaced`() {
         // active_period is optional in GTFS-RT; getActivePeriod(0) would throw. Must return false, not crash.
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(GtfsRealtime.Alert.newBuilder().build(), nowMs))
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(GtfsRealtime.Alert.newBuilder().build(), now))
+    }
+
+    @Test
+    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
+    @Suppress("DEPRECATION")
+    fun `range with no start is not treated as an epoch-zero start`() {
+        // `start` is optional within a TimeRange too: an open-ended range began at "the beginning of
+        // time", so it is never a recent start — and must not read as 0, which would also be false
+        // but for the wrong reason. Pinned alongside a genuinely recent sibling range.
+        val openEnded = GtfsRealtime.TimeRange.newBuilder().setEnd(nowSec + hourSec).build()
+        assertFalse(
+            GtfsAlertsHelper.isStartDateWithin24Hours(
+                GtfsRealtime.Alert.newBuilder().addActivePeriod(openEnded).build(),
+                now
+            )
+        )
+        assertTrue(
+            GtfsAlertsHelper.isStartDateWithin24Hours(
+                GtfsRealtime.Alert.newBuilder()
+                    .addActivePeriod(openEnded)
+                    .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
+                    .build(),
+                now
+            )
+        )
     }
 
     @Test
@@ -69,7 +96,7 @@ class GtfsAlertsHelperTest {
         val alert = GtfsRealtime.Alert.newBuilder()
             .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
             .build()
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
     }
 
     @Test
@@ -77,7 +104,7 @@ class GtfsAlertsHelperTest {
         val alert = GtfsRealtime.Alert.newBuilder()
             .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
             .build()
-        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
     }
 
     @Test
@@ -90,7 +117,55 @@ class GtfsAlertsHelperTest {
             .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
             .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
             .build()
-        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, nowMs))
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+    }
+
+    @Test
+    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
+    @Suppress("DEPRECATION")
+    fun `a later active period range within the window is surfaced despite a stale first range`() {
+        // #2175: active_period is `repeated`, and the spec makes the alert applicable during any of
+        // its ranges — a recurring closure whose first range is weeks old must not be silenced by
+        // reading only index 0.
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 30 * 24 * hourSec).build())
+            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 2 * hourSec).build())
+            .build()
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+    }
+
+    @Test
+    fun `a later communication period range within the window is surfaced despite a stale first range`() {
+        // #2175: the same repeated-field rule for the preferred communication_period list.
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 30 * 24 * hourSec).build())
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 2 * hourSec).build())
+            .build()
+        assertTrue(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+    }
+
+    @Test
+    fun `every range outside the window is still not surfaced`() {
+        // The any-match rule widens what's surfaced; it must not surface an alert with no recent
+        // range at all — one stale, one future-dated.
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec + hourSec).build())
+            .build()
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
+    }
+
+    @Test
+    // Exercises the deprecated active_period fallback; see https://github.com/OneBusAway/onebusaway-android/issues/2160.
+    @Suppress("DEPRECATION")
+    fun `a recent active period range does not rescue a populated communication period list`() {
+        // #2160 precedence holds at the list level: once communication_period is populated it is the
+        // authoritative list, and active_period is not consulted for any of its ranges.
+        val alert = GtfsRealtime.Alert.newBuilder()
+            .addCommunicationPeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - 25 * hourSec).build())
+            .addActivePeriod(GtfsRealtime.TimeRange.newBuilder().setStart(nowSec - hourSec).build())
+            .build()
+        assertFalse(GtfsAlertsHelper.isStartDateWithin24Hours(alert, now))
     }
 
     // Mirrors the deprecated-but-still-universal `active_period` fallback read in the helper


### PR DESCRIPTION
Fixes #2175. Both items from the CodeRabbit review on #2174, deferred out of scope there.

## 1. Only the first period in each repeated field was checked

`communication_period` and `active_period` are both `repeated TimeRange`, and the GTFS-realtime spec treats an alert as applicable during *any* of its configured ranges — but `GtfsAlertsHelper` only read index 0. An alert whose first range is stale but whose second opened an hour ago was silently dropped by `GtfsAlerts.processAlerts`. The check now matches any range in the selected list.

Field precedence from #2174 is unchanged, and is now stated at the **list** level: once `communication_period` is populated it is authoritative and `active_period` is not consulted for any of its ranges. Previously that fell out of two `?:`-chained start-extractors; it's now one `ifEmpty` expression, so "which list wins" and "which range matches" are separable questions.

**One judgment call worth a reviewer's eye:** `TimeRange.start` is optional, and the old code would have read an unset one as `0`. Rather than let epoch-0 fall outside the window by accident, a range without a `start` is now an explicit non-match — per the spec such a range began at "the beginning of time," which is never a recent start. Same outcome, stated deliberately rather than relying on `0` being far enough in the past.

## 2. Raw `Long` time math replaced with typed time

The helper mixed POSIX seconds (GTFS-rt wire) with millis ("now") as raw `Long`s. Per CLAUDE.md's time-domain rules it now takes `now: ServerTime` and mints each period start into `ServerTime` at the wire boundary, comparing the resulting `Duration` against a named `RECENT_START_WINDOW` (`Duration.ZERO..24.hours`) — so the future-start guard and the 24h cutoff are one value in the `Duration` domain rather than two hand-rolled millis bounds, and a cross-domain mix is a compile error.

`serverTimeFromGtfsSeconds` is the single `internal` place the seconds→millis conversion lives for this feed, mirroring `situationEpochToMillis`. `GtfsAlerts` uses it for the feed header timestamp too, and passes its `ServerTime` straight through instead of unwrapping to `.epochMs`.

No heuristic is involved: the GTFS-rt wire unit is fixed seconds per spec. The polymorphic seconds-vs-millis rule is the OBA `situation` path's, and deliberately does not apply here — noted at the call site.

## Testing

`GtfsAlertsHelperTest` goes 8 → 13 tests, all passing. New cases: the stale-first/recent-later regression for both fields, an all-ranges-outside guard, precedence-at-list-level, and the absent-`start` case. Every alert is now built through one `alert(...)` helper, which also gives the `active_period` deprecation suppression a single home instead of one per test.

Verified locally: `testObaGoogleDebugUnitTest` (13/13), `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean, `spotlessCheck` clean. Lint left to CI per CLAUDE.md — the change moves in the typed-time checks' favor (one `.epochMs` unwrap removed, no new raw clock reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GTFS alert timing validation using server-provided time.
  * Alerts now correctly handle multiple communication periods, open-ended ranges, missing periods, and legacy active periods.
  * Improved detection of recently started alerts while filtering stale or future alerts.

* **Tests**
  * Added coverage for alert timing and period-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->