### PR TITLE
Read OTP's `rentedBike` instead of inferring a rental leg from its endpoints (#2159)

### DIFF
--- a/onebusaway-android/src/main/graphql/otp2/Plan.graphql
+++ b/onebusaway-android/src/main/graphql/otp2/Plan.graphql
@@ -113,6 +113,16 @@ query Plan(
                     duration
                     distance
                     realTime
+                    # Whether the rider is on a hired vehicle for this leg — the fact that separates a
+                    # bikeshare ride from one on the rider's own bike, which `mode` does not (OTP calls
+                    # both plain `BICYCLE`). Stated by the server rather than inferred from the leg's
+                    # endpoints: OTP sets it from the routing state itself
+                    # (`StreetPathToLegsMapper` → `withRentedVehicle(firstState.isRentingVehicle())`),
+                    # so despite the legacy field name it means *any* rented vehicle, and it is non-null
+                    # on every street leg. It is null on a transit leg and on OTP's zero-distance
+                    # transfer legs — neither of which is a street leg at all (`Leg.rentedVehicle()`
+                    # defaults to null), so the adapter's null→false loses nothing.
+                    rentedBike
                     interlineWithPreviousLeg
                     start {
                         scheduledTime

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/Otp2PlanAdapters.kt
@@ -77,6 +77,9 @@ private fun PlanQuery.Leg.toTripLeg(): TripLeg = TripLeg(
     headsign = trip?.tripHeadsign,
     tripId = trip?.gtfsId,
     realTime = realTime ?: false,
+    // Null on every leg that isn't a street leg, which is where the question doesn't arise — see the
+    // field's note in Plan.graphql and on [TripLeg.rentedVehicle].
+    rentedVehicle = rentedBike ?: false,
     interlineWithPreviousLeg = interlineWithPreviousLeg ?: false,
     distance = distance ?: 0.0,
     duration = (duration ?: 0.0).seconds,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripPlanAdapters.kt
@@ -68,6 +68,10 @@ fun OtpLegDto.toTripLeg(): TripLeg = TripLeg(
     headsign = headsign,
     tripId = tripId,
     realTime = realTime ?: false,
+    // OTP1 publishes the same fact under the same name as OTP2 (see [TripLeg.rentedVehicle]), so the
+    // bikeshare/own-bike split works on this path too — which endpoint inference never gave it, OTP1's
+    // `/plan` carrying no rental facts beyond a bare `bikeShareId`.
+    rentedVehicle = rentedBike ?: false,
     distance = distance ?: 0.0,
     duration = (duration?.toLong() ?: 0L).seconds,
     departureDelay = (departureDelay?.toInt() ?: 0).seconds,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/OtpPlanModels.kt
@@ -116,6 +116,11 @@ data class OtpLegDto(
     val headsign: String? = null,
     val tripId: String? = null,
     val realTime: Boolean? = null,
+    // OTP1's `Leg.rentedBike`, the counterpart of OTP2's field of the same name: true when the rider
+    // is on a hired bike for the whole leg (`states[0].isBikeRenting() && states[last].isBikeRenting()`
+    // in OTP1's GraphPathToTripPlanConverter). Serialized on every leg, so absence here means a
+    // response that isn't OTP1's `/plan` at all.
+    val rentedBike: Boolean? = null,
     val distance: Double? = null,
     val duration: Double? = null,
     val departureDelay: Double? = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/model/TripItinerary.kt
@@ -87,6 +87,18 @@ data class TripLeg(
     // previous leg's card instead of emitting a spurious get-off/get-on pair (#2000). Always false on
     // the OTP1 path.
     val interlineWithPreviousLeg: Boolean = false,
+    // Whether the rider covers this leg on a *hired* vehicle — OTP's `rentedBike`, published on both
+    // protocols (OTP2 `Leg.rentedBike`, OTP1 `leg.rentedBike`). The one thing that separates a
+    // bikeshare ride from a ride on the rider's own bike, since OTP gives both the plain `BICYCLE`
+    // mode; read rather than inferred from the leg's endpoints (#2159). Despite the wire name it is
+    // not bike-specific on OTP2 — the server sets it from `isRentingVehicle()` — so the domain calls
+    // it what it means.
+    //
+    // False rather than null when the wire didn't say: OTP2 leaves it null on exactly the legs that
+    // aren't street legs (transit legs, zero-distance transfer legs), where "is the rider on a hired
+    // vehicle" has no meaning, and OTP1 states it on every leg. So there is no leg where the
+    // difference between "false" and "unstated" is a fact about the trip.
+    val rentedVehicle: Boolean = false,
     val distance: Double = 0.0,
     @Serializable(with = DurationSerializer::class) val duration: Duration = Duration.ZERO,
     @Serializable(with = DurationSerializer::class) val departureDelay: Duration = Duration.ZERO,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -19,7 +19,6 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
-import org.onebusaway.android.directions.model.TripVertexType
 import org.onebusaway.android.directions.model.routeDisplayLabel
 import org.onebusaway.android.map.layout.RouteBadgePath
 import org.onebusaway.android.map.layout.RouteBadgeRequest
@@ -71,17 +70,19 @@ internal data class ItineraryLegStyle(
 internal enum class ItineraryLegKind { WALK, BIKE, BIKESHARE, CAR, TRANSIT }
 
 /**
- * Which stroke this leg draws. A bikeshare leg is a `BICYCLE` leg that *starts* at a rental dock, which is
- * how OTP models one: walk to the dock, ride, dock again. It reads only the near end deliberately — this
- * asks what the rider is doing for the whole leg, not where its docks are, which is
- * [DirectionsMapController.bikeStationIdsFromItinerary]'s question (it reads both ends, because a ride has
- * a station to show at each).
+ * Which stroke this leg draws. A bikeshare leg is a `BICYCLE` leg OTP flagged as ridden on a hired vehicle
+ * ([TripLeg.rentedVehicle], the server's own `rentedBike`) — the same fact the option card's
+ * [streetMode][org.onebusaway.android.ui.tripresults.streetMode] reads, so the line under a card can't be
+ * a plain bike while the card's glyph says bikeshare. It used to be inferred from the leg *starting* at a
+ * rental place, which asked where the docks were in order to answer what the rider is doing (#2159); where
+ * the docks are is [DirectionsMapController.bikeStationIdsFromItinerary]'s question, and it still reads
+ * both endpoints, because a ride has a station to show at each.
  */
 internal fun TripLeg.legKind(): ItineraryLegKind = when {
     mode?.isTransit == true -> ItineraryLegKind.TRANSIT
     mode == TripMode.CAR -> ItineraryLegKind.CAR
     mode == TripMode.BICYCLE ->
-        if (from.vertexType == TripVertexType.BIKESHARE) ItineraryLegKind.BIKESHARE else ItineraryLegKind.BIKE
+        if (rentedVehicle) ItineraryLegKind.BIKESHARE else ItineraryLegKind.BIKE
     // Everything else walks, matching how the drawer's timeline classifies a leg it has no verb for.
     else -> ItineraryLegKind.WALK
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ModeSymbols.kt
@@ -19,7 +19,6 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
-import org.onebusaway.android.directions.model.TripVertexType
 
 /**
  * Builds the [ModeSymbol] sequence an itinerary option card shows (#2047) — the whole trip in travel
@@ -132,19 +131,22 @@ internal object ModeSymbols {
  * verb, everything else walks — so the timeline's header can't disagree with the step text the same
  * leg produced.
  *
- * A `BICYCLE` leg is a *rented* bike when either of its endpoints is a vehicle-rental place: OTP
- * populates `rentalVehicle`/`vehicleRentalStation` on exactly those places, which the adapter turns
- * into [TripVertexType.BIKESHARE] (see `Otp2PlanAdapters.inferVertexType`), so reading it is a
- * structural fact rather than a guess about the leg. Either endpoint counts, not just the pick-up: a
- * dockless rental can be left at a plain street corner and a docked one starts at a station, and both
- * are the same act to the rider.
+ * A `BICYCLE` leg is a *rented* bike when OTP says the rider is on a hired one — [TripLeg.rentedVehicle],
+ * the server's own `rentedBike`, which it sets from the routing state that produced the leg. This used
+ * to be read off the leg's endpoints instead (either one being a vehicle-rental place), which is a
+ * structural signal rather than a guess but still an inference about a fact the server states outright
+ * (#2159). Reading the stated field also gives the OTP1 path the split, which endpoint metadata alone
+ * could not.
+ *
+ * The two were checked against the live OTP2 deployment before the switch (2026-08-06, 60 bikeshare
+ * plans over 784 legs) and never disagreed on a `BICYCLE` leg: all 58 rental rides were both flagged
+ * and endpoint-marked, and an own-bike plan's ride came back flagged false with no rental endpoint.
+ * They disagree only on the *walk* legs either side of a rental ride — 58 of them, each ending at the
+ * hired vehicle and so endpoint-marked, none flagged, because a walk to a bike is not ridden on one —
+ * which this never asked about, since only `BICYCLE` reaches the branch.
  */
 internal fun TripLeg.streetMode(): StreetMode = when (mode) {
-    TripMode.BICYCLE -> if (from.vertexType == TripVertexType.BIKESHARE || to.vertexType == TripVertexType.BIKESHARE) {
-        StreetMode.BIKESHARE
-    } else {
-        StreetMode.BIKE
-    }
+    TripMode.BICYCLE -> if (rentedVehicle) StreetMode.BIKESHARE else StreetMode.BIKE
     TripMode.CAR -> StreetMode.CAR
     else -> StreetMode.WALK
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/RentalPickups.kt
@@ -116,10 +116,19 @@ enum class RentalVehicleKind { BIKE, EBIKE, CARGO_BIKE, ELECTRIC_CARGO_BIKE, SCO
  *
  * Either endpoint's rental counts, and the pickup wins when both do: a docked trip starts and ends at a
  * station, a dockless one may start at a vehicle and end nowhere in particular, and it is where the
- * rider *gets* the bike that decides whether they're looking for a dock. That mirrors
- * [streetMode][org.onebusaway.android.ui.tripresults.streetMode], which reads the same two endpoints to
- * decide the leg is a rental at all, so a leg cannot be a bikeshare leg with no rental to show or the
- * other way round.
+ * rider *gets* the bike that decides whether they're looking for a dock.
+ *
+ * **A rental leg with no rental endpoint draws the bikeshare glyph and no operator chip**, and that is
+ * the intended degradation (#2159). Whether the leg is a rental is now OTP's own
+ * [rentedVehicle][TripLeg.rentedVehicle] flag, read by
+ * [streetMode][org.onebusaway.android.ui.tripresults.streetMode]; everything the row says *about* the
+ * vehicle — whose it is, what kind, which dock, where the unlock tap goes — exists only on the endpoint
+ * places, so a leg flagged as hired whose endpoints carry no rental has the fact but not the facts.
+ * Saying "you ride a shared bike here" without naming an operator is the honest reading of that, and
+ * strictly more than the plain-bike row this leg would otherwise get: it beats both inventing an
+ * operator and hiding a rental the server stated. The live OTP2 deployment does not produce such a leg
+ * today (every flagged ride there also has a rental endpoint — see [streetMode]); the OTP1 path reaches
+ * the same row by the other route, its endpoints carrying a bare `bikeShareId` with no network to name.
  */
 internal fun TripLeg.rentalPickup(): RentalPickup? = if (streetMode() == StreetMode.BIKESHARE) {
     rentalPickup(from.rental ?: to.rental)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -268,10 +268,10 @@ enum class TerminalKind { START, ARRIVE }
  * leg the rider *rents*, split out because the two are different acts to the rider (find a dock vs.
  * take the bike you brought) and the app draws them with different symbols.
  *
- * [BIKESHARE] is not a wire mode: OTP calls such a leg `BICYCLE` like any other and says it's a rental
- * by giving the leg a vehicle-rental endpoint ([TripVertexType.BIKESHARE][
- * org.onebusaway.android.directions.model.TripVertexType]) — a structural fact off the wire, not a
- * guess. See `ModeSymbols.streetMode`.
+ * [BIKESHARE] is not a wire *mode*: OTP calls such a leg `BICYCLE` like any other and says it's a rental
+ * on a separate field, [TripLeg.rentedVehicle][org.onebusaway.android.directions.model.TripLeg] (its own
+ * `rentedBike`, on both OTP protocols) — read as stated rather than inferred from the leg's endpoints
+ * (#2159). See `ModeSymbols.streetMode`.
  */
 enum class StreetMode { WALK, BIKE, BIKESHARE, CAR }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/Otp2PlanDecodeTest.kt
@@ -61,6 +61,9 @@ class Otp2PlanDecodeTest {
             duration = 120.0,
             distance = 123.4,
             realTime = null,
+            // The approach walk to a hired bike is not itself ridden on one — OTP flags it false, and
+            // this leg's `to` isn't a rental place either.
+            rentedBike = false,
             interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:02:00-07:00", estimated = null),
@@ -99,6 +102,9 @@ class Otp2PlanDecodeTest {
             duration = 600.0,
             distance = null,
             realTime = true,
+            // Null on every transit leg: OTP's `rentedVehicle` is a street-leg fact and defaults to
+            // null elsewhere, which the adapter reads as "not a hired vehicle".
+            rentedBike = null,
             interlineWithPreviousLeg = true,
             start = PlanQuery.Start(
                 scheduledTime = "2026-07-11T10:02:00-07:00",
@@ -315,6 +321,46 @@ class Otp2PlanDecodeTest {
     }
 
     /**
+     * The rental flag is read as OTP states it, on the leg itself (#2159) — the fact that separates a
+     * bikeshare ride from one on the rider's own bike, which `mode` cannot (OTP calls both `BICYCLE`).
+     * Null is not a leg whose rental status is unknown: OTP leaves it null on exactly the legs that
+     * aren't street legs, where the question doesn't arise, so it maps to false.
+     */
+    @Test
+    fun mapsTheRentedVehicleFlagAsStated() {
+        fun rentedVehicleOf(rentedBike: Boolean?) = planDataWithSingleLeg(mode = Mode.BICYCLE, rentedBike = rentedBike)
+            .toTripItineraries()[0]
+            .legs[0]
+            .rentedVehicle
+
+        assertTrue(rentedVehicleOf(true))
+        assertFalse(rentedVehicleOf(false))
+        assertFalse(rentedVehicleOf(null))
+        // ...and it doesn't come from the endpoints: a leg that starts at a rental station but wasn't
+        // flagged is the rider's own bike, parked beside a dock.
+        val atADockButNotFlagged = planDataWithSingleLeg(
+            mode = Mode.BICYCLE,
+            fromPlace = place(
+                name = "Pine St & 3rd Ave",
+                lat = 47.61,
+                lon = -122.33,
+                vehicleRentalStation = PlaceFields.VehicleRentalStation(
+                    stationId = "seattle_bikes:42",
+                    name = "Pine St & 3rd Ave",
+                    rentalNetwork = PlaceFields.RentalNetwork1(
+                        __typename = "VehicleRentalNetwork",
+                        rentalNetworkFields = network("seattle_bikes")
+                    ),
+                    rentalUris = null
+                )
+            ),
+            rentedBike = false
+        ).toTripItineraries()[0].legs[0]
+        assertFalse(atADockButNotFlagged.rentedVehicle)
+        assertEquals(TripVertexType.BIKESHARE, atADockButNotFlagged.from.vertexType)
+    }
+
+    /**
      * A docked pickup — OTP's other rental shape. Both shapes land on one domain type, and the
      * station's name is what survives of the difference: it is the dock the row sends the rider to.
      */
@@ -398,13 +444,15 @@ class Otp2PlanDecodeTest {
         mode: Mode,
         itineraryStart: String? = "2026-07-11T10:00:00-07:00",
         stopCalls: List<PlanQuery.StopCall> = emptyList(),
-        fromPlace: PlaceFields = place(name = "X", lat = 1.0, lon = 2.0)
+        fromPlace: PlaceFields = place(name = "X", lat = 1.0, lon = 2.0),
+        rentedBike: Boolean? = null
     ): PlanQuery.Data {
         val leg = PlanQuery.Leg(
             mode = mode,
             duration = 60.0,
             distance = 10.0,
             realTime = false,
+            rentedBike = rentedBike,
             interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:01:00-07:00", estimated = null),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/OtpPlanDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/OtpPlanDecodeTest.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.api
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -151,6 +152,33 @@ class OtpPlanDecodeTest {
         val error = response.error!!
         assertEquals(404, error.id)
         assertEquals("Path not found", error.msg)
+    }
+
+    /**
+     * OTP1 publishes the same `rentedBike` OTP2 does, on every leg (#2159) — so this path gets the
+     * bikeshare/own-bike split too, which the endpoint metadata alone never gave it: OTP1's `/plan`
+     * carries a bare `bikeShareId` and no network, vehicle type or rental URI at all.
+     */
+    @Test
+    fun mapsTheRentedVehicleFlag() {
+        val body = """
+            { "plan": { "itineraries": [ { "startTime": 1, "legs": [
+              { "mode": "BICYCLE", "startTime": 1, "endTime": 2, "rentedBike": true,
+                "from": { "name": "X", "vertexType": "BIKESHARE", "bikeShareId": "bs_9" },
+                "to": { "name": "Y" } },
+              { "mode": "BICYCLE", "startTime": 1, "endTime": 2, "rentedBike": false,
+                "from": { "name": "X" }, "to": { "name": "Y" } },
+              { "mode": "WALK", "startTime": 1, "endTime": 2,
+                "from": { "name": "X" }, "to": { "name": "Y" } }
+            ] } ] } }
+        """.trimIndent()
+
+        val legs = OtpPlanParser.parse(body).plan!!.itineraries[0].toTripItinerary().legs
+        assertTrue(legs[0].rentedVehicle)
+        assertFalse(legs[1].rentedVehicle)
+        // A leg that didn't state it isn't one whose rental status is unknown — OTP1 states it on
+        // every leg, so absence means a response that isn't OTP1's `/plan`.
+        assertFalse(legs[2].rentedVehicle)
     }
 
     /** An unknown enum string must degrade to null rather than blow up the whole parse. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -35,14 +35,26 @@ class ItineraryLegStyleTest {
     private val bikeShareDock = TripPlace(vertexType = TripVertexType.BIKESHARE, rental = TripVehicleRental(id = "dock-1"))
 
     @Test
-    fun `a bicycle leg from a rental dock is bikeshare, from anywhere else own-bike`() {
+    fun `a bicycle leg OTP flagged as hired is bikeshare, any other is own-bike`() {
         assertEquals(
             ItineraryLegKind.BIKESHARE,
-            TripLeg(mode = TripMode.BICYCLE, from = bikeShareDock).legKind()
+            TripLeg(mode = TripMode.BICYCLE, rentedVehicle = true, from = bikeShareDock).legKind()
         )
         assertEquals(
             ItineraryLegKind.BIKE,
             TripLeg(mode = TripMode.BICYCLE, from = TripPlace(name = "Home")).legKind()
+        )
+        // The flag, not the dock the leg starts at (#2159): a rider setting off from beside a rental
+        // dock on their own bike is riding their own bike, and OTP is the one that knows which.
+        assertEquals(
+            ItineraryLegKind.BIKE,
+            TripLeg(mode = TripMode.BICYCLE, from = bikeShareDock).legKind()
+        )
+        // ...and a hired ride keeps its stroke wherever it starts, which a dockless one may be nowhere
+        // in particular.
+        assertEquals(
+            ItineraryLegKind.BIKESHARE,
+            TripLeg(mode = TripMode.BICYCLE, rentedVehicle = true, from = TripPlace(name = "Kerb")).legKind()
         )
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/Otp2PlanResolveTest.kt
@@ -347,6 +347,7 @@ class Otp2PlanResolveTest {
             duration = 2400.0,
             distance = 3200.0,
             realTime = null,
+            rentedBike = false,
             interlineWithPreviousLeg = null,
             start = PlanQuery.Start(scheduledTime = "2026-07-11T10:00:00-07:00", estimated = null),
             end = PlanQuery.End(scheduledTime = "2026-07-11T10:40:00-07:00", estimated = null),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ModeSymbolsTest.kt
@@ -51,19 +51,16 @@ class ModeSymbolsTest {
     private fun walk(meters: Double) = TripLeg(mode = TripMode.WALK, distance = meters)
 
     /**
-     * A bicycle leg. [rentedAt] says which endpoint (if either) is a vehicle-rental place — the whole
-     * signal that separates a shared bike from the rider's own.
+     * A bicycle leg. [rented] is OTP's own `rentedBike` for it — the whole signal that separates a
+     * shared bike from the rider's own (#2159). [rentalEndpoint] independently marks the leg's `to` as
+     * a vehicle-rental place, so the tests can put the two in conflict; nothing but [rented] decides.
      */
-    private fun bike(meters: Double, rentedAt: Endpoint = Endpoint.NEITHER) = TripLeg(
+    private fun bike(meters: Double, rented: Boolean = false, rentalEndpoint: Boolean = false) = TripLeg(
         mode = TripMode.BICYCLE,
+        rentedVehicle = rented,
         distance = meters,
-        from = TripPlace(vertexType = vertexTypeFor(rentedAt == Endpoint.FROM)),
-        to = TripPlace(vertexType = vertexTypeFor(rentedAt == Endpoint.TO))
+        to = TripPlace(vertexType = if (rentalEndpoint) TripVertexType.BIKESHARE else TripVertexType.NORMAL)
     )
-
-    private enum class Endpoint { FROM, TO, NEITHER }
-
-    private fun vertexTypeFor(rental: Boolean) = if (rental) TripVertexType.BIKESHARE else TripVertexType.NORMAL
 
     /** The symbols as a readable sequence: a street glyph's mode, or a ride's route names. */
     private fun symbolsOf(legs: List<TripLeg>): List<Any> = ModeSymbols.forLegs(legs, legs.map { emptyList() }).map { it.describe() }
@@ -110,7 +107,7 @@ class ModeSymbolsTest {
     fun aStreetOnlyTripKeepsOneSymbolEvenBelowTheThreshold() {
         assertEquals(listOf(StreetMode.WALK), symbolsOf(listOf(walk(NEAR))))
         // The longest leg names the trip, so a stroll to a rented bike doesn't relabel the ride a walk.
-        assertEquals(listOf(StreetMode.BIKESHARE), symbolsOf(listOf(walk(NEAR), bike(NEAR * 2, rentedAt = Endpoint.FROM), walk(NEAR))))
+        assertEquals(listOf(StreetMode.BIKESHARE), symbolsOf(listOf(walk(NEAR), bike(NEAR * 2, rented = true), walk(NEAR))))
     }
 
     @Test
@@ -123,19 +120,25 @@ class ModeSymbolsTest {
     fun aBikeLegSaysWhetherTheBikeIsRented() {
         assertEquals(
             listOf(StreetMode.WALK, StreetMode.BIKESHARE, StreetMode.WALK),
-            symbolsOf(listOf(longWalk, bike(FAR, rentedAt = Endpoint.FROM), longWalk))
+            symbolsOf(listOf(longWalk, bike(FAR, rented = true), longWalk))
         )
         assertEquals(listOf(StreetMode.BIKE), symbolsOf(listOf(bike(FAR))))
     }
 
     /**
-     * Either endpoint marks the rental, not just the pick-up: a dockless bike can be left at a plain
-     * street corner and a docked one is returned to a station, so a leg that only *ends* at a rental
-     * place is the same act to the rider.
+     * The flag decides, not the leg's endpoints (#2159). A ride OTP flagged is a rented bike even where
+     * it starts and ends nowhere in particular — a dockless one can be picked up and left at a plain
+     * street corner — and a ride it didn't flag stays the rider's own bike even when it happens to end
+     * at a rental place, which is a bike parked there rather than the one being ridden.
      */
     @Test
-    fun aBikeReturnedToARentalPlaceIsAlsoARentedBike() {
-        assertEquals(listOf(StreetMode.BIKESHARE), symbolsOf(listOf(bike(FAR, rentedAt = Endpoint.TO))))
+    fun theRentalFlagDecides_notTheLegsEndpoints() {
+        assertEquals(listOf(StreetMode.BIKESHARE), symbolsOf(listOf(bike(FAR, rented = true))))
+        assertEquals(listOf(StreetMode.BIKE), symbolsOf(listOf(bike(FAR, rentalEndpoint = true))))
+        assertEquals(
+            listOf(StreetMode.BIKESHARE),
+            symbolsOf(listOf(bike(FAR, rented = true, rentalEndpoint = true)))
+        )
     }
 
     /** Two street legs in a row are one act to the rider; the card must not stutter "walk, walk". */
@@ -199,7 +202,7 @@ class ModeSymbolsTest {
             mapOf(StreetMode.WALK to 900.0, StreetMode.BIKESHARE to 2000.0),
             listOf(
                 walk(FAR),
-                bike(2000.0, rentedAt = Endpoint.FROM),
+                bike(2000.0, rented = true),
                 walk(300.0),
                 transit("8")
             ).streetDistancesMeters()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RentalPickupsTest.kt
@@ -158,6 +158,7 @@ class RentalPickupsTest {
     fun `the pickup endpoint wins over the drop-off one`() {
         val leg = TripLeg(
             mode = TripMode.BICYCLE,
+            rentedVehicle = true,
             from = place(rental(networkId = "lime_seattle")),
             to = place(rental(networkId = "some_city_bikes", stationName = "Dock"))
         )
@@ -172,6 +173,7 @@ class RentalPickupsTest {
         // with no rental record of its own; the row then has the dock to name.
         val leg = TripLeg(
             mode = TripMode.BICYCLE,
+            rentedVehicle = true,
             from = TripPlace(name = "Origin"),
             to = place(rental(networkId = "some_city_bikes", stationName = "Dock"))
         )
@@ -182,12 +184,40 @@ class RentalPickupsTest {
     fun `a plain walk or an own-bike leg has no rental`() {
         assertNull(TripLeg(mode = TripMode.WALK, from = TripPlace(name = "Origin")).rentalPickup())
         assertNull(TripLeg(mode = TripMode.BICYCLE, from = TripPlace(name = "Home")).rentalPickup())
+        // Not even one that ends where a bike happens to be parked: OTP says whether the rider hired
+        // one, and on this leg it said no (#2159).
+        assertNull(
+            TripLeg(
+                mode = TripMode.BICYCLE,
+                from = TripPlace(name = "Home"),
+                to = place(rental(networkId = "lime_seattle"))
+            ).rentalPickup()
+        )
+    }
+
+    /**
+     * The deliberate degradation of reading OTP's flag instead of the endpoints (#2159): the leg is a
+     * rental — it gets the bikeshare glyph — but everything the row *says* about the vehicle lives on
+     * the endpoint places, so with none there is no operator to chip and no unlock to offer.
+     */
+    @Test
+    fun `a rental leg with no rental endpoint draws the bikeshare glyph and no chip`() {
+        val leg = TripLeg(
+            mode = TripMode.BICYCLE,
+            rentedVehicle = true,
+            from = TripPlace(name = "Origin"),
+            to = TripPlace(name = "Destination")
+        )
+        assertEquals(StreetMode.BIKESHARE, leg.streetMode())
+        assertNull(leg.rentalPickup())
     }
 
     @Test
     fun `the walk to the bike is not itself a rental row`() {
         // Its `to` *is* the rental vehicle — OTP ends the approach walk there — but the rider is told
-        // whose bike it is on the row where they ride it, once, not on both legs that touch it.
+        // whose bike it is on the row where they ride it, once, not on both legs that touch it. OTP
+        // agrees: on the live deployment the approach walk comes back `rentedBike: false` even though
+        // it ends at the hired vehicle (#2159), which is exactly the leg it is.
         val walk = TripLeg(
             mode = TripMode.WALK,
             from = TripPlace(name = "Origin"),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -199,22 +199,19 @@ class TripLogBuilderTest {
         assertEquals(StreetMode.BIKE, modeOf(walkLeg.copy(mode = TripMode.BICYCLE)))
         assertEquals(StreetMode.CAR, modeOf(walkLeg.copy(mode = TripMode.CAR)))
         assertEquals(StreetMode.WALK, modeOf(walkLeg.copy(mode = TripMode.WALK)))
-        // A bike picked up at — or returned to — a rental place is a *shared* bike, and draws the
-        // bikeshare glyph rather than the rider's-own-bike one (#2047).
+        // A bike OTP says the rider hired is a *shared* bike, and draws the bikeshare glyph rather
+        // than the rider's-own-bike one (#2047) — read off the leg's own flag (#2159), so the
+        // timeline can't call a leg a rental that the option card above it calls an own-bike ride.
         assertEquals(
             StreetMode.BIKESHARE,
-            modeOf(
-                walkLeg.copy(
-                    mode = TripMode.BICYCLE,
-                    from = walkLeg.from.copy(vertexType = TripVertexType.BIKESHARE)
-                )
-            )
+            modeOf(walkLeg.copy(mode = TripMode.BICYCLE, rentedVehicle = true))
         )
         assertEquals(
             StreetMode.BIKESHARE,
             modeOf(
                 walkLeg.copy(
                     mode = TripMode.BICYCLE,
+                    rentedVehicle = true,
                     to = walkLeg.to.copy(vertexType = TripVertexType.BIKESHARE)
                 )
             )
@@ -227,6 +224,7 @@ class TripLogBuilderTest {
         // scooter nothing about whose it is or which app unlocks it (#2150).
         val leg = walkLeg.copy(
             mode = TripMode.BICYCLE,
+            rentedVehicle = true,
             from = walkLeg.from.copy(
                 vertexType = TripVertexType.BIKESHARE,
                 rental = TripVehicleRental(


### PR DESCRIPTION
Closes #2159.

`ModeSymbols.streetMode()` decided a `BICYCLE` leg was bikeshare by checking whether either endpoint was a vehicle-rental place. Structural rather than a guess — but OTP publishes the fact outright as `rentedBike` on the leg, in both OTP 1.x REST and 2.x GraphQL, and it was already in our pinned schema, unqueried. This reads the field the server states, per CLAUDE.md's "carry an explicit field, don't infer".

## What changed

- `rentedBike` selected in `Plan.graphql`; added to `OtpLegDto` (OTP1).
- Carried on `TripLeg` as **`rentedVehicle`** — what it means, rather than the legacy wire name: OTP2 sets it from `isRentingVehicle()`, so it covers any hired vehicle, not just bikes.
- Mapped in both `Otp2PlanAdapters` and `TripPlanAdapters`. Null → false: OTP2 leaves it null on exactly the legs that aren't street legs (transit legs, zero-distance transfer legs), where the question doesn't arise; OTP1 states it on every leg.
- Both `streetMode()` and the map's `legKind()` read it. They were two separate copies of the same inference (the map's read only `from`), so the card's glyph, the option card's per-mode distances (#2122) and the map's leg stroke now come from one stated fact and can't disagree.
- The OTP1 path gets the bikeshare/own-bike split for the first time — its `/plan` carries no rental endpoint metadata beyond a bare `bikeShareId`.

`DirectionsMapController.bikeStationIdsFromItinerary` still reads both endpoints: which stations to show on the map genuinely *is* an endpoint question.

## Do the two ever disagree on live data?

Checked before switching, against the Puget Sound OTP2 deployment (2026-08-06, 60 bikeshare plans over 30 origin/destination pairs, 784 legs):

| mode | `rentedBike` | endpoint is a rental place | legs |
|---|---|---|---|
| WALK | false | false | 365 |
| BUS | null | false | 160 |
| TRAM | null | false | 123 |
| BICYCLE | **true** | **true** | 58 |
| WALK | **false** | **true** | 58 |
| WALK | null | false | 20 |

- **They never disagree on a `BICYCLE` leg** — the only legs `streetMode()` asked about. All 58 rental rides were both flagged and endpoint-marked; a separate own-bike (`BICYCLE` direct) plan returned its ride flagged false with no rental endpoint, which is the case the old rule also got right.
- The 58 disagreements are all the **approach walk**: it ends at the hired vehicle, so it is endpoint-marked, and OTP flags it `false` because a walk to a bike is not ridden on one. Correct on both counts, and `streetMode()` never reached that branch for a `WALK` leg.
- `rentedBike` is null only on non-street legs (transit, and one 0 m transfer leg), matching OTP's own `Leg.rentedVehicle()` default — hence null → false.

The OTP1 counterpart **could not be sampled live**: Tampa Bay is the only OTP1 region with `supportsOtpBikeshare`, and its OTP host no longer resolves. That path rests on OTP1's source (`leg.rentedBike = states[0].isBikeRenting() && states[states.length - 1].isBikeRenting()`, `GraphPathToTripPlanConverter`) and on the field being present on every leg of a live OTP1 response (verified against Puget Sound's OTP1 server, which has no bikeshare configured, so every leg came back `false`).

## A rental leg with no rental endpoint

It draws the bikeshare glyph and no operator chip — deliberately (issue task 3). `RentalPickups.rentalPickup()` hangs everything the row shows — operator, vehicle kind, dock name, unlock link — off `from.rental ?: to.rental`, so a leg flagged as hired whose endpoints carry no rental has the fact but not the facts. Saying "you ride a shared bike here" without naming an operator beats both inventing an operator and hiding a rental the server stated, and it is strictly more than the plain-bike row that leg used to get. Documented at the call site and pinned by a test. The live OTP2 deployment produces no such leg today; the OTP1 path reaches the same row from the other side, its endpoints carrying a `bikeShareId` with no network to name.

## Testing

- `ModeSymbolsTest` now puts the flag and the endpoints in conflict and asserts only the flag decides; `ItineraryLegStyleTest`, `TripLogBuilderTest`, `RentalPickupsTest` updated the same way, plus the new degradation test.
- Decode tests on both protocols pin the wire→domain mapping, including null → false.
- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, `testObaGoogleDebugUnitTest`, `testObaMaplibreDebugUnitTest`, `spotlessCheck` all pass locally. Lint left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)