### PR TITLE
Shorten the pinned time callout, and state it in full in its menu (#2185)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripplan/TripPlanFormRenderTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -308,6 +309,62 @@ class TripPlanFormRenderTest {
     }
 
     /**
+     * A pinned instant reads time-first, and states the day only when the day needs stating (#2185).
+     * The callout is the bar's one elastic slot and routinely ellipsizes, so a date the rider already
+     * knows — today's — is exactly what pushes the time they opened the form for off the end.
+     */
+    @Test
+    fun aTripLaterTodayReadsAsJustItsTime() {
+        renderForm(pinnedOn(TripDay.TODAY))
+
+        composeRule.onNodeWithText("3:45 PM").assertIsDisplayed()
+        assertEquals(
+            "a trip later today should not restate today's date",
+            0,
+            composeRule.onAllNodesWithText("June 10", substring = true).fetchSemanticsNodes().size
+        )
+    }
+
+    @Test
+    fun aTripTomorrowNamesTheDayInWords() {
+        renderForm(pinnedOn(TripDay.TOMORROW))
+
+        composeRule.onNodeWithText("3:45 PM, tomorrow").assertIsDisplayed()
+    }
+
+    @Test
+    fun aTripFurtherOutFallsBackToItsDate() {
+        renderForm(pinnedOn(TripDay.OTHER))
+
+        composeRule.onNodeWithText("3:45 PM, June 10").assertIsDisplayed()
+    }
+
+    /**
+     * What the shortened callout leaves out has to stay reachable: the menu it opens states the pinned
+     * instant in full, above the choices, so the rider can check what the trip is pinned to without
+     * opening the picker to find out.
+     */
+    @Test
+    fun theTimeMenuStatesThePinnedInstantInFull() {
+        renderForm(pinnedOn(TripDay.TODAY))
+
+        composeRule.onNodeWithTag(TripPlanTestTags.WHEN_TIME).performClick()
+
+        composeRule.onNodeWithTag(TripPlanTestTags.WHEN_TIME_HEADER)
+            .assertTextEquals("June 10, 3:45 PM")
+    }
+
+    /** A trip anchored to "now" has no pinned instant, so there is nothing to state above the rows. */
+    @Test
+    fun theTimeMenuStatesNothingForANowTrip() {
+        renderForm(plannedState)
+
+        composeRule.onNodeWithTag(TripPlanTestTags.WHEN_TIME).performClick()
+
+        composeRule.onNodeWithTag(TripPlanTestTags.WHEN_TIME_HEADER).assertDoesNotExist()
+    }
+
+    /**
      * The action bar's trailing buttons stay put whatever the time segment reads. The segment is the
      * bar's one flexible slot, so it has to both hold the buttons against the edge when the label is
      * the single word "now" and cap itself when the label is a full date and time — sharing that
@@ -493,6 +550,9 @@ class TripPlanFormRenderTest {
         val y = with(d) { (4.dp + 24.dp + 49.dp * row).roundToPx() }
         return pixels[x, y]
     }
+
+    /** [plannedState] with its trip pinned to an instant that falls on [day]. */
+    private fun pinnedOn(day: TripDay) = plannedState.copy(departNow = false, dayRelation = day)
 
     private fun renderForm(
         state: TripPlanFormState,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -164,6 +164,9 @@ object TripPlanTestTags {
     const val VEHICLE_MODE = "tripPlanVehicleMode"
     const val STREET_MODE = "tripPlanStreetMode"
 
+    /** The pinned instant, stated in full at the head of the time segment's menu. */
+    const val WHEN_TIME_HEADER = "tripPlanWhenTimeHeader"
+
     /** The swap-endpoints button. */
     const val REVERSE = "tripPlanReverse"
 
@@ -270,6 +273,7 @@ fun TripPlanForm(
             departNow = state.departNow,
             dateLabel = state.dateLabel,
             timeLabel = state.timeLabel,
+            dayRelation = state.dayRelation,
             modes = state.modes,
             availableStreetModes = availableStreetModes,
             onSetArriving = onSetArriving,
@@ -623,6 +627,7 @@ private fun TripActionBar(
     departNow: Boolean,
     dateLabel: String,
     timeLabel: String,
+    dayRelation: TripDay,
     modes: TripModeSelection,
     availableStreetModes: List<StreetMode>,
     onSetArriving: (Boolean) -> Unit,
@@ -663,6 +668,7 @@ private fun TripActionBar(
             departNow = departNow,
             dateLabel = dateLabel,
             timeLabel = timeLabel,
+            dayRelation = dayRelation,
             onDepartNow = onDepartNow,
             onPickDateTime = onPickDateTime
         )
@@ -810,6 +816,7 @@ private fun WhenTimeSegment(
     departNow: Boolean,
     dateLabel: String,
     timeLabel: String,
+    dayRelation: TripDay,
     onDepartNow: () -> Unit,
     onPickDateTime: () -> Unit
 ) {
@@ -817,16 +824,27 @@ private fun WhenTimeSegment(
     val nowLabel = stringResource(R.string.trip_plan_now)
     Box(modifier) {
         SegmentButton(
-            text = if (departNow) {
-                nowLabel
-            } else {
-                stringResource(R.string.trip_plan_date_time, dateLabel, timeLabel)
-            },
+            text = if (departNow) nowLabel else whenLabel(dayRelation, dateLabel, timeLabel),
             emphasized = false,
             testTag = TripPlanTestTags.WHEN_TIME,
             onClick = { expanded = true }
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            if (!departNow) {
+                // The pinned instant in full, stated once at the head of the menu. The callout is the
+                // action bar's one elastic slot and routinely ellipsizes — its abbreviated label is
+                // what fits, not necessarily what the rider needs to check — so the menu it opens is
+                // where the whole date and time are legible. A "now" trip has no such instant to state.
+                Text(
+                    text = stringResource(R.string.trip_plan_date_time, dateLabel, timeLabel),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .testTag(TripPlanTestTags.WHEN_TIME_HEADER)
+                )
+                HorizontalDivider()
+            }
             DropdownMenuItem(
                 text = { Text(nowLabel) },
                 trailingIcon = if (departNow) {
@@ -865,6 +883,20 @@ private fun WhenTimeSegment(
             )
         }
     }
+}
+
+/**
+ * A pinned instant as the callout states it (#2185): the time first, then the day — but only when the
+ * day needs saying at all. Most pinned trips are for later today, where the date was pure noise
+ * crowding out the one part the rider is reading for; tomorrow has a word, so it gets the word; and
+ * anything further out falls back to its date. The full instant is still one tap away, at the head of
+ * the menu this segment opens.
+ */
+@Composable
+private fun whenLabel(dayRelation: TripDay, dateLabel: String, timeLabel: String): String = when (dayRelation) {
+    TripDay.TODAY -> timeLabel
+    TripDay.TOMORROW -> stringResource(R.string.trip_plan_time_tomorrow, timeLabel)
+    TripDay.OTHER -> stringResource(R.string.trip_plan_time_date, timeLabel, dateLabel)
 }
 
 /** One tappable half of the "when" sentence: text plus a small chevron, on a rounded press surface. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -120,6 +120,17 @@ data class AdvancedSettings(
     val bikePreference: BikePreference = BikePreference.MEDIUM
 )
 
+/**
+ * Which day a pinned trip instant falls on, as a rider would name it. Settled where the form's
+ * date/time labels are — against a clock reading, in the ViewModel — so the callout can state the
+ * day in words instead of a date whenever there is a word for it (#2185).
+ */
+enum class TripDay {
+    TODAY,
+    TOMORROW,
+    OTHER
+}
+
 /** A fully-specified plan request handed to [TripPlanRepository]. */
 data class TripPlanParams(
     val from: TripEndpoint,
@@ -153,6 +164,13 @@ data class TripPlanFormState(
     val departNow: Boolean = true,
     val dateLabel: String = "",
     val timeLabel: String = "",
+    /**
+     * Which day [dateTimeMillis] falls on, relative to the clock as it read when the labels above
+     * were written. The callout leads with the time and names the day only when it isn't today, so
+     * this travels with [dateLabel]/[timeLabel] rather than being re-derived per recomposition —
+     * one instant, one set of labels, no way for them to disagree.
+     */
+    val dayRelation: TripDay = TripDay.TODAY,
     val modes: TripModeSelection = TripModeSelection(),
     val wheelchair: Boolean = false,
     val optimizeTransfers: Boolean = false,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -420,9 +420,12 @@ class TripPlanViewModel @Inject constructor(
          */
         val REVERSE_GEOCODE_TIMEOUT = 4.seconds
 
-        // Mirror OTPConstants.TRIP_PLAN_DATE/TIME_STRING_FORMAT (inlined to keep this JVM-pure).
+        // Inlined rather than taken from OTPConstants.TRIP_PLAN_DATE/TIME_STRING_FORMAT, to keep this
+        // JVM-pure. The hour is `h`, not that constant's `hh`: an hour is never zero-padded when
+        // spoken, and the callout now leads with the time (#2185), so "06:44 PM" put its widest,
+        // least-informative character first.
         const val DATE_PATTERN = "MMMM dd"
-        const val TIME_PATTERN = "hh:mm a"
+        const val TIME_PATTERN = "h:mm a"
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.text.SimpleDateFormat
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
 import java.util.Locale
@@ -46,6 +47,7 @@ import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.location.SearchCenter
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.TimeProvider
 
 /**
@@ -73,7 +75,7 @@ class TripPlanViewModel @Inject constructor(
      */
     fun mapPickerCenter(): Location? = searchCenter.current()
 
-    private val initialDateTimeMillis = timeProvider.now()
+    private val initialNow = WallTime(timeProvider.now())
     private val initialSettings = settingsRepository.load()
 
     /**
@@ -94,7 +96,7 @@ class TripPlanViewModel @Inject constructor(
             walkPreference = initialSettings.walkPreference,
             cyclingPreference = initialSettings.cyclingPreference,
             bikePreference = initialSettings.bikePreference
-        ).withWhen(initialDateTimeMillis, departNow = true)
+        ).withWhen(initialNow, departNow = true, now = initialNow)
     )
     val formState: StateFlow<TripPlanFormState> = _formState.asStateFlow()
 
@@ -253,7 +255,8 @@ class TripPlanViewModel @Inject constructor(
      * the time together, so this is one write and one re-plan for both halves.
      */
     fun setDateTime(millis: Long) {
-        _formState.update { it.withWhen(millis, departNow = false) }
+        val now = WallTime(timeProvider.now())
+        _formState.update { it.withWhen(WallTime(millis), departNow = false, now = now) }
         replanOrClearResult()
     }
 
@@ -263,8 +266,10 @@ class TripPlanViewModel @Inject constructor(
      * instant that was abandoned.
      */
     fun setDepartNow() {
-        val now = timeProvider.now()
-        _formState.update { it.withWhen(now, departNow = true) }
+        // One reading, serving as both the instant to pin and the reference its day is measured
+        // against. Two reads could straddle midnight and label the clock's own "now" as tomorrow.
+        val now = WallTime(timeProvider.now())
+        _formState.update { it.withWhen(now, departNow = true, now = now) }
         replanOrClearResult()
     }
 
@@ -275,13 +280,16 @@ class TripPlanViewModel @Inject constructor(
      * instant in the form's time callout, which is the thing the rider then moves.
      */
     fun setArriving(arriving: Boolean) {
+        // Read outside the update, so the pinned instant and the day it is labelled with come from
+        // one reading — and so a retried update can't re-read the clock mid-write.
+        val now = WallTime(timeProvider.now())
         _formState.update { state ->
             if (!arriving || !state.departNow) {
                 state.copy(arriving = arriving)
             } else {
                 // Pin to the clock now, not to dateTimeMillis — under the "now" anchor that field
                 // still holds the instant the ViewModel was built, which may be long past.
-                state.copy(arriving = true).withWhen(timeProvider.now(), departNow = false)
+                state.copy(arriving = true).withWhen(now, departNow = false, now = now)
             }
         }
         replanOrClearResult()
@@ -339,6 +347,7 @@ class TripPlanViewModel @Inject constructor(
         arriving: Boolean,
         itineraries: List<TripItinerary>
     ) {
+        val now = WallTime(timeProvider.now())
         _formState.update {
             // A restored trip carries the instant it was planned for, so it is pinned rather than
             // anchored to "now" — re-anchoring would silently re-time the very trip being restored.
@@ -346,7 +355,7 @@ class TripPlanViewModel @Inject constructor(
                 from = from ?: it.from,
                 to = to ?: it.to,
                 arriving = arriving
-            ).withWhen(dateTimeMillis, departNow = false)
+            ).withWhen(WallTime(dateTimeMillis), departNow = false, now = now)
         }
         if (itineraries.isNotEmpty()) {
             _planState.value = PlanResult.Success(itineraries)
@@ -374,16 +383,20 @@ class TripPlanViewModel @Inject constructor(
     }
 
     /**
-     * This form with its "when" set to [millis], and every label describing it re-derived in the same
+     * This form with its "when" set to [instant], and every label describing it re-derived in the same
      * write. The three are one fact about one instant — the date, the time, and which day that is —
      * so they move together and can never be left describing the instant before.
+     *
+     * [now] is passed in rather than read here, so one clock reading serves the whole write: the caller
+     * that pins *the clock itself* hands the same value as both arguments, and no update can straddle
+     * midnight between choosing an instant and deciding which day it falls on.
      */
-    private fun TripPlanFormState.withWhen(millis: Long, departNow: Boolean): TripPlanFormState = copy(
-        dateTimeMillis = millis,
+    private fun TripPlanFormState.withWhen(instant: WallTime, departNow: Boolean, now: WallTime): TripPlanFormState = copy(
+        dateTimeMillis = instant.epochMs,
         departNow = departNow,
-        dateLabel = formatDate(millis),
-        timeLabel = formatTime(millis),
-        dayRelation = dayRelationOf(millis)
+        dateLabel = formatDate(instant.epochMs),
+        timeLabel = formatTime(instant.epochMs),
+        dayRelation = dayRelationOf(instant, now)
     )
 
     private fun formatDate(millis: Long): String = SimpleDateFormat(DATE_PATTERN, Locale.getDefault()).format(Date(millis))
@@ -391,24 +404,28 @@ class TripPlanViewModel @Inject constructor(
     private fun formatTime(millis: Long): String = SimpleDateFormat(TIME_PATTERN, Locale.getDefault()).format(Date(millis))
 
     /**
-     * Which day [millis] falls on, in the device's own zone — the same wall clock [formatDate] renders
-     * in, and the one the picker composes its instants in ([TripDateTimeDialog]).
+     * Which day [instant] falls on relative to [now]. Both are [WallTime] — the device's own clock,
+     * which is the domain a rider's "today" belongs to and the one [formatDate] renders in; a server
+     * instant compared against it here would be a #1612-class skew bug, and now won't compile.
      *
-     * Read against the clock at the moment the label is written, which is what makes this a label and
-     * not live state: a form left open across midnight keeps saying what it said when the rider pinned
-     * the trip, exactly as the picker's own day dropdown holds its "Today" for as long as it is open.
-     * The instant itself never moves, so the trip that gets planned is unaffected either way.
+     * Measured against the clock at the moment the label is *written*, which is what makes this a label
+     * and not live state: a form left open across midnight keeps saying what it said when the rider
+     * pinned the trip, exactly as the picker's own day dropdown holds its "Today" for as long as it is
+     * open. The instant itself never moves, so the trip that gets planned is unaffected either way.
      */
-    private fun dayRelationOf(millis: Long): TripDay {
+    private fun dayRelationOf(instant: WallTime, now: WallTime): TripDay {
         val zone = ZoneId.systemDefault()
-        val day = Instant.ofEpochMilli(millis).atZone(zone).toLocalDate()
-        val today = Instant.ofEpochMilli(timeProvider.now()).atZone(zone).toLocalDate()
+        val day = instant.toLocalDate(zone)
+        val today = now.toLocalDate(zone)
         return when (day) {
             today -> TripDay.TODAY
             today.plusDays(1) -> TripDay.TOMORROW
             else -> TripDay.OTHER
         }
     }
+
+    /** The calendar day this instant falls on in [zone] — an unwrap for java.time, which wants millis. */
+    private fun WallTime.toLocalDate(zone: ZoneId): LocalDate = Instant.ofEpochMilli(epochMs).atZone(zone).toLocalDate()
 
     private companion object {
         const val SUGGEST_DEBOUNCE_MS = 350L

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
@@ -85,9 +87,6 @@ class TripPlanViewModel @Inject constructor(
 
     private val _formState = MutableStateFlow(
         TripPlanFormState(
-            dateTimeMillis = initialDateTimeMillis,
-            dateLabel = formatDate(initialDateTimeMillis),
-            timeLabel = formatTime(initialDateTimeMillis),
             modes = initialSettings.modes,
             maxWalkMeters = initialSettings.maxWalkMeters,
             optimizeTransfers = initialSettings.optimizeTransfers,
@@ -95,7 +94,7 @@ class TripPlanViewModel @Inject constructor(
             walkPreference = initialSettings.walkPreference,
             cyclingPreference = initialSettings.cyclingPreference,
             bikePreference = initialSettings.bikePreference
-        )
+        ).withWhen(initialDateTimeMillis, departNow = true)
     )
     val formState: StateFlow<TripPlanFormState> = _formState.asStateFlow()
 
@@ -254,14 +253,7 @@ class TripPlanViewModel @Inject constructor(
      * the time together, so this is one write and one re-plan for both halves.
      */
     fun setDateTime(millis: Long) {
-        _formState.update {
-            it.copy(
-                dateTimeMillis = millis,
-                departNow = false,
-                dateLabel = formatDate(millis),
-                timeLabel = formatTime(millis)
-            )
-        }
+        _formState.update { it.withWhen(millis, departNow = false) }
         replanOrClearResult()
     }
 
@@ -272,14 +264,7 @@ class TripPlanViewModel @Inject constructor(
      */
     fun setDepartNow() {
         val now = timeProvider.now()
-        _formState.update {
-            it.copy(
-                dateTimeMillis = now,
-                departNow = true,
-                dateLabel = formatDate(now),
-                timeLabel = formatTime(now)
-            )
-        }
+        _formState.update { it.withWhen(now, departNow = true) }
         replanOrClearResult()
     }
 
@@ -296,14 +281,7 @@ class TripPlanViewModel @Inject constructor(
             } else {
                 // Pin to the clock now, not to dateTimeMillis — under the "now" anchor that field
                 // still holds the instant the ViewModel was built, which may be long past.
-                val now = timeProvider.now()
-                state.copy(
-                    arriving = true,
-                    departNow = false,
-                    dateTimeMillis = now,
-                    dateLabel = formatDate(now),
-                    timeLabel = formatTime(now)
-                )
+                state.copy(arriving = true).withWhen(timeProvider.now(), departNow = false)
             }
         }
         replanOrClearResult()
@@ -362,17 +340,13 @@ class TripPlanViewModel @Inject constructor(
         itineraries: List<TripItinerary>
     ) {
         _formState.update {
+            // A restored trip carries the instant it was planned for, so it is pinned rather than
+            // anchored to "now" — re-anchoring would silently re-time the very trip being restored.
             it.copy(
                 from = from ?: it.from,
                 to = to ?: it.to,
-                dateTimeMillis = dateTimeMillis,
-                // A restored trip carries the instant it was planned for, so it is pinned rather than
-                // anchored to "now" — re-anchoring would silently re-time the very trip being restored.
-                departNow = false,
-                dateLabel = formatDate(dateTimeMillis),
-                timeLabel = formatTime(dateTimeMillis),
                 arriving = arriving
-            )
+            ).withWhen(dateTimeMillis, departNow = false)
         }
         if (itineraries.isNotEmpty()) {
             _planState.value = PlanResult.Success(itineraries)
@@ -399,9 +373,42 @@ class TripPlanViewModel @Inject constructor(
         planInputs.trySend(if (form.canSubmit) form.toParams(timeProvider.now()) else null)
     }
 
+    /**
+     * This form with its "when" set to [millis], and every label describing it re-derived in the same
+     * write. The three are one fact about one instant — the date, the time, and which day that is —
+     * so they move together and can never be left describing the instant before.
+     */
+    private fun TripPlanFormState.withWhen(millis: Long, departNow: Boolean): TripPlanFormState = copy(
+        dateTimeMillis = millis,
+        departNow = departNow,
+        dateLabel = formatDate(millis),
+        timeLabel = formatTime(millis),
+        dayRelation = dayRelationOf(millis)
+    )
+
     private fun formatDate(millis: Long): String = SimpleDateFormat(DATE_PATTERN, Locale.getDefault()).format(Date(millis))
 
     private fun formatTime(millis: Long): String = SimpleDateFormat(TIME_PATTERN, Locale.getDefault()).format(Date(millis))
+
+    /**
+     * Which day [millis] falls on, in the device's own zone — the same wall clock [formatDate] renders
+     * in, and the one the picker composes its instants in ([TripDateTimeDialog]).
+     *
+     * Read against the clock at the moment the label is written, which is what makes this a label and
+     * not live state: a form left open across midnight keeps saying what it said when the rider pinned
+     * the trip, exactly as the picker's own day dropdown holds its "Today" for as long as it is open.
+     * The instant itself never moves, so the trip that gets planned is unaffected either way.
+     */
+    private fun dayRelationOf(millis: Long): TripDay {
+        val zone = ZoneId.systemDefault()
+        val day = Instant.ofEpochMilli(millis).atZone(zone).toLocalDate()
+        val today = Instant.ofEpochMilli(timeProvider.now()).atZone(zone).toLocalDate()
+        return when (day) {
+            today -> TripDay.TODAY
+            today.plusDays(1) -> TripDay.TOMORROW
+            else -> TripDay.OTHER
+        }
+    }
 
     private companion object {
         const val SUGGEST_DEBOUNCE_MS = 350L

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -949,8 +949,15 @@
     <!-- The directions form's time callout, e.g. "Leaving · now". Lowercase: it reads as part of a
          sentence next to Leaving/Arriving, not as a heading. -->
     <string name="trip_plan_now">now</string>
-    <!-- A pinned departure/arrival in the time callout: date, then time. -->
+    <!-- A pinned departure/arrival stated in full, at the head of the time callout's menu: date,
+         then time. -->
     <string name="trip_plan_date_time">%1$s, %2$s</string>
+    <!-- The same instant as the callout itself states it, leading with the time because that is what
+         a rider is reading for, and naming the day only when it isn't today. A trip later today is
+         just the time, with no suffix at all. Lowercase, like trip_plan_now: it reads as part of a
+         sentence next to Leaving/Arriving. %1$s is the time, %2$s the date. -->
+    <string name="trip_plan_time_tomorrow">%1$s, tomorrow</string>
+    <string name="trip_plan_time_date">%1$s, %2$s</string>
     <!-- The one row of the time callout's menu that opens the combined date/time picker. -->
     <string name="trip_plan_choose_date_time">Choose date and time…</string>
     <!-- The third row of that picker's day dropdown, which opens the calendar. -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -121,6 +121,17 @@ class TripPlanViewModelTest {
         override fun now(): Long = nowMillis
     }
 
+    /**
+     * A clock that moves *between reads*, walking [readings] and then holding the last one. Where
+     * [FakeClock] holds still — and so cannot tell one read apart from two — this makes the number of
+     * reads a helper takes observable.
+     */
+    private class TickingClock(var readings: List<Long>) : TimeProvider {
+        var index = 0
+
+        override fun now(): Long = readings[minOf(index++, readings.lastIndex)]
+    }
+
     private fun viewModel(
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
         plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(TripItinerary()))),
@@ -726,6 +737,28 @@ class TripPlanViewModelTest {
     @Test
     fun `a form starts on today`() = runTest {
         assertEquals(TripDay.TODAY, viewModel().formState.value.dayRelation)
+    }
+
+    /**
+     * Pinning the clock takes *one* reading, which then serves as both the instant pinned and the
+     * reference its day is measured against. Two readings can straddle midnight, and the trip the
+     * rider just pinned to "now" would come back labelled with a different day than the clock it was
+     * taken from — so the clock is read at the call site and passed down, never inside the helper.
+     */
+    @Test
+    fun `pinning the clock takes a single reading, even across midnight`() = runTest {
+        val midnight = LocalDate.of(2026, 6, 11).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val clock = TickingClock(listOf(midnight - 1))
+        val vm = viewModel(clock = clock)
+
+        // From here the clock ticks over midnight on its second read, so a helper that reads it again
+        // mid-write lands on the next day and labels 23:59:59.999 as something other than today.
+        clock.readings = listOf(midnight - 1, midnight)
+        clock.index = 0
+        vm.setDepartNow()
+
+        assertEquals(TripDay.TODAY, vm.formState.value.dayRelation)
+        assertEquals(midnight - 1, vm.formState.value.dateTimeMillis)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -575,6 +575,23 @@ class TripPlanViewModelTest {
         assertEquals(1_700_000_000_000L, state.dateTimeMillis)
     }
 
+    /**
+     * A single-digit hour isn't padded — "6:44 PM", not "06:44 PM". Asserted as the absence of the
+     * pad rather than against a literal, which would pin the runner's locale: the padding is the
+     * pattern's doing (`h`, not `hh`) and so is locale-independent, but the digits aren't.
+     */
+    @Test
+    fun `the time label does not zero-pad the hour`() = runTest {
+        val vm = viewModel()
+
+        vm.setDateTime(millisOn(LocalDate.of(2026, 6, 10), hour = 6))
+
+        assertFalse(
+            "expected an unpadded hour, but the label was ${vm.formState.value.timeLabel}",
+            vm.formState.value.timeLabel.startsWith("0")
+        )
+    }
+
     @Test
     fun `a form starts anchored to now`() = runTest {
         assertTrue(viewModel().formState.value.departNow)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -16,6 +16,8 @@
 package org.onebusaway.android.ui.tripplan
 
 import java.io.IOException
+import java.time.LocalDate
+import java.time.ZoneId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -137,6 +139,13 @@ class TripPlanViewModelTest {
             FakeAdvancedSettingsRepository()
         )
     }
+
+    /**
+     * A wall-clock instant on [date], in the device's own zone — the zone the form reasons about days
+     * in, so a fixed epoch millis would place these cases on a different date depending on where the
+     * test runs.
+     */
+    private fun millisOn(date: LocalDate, hour: Int): Long = date.atTime(hour, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
     /** Sets both resolved endpoints (which auto-submits a plan once both have coordinates). */
     private fun setBothEndpoints(vm: TripPlanViewModel) {
@@ -656,6 +665,50 @@ class TripPlanViewModelTest {
         assertFalse(state.departNow)
         // Pinned to the clock at the moment of the switch, not to the stale construction stamp.
         assertEquals(60_000L, state.dateTimeMillis)
+    }
+
+    /**
+     * The callout names the day in words where there is a word for it (#2185), so the ViewModel
+     * settles which day a pinned instant falls on alongside the labels it formats.
+     */
+    @Test
+    fun `a pinned instant is classified by the day it falls on`() = runTest {
+        val today = LocalDate.of(2026, 6, 10)
+        val vm = viewModel(clock = FakeClock(millisOn(today, hour = 9)))
+
+        vm.setDateTime(millisOn(today, hour = 17))
+        assertEquals(TripDay.TODAY, vm.formState.value.dayRelation)
+
+        vm.setDateTime(millisOn(today.plusDays(1), hour = 8))
+        assertEquals(TripDay.TOMORROW, vm.formState.value.dayRelation)
+
+        vm.setDateTime(millisOn(today.plusDays(2), hour = 8))
+        assertEquals(TripDay.OTHER, vm.formState.value.dayRelation)
+
+        // Yesterday is a different day, not a near-enough one — the relation is about the calendar,
+        // not about how far off the instant is.
+        vm.setDateTime(millisOn(today.minusDays(1), hour = 23))
+        assertEquals(TripDay.OTHER, vm.formState.value.dayRelation)
+    }
+
+    /**
+     * Calendar days, not elapsed hours: half an hour past midnight is *tomorrow* to a rider standing
+     * there at 23:30, and would be "today" to any rule that measured the gap instead of the date.
+     */
+    @Test
+    fun `the day a pinned instant falls on is measured in dates, not hours`() = runTest {
+        val today = LocalDate.of(2026, 6, 10)
+        val vm = viewModel(clock = FakeClock(millisOn(today, hour = 23)))
+
+        vm.setDateTime(millisOn(today.plusDays(1), hour = 0))
+
+        assertEquals(TripDay.TOMORROW, vm.formState.value.dayRelation)
+    }
+
+    /** A trip anchored to "now" is by definition for today. */
+    @Test
+    fun `a form starts on today`() = runTest {
+        assertEquals(TripDay.TODAY, viewModel().formState.value.dayRelation)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2185.

## The problem

The directions form's time callout stated a pinned departure as `June 10, 03:45 PM` whatever day it was for. It is the action bar's one elastic slot, so that label routinely ellipsized — and what it cut first was the *time*, which is the part a rider opened it to read, in favour of a date most of them already knew.

## What changed

**The callout leads with the time, and names the day only when the day needs naming:**

| The trip is for | Before | After |
| --- | --- | --- |
| later today | `June 10, 03:45 PM` | `3:45 PM` |
| tomorrow | `June 11, 03:45 PM` | `3:45 PM, tomorrow` |
| any further day | `June 14, 03:45 PM` | `3:45 PM, June 14` |

**The hour is no longer zero-padded** — `6:44 PM`, not `06:44 PM` (`h`, not `hh`). An hour isn't padded when spoken, and now that the time comes first the pad put the label's widest, least-informative character at the front.

**The menu states the instant in full.** Whichever form the shortened label takes, the dropdown it opens now carries the whole date and time as a header above its two rows ("now" / "Choose date and time…"), so nothing the label leaves out is more than a tap away. A trip anchored to "now" has no pinned instant, so it gets no header.

## How the day is decided

Which day a pinned instant falls on is a fact about a clock reading, so it is settled in `TripPlanViewModel` alongside the date and time labels rather than re-derived per recomposition — one instant, one `withWhen()` write, no way for the three to disagree — and carried to the form as `TripPlanFormState.dayRelation` (`TripDay.TODAY` / `TOMORROW` / `OTHER`).

It's a **calendar-date comparison in the device's own zone** — the zone the labels are formatted in and the picker composes its instants in — not an elapsed-hours guess: 00:30 is *tomorrow* to a rider standing there at 23:30, and any rule measuring the gap instead of the date would call it today.

Like the picker's own day dropdown, the relation is a label written once against the clock, not live state: a form left open across midnight keeps saying what it said when the rider pinned the trip. The instant itself never moves, so the trip that actually gets planned is unaffected either way.

## Refactor along the way

The four places that wrote `dateTimeMillis` + `dateLabel` + `timeLabel` (`setDateTime`, `setDepartNow`, `setArriving`, `restoreFrom`, plus the seed) now go through one `TripPlanFormState.withWhen(millis, departNow)`, which is what keeps the new third field from being forgotten at one of them.

## Tests

Both suites run and green.

- `TripPlanViewModelTest` (JVM): the day classification across today / tomorrow / two days out / yesterday; that it is measured in dates and not hours (23:00 → 00:30 next day is TOMORROW); that a fresh form starts on today; and that the hour isn't zero-padded.
- `TripPlanFormRenderTest` (instrumented, run on a Pixel 7 Pro): each of the three callout forms renders; the menu states the pinned instant in full; a "now" trip gets no header. 24 of the class's 25 tests pass — the one failure, `reverseSitsBetweenTheTwoEndpointFields`, is **pre-existing and unrelated** (a 1px rounding artifact at this device's density: expected 139, got 140). Verified by running that same test on `main`, where it fails identically.

Also compiles clean under `-PwarningsAsErrors=true`, and `spotlessCheck` passes.

New strings are English-only (`trip_plan_time_tomorrow`, `trip_plan_time_date`); translations fall back to English until translators pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip planner time labels now distinguish trips happening today, tomorrow, or on a later date.
  * Expanded time menus display the complete pinned date and time when applicable.
  * “Now” trips no longer show an unnecessary time header.
  * Single-digit hours now display without a leading zero.
  * Date and time labels now consistently reflect the device’s local timezone.

* **Tests**
  * Added coverage for date labeling, midnight boundaries, restored trips, and time-menu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->