### PR TITLE
Add a refresh button to the directions action bar (#2135)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
@@ -341,6 +342,56 @@ class TripPlanFormRenderTest {
     }
 
     /**
+     * Refresh re-plans the trip the form already states (#2135), so — unlike reverse — it belongs with
+     * the rest of the trip's terms, in the action bar's trailing group and immediately before
+     * additional-preferences. Position is the whole of the issue's ask, so it's asserted here.
+     */
+    @Test
+    fun refreshSitsBetweenTheModePickersAndAdditionalPreferences() {
+        renderForm(plannedState)
+
+        val streetMode = bounds(TripPlanTestTags.STREET_MODE)
+        val refresh = bounds(TripPlanTestTags.REFRESH)
+        val settings = bounds(TripPlanTestTags.ADVANCED_SETTINGS)
+
+        assertTrue(
+            "refresh should sit between the street-mode picker (ending ${streetMode.right}) and " +
+                "additional-preferences (starting ${settings.left}), but spanned " +
+                "${refresh.left}..${refresh.right}",
+            refresh.left >= streetMode.right && refresh.right <= settings.left
+        )
+    }
+
+    /** The form is stateless, so what's checked is the ask — the re-plan itself is the ViewModel's. */
+    @Test
+    fun tappingRefreshAsksForTheSameTripAgain() {
+        var refreshes = 0
+        renderForm(state = { plannedState }, onRefresh = { refreshes++ })
+
+        composeRule.onNodeWithTag(TripPlanTestTags.REFRESH).performClick()
+
+        assertEquals("tapping refresh should ask the host to re-plan", 1, refreshes)
+    }
+
+    /**
+     * A form that doesn't yet name both ends of a trip has no trip to re-plan, and asking anyway would
+     * clear whatever is on screen rather than refresh it. The button stays in place (so the trailing
+     * group doesn't shuffle as the form is filled in) but does nothing.
+     */
+    @Test
+    fun refreshIsInertUntilTheFormNamesBothEnds() {
+        var refreshes = 0
+        renderForm(
+            state = { plannedState.copy(to = TripEndpoint.FreeText("")) },
+            onRefresh = { refreshes++ }
+        )
+
+        composeRule.onNodeWithTag(TripPlanTestTags.REFRESH).assertIsNotEnabled().performClick()
+
+        assertEquals("a half-filled form has nothing to refresh", 0, refreshes)
+    }
+
+    /**
      * Reverse acts on the two endpoints, so it sits beside them rather than in the action bar (#2110):
      * clear of both fields and centred across the pair, which puts it on the divider between them.
      * Position is the whole point of the move, so it's asserted rather than left to the eye.
@@ -511,6 +562,7 @@ class TripPlanFormRenderTest {
         onVehicleModeSelected: (VehicleMode) -> Unit = {},
         onStreetModeSelected: (StreetMode) -> Unit = {},
         onReverse: () -> Unit = {},
+        onRefresh: () -> Unit = {},
         onPickDateTime: () -> Unit = {}
     ) {
         composeRule.setContent {
@@ -529,6 +581,7 @@ class TripPlanFormRenderTest {
                         onVehicleModeSelected = onVehicleModeSelected,
                         onStreetModeSelected = onStreetModeSelected,
                         onReverse = onReverse,
+                        onRefresh = onRefresh,
                         onAdvancedSettings = {}
                     )
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -205,6 +205,7 @@ fun DirectionsFormCard(
                     PreferenceUtils.saveString(streetModePreference, street.name)
                 },
                 onReverse = viewModel::reverseTrip,
+                onRefresh = viewModel::refreshPlan,
                 onAdvancedSettings = { showAdvanced = true }
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -111,6 +111,18 @@ private val ICON_BUTTON_SIZE = 40.dp
 private val ACTION_BAR_HEIGHT = ICON_BUTTON_SIZE
 
 /**
+ * Where the action bar's content starts, now that the bar carries no leading glyph of its own (#2135).
+ *
+ * The band above it opens with [RAIL_WIDTH] of endpoint rail; this one opens with the "when" sentence,
+ * and [SegmentButton] insets its own text by 6dp, so 10dp here lands that text on the same 16dp keyline
+ * the endpoint dots sit on. The 34dp the retired glyph gives back is what pays for the refresh button.
+ */
+private val ACTION_BAR_START_INSET = 10.dp
+
+/** Material 3's disabled-content alpha, applied by hand where a call site sets its own tint. */
+private const val DISABLED_ICON_ALPHA = 0.38f
+
+/**
  * Gap between the card's trailing edge and the icon buttons against it. The trailing counterpart of
  * [RAIL_WIDTH], and shared by both bands for the same reason: so their buttons line up in one column.
  * Applied through [formBand] rather than by hand, so there is one gutter and not two that agree.
@@ -166,6 +178,9 @@ object TripPlanTestTags {
 
     /** The swap-endpoints button. */
     const val REVERSE = "tripPlanReverse"
+
+    /** The action bar's re-plan-this-same-trip button. */
+    const val REFRESH = "tripPlanRefresh"
 
     /** The action bar's trailing button, which reverse is column-aligned with. */
     const val ADVANCED_SETTINGS = "tripPlanAdvancedSettings"
@@ -227,6 +242,7 @@ fun TripPlanForm(
     onVehicleModeSelected: (VehicleMode) -> Unit,
     onStreetModeSelected: (StreetMode) -> Unit,
     onReverse: () -> Unit,
+    onRefresh: () -> Unit,
     onAdvancedSettings: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -272,11 +288,13 @@ fun TripPlanForm(
             timeLabel = state.timeLabel,
             modes = state.modes,
             availableStreetModes = availableStreetModes,
+            canRefresh = state.canSubmit,
             onSetArriving = onSetArriving,
             onDepartNow = onDepartNow,
             onPickDateTime = onPickDateTime,
             onVehicleModeSelected = onVehicleModeSelected,
             onStreetModeSelected = onStreetModeSelected,
+            onRefresh = onRefresh,
             onAdvancedSettings = onAdvancedSettings
         )
     }
@@ -292,13 +310,18 @@ private fun FormIconButton(
     painter: Painter,
     contentDescription: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
 ) {
-    IconButton(onClick = onClick, modifier = modifier.size(ICON_BUTTON_SIZE)) {
+    IconButton(onClick = onClick, enabled = enabled, modifier = modifier.size(ICON_BUTTON_SIZE)) {
         Icon(
             painter = painter,
             contentDescription = contentDescription,
+            // The tint is stated here rather than inherited from the button's content colour, so the
+            // disabled case has to be stated too — otherwise a disabled button draws at full strength
+            // and reads as one that simply doesn't work.
             tint = MaterialTheme.colorScheme.onSurfaceVariant
+                .copy(alpha = if (enabled) 1f else DISABLED_ICON_ALPHA)
         )
     }
 }
@@ -613,9 +636,13 @@ private fun PinnedActionIcon(painter: Painter) {
  * The bottom band: when the trip is for, and how it may be travelled.
  *
  * The time reads as one sentence — "Depart · now" — split into two separately-tappable segments, each
- * opening its own menu. The mode pickers and additional preferences sit at the trailing edge; reverse
- * is not here, because it acts on the two endpoints rather than on the trip's terms, and so lives
- * beside them (#2110).
+ * opening its own menu. The mode pickers, refresh and additional preferences sit at the trailing edge;
+ * reverse is not here, because it acts on the two endpoints rather than on the trip's terms, and so
+ * lives beside them (#2110).
+ *
+ * The bar opened with a clock glyph in a [RAIL_WIDTH] rail until #2135. It said nothing the sentence
+ * beside it didn't already say in words, and the bar had no width to spare for the refresh button, so
+ * it is the glyph that went — see [ACTION_BAR_START_INSET] for what keeps the sentence on its keyline.
  */
 @Composable
 private fun TripActionBar(
@@ -625,28 +652,19 @@ private fun TripActionBar(
     timeLabel: String,
     modes: TripModeSelection,
     availableStreetModes: List<StreetMode>,
+    canRefresh: Boolean,
     onSetArriving: (Boolean) -> Unit,
     onDepartNow: () -> Unit,
     onPickDateTime: () -> Unit,
     onVehicleModeSelected: (VehicleMode) -> Unit,
     onStreetModeSelected: (StreetMode) -> Unit,
+    onRefresh: () -> Unit,
     onAdvancedSettings: () -> Unit
 ) {
     Row(
-        modifier = Modifier.formBand().height(ACTION_BAR_HEIGHT),
+        modifier = Modifier.formBand().padding(start = ACTION_BAR_START_INSET).height(ACTION_BAR_HEIGHT),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier.width(RAIL_WIDTH).height(ACTION_BAR_HEIGHT),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_arrival_time),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(18.dp)
-            )
-        }
         WhenModeSegment(arriving = arriving, onSetArriving = onSetArriving)
         Text(
             text = "·",
@@ -686,6 +704,15 @@ private fun TripActionBar(
             label = { streetModeLabel(it) },
             testTag = TripPlanTestTags.STREET_MODE,
             onSelected = onStreetModeSelected
+        )
+        FormIconButton(
+            painter = painterResource(R.drawable.ic_action_navigation_refresh),
+            contentDescription = stringResource(R.string.trip_plan_refresh),
+            onClick = onRefresh,
+            // Nothing to re-plan until the form names both ends of a trip. Disabled rather than absent,
+            // so the bar's trailing buttons don't shuffle sideways as the rider fills the form in.
+            enabled = canRefresh,
+            modifier = Modifier.testTag(TripPlanTestTags.REFRESH)
         )
         FormIconButton(
             painter = rememberVectorPainter(AppIcons.Settings),
@@ -941,7 +968,7 @@ private fun TripPlanFormPreview() {
             onPickDateTime = {},
             availableStreetModes = StreetMode.entries,
             onVehicleModeSelected = {}, onStreetModeSelected = {},
-            onReverse = {}, onAdvancedSettings = {}
+            onReverse = {}, onRefresh = {}, onAdvancedSettings = {}
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -84,13 +85,21 @@ import org.onebusaway.android.ui.icons.AppIcons
 private val ENDPOINT_ROW_HEIGHT = 48.dp
 
 /**
- * Width of the leading rail — sized so the dot's leading edge lands exactly on Material's 16dp
- * keyline. Reused as the dividers' inset, so the hairline starts where the text does.
+ * Material's content keyline: where the card's content begins, in both bands — the endpoint dot's
+ * leading edge above, the "when" sentence's first character below. Written once and derived from,
+ * rather than restated per band, for the same reason [TRAILING_GUTTER] is: two bands that lay
+ * themselves out independently land on one keyline only if the keyline itself is one value.
  */
-private val RAIL_WIDTH = 44.dp
+private val CONTENT_KEYLINE = 16.dp
 
 /** Diameter of the endpoint dot, in the rail and in the suggestion row that fills that endpoint. */
 private val ENDPOINT_DOT_SIZE = 12.dp
+
+/**
+ * Width of the leading rail — the dot centred in it, which is what puts its leading edge on
+ * [CONTENT_KEYLINE]. Reused as the dividers' inset, so the hairline starts where the text does.
+ */
+private val RAIL_WIDTH = CONTENT_KEYLINE * 2 + ENDPOINT_DOT_SIZE
 
 /** The box the endpoint dot occupies when it stands in a menu row's leading icon slot. */
 private val ENDPOINT_DOT_ICON_SIZE = 22.dp
@@ -110,17 +119,18 @@ private val ICON_BUTTON_SIZE = 40.dp
  */
 private val ACTION_BAR_HEIGHT = ICON_BUTTON_SIZE
 
+/** [SegmentButton]'s own horizontal padding, held apart because [ACTION_BAR_START_INSET] subtracts it. */
+private val SEGMENT_TEXT_INSET = 6.dp
+
 /**
  * Where the action bar's content starts, now that the bar carries no leading glyph of its own (#2135).
  *
- * The band above it opens with [RAIL_WIDTH] of endpoint rail; this one opens with the "when" sentence,
- * and [SegmentButton] insets its own text by 6dp, so 10dp here lands that text on the same 16dp keyline
- * the endpoint dots sit on. The 34dp the retired glyph gives back is what pays for the refresh button.
+ * The band above opens with [RAIL_WIDTH] of endpoint rail; this one opens with the "when" sentence, so
+ * it reaches [CONTENT_KEYLINE] by padding — less the padding [SegmentButton] already applies, since it
+ * is the sentence's *text* that belongs on the keyline and not its press surface. The rest of what the
+ * retired glyph gives back is what pays for the refresh button.
  */
-private val ACTION_BAR_START_INSET = 10.dp
-
-/** Material 3's disabled-content alpha, applied by hand where a call site sets its own tint. */
-private const val DISABLED_ICON_ALPHA = 0.38f
+private val ACTION_BAR_START_INSET = CONTENT_KEYLINE - SEGMENT_TEXT_INSET
 
 /**
  * Gap between the card's trailing edge and the icon buttons against it. The trailing counterpart of
@@ -313,16 +323,17 @@ private fun FormIconButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
-    IconButton(onClick = onClick, enabled = enabled, modifier = modifier.size(ICON_BUTTON_SIZE)) {
-        Icon(
-            painter = painter,
-            contentDescription = contentDescription,
-            // The tint is stated here rather than inherited from the button's content colour, so the
-            // disabled case has to be stated too — otherwise a disabled button draws at full strength
-            // and reads as one that simply doesn't work.
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                .copy(alpha = if (enabled) 1f else DISABLED_ICON_ALPHA)
-        )
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        // The tint travels as the button's content colour rather than being set on the Icon, so the
+        // disabled case comes from Material's own token instead of an alpha restated here.
+        colors = IconButtonDefaults.iconButtonColors(
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        ),
+        modifier = modifier.size(ICON_BUTTON_SIZE)
+    ) {
+        Icon(painter = painter, contentDescription = contentDescription)
     }
 }
 
@@ -909,7 +920,7 @@ private fun SegmentButton(
             // The value is the label, so TalkBack reads it as-is; the click label supplies the verb the
             // bare text can't ("Depart" alone doesn't say it's changeable).
             .clickable(onClickLabel = stringResource(R.string.trip_plan_change_when), onClick = onClick)
-            .padding(horizontal = 6.dp)
+            .padding(horizontal = SEGMENT_TEXT_INSET)
             .testTag(testTag),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(2.dp)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -355,8 +355,7 @@ class TripPlanViewModel @Inject constructor(
      * clock, and the rider. A "depart now" trip planned five minutes ago is a trip from five minutes ago
      * and from wherever they were standing then.
      *
-     * [replanOrClearResult] is exactly that re-submission — it re-reads the device fix and the clock at
-     * submit — so refreshing is that one call and nothing else. A trip pinned to an explicit instant
+     * Refreshing is [replanOrClearResult] and nothing else. A trip pinned to an explicit instant
      * re-plans that same instant, picking up whatever the server now says about it rather than silently
      * re-timing the trip the rider asked for.
      */
@@ -399,10 +398,13 @@ class TripPlanViewModel @Inject constructor(
     }
 
     /**
-     * Called after any form change: hand the latest plan inputs to the [planInputs] pipeline, which
+     * Submits the form as it now stands: hand the latest plan inputs to the [planInputs] pipeline, which
      * re-plans when both endpoints resolve and otherwise drops a stale result back to [PlanResult.Idle]
      * so a changed or cleared endpoint can't leave an old route on screen (the results sheet keys off
      * [PlanResult.Success]). Emitting supersedes any in-flight plan via the collector's [mapLatest].
+     *
+     * Every form edit ends here, but nothing about it is edit-specific — [refreshPlan] re-submits an
+     * unchanged form through the same path rather than needing one of its own.
      */
     private fun replanOrClearResult() {
         // Re-read the device fix here, at submit, so a "my location" end plans from where the rider is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -345,6 +345,25 @@ class TripPlanViewModel @Inject constructor(
         replanOrClearResult()
     }
 
+    /**
+     * Re-plans the trip the form already states, without changing what it states (#2135).
+     *
+     * Every other action that re-plans does so as a side effect of editing the trip, which left no way
+     * to ask for the *same* trip again — the closest thing was re-picking "now" from the time menu,
+     * which only worked because it happened to re-submit, and which pins nothing a rider who is already
+     * on "now" wants changed. But the two things a plan is measured against both move on their own: the
+     * clock, and the rider. A "depart now" trip planned five minutes ago is a trip from five minutes ago
+     * and from wherever they were standing then.
+     *
+     * [replanOrClearResult] is exactly that re-submission — it re-reads the device fix and the clock at
+     * submit — so refreshing is that one call and nothing else. A trip pinned to an explicit instant
+     * re-plans that same instant, picking up whatever the server now says about it rather than silently
+     * re-timing the trip the rider asked for.
+     */
+    fun refreshPlan() {
+        replanOrClearResult()
+    }
+
     /** Clears a surfaced error after the host shows it. */
     fun clearPlanResult() {
         _planState.value = PlanResult.Idle

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -960,6 +960,9 @@
     <string name="trip_plan_date_tomorrow">Tomorrow</string>
     <!-- Accessibility click label for either half of the time callout. -->
     <string name="trip_plan_change_when">Change when</string>
+    <!-- The directions action bar's button that re-plans the same trip against the current time and
+         the rider's current position. Glyph-only, so this names it for TalkBack and its tooltip. -->
+    <string name="trip_plan_refresh">Refresh directions</string>
     <string name="trip_plan_leaving">Leaving</string>
     <string name="trip_plan_arriving">Arriving</string>
     <string name="trip_plan_date">Date</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -624,6 +624,66 @@ class TripPlanViewModelTest {
         assertEquals(120_000L, (vm.planState.value as PlanResult.Success).params?.dateTimeMillis)
     }
 
+    /**
+     * Refresh's whole reason for existing (#2135): a "depart now" trip is planned against a clock that
+     * keeps moving, and until this there was no way to ask for the same trip against the current one
+     * without editing the trip.
+     */
+    @Test
+    fun `refreshing a depart-now trip re-plans it against the current clock`() = runTest {
+        val clock = FakeClock(0L)
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(plan = plan, clock = clock)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertEquals(1, plan.calls)
+        assertEquals(0L, plan.lastParams?.dateTimeMillis)
+
+        clock.nowMillis = 600_000L
+        vm.refreshPlan()
+        advanceUntilIdle()
+
+        assertEquals(2, plan.calls)
+        assertEquals(600_000L, plan.lastParams?.dateTimeMillis)
+    }
+
+    /** A pinned trip is re-planned, not re-timed — refresh must not quietly move what the rider asked for. */
+    @Test
+    fun `refreshing a pinned trip re-plans the same instant`() = runTest {
+        val clock = FakeClock(0L)
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(plan = plan, clock = clock)
+        setBothEndpoints(vm)
+        vm.setDateTime(1_700_000_000_000L)
+        advanceUntilIdle()
+        val callsBefore = plan.calls
+
+        clock.nowMillis = 600_000L
+        vm.refreshPlan()
+        advanceUntilIdle()
+
+        assertEquals(callsBefore + 1, plan.calls)
+        assertEquals(1_700_000_000_000L, plan.lastParams?.dateTimeMillis)
+        assertFalse(vm.formState.value.departNow)
+    }
+
+    /**
+     * Refresh on a form that names only one end has no trip to re-plan. The button is disabled there,
+     * so this pins the ViewModel's own half: it must not issue a request for an incomplete form.
+     */
+    @Test
+    fun `refreshing an incomplete form plans nothing`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(plan = plan)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
+        advanceUntilIdle()
+
+        vm.refreshPlan()
+        advanceUntilIdle()
+
+        assertEquals(0, plan.calls)
+    }
+
     @Test
     fun `a restored trip stays pinned to the instant it was planned for`() = runTest {
         val vm = viewModel(clock = FakeClock(0L))


### PR DESCRIPTION
Fixes #2135.

## The problem

A "depart now" trip is planned against two things that keep moving on their own — the clock, and the rider. But every action that re-plans does so as a side effect of *editing* the trip (a mode change, a date nudge, editing an endpoint), so there was no way to ask for the **same** trip again. The closest thing was re-picking "now" from the time menu, which worked only because it happened to re-submit, and which pins nothing a rider already on "now" wants changed.

## The change

`TripPlanViewModel.refreshPlan()` is that re-submission and nothing else. `replanOrClearResult()` already re-reads the device fix (#2134) and the clock at submit, so:

- a **"depart now"** trip re-plans from where the rider is and when it is;
- a trip **pinned to an explicit instant** re-plans that same instant, picking up whatever the server now says about it rather than quietly re-timing the trip the rider asked for;
- a form that names only one end plans nothing — and the button is disabled there.

The button sits in the action bar's trailing group, immediately left of additional-preferences, using the app's existing `ic_action_navigation_refresh`. It is disabled rather than absent while the form is incomplete, so the trailing buttons don't shuffle sideways as the rider fills it in. `FormIconButton` gained an `enabled` flag that also dims its tint — the tint is set at the call site, so it wouldn't otherwise reflect the state.

### What paid for the space

As the issue proposed, the bar's leading clock glyph is retired: it said nothing the "Leaving · now" sentence beside it didn't already say in words, and the bar had no width to spare. A new `ACTION_BAR_START_INSET` (10dp) keeps that sentence's first character on the same 16dp keyline the endpoint dots sit on — `SegmentButton` insets its own text by 6dp. The `ic_arrival_time` drawable stays; the report flow still uses it.

## Tests

JVM (`TripPlanViewModelTest`):
- refreshing a depart-now trip re-plans it against the current clock
- refreshing a pinned trip re-plans the same instant
- refreshing an incomplete form plans nothing

Render (`TripPlanFormRenderTest`):
- refresh sits between the street-mode picker and additional-preferences
- tapping it asks the host to re-plan
- it is disabled and inert until the form names both ends

## Verification

`compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean, `TripPlanViewModelTest` passes, `spotlessCheck` passes, instrumented sources compile. **Not yet exercised on a device** — the render tests above are written but haven't been run on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh action to the trip-planning directions screen.
  * Refreshing directions updates current location and time when applicable while preserving selected travel times.
  * Refresh is disabled when required trip details, such as a destination, are missing.
  * Added accessible labeling for the refresh control.

* **Tests**
  * Added coverage for refresh placement, callback behavior, disabled states, and incomplete trip plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->