### PR TITLE
Stop labelling departed buses "NOW" on starred-stop badges (#2180)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListRepository.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.text.format.DateUtils
 import androidx.annotation.ArrayRes
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -400,8 +401,24 @@ private fun List<ArrivalBadge>.flagTracked(tracked: Set<TrackedRouteKey>): List<
     badge.copy(tracked = key != null && key in tracked)
 }
 
+/**
+ * Whether a badge's ETA reads "NOW": the arrival falls in the current minute, and only then.
+ *
+ * Deliberately *not* `eta <= 0`, which is what this used to be (#2180). Departed buses reach this
+ * surface routinely — the arrivals request sends no `minutesBefore`, so the server's own past window
+ * applies, and [convertArrivals] keeps negative ETAs whenever "Show departed buses" is on (the
+ * default) — so an unbounded test labelled a bus that left five minutes ago "NOW". Exact zero is the
+ * cutoff [org.onebusaway.android.ui.arrivals.components.EtaPill] and the flat arrival row have always
+ * used; a departed bus shows its negative minutes here the way it does there.
+ *
+ * Kept as a pure function so the rule is JVM-testable — the rest of [toBadge] needs a `Context` for
+ * its strings, and that is exactly how the wrong cutoff went unnoticed.
+ */
+@VisibleForTesting
+internal fun badgeEtaIsNow(eta: Long): Boolean = eta == 0L
+
 private fun ArrivalInfo.toBadge(context: Context, stop: StopListItem): ArrivalBadge {
-    val etaText = if (eta <= 0) {
+    val etaText = if (badgeEtaIsNow(eta)) {
         context.getString(R.string.starred_stop_arrival_now)
     } else {
         context.getString(R.string.starred_stop_arrival_min, eta.toInt())

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/mylists/BadgeEtaCutoffTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/mylists/BadgeEtaCutoffTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.mylists
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The starred-stop badge says "NOW" only for a bus arriving this minute (issue #2180).
+ *
+ * It used to test `eta <= 0`, unbounded, so every departed bus in the response got a badge claiming
+ * it was here now — and departed buses are routine on this path, since the arrivals request sends no
+ * `minutesBefore` and negative ETAs survive `convertArrivals` by default.
+ */
+class BadgeEtaCutoffTest {
+
+    @Test
+    fun `only an arrival in the current minute reads NOW`() {
+        assertTrue(badgeEtaIsNow(0))
+        assertFalse(badgeEtaIsNow(1))
+    }
+
+    @Test
+    fun `a departed bus never reads NOW`() {
+        // The regression itself. -5 is about as far back as the server's default past window reaches;
+        // -1 is the value the old `<= 0` test got wrong first, and the one a rider is most likely to
+        // catch, since every bus passes through it.
+        assertFalse(badgeEtaIsNow(-1))
+        assertFalse(badgeEtaIsNow(-5))
+    }
+}


### PR DESCRIPTION
Fixes #2180.

## The bug

`MyListRepository.toBadge` picked its "NOW" text with an unbounded `eta <= 0`, so **every** departed bus in the response got a badge claiming it was here now — not just one arriving in the current minute.

Not an edge case: `ObaWebService.arrivals(...)` sends only `minutesAfter` (no `minutesBefore`), so the server's own past window applies, and `convertArrivals` keeps negative ETAs whenever "Show departed buses" is on — the default. ETAs down to about -5 reach the badge in a stock configuration.

## The fix

Test `eta == 0L`, the cutoff `EtaPill` and the flat arrival row have used since `1d9bc9c5d` (2015-03-25). A departed bus now shows its negative minute count here the way it already does on those two surfaces.

**This is deliberately not #2177.** That issue proposed widening NOW to a 2-minute window across every surface and was closed as not-planned once the history showed `== 0` was longstanding rather than a regression. Nothing here introduces a window, and no surface other than the badge changes. The badge was simply the one place out of line:

| surface | before | after |
|---|---|---|
| `EtaStrip.EtaPill` | `eta == 0L` | unchanged |
| `ArrivalRows.EtaContent` | `eta == 0L` | unchanged |
| `MyListRepository.toBadge` | **`eta <= 0`, unbounded** | `eta == 0L` |
| `TripTrackingNotifications.metric` | `<= 0`, bounded at -2 upstream | unchanged |

The notification is left alone on purpose. Its `<= 0` can never see a departure older than -2, because `trackingOutcome` drops them past `TRACKING_LINGER` first — that window is a shipped product decision from #2166/#2173 about how long the tracking card holds a bus through boarding, and it is not this PR's to revisit.

## On the extraction

The cutoff moves into a pure `badgeEtaIsNow(eta)` rather than staying inline. The rest of `toBadge` needs a `Context` for its strings, and there is no Robolectric in this project, so nothing on this path could be asserted on without a device — which is how the wrong cutoff survived. The pure-core + `@VisibleForTesting` shape follows `DisplayFormat.formatEtaParts` and `EtaStrip.countBefore`.

## Not in scope

`fetchStopBadges` takes the first `MAX_ARRIVALS_PER_STOP` (3) from an ETA-sorted list that leads with departed trips, so a busy stop's card can be entirely buses that have already gone — whatever they are labelled. Whether this summary surface should honor "Show departed buses" at all is a product question, noted on #2180 rather than decided here.

## Testing

`BadgeEtaCutoffTest` (JVM): only an arrival in the current minute reads NOW; -1 and -5 do not. Both negative cases fail against the old `<= 0`.

Verified: `testObaGoogleDebugUnitTest` and `spotlessCheck` green. No device run — the change is a pure predicate with no rendering component, and its test covers it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Arrival badges now display “NOW” only when the estimated arrival time is exactly zero.
  * Departed arrivals with negative times now display their numeric minutes instead of incorrectly showing “NOW.”

* **Tests**
  * Added coverage for current, upcoming, and departed arrival badge states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->