### PR TITLE
Bundle RouteMapController's change-guard inputs (#2149)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -315,21 +315,19 @@ class MapViewModel @Inject constructor(
     }
 
     /**
-     * Enter route mode for [routeId], framing its bounding box unless [zoomToRoute] is false (a silent
-     * restore). Callers ([toRoute] and the restore in `init`) only ever pass a route different from the
-     * current one — re-selecting the active route is handled (re-framed) by [toRoute].
+     * Enter route mode for [request]'s route, framing its bounding box unless [zoomToRoute] is false (a
+     * silent restore). Callers ([toRoute] and the restore in `init`) only ever pass a route different from
+     * the current one — re-selecting the active route is handled (re-framed) by [toRoute].
+     *
+     * The request is handed to the controller whole, exactly as [RouteMapController.reframe] takes it, so
+     * a field added to [ShowRouteRequest] can't be honoured by one entry and dropped by the other (#1797,
+     * #2149). The remaining parameters are what *this view* contributes on top of the request:
+     * whether to keep the current stop focus / drawn itinerary, and what the route is drawn with.
      */
     private fun enterRoute(
-        routeId: String,
+        request: ShowRouteRequest,
         zoomToRoute: Boolean,
-        directionStopId: String?,
-        initialDirectionId: Int? = null,
-        focusTripId: String? = null,
         preserveStopFocus: Boolean = false,
-        riddenSpans: List<RiddenSpan> = emptyList(),
-        extraSegments: List<RouteFocusSegment> = emptyList(),
-        alightStopId: String? = null,
-        directionHeadsign: String? = null,
         itineraryContext: List<RoutePolyline> = emptyList(),
         preserveItinerary: Boolean = false,
         palette: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
@@ -339,17 +337,10 @@ class MapViewModel @Inject constructor(
         // Preserve based on the transition's origin rather than the context list: an itinerary whose
         // legs have no drawable geometry still has start/end pins and retained controller state to keep.
         leaveCurrentView(clearStopFocus = !preserveStopFocus, keepItinerary = preserveItinerary)
-        persistRoute(routeId, directionStopId, initialDirectionId)
+        persistRoute(request.routeId, request.directionStopId, request.initialDirectionId)
         routeController.start(
-            routeId = routeId,
+            request = request,
             zoomToRoute = zoomToRoute,
-            directionStopId = directionStopId,
-            initialDirectionId = initialDirectionId,
-            focusTripId = focusTripId,
-            riddenSpans = riddenSpans,
-            extraSegments = extraSegments,
-            alightStopId = alightStopId,
-            directionHeadsign = directionHeadsign,
             itineraryContext = itineraryContext,
             palette = palette
         )
@@ -510,16 +501,9 @@ class MapViewModel @Inject constructor(
             routeController.reframe(request, frameRoute)
         } else {
             enterRoute(
-                request.routeId,
+                request,
                 zoomToRoute = frameRoute,
-                directionStopId = request.directionStopId,
-                initialDirectionId = request.initialDirectionId,
-                focusTripId = request.focusTripId,
                 preserveStopFocus = stopScoped,
-                riddenSpans = request.riddenSpans,
-                extraSegments = request.extraSegments,
-                alightStopId = request.alightStopId,
-                directionHeadsign = request.directionHeadsign,
                 // Read before entering: the transition tears the drawn itinerary down, and this is what
                 // survives it.
                 itineraryContext = if (withinDirections) directionsController.contextPolylines() else emptyList(),
@@ -711,11 +695,13 @@ class MapViewModel @Inject constructor(
             // deliberately doesn't write it, so a process-death restore keeps the saved camera rather
             // than re-framing the route.
             enterRoute(
-                restoreRouteId,
+                ShowRouteRequest(
+                    routeId = restoreRouteId,
+                    directionStopId = savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID],
+                    // A user-selected direction persisted before process death wins over the anchor stop.
+                    initialDirectionId = savedStateHandle[MapParams.ROUTE_DIRECTION_ID]
+                ),
                 zoomToRoute = savedStateHandle[MapParams.ZOOM_TO_ROUTE] ?: false,
-                directionStopId = savedStateHandle[MapParams.ROUTE_DIRECTION_STOP_ID],
-                // A user-selected direction persisted before process death wins over the anchor stop.
-                initialDirectionId = savedStateHandle[MapParams.ROUTE_DIRECTION_ID],
                 preserveStopFocus = false
             )
         } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -58,6 +58,69 @@ import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.toGeoPoint
 
 /**
+ * The part of a [ShowRouteRequest] that describes **the ride drawn on the route** — the trip-plan leg a
+ * rider drilled into — as one value, so [RouteMapController.reframe] can decide "is this a different
+ * ride?" with a single comparison instead of a hand-written chain over four fields it also has to
+ * assign by hand (#2149).
+ *
+ * [RouteMapController.start] and [RouteMapController.reframe] both take it from a request via [of], so
+ * the two entries cannot honour different fields — the divergence #1797 fixed one layer up, and the
+ * reason `reframe`'s KDoc used to warn that `start`'s parameter list needed a matching update.
+ *
+ * **Adding a field here is the whole change**: it joins the guard, both entries and the redraw
+ * together. `RouteMapGuardInputsTest` pins this against [ShowRouteRequest]'s own field set, so a new
+ * request field has to be sorted into "part of the ride" (here) or "handled by name in `reframe`"
+ * rather than silently ignored by one of them.
+ *
+ * Compared by value, not identity: the spans/segments are rebuilt per request by the launcher, so an
+ * identity compare would report a change on every re-tap and redraw the same ride.
+ */
+internal data class RouteFocusSpec(
+    val riddenSpans: List<RiddenSpan>,
+    val extraSegments: List<RouteFocusSegment>,
+    val alightStopId: String?,
+    val directionHeadsign: String?
+) {
+    companion object {
+        /** No leg drilled in — every non-directions route launch, and the state [RouteMapController.stop] returns to. */
+        val None = RouteFocusSpec(emptyList(), emptyList(), null, null)
+
+        fun of(request: ShowRouteRequest) = RouteFocusSpec(
+            riddenSpans = request.riddenSpans,
+            extraSegments = request.extraSegments,
+            alightStopId = request.alightStopId,
+            directionHeadsign = request.directionHeadsign
+        )
+    }
+}
+
+/**
+ * Everything a drawn vehicle's colour is resolved from, as one value (#2149).
+ *
+ * The memo behind [RouteMapController.displayedRouteColor] is invalidated by comparing this whole, and
+ * the resolution it guards reads its inputs from nowhere else — so "an input the guard forgot" is not a
+ * mistake that can be made here. It used to be three separate fields compared by a hand-written `||`
+ * chain, while the resolution took one input as a parameter and reached for another as a field: a
+ * fourth input had two places to register and neither was enforced. A miss shows up as vehicles drawn
+ * in a stale route colour until the next poll — a plausible-looking wrong answer, not a visible failure.
+ *
+ * The `response` a vehicle resolves against is not a field here because it is a *projection* of this
+ * value: every vehicle is paired with the poll it came out of, which is either [poll] or one of
+ * [extras] (an extra route's vehicle resolves its trip/route out of that route's references, #2043).
+ *
+ * Compared by value, not identity: [poll]/[extras] hold instances a landed poll replaces wholesale and
+ * [palette] is set once per session, so value and identity agree for them, while [assignment] is a
+ * small map the adjacency layer republishes — for it, identity would clear the memo more often than
+ * the colours actually change.
+ */
+internal data class RouteColorInputs(
+    val poll: VehiclePoll,
+    val extras: Map<String, VehiclePoll>,
+    val assignment: Map<RouteDirectionKey, Int>,
+    val palette: RouteLinePalette
+)
+
+/**
  * Drives the home map while it is showing a single route. Given a route id (via [start]), it loads the
  * route's shape and metadata, draws the shape into [MapHost.renderState], hands the route's stops to the
  * shared [stopsController] (so they accumulate and focus like nearby stops), and continuously tracks the
@@ -129,12 +192,18 @@ class RouteMapController(
     var directionStopId: String? = null
         private set
 
+    // The trip-plan leg this session draws, as one value: which spans are ridden, which extra routes ride
+    // along, where the rider gets off, which direction they board. [RouteFocusSpec.None] for every
+    // non-directions route launch. Set from a [ShowRouteRequest] in start() and reframe() — one
+    // assignment, so no redraw can key off a fresh span list against a stale alighting bound — and
+    // restored to None in stop(). The four reads below are derived from it, never separately assigned.
+    private var routeFocus: RouteFocusSpec = RouteFocusSpec.None
+
     // The board→alight ride of a trip-plan transit leg drilled into route focus, drawn thick over the full
     // route (empty for every non-directions route launch) — one span per route it is ridden on, so a
-    // stay-aboard interline keeps each route's own colour and its cutover marks (see [RiddenSpan]). Set in
-    // start(); overlaid last in publishMapPresentation so it survives re-publishes (vehicle polls,
-    // direction changes).
-    private var riddenSpans: List<RiddenSpan> = emptyList()
+    // stay-aboard interline keeps each route's own colour and its cutover marks (see [RiddenSpan]).
+    // Overlaid last in publishMapPresentation so it survives re-publishes (vehicle polls, direction changes).
+    private val riddenSpans: List<RiddenSpan> get() = routeFocus.riddenSpans
 
     // The same ride as one path — where the rider boards and alights, what to frame, which stops and
     // vehicles are on it. Those questions are about the ride, not about which route each part of it is
@@ -155,17 +224,17 @@ class RouteMapController(
 
     // Additional route/directions shown with the primary route: either stay-aboard continuations (#2000)
     // or interchangeable routes (#2042). Their relationship controls vehicle filtering; both contribute
-    // their relevant shape and stops. Set in start(); the maps/polls below are rebuilt as routes load.
-    private var extraSegments: List<RouteFocusSegment> = emptyList()
+    // their relevant shape and stops. The maps/polls below are rebuilt as routes load.
+    private val extraSegments: List<RouteFocusSegment> get() = routeFocus.extraSegments
 
     // The OBA stop where the rider leaves the whole ride (null outside leg focus, or when the OTP→OBA
     // resolution failed). The one bound the queue-driven selection needs: admission comes from the
     // boarding stop's arrivals, so this only has to answer "is this ride over yet".
-    private var alightStopId: String? = null
+    private val alightStopId: String? get() = routeFocus.alightStopId
 
     // The planned leg's headsign, used to pick the ridden direction group among the boarding stop's
     // arrival rows — the same pick the leg card's ETA strip makes.
-    private var directionHeadsign: String? = null
+    private val directionHeadsign: String? get() = routeFocus.directionHeadsign
 
     // Distinct other route ids to load and poll alongside the leader. A self-interline segment reuses the
     // leader route, so it is excluded (its shape/stops/vehicles already come from the leader).
@@ -261,9 +330,9 @@ class RouteMapController(
     // is replaced — including extraPolls, since a composite's vehicles resolve out of several responses
     // and a per-call identity check would clear the memo on every alternation.
     private val routeColorMemo = HashMap<String, Int?>()
-    private var routeColorMemoPoll: VehiclePoll? = null
-    private var routeColorMemoExtras: Map<String, VehiclePoll>? = null
-    private var routeColorMemoAssignment: Map<RouteDirectionKey, Int> = emptyMap()
+
+    /** What [routeColorMemo] holds colours for; see [RouteColorInputs] for why it is one value. */
+    private var routeColorInputs: RouteColorInputs? = null
 
     // The one-shot route shape/stops/header load. The long-running periodic vehicle poll lives in
     // [vehiclePoller], suspended/resumed independently with the map lifecycle.
@@ -288,40 +357,39 @@ class RouteMapController(
     private var pendingFocus: String? = null
 
     /**
-     * Show route [routeId]: load the route + header and start the vehicle poll. [zoomToRoute] frames
-     * the shape once it loads (consumed once). [directionStopId], when non-null, narrows the overlay to
-     * the single direction that serves that stop (the arrivals "show vehicles on map" launch); null
-     * shows the whole route. [initialDirectionId] is an explicit badge/restore override that wins over
-     * the anchor stop when it's still a valid direction.
-     * [focusTripId], when non-null, asks the map to fit that trip's live vehicle together with the
-     * originating [directionStopId] once the vehicle appears; the on-load framing is deferred until that
-     * decision so a successful vehicle+stop fit isn't first yanked out to the whole-route extent, and a
-     * route frame is the fallback when no such vehicle exists.
+     * Show [request]'s route: load the route + header and start the vehicle poll. [zoomToRoute] frames
+     * the shape once it loads (consumed once). [ShowRouteRequest.directionStopId], when non-null,
+     * narrows the overlay to the single direction that serves that stop (the arrivals "show vehicles on
+     * map" launch); null shows the whole route. [ShowRouteRequest.initialDirectionId] is an explicit
+     * badge/restore override that wins over the anchor stop when it's still a valid direction.
+     * [ShowRouteRequest.focusTripId], when non-null, asks the map to fit that trip's live vehicle
+     * together with the originating stop once the vehicle appears; the on-load framing is deferred until
+     * that decision so a successful vehicle+stop fit isn't first yanked out to the whole-route extent,
+     * and a route frame is the fallback when no such vehicle exists.
      *
-     * [palette] renders this session's route colours. It is the one thing a drill-in from the directions
-     * drawer changes about how the route is drawn: the leg the rider tapped keeps the badge colour it had in
-     * the itinerary, so the whole corridor it belongs to is drawn in that colour too rather than shifting to
-     * the basemap palette the moment the rider drills in.
+     * Takes the whole [request], like [reframe] — the two entries into a route session then honour one
+     * field set by construction, rather than a parameter list here that has to be kept in step with the
+     * request by hand (#1797, #2149).
+     *
+     * [itineraryContext] and [palette] are not part of the request: they are what the *view* the drill-in
+     * came from hands down. [palette] renders this session's route colours, and is the one thing a
+     * drill-in from the directions drawer changes about how the route is drawn: the leg the rider tapped
+     * keeps the badge colour it had in the itinerary, so the whole corridor it belongs to is drawn in
+     * that colour too rather than shifting to the basemap palette the moment the rider drills in.
      */
     fun start(
-        routeId: String,
+        request: ShowRouteRequest,
         zoomToRoute: Boolean,
-        directionStopId: String? = null,
-        initialDirectionId: Int? = null,
-        focusTripId: String? = null,
-        riddenSpans: List<RiddenSpan> = emptyList(),
-        extraSegments: List<RouteFocusSegment> = emptyList(),
-        alightStopId: String? = null,
-        directionHeadsign: String? = null,
         itineraryContext: List<RoutePolyline> = emptyList(),
         palette: RouteLinePalette
     ) {
+        val routeId = request.routeId
+        val focusTripId = request.focusTripId
+        val directionStopId = request.directionStopId
+        val initialDirectionId = request.initialDirectionId
         this.routeId = routeId
         this.directionStopId = directionStopId
-        this.riddenSpans = riddenSpans
-        this.extraSegments = extraSegments
-        this.alightStopId = alightStopId
-        this.directionHeadsign = directionHeadsign
+        this.routeFocus = RouteFocusSpec.of(request)
         this.itineraryContext = itineraryContext
         this.palette = palette
         // (Re)built as the extra routes load in onRouteLoaded; cleared here so a prior focus's routes
@@ -391,7 +459,8 @@ class RouteMapController(
      * initial-load tail ([onRouteLoaded]) uses; absent a focus, [frameRoute] controls whether to reframe
      * now via [MapHost.frameRoute]. Undo restoration passes false before applying its captured viewport.
      * Takes the whole [request] rather than picking fields, so a new [ShowRouteRequest] field is at least
-     * reachable here — though [start]'s own parameter list still needs a matching update (#1797).
+     * reachable here — and [start] now takes the whole request too, so the two no longer have to be kept
+     * in step by hand (#1797, #2149).
      */
     fun reframe(request: ShowRouteRequest, frameRoute: Boolean = true) {
         // [request] carries the whole desired focus state, so a previous request's focus ends here —
@@ -402,24 +471,20 @@ class RouteMapController(
         // unconditional set [start] does.
         pendingFocus = null
         rideSelection.clearSeed()
-        // A reframe onto the same route+direction-stop can still carry a different (or empty) segment —
+        // A reframe onto the same route+direction-stop can still carry a different (or empty) ride —
         // e.g. tapping a different leg of the same route. Re-emphasize the polyline and re-filter the
         // shown stops so a stale segment doesn't linger. start() sets this unconditionally; here we only
         // republish when it actually changes.
-        if (riddenSpans != request.riddenSpans ||
-            extraSegments != request.extraSegments ||
-            alightStopId != request.alightStopId ||
-            directionHeadsign != request.directionHeadsign
-        ) {
-            riddenSpans = request.riddenSpans
-            // Move all the segment fields together so a redraw can't key off fresh riddenSpans while
-            // extraSegments or the alighting bound stays stale (or vice versa). No reload here (reframe
-            // contract), so extra routes aren't re-fetched — in practice this path is only hit for a
-            // same-route+direction re-tap where changed extras are already loaded (a new cross-route id
-            // requires a full re-enter).
-            extraSegments = request.extraSegments
-            alightStopId = request.alightStopId
-            directionHeadsign = request.directionHeadsign
+        //
+        // One value, one comparison, one assignment ([RouteFocusSpec]): a redraw cannot key off fresh
+        // riddenSpans while the alighting bound stays stale, and a field added to the ride cannot be
+        // left out of the guard while the redraw below reads it (#2149). No reload here (reframe
+        // contract), so extra routes aren't re-fetched — in practice this path is only hit for a
+        // same-route+direction re-tap where changed extras are already loaded (a new cross-route id
+        // requires a full re-enter).
+        val focus = RouteFocusSpec.of(request)
+        if (focus != routeFocus) {
+            routeFocus = focus
             rideSelection.rideChanged()
             // Re-draw against the already-loaded routes so a stale segment doesn't linger; each show*
             // call publishes.
@@ -519,9 +584,13 @@ class RouteMapController(
         } else {
             merged
         }
-        refreshRouteColorMemo(poll, extraPolls, stopFocus.routeColors.value)
+        // Gathered once, then both the memo guard and the resolution it guards read this and nothing else
+        // — that is what keeps a new colour input from being registered in one place and forgotten in the
+        // other (#2149).
+        val colors = RouteColorInputs(poll, extraPolls, stopFocus.routeColors.value, palette)
+        refreshRouteColorMemo(colors)
         return MapVehicles(
-            markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source) },
+            markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source, colors) },
             response = poll.response
         )
     }
@@ -746,10 +815,7 @@ class RouteMapController(
         selectionJob = null
         routeId = null
         directionStopId = null
-        riddenSpans = emptyList()
-        extraSegments = emptyList()
-        alightStopId = null
-        directionHeadsign = null
+        routeFocus = RouteFocusSpec.None
         itineraryContext = emptyList()
         palette = BASEMAP_ROUTE_LINE_PALETTE
         extraRouteMaps = emptyMap()
@@ -1164,8 +1230,11 @@ class RouteMapController(
      * Builds the render [VehicleMarker] from a display-free [ExtrapolatedVehicle], carrying the
      * draw-time live-vs-scheduled flag through (the renderer picks its icon from it) and the color its
      * route is currently drawn with (the disc rides its own line's color, #2043).
+     *
+     * [response] is the poll this vehicle came out of — one of [colors]' own polls, since that pairing is
+     * what [sampleVehicles] builds the vehicle list from.
      */
-    private fun ExtrapolatedVehicle.toMarker(response: RouteTrips): VehicleMarker = VehicleMarker(
+    private fun ExtrapolatedVehicle.toMarker(response: RouteTrips, colors: RouteColorInputs): VehicleMarker = VehicleMarker(
         // Vehicles are only built for trips with a resolvable active id, so this is non-null here.
         activeTripId = status.activeTripId.orEmpty(),
         point = point,
@@ -1174,7 +1243,7 @@ class RouteMapController(
         fixTimeMs = fixTimeMs,
         bearing = bearing,
         dataFixPoint = dataFixPoint,
-        routeColor = displayedRouteColor(response, status.activeTripId)
+        routeColor = displayedRouteColor(colors, response, status.activeTripId)
     )
 
     /**
@@ -1194,45 +1263,39 @@ class RouteMapController(
      * a 15-vehicle route would churn thousands of throwaway allocations a second on the frame loop to
      * recompute a value that can only change when a new poll lands (every 10-30 s).
      */
-    private fun displayedRouteColor(response: RouteTrips, activeTripId: String?): Int? {
+    private fun displayedRouteColor(
+        colors: RouteColorInputs,
+        response: RouteTrips,
+        activeTripId: String?
+    ): Int? {
         val tripId = activeTripId ?: return null
         // Not getOrPut: a legitimately-null color must stay memoized rather than re-resolving forever.
         if (!routeColorMemo.containsKey(tripId)) {
-            routeColorMemo[tripId] = resolveDisplayedRouteColor(response, routeColorMemoAssignment, tripId)
+            routeColorMemo[tripId] = resolveDisplayedRouteColor(colors, response, tripId)
         }
         return routeColorMemo[tripId]
     }
 
-    /** Drops the [routeColorMemo] when anything it was derived from has been replaced. */
-    private fun refreshRouteColorMemo(
-        poll: VehiclePoll,
-        extras: Map<String, VehiclePoll>,
-        assignment: Map<RouteDirectionKey, Int>
-    ) {
-        // Identity compares: a new poll, extra-poll map or adjacency assignment is a fresh instance.
-        if (poll !== routeColorMemoPoll ||
-            extras !== routeColorMemoExtras ||
-            assignment !== routeColorMemoAssignment
-        ) {
-            routeColorMemoPoll = poll
-            routeColorMemoExtras = extras
-            routeColorMemoAssignment = assignment
+    /** Drops the [routeColorMemo] when anything it was derived from has been replaced — see [RouteColorInputs]. */
+    private fun refreshRouteColorMemo(colors: RouteColorInputs) {
+        if (colors != routeColorInputs) {
+            routeColorInputs = colors
             routeColorMemo.clear()
         }
     }
 
     private fun resolveDisplayedRouteColor(
+        colors: RouteColorInputs,
         response: RouteTrips,
-        assignment: Map<RouteDirectionKey, Int>,
         activeTripId: String
     ): Int? {
         val trip = response.trip(activeTripId) ?: return null
-        val assigned = assignment[RouteDirectionKey(trip.routeId, trip.directionId)]
+        val assigned = colors.assignment[RouteDirectionKey(trip.routeId, trip.directionId)]
         // Exactly what RouteViewGeometry does for the lines: an adjacency-assigned hue is already a
         // drawn color and passes through, while an agency's GTFS color goes through the map's route-line
         // policy (#2041) first. Skipping that policy here would put the disc on the raw agency color
         // while its line drew the normalized one — the disagreement this resolution exists to prevent.
-        return assigned ?: palette.lineColor(response.route(trip.routeId)?.color)
+        return assigned ?: colors.palette.lineColor(response.route(trip.routeId)?.color)
     }
 }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapGuardInputsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapGuardInputsTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map
+
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.ObaTrip
+import org.onebusaway.android.models.ObaTripDetails
+import org.onebusaway.android.models.RouteDirectionKey
+import org.onebusaway.android.models.RouteTrips
+import org.onebusaway.android.time.ElapsedTime
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * Tripwires for [RouteMapController]'s two bundled change guards (#2149), plus the equality they need.
+ *
+ * Neither guard can be exercised through the controller from a JVM test — both sit behind a map host and
+ * a live poll — but both failure modes this file guards against are structural, and reachable here:
+ *
+ *  - **An input the guard forgot.** A cache or early-return guard that hand-compares several separately
+ *    stored inputs, while the work it guards reads them from somewhere else, drifts silently: the symptom
+ *    is a *stale* value, not a crash. That shipped twice in `RideSelectionController` (see
+ *    [RideSelectionControllerTest]) before the inputs were bundled. Bundling makes the guard and the pass
+ *    one field set — provided every input is actually *in* the bundle, which is what the field pins below
+ *    assert.
+ *  - **A field declared but left out of `equals`.** A bundle field written outside the primary constructor
+ *    is invisible to a data class's generated `equals`, so the guard would hold across a change to it —
+ *    exactly the bug the bundle exists to prevent, reintroduced quietly. Each field is checked to move the
+ *    comparison on its own.
+ *
+ * The field pins are deliberately written as "the set of fields I have a case for" vs "the set the class
+ * declares", so a new input fails here until it is covered rather than merely renaming a constant.
+ */
+class RouteMapGuardInputsTest {
+
+    /**
+     * A data class's declared *instance* fields — its properties. Statics are skipped: a companion object
+     * and Compose's synthetic `$stable` both land in `declaredFields` and neither is an input.
+     */
+    private fun declaredFields(type: Class<*>): List<String> = type.declaredFields
+        .filterNot { Modifier.isStatic(it.modifiers) }
+        .map { it.name }
+        .filterNot { it.startsWith("$") }
+        .sorted()
+
+    // -- reframe's change-detect: the drawn ride ([RouteFocusSpec]) --
+
+    /**
+     * [RouteMapController.reframe] honours a [ShowRouteRequest] in two ways: the fields that describe the
+     * *ride drawn on the route* are compared as one [RouteFocusSpec] (a change redraws the ride), and the
+     * rest are applied by name in the tail. A new request field belongs to exactly one of those, and this
+     * fails until it's in one — the #1797 shape (two places that must list the same fields, nothing making
+     * them agree) is the whole reason this type exists.
+     */
+    @Test
+    fun `every ShowRouteRequest field is either part of the drawn ride or applied by name`() {
+        // Applied by name in reframe: the route + direction anchor decide reframe-vs-re-enter (MapViewModel),
+        // initialDirectionId goes to selectDirection, focusTripId to requestFocus.
+        val appliedByName = listOf("routeId", "directionStopId", "initialDirectionId", "focusTripId")
+        assertEquals(
+            "A new ShowRouteRequest field must either join RouteFocusSpec (so a reframe redraws the ride) " +
+                "or be applied by name in RouteMapController.reframe",
+            declaredFields(ShowRouteRequest::class.java),
+            (appliedByName + declaredFields(RouteFocusSpec::class.java)).sorted()
+        )
+    }
+
+    @Test
+    fun `every field of the drawn ride moves the reframe guard on its own`() {
+        val base = RouteFocusSpec.None
+        val changed = mapOf(
+            "riddenSpans" to base.copy(riddenSpans = listOf(RiddenSpan(listOf(GeoPoint(1.0, 2.0), GeoPoint(3.0, 4.0))))),
+            "extraSegments" to base.copy(extraSegments = listOf(RouteFocusSegment("route_b", anchorStopId = "seam"))),
+            "alightStopId" to base.copy(alightStopId = "alight"),
+            "directionHeadsign" to base.copy(directionHeadsign = "Downtown")
+        )
+        assertEquals(
+            "A new RouteFocusSpec field needs a case here proving reframe reacts to it",
+            declaredFields(RouteFocusSpec::class.java),
+            changed.keys.sorted()
+        )
+        changed.forEach { (field, spec) ->
+            assertNotEquals("changing $field must reopen the reframe guard", base, spec)
+        }
+    }
+
+    /**
+     * Value equality, not identity — the detail that turned out load-bearing when this pattern was applied
+     * to the ride selection. Every launcher builds its spans and segments fresh, so an identity compare
+     * would report a change on every re-tap and redraw (and reset the vehicle selection for) the same ride.
+     */
+    @Test
+    fun `two requests describing the same ride compare equal`() {
+        val request = ShowRouteRequest(
+            routeId = "route_a",
+            riddenSpans = listOf(RiddenSpan(listOf(GeoPoint(1.0, 2.0), GeoPoint(3.0, 4.0)))),
+            extraSegments = listOf(RouteFocusSegment("route_b", anchorStopId = "seam")),
+            alightStopId = "alight",
+            directionHeadsign = "Downtown"
+        )
+        val rebuilt = request.copy(
+            riddenSpans = listOf(RiddenSpan(listOf(GeoPoint(1.0, 2.0), GeoPoint(3.0, 4.0)))),
+            extraSegments = listOf(RouteFocusSegment("route_b", anchorStopId = "seam"))
+        )
+        assertEquals(RouteFocusSpec.of(request), RouteFocusSpec.of(rebuilt))
+    }
+
+    /** The focus fields a request carries reach the spec — [RouteFocusSpec.of] is where both entries read them. */
+    @Test
+    fun `the spec is taken from the request's own fields`() {
+        val spans = listOf(RiddenSpan(listOf(GeoPoint(1.0, 2.0), GeoPoint(3.0, 4.0))))
+        val segments = listOf(RouteFocusSegment("route_b", anchorStopId = "seam"))
+        val spec = RouteFocusSpec.of(
+            ShowRouteRequest(
+                routeId = "route_a",
+                riddenSpans = spans,
+                extraSegments = segments,
+                alightStopId = "alight",
+                directionHeadsign = "Downtown"
+            )
+        )
+        assertEquals(RouteFocusSpec(spans, segments, "alight", "Downtown"), spec)
+    }
+
+    // -- the vehicle colour memo ([RouteColorInputs]) --
+
+    @Test
+    fun `every route colour input moves the memo guard on its own`() {
+        val base = RouteColorInputs(
+            poll = poll(),
+            extras = emptyMap(),
+            assignment = emptyMap(),
+            palette = BASEMAP_ROUTE_LINE_PALETTE
+        )
+        val changed = mapOf(
+            "poll" to base.copy(poll = poll()),
+            "extras" to base.copy(extras = mapOf("route_b" to poll())),
+            "assignment" to base.copy(assignment = mapOf(RouteDirectionKey("route_a", 0) to DEFAULT_ROUTE_LINE_COLOR)),
+            "palette" to base.copy(palette = RouteLinePalette { it })
+        )
+        assertEquals(
+            "A new colour input needs a case here proving a change to it drops the memo",
+            declaredFields(RouteColorInputs::class.java),
+            changed.keys.sorted()
+        )
+        changed.forEach { (field, inputs) ->
+            assertNotEquals("changing $field must drop the route colour memo", base, inputs)
+        }
+    }
+
+    /**
+     * The complementary half: the guard must also *hold* between polls, since it runs on the per-frame
+     * vehicle sampler. Re-gathering the same inputs — which every frame does — must compare equal, or the
+     * memo would be cleared 20 times a second and the resolution it exists to avoid would run every frame.
+     */
+    @Test
+    fun `re-gathering the same colour inputs compares equal`() {
+        val poll = poll()
+        val extras = mapOf("route_b" to poll())
+        val assignment = mapOf(RouteDirectionKey("route_a", 0) to DEFAULT_ROUTE_LINE_COLOR)
+        assertEquals(
+            RouteColorInputs(poll, extras, assignment, BASEMAP_ROUTE_LINE_PALETTE),
+            RouteColorInputs(poll, extras.toMap(), assignment.toMap(), BASEMAP_ROUTE_LINE_PALETTE)
+        )
+    }
+
+    /** A distinct poll instance per call — a landed poll replaces the response wholesale. */
+    private fun poll(): VehiclePoll = VehiclePoll(
+        response = object : RouteTrips {
+            override val trips: List<ObaTripDetails> = emptyList()
+
+            override fun trip(tripId: String?): ObaTrip? = null
+
+            override fun route(routeId: String): ObaRoute? = null
+
+            override val currentTimeMs: Long = 0L
+        },
+        loadTime = ElapsedTime(0L)
+    )
+}


### PR DESCRIPTION
Fixes #2149.

The two remaining instances of #1797's shape: a guard that decides "has anything changed?" by
hand-comparing several separately-stored inputs, while the work it guards reads those inputs from
somewhere else. Nothing makes the two lists agree, and when they drift the symptom is a *stale*
value rather than a crash. Both are fixed the way `RideSelectionController` was: bundle every guarded
input into one value, and let the pass that follows read its inputs from nowhere else.

### 1. `refreshRouteColorMemo` → `RouteColorInputs`

Three fields compared by a hand-written `||` chain, while the resolution took `response` as a
parameter and reached for `routeColorMemoAssignment` as a field — a fourth colour input had two
places it had to be registered and neither was enforced. A miss draws vehicles in a stale route
colour until the next poll: a plausible-looking wrong answer, not a visible failure.

`sampleVehicles` now gathers one `RouteColorInputs(poll, extras, assignment, palette)`; the guard
compares it, and `displayedRouteColor` / `resolveDisplayedRouteColor` take it and read nothing else.
`response` stays a per-vehicle parameter because it is a *projection* of the bundle — every vehicle is
paired with the poll it came out of, which is the leader poll or one of the extras (#2043).

One behaviour change falls out: `palette` is a real input to the colour resolution that the old guard
never watched. It is in the bundle now, so a session that changes palette can't serve colours memoized
under the previous one.

### 2. `reframe`'s change-detect → `RouteFocusSpec`

Four `ShowRouteRequest` fields compared by hand and then assigned by hand. They are now one
`RouteFocusSpec` — one comparison, one assignment — and `start()` takes the whole `ShowRouteRequest`
too, so the two entries into a route session honour one field set by construction. That retires the
`start()`/`reframe` divergence `reframe`'s KDoc warned about (#1797), and `MapViewModel.enterRoute`
stops re-listing the request's fields on the way down.

The split is deliberate: the fields describing *the ride drawn on the route* are the ones a reframe
must redraw for, so they are the spec; `routeId`/`directionStopId` (which decide reframe-vs-re-enter),
`initialDirectionId` and `focusTripId` keep being applied by name in the tail. Comparing the whole
request instead would reset the ride selection on a same-ride pill tap.

The four fields stay readable at their ~20 call sites as derived `private val`s off `routeFocus`, so
nothing in the controller can assign them individually any more.

### Tests

`RouteMapGuardInputsTest` (new, JVM):

- A new `ShowRouteRequest` field must be sorted into the drawn ride or applied by name in `reframe` —
  the field sets are pinned against each other, so a new field fails until it's in one.
- Each bundle field is checked to move its guard on its own. This catches the quiet reintroduction of
  the same bug: a field written outside a data class's primary constructor is invisible to the
  generated `equals`, so the guard would hold across a change to it.
- Re-gathering identical colour inputs must compare *equal* — that guard sits on the 20 Hz sampler, so
  a comparison that never holds would clear the memo every frame, the exact opposite of the point.

`./gradlew :onebusaway-android:test` (obaGoogle + obaMaplibre) and `spotlessCheck` pass;
`compileObaGoogleDebugKotlin -PwarningsAsErrors=true` is clean. No lint run locally — leaving that to CI
per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)