### PR TITLE
Draw a drilled-into ride in its planned colour while its route loads (#2186)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -301,9 +301,13 @@ class RouteMapController(
     private val isInterlineComposite: Boolean
         get() = extraSegments.any { it.relationship == RouteFocusRelationship.STAY_ABOARD }
 
-    /** The loaded [RouteMap] backing an extra segment: the leader's own route when the ids match (a
-     *  self-interline's other direction), else its separately-loaded route (null until it loads). */
-    private fun RouteFocusSegment.routeMap(): RouteMap? = if (routeId == this@RouteMapController.routeId) routeShape else extraRouteMaps[routeId]
+    /** The loaded [RouteMap] a piece of the ride is drawn from — an extra segment, or a ridden span
+     *  ([spanColor]): the leader's own route when the ids match (a self-interline's other direction) or the
+     *  piece names none, else that route's separately-loaded map. Null until that load lands, which is what
+     *  a caller reads as "not loaded yet". */
+    private fun loadedRouteMap(id: String?): RouteMap? = if (id == null || id == routeId) routeShape else extraRouteMaps[id]
+
+    private fun RouteFocusSegment.routeMap(): RouteMap? = loadedRouteMap(routeId)
 
     private fun RouteFocusSegment.directionId(): Int? = routeMap()?.let { route -> resolveRouteFocusSegmentDirection(this, route) }
 
@@ -687,15 +691,12 @@ class RouteMapController(
      * over can't disagree. A stay-aboard interline therefore changes colour at its cutover exactly as the
      * itinerary map and the drawer's badges do, instead of drawing two routes as one.
      *
-     * Falls back to [leaderColor] for a span whose route isn't identified or hasn't loaded yet: the shown
-     * route's colour is what the whole ride used to draw in, so an unresolved span looks exactly as it did
-     * before rather than dropping to a default the rest of the view isn't using. A late-loading extra route
-     * republishes, so the fallback lasts only as long as the load.
+     * Which colour it asks the palette for is [riddenSpanColorSource]: until the span's route has loaded
+     * there is none to ask for, and the span draws in the one the plan gave it instead. [leaderColor] is the
+     * last resort either way — the shown route's colour, which is what the whole ride used to draw in — and
+     * a late-loading extra route republishes, so a span reaches its own colour as soon as there is one.
      */
-    private fun spanColor(span: RiddenSpan, leaderColor: Int): Int {
-        val route = span.routeId?.takeIf { it != routeId }?.let { extraRouteMaps[it] } ?: return leaderColor
-        return palette.lineColor(route.route?.color) ?: leaderColor
-    }
+    private fun spanColor(span: RiddenSpan, leaderColor: Int): Int = palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(span.routeId)?.route)) ?: leaderColor
 
     /**
      * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
@@ -856,8 +857,9 @@ class RouteMapController(
     // state is resolved into plain data first ([selectedTripRenderInput]); the mode-merging policy lives
     // in the pure function, so this stays a plumb-through.
     private fun publishMapPresentation() {
-        // Both the selected trip's fallback and the ridden segment draw in the shown route's colour;
-        // resolve it once so a publish runs the colour policy a single time.
+        // The shown route's colour: what the selected trip falls back to, and what a ridden span falls back
+        // to when neither its own route nor the plan can colour it ([spanColor]). Resolved once here rather
+        // than by each consumer, so the two can't answer it differently.
         val routeColor = currentRouteColor()
         // One snapshot of the focused-stop layer for the whole publish, so the plan can't read a
         // half-swapped focus (its geometry and stops resolve independently).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -679,9 +679,9 @@ class RouteMapController(
 
     /**
      * The shown route's colour as this map draws it (also the band tint's basis): the agency's hue put
-     * through this session's [palette], or the default when the route carries no usable colour. This is what
-     * a ridden directions leg's highlighted segment is drawn in, so tapping a leg in the drawer lands on the
-     * same colour the itinerary's own line had — which is why the palette travels with the drill-in.
+     * through this session's [palette], or the default when the route carries no usable colour. The palette
+     * is what makes a drill-in land on the colour the itinerary's own line had, which is why it travels with
+     * it; the ridden segment resolves its own colour per span ([spanColor]) rather than through here.
      */
     private fun currentRouteColor(): Int = palette.lineColor((_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color) ?: DEFAULT_ROUTE_LINE_COLOR
 
@@ -692,11 +692,16 @@ class RouteMapController(
      * itinerary map and the drawer's badges do, instead of drawing two routes as one.
      *
      * Which colour it asks the palette for is [riddenSpanColorSource]: until the span's route has loaded
-     * there is none to ask for, and the span draws in the one the plan gave it instead. [leaderColor] is the
-     * last resort either way — the shown route's colour, which is what the whole ride used to draw in — and
-     * a late-loading extra route republishes, so a span reaches its own colour as soon as there is one.
+     * there is none to ask for, and the span draws in the one the plan gave it instead. The load
+     * republishes, so a span reaches its own colour as soon as there is one.
+     *
+     * Null — nothing loaded and no planned colour, or a loaded route publishing nothing usable — is left
+     * for the renderer to resolve ([RoutePolyline.resolvedColor]), which is what [directionPolylines] does
+     * with its own null. That is the whole point of declining to stand in for a loaded route here: the
+     * corridor beneath the span is drawn from that same route, so both must reach the fallback together or
+     * the span is a line its own approach can't match.
      */
-    private fun spanColor(span: RiddenSpan, leaderColor: Int): Int = palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(span.routeId)?.route)) ?: leaderColor
+    private fun spanColor(span: RiddenSpan): Int? = palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(span.routeId)?.route))
 
     /**
      * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
@@ -857,9 +862,9 @@ class RouteMapController(
     // state is resolved into plain data first ([selectedTripRenderInput]); the mode-merging policy lives
     // in the pure function, so this stays a plumb-through.
     private fun publishMapPresentation() {
-        // The shown route's colour: what the selected trip falls back to, and what a ridden span falls back
-        // to when neither its own route nor the plan can colour it ([spanColor]). Resolved once here rather
-        // than by each consumer, so the two can't answer it differently.
+        // The shown route's colour, for the selected trip to fall back to. A ridden span resolves its own
+        // ([spanColor]) and reaches the renderer's default the way every other route line does, so it isn't
+        // a consumer of this.
         val routeColor = currentRouteColor()
         // One snapshot of the focused-stop layer for the whole publish, so the plan can't read a
         // half-swapped focus (its geometry and stops resolve independently).
@@ -884,7 +889,7 @@ class RouteMapController(
             polylines = routePolylinesWithSegment(
                 plan.polylines,
                 riddenSpans,
-                colorOf = { spanColor(it, leaderColor = routeColor) },
+                colorOf = ::spanColor,
                 itineraryContext = itineraryContext
             ),
             framingPolylines = plan.framingPolylines,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -301,11 +301,13 @@ class RouteMapController(
     private val isInterlineComposite: Boolean
         get() = extraSegments.any { it.relationship == RouteFocusRelationship.STAY_ABOARD }
 
-    /** The loaded [RouteMap] a piece of the ride is drawn from — an extra segment, or a ridden span
-     *  ([spanColor]): the leader's own route when the ids match (a self-interline's other direction) or the
-     *  piece names none, else that route's separately-loaded map. Null until that load lands, which is what
-     *  a caller reads as "not loaded yet". */
-    private fun loadedRouteMap(id: String?): RouteMap? = if (id == null || id == routeId) routeShape else extraRouteMaps[id]
+    /** The loaded [RouteMap] a piece of the ride naming route [id] is drawn from — an extra segment, or a
+     *  ridden span ([spanColor]): the leader's own route when the ids match (a self-interline's other
+     *  direction), else that route's separately-loaded map. Null until that load lands, which is what a
+     *  caller reads as "not loaded yet". Takes an id a piece actually names: a piece naming *no* route has
+     *  no map of its own to wait for, and answering the leader's for it would say a route it isn't ridden
+     *  as is the one that colours it. */
+    private fun loadedRouteMap(id: String): RouteMap? = if (id == routeId) routeShape else extraRouteMaps[id]
 
     private fun RouteFocusSegment.routeMap(): RouteMap? = loadedRouteMap(routeId)
 
@@ -681,7 +683,8 @@ class RouteMapController(
      * The shown route's colour as this map draws it (also the band tint's basis): the agency's hue put
      * through this session's [palette], or the default when the route carries no usable colour. The palette
      * is what makes a drill-in land on the colour the itinerary's own line had, which is why it travels with
-     * it; the ridden segment resolves its own colour per span ([spanColor]) rather than through here.
+     * it; a ridden segment resolves its own colour per span ([spanColor]) and reaches this only for a span
+     * that names no route at all.
      */
     private fun currentRouteColor(): Int = palette.lineColor((_loadedRoute.value as? LoadedRoute.Loaded)?.route?.color) ?: DEFAULT_ROUTE_LINE_COLOR
 
@@ -700,8 +703,19 @@ class RouteMapController(
      * with its own null. That is the whole point of declining to stand in for a loaded route here: the
      * corridor beneath the span is drawn from that same route, so both must reach the fallback together or
      * the span is a line its own approach can't match.
+     *
+     * A span naming **no** route is the exception, and takes the other branch entirely: no load will ever
+     * answer for it, so the plan has the only colour it will ever have — permanently, not for a window. Such
+     * a span is either a ride leg whose route couldn't be resolved to an OBA id (dropped from
+     * [extraSegments] too, so no corridor of its own is drawn to match) or the whole undivided ride the
+     * drawer falls back to, which has no plan colour either and draws in the shown route's, as that ride
+     * always has. Never the leader's loaded route: it is not ridden as that route, and borrowing its colour
+     * would draw the mid-ride change of route away.
      */
-    private fun spanColor(span: RiddenSpan): Int? = palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(span.routeId)?.route))
+    private fun spanColor(span: RiddenSpan): Int? = when (val id = span.routeId) {
+        null -> palette.lineColor(riddenSpanColorSource(span, loadedRoute = null)) ?: currentRouteColor()
+        else -> palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(id)?.route))
+    }
 
     /**
      * Resolve (or clear) the selected vehicle's route continuation (#1691); driven by [selectionJob]'s
@@ -863,8 +877,9 @@ class RouteMapController(
     // in the pure function, so this stays a plumb-through.
     private fun publishMapPresentation() {
         // The shown route's colour, for the selected trip to fall back to. A ridden span resolves its own
-        // ([spanColor]) and reaches the renderer's default the way every other route line does, so it isn't
-        // a consumer of this.
+        // ([spanColor]) and reaches the renderer's default the way every other route line does, so it reads
+        // this only in the one case that has no route to resolve through — and asks for it there itself,
+        // rather than every publish resolving it for a span that usually doesn't want it.
         val routeColor = currentRouteColor()
         // One snapshot of the focused-stop layer for the whole publish, so the plan can't read a
         // half-swapped focus (its geometry and stops resolve independently).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -711,10 +711,16 @@ class RouteMapController(
      * drawer falls back to, which has no plan colour either and draws in the shown route's, as that ride
      * always has. Never the leader's loaded route: it is not ridden as that route, and borrowing its colour
      * would draw the mid-ride change of route away.
+     *
+     * The load is read as [LoadedSpanRoute] off the *map*, not off its route: a [RouteMap] whose response
+     * carried no route in its references has still landed, and answers with the colour it has (none) — the
+     * very colour [directionPolylines] draws its corridor in. Reading `route` for the landing instead would
+     * make that span the one case where the two disagree. A load that *failed* is a different thing and
+     * stays absent: nothing will republish for it, so the plan keeps that span for good.
      */
     private fun spanColor(span: RiddenSpan): Int? = when (val id = span.routeId) {
-        null -> palette.lineColor(riddenSpanColorSource(span, loadedRoute = null)) ?: currentRouteColor()
-        else -> palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(id)?.route))
+        null -> palette.lineColor(riddenSpanColorSource(span, loaded = null)) ?: currentRouteColor()
+        else -> palette.lineColor(riddenSpanColorSource(span, loadedRouteMap(id)?.let { LoadedSpanRoute(it.route?.color) }))
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -75,8 +75,8 @@ data class RiddenSpan(
 /**
  * The colour a ridden span is drawn from, for a palette to render: its own route's published colour once
  * that route has loaded ([loadedRoute]), else the colour the plan gave it ([RiddenSpan.plannedColor]). Null
- * when neither publishes one, which is the caller's own fallback — the same `palette.lineColor(…) ?: …`
- * shape every other route line on this map is coloured by.
+ * when neither publishes one — a colour left unstated, which the renderer resolves to its default, exactly
+ * as it does for a route line whose route publishes nothing usable.
  *
  * The plan answers for the load window, which is a network round trip the rider spends looking at the map
  * (#2186). Nothing answered for it before: the span was drawn in the *shown route's* colour, which until
@@ -84,10 +84,11 @@ data class RiddenSpan(
  * before it settled into its route's colour. The plan already published that colour; it just wasn't asked.
  *
  * A loaded route then answers alone, its own missing colour included, rather than the plan filling in for
- * it: the corridor beneath the span is drawn from that same route (`directionPolylines`), so a span that
- * kept a planned colour there would be a line its own approach couldn't match. Passing the route itself
- * rather than its colour is what keeps "hasn't loaded" and "loaded, publishes nothing" apart — they take
- * opposite branches here, and a bare `Int?` cannot tell them apart.
+ * it: the corridor beneath the span is drawn from that same route (`directionPolylines`), which states no
+ * colour for it either — so both reach the renderer's default together, where a span that kept a planned
+ * colour would be a line its own approach couldn't match. Passing the route itself rather than its colour
+ * is what keeps "hasn't loaded" and "loaded, publishes nothing" apart — they take opposite branches here,
+ * and a bare `Int?` cannot tell them apart.
  */
 internal fun riddenSpanColorSource(span: RiddenSpan, loadedRoute: ObaRoute?): Int? = if (loadedRoute == null) span.plannedColor else loadedRoute.color
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.map
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.Polyline
@@ -25,9 +26,11 @@ import org.onebusaway.android.util.haversineDistance
 
 /**
  * Presenting a trip-plan leg's **ridden segment** over its route in route focus: draw the route's approach
- * to the boarding point, the segment cased on top, and keep only the segment's stops. Pure
- * geometry over flavor-neutral [GeoPoint]/[RoutePolyline]/[ObaStop] (like [RouteViewGeometry] /
- * [projectStopsOntoPolylines]), so it stays JVM-testable and out of [RouteMapController]'s state plumbing.
+ * to the boarding point, the segment cased on top, keep only the segment's stops, and pick which colour the
+ * segment is drawn from ([riddenSpanColorSource] — the source, not the rendering, which stays with the
+ * caller's palette). Pure, over flavor-neutral [GeoPoint]/[RoutePolyline]/[ObaStop]/[ObaRoute] (like
+ * [RouteViewGeometry] / [projectStopsOntoPolylines]), so it stays JVM-testable and out of
+ * [RouteMapController]'s state plumbing.
  */
 
 /** How close a stop must sit to the ridden path to count as "on the segment" — well below transit stop
@@ -57,12 +60,36 @@ internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
  * `Interlines.chains` transitions the drawer and the itinerary map read, so all three mark the same joins. A
  * self-interline — one route reversing onto itself — is a span boundary with no cutover, exactly as it is a
  * seam the drawer announces nothing at.
+ *
+ * [plannedColor] is the GTFS colour the *plan* published for that route, already parsed — the same source
+ * the itinerary's own line for this leg was styled from — carried along so the span can be drawn before
+ * [routeId]'s route has loaded (see [riddenSpanColorSource]). Null when the plan published none.
  */
 data class RiddenSpan(
     val points: List<GeoPoint>,
     val routeId: String? = null,
+    val plannedColor: Int? = null,
     val startsCutover: Boolean = false
 )
+
+/**
+ * The colour a ridden span is drawn from, for a palette to render: its own route's published colour once
+ * that route has loaded ([loadedRoute]), else the colour the plan gave it ([RiddenSpan.plannedColor]). Null
+ * when neither publishes one, which is the caller's own fallback — the same `palette.lineColor(…) ?: …`
+ * shape every other route line on this map is coloured by.
+ *
+ * The plan answers for the load window, which is a network round trip the rider spends looking at the map
+ * (#2186). Nothing answered for it before: the span was drawn in the *shown route's* colour, which until
+ * the load lands is the renderer's `DEFAULT_ROUTE_LINE_COLOR` — so tapping a leg flashed the ride pure blue
+ * before it settled into its route's colour. The plan already published that colour; it just wasn't asked.
+ *
+ * A loaded route then answers alone, its own missing colour included, rather than the plan filling in for
+ * it: the corridor beneath the span is drawn from that same route (`directionPolylines`), so a span that
+ * kept a planned colour there would be a line its own approach couldn't match. Passing the route itself
+ * rather than its colour is what keeps "hasn't loaded" and "loaded, publishes nothing" apart — they take
+ * opposite branches here, and a bare `Int?` cannot tell them apart.
+ */
+internal fun riddenSpanColorSource(span: RiddenSpan, loadedRoute: ObaRoute?): Int? = if (loadedRoute == null) span.plannedColor else loadedRoute.color
 
 /** The whole ride as one path, for the questions that are about the ride and not about its routes: where
  *  the rider boards and alights, what to frame, which stops are on it. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -89,6 +89,11 @@ data class RiddenSpan(
  * colour would be a line its own approach couldn't match. Passing the route itself rather than its colour
  * is what keeps "hasn't loaded" and "loaded, publishes nothing" apart — they take opposite branches here,
  * and a bare `Int?` cannot tell them apart.
+ *
+ * A span whose [RiddenSpan.routeId] never resolved is handed no [loadedRoute] at all — not the ride's shown
+ * route, which is not what it is ridden as — so the plan answers for it permanently rather than for a load
+ * window. The caller decides what a span with neither is (see [RouteMapController.spanColor]); here it is
+ * the same "nothing published a colour" null as any other.
  */
 internal fun riddenSpanColorSource(span: RiddenSpan, loadedRoute: ObaRoute?): Int? = if (loadedRoute == null) span.plannedColor else loadedRoute.color
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.map
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
-import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.Polyline
@@ -28,7 +27,7 @@ import org.onebusaway.android.util.haversineDistance
  * Presenting a trip-plan leg's **ridden segment** over its route in route focus: draw the route's approach
  * to the boarding point, the segment cased on top, keep only the segment's stops, and pick which colour the
  * segment is drawn from ([riddenSpanColorSource] — the source, not the rendering, which stays with the
- * caller's palette). Pure, over flavor-neutral [GeoPoint]/[RoutePolyline]/[ObaStop]/[ObaRoute] (like
+ * caller's palette). Pure, over flavor-neutral [GeoPoint]/[RoutePolyline]/[ObaStop] (like
  * [RouteViewGeometry] / [projectStopsOntoPolylines]), so it stays JVM-testable and out of
  * [RouteMapController]'s state plumbing.
  */
@@ -73,29 +72,40 @@ data class RiddenSpan(
 )
 
 /**
+ * What a ridden span's own route load has landed with: the colour that route publishes, which may be none
+ * ([publishedColor] null — an agency that states no colour, or a response that carried no route to state
+ * one). Wrapping it is what lets `null` *itself* mean "hasn't landed": the two are opposite answers, and a
+ * bare `Int?` folds them into one value — see [riddenSpanColorSource], whose whole rule is telling them
+ * apart.
+ */
+@JvmInline
+internal value class LoadedSpanRoute(val publishedColor: Int?)
+
+/**
  * The colour a ridden span is drawn from, for a palette to render: its own route's published colour once
- * that route has loaded ([loadedRoute]), else the colour the plan gave it ([RiddenSpan.plannedColor]). Null
- * when neither publishes one — a colour left unstated, which the renderer resolves to its default, exactly
- * as it does for a route line whose route publishes nothing usable.
+ * that route's load has landed ([loaded]), else the colour the plan gave it ([RiddenSpan.plannedColor]).
+ * Null when neither publishes one — a colour left unstated, which the renderer resolves to its default,
+ * exactly as it does for a route line whose route publishes nothing usable.
  *
  * The plan answers for the load window, which is a network round trip the rider spends looking at the map
  * (#2186). Nothing answered for it before: the span was drawn in the *shown route's* colour, which until
  * the load lands is the renderer's `DEFAULT_ROUTE_LINE_COLOR` — so tapping a leg flashed the ride pure blue
  * before it settled into its route's colour. The plan already published that colour; it just wasn't asked.
  *
- * A loaded route then answers alone, its own missing colour included, rather than the plan filling in for
- * it: the corridor beneath the span is drawn from that same route (`directionPolylines`), which states no
- * colour for it either — so both reach the renderer's default together, where a span that kept a planned
- * colour would be a line its own approach couldn't match. Passing the route itself rather than its colour
- * is what keeps "hasn't loaded" and "loaded, publishes nothing" apart — they take opposite branches here,
- * and a bare `Int?` cannot tell them apart.
+ * A landed load then answers alone, its own missing colour included, rather than the plan filling in for it:
+ * the corridor beneath the span is drawn from that same load (`directionPolylines`), which states no colour
+ * for it either — so both reach the renderer's default together, where a span that kept a planned colour
+ * would be a line its own approach couldn't match. That is why the load is passed as [LoadedSpanRoute] and
+ * not as the colour it carries: "hasn't landed" and "landed, publishes nothing" take opposite branches here,
+ * so they must stay distinguishable all the way from the caller, including for a load that landed with no
+ * route in it at all.
  *
- * A span whose [RiddenSpan.routeId] never resolved is handed no [loadedRoute] at all — not the ride's shown
- * route, which is not what it is ridden as — so the plan answers for it permanently rather than for a load
- * window. The caller decides what a span with neither is (see [RouteMapController.spanColor]); here it is
- * the same "nothing published a colour" null as any other.
+ * A span whose [RiddenSpan.routeId] never resolved is handed no load at all — not the ride's shown route,
+ * which is not what it is ridden as — so the plan answers for it permanently rather than for a window, as it
+ * does for a route whose load failed. The caller decides what a span with neither is (see
+ * [RouteMapController.spanColor]); here it is the same "nothing published a colour" null as any other.
  */
-internal fun riddenSpanColorSource(span: RiddenSpan, loadedRoute: ObaRoute?): Int? = if (loadedRoute == null) span.plannedColor else loadedRoute.color
+internal fun riddenSpanColorSource(span: RiddenSpan, loaded: LoadedSpanRoute?): Int? = if (loaded == null) span.plannedColor else loaded.publishedColor
 
 /** The whole ride as one path, for the questions that are about the ride and not about its routes: where
  *  the rider boards and alights, what to frame, which stops are on it. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -880,10 +880,17 @@ class HomeViewModel @Inject constructor(
 
     /**
      * The ride to draw over the route, preferring the per-route spans the leg was built with (#2127) and
-     * falling back to the tapped row's own joined geometry ([fallbackPoints]) as a single span. The fallback
-     * covers a ride whose ref carries no spans at all — an OTP1 plan, or a leg the results repository
-     * couldn't resolve — where one undivided span is exactly what the map drew before there were spans to
-     * divide, and, carrying no [RiddenSpan.plannedColor] either, in the shown route's colour as it did then.
+     * falling back to the tapped row's own joined geometry ([fallbackPoints]) as one undivided span —
+     * exactly what the map drew before there were spans to divide, and (carrying no
+     * [RiddenSpan.plannedColor]) in the shown route's colour as it did then.
+     *
+     * Defensive rather than a live path: the results repository emits one span per ridden leg, so a ref it
+     * built always has them, and the ref the drawer synthesizes when it couldn't resolve one
+     * (`TripLogBuilder.fallbackRouteLeg`) names neither a route nor a boarding stop — so it never reaches a
+     * route focus at all, by either entry. A leg tap degrades to framing the leg ([focusItineraryRouteLeg]),
+     * and the inline ETA strip that owns the other entry draws nothing without an OBA stop id to poll. This
+     * stands so a ref that somehow arrives without spans still draws its ride rather than nothing; nothing
+     * that reaches it today has a planned colour to lose.
      */
     private fun RouteLegRef.riddenSpansOr(fallbackPoints: List<GeoPoint>): List<RiddenSpan> = riddenSpans.ifEmpty { listOf(RiddenSpan(fallbackPoints)) }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -883,7 +883,7 @@ class HomeViewModel @Inject constructor(
      * falling back to the tapped row's own joined geometry ([fallbackPoints]) as a single span. The fallback
      * covers a ride whose ref carries no spans at all — an OTP1 plan, or a leg the results repository
      * couldn't resolve — where one undivided span is exactly what the map drew before there were spans to
-     * divide.
+     * divide, and, carrying no [RiddenSpan.plannedColor] either, in the shown route's colour as it did then.
      */
     private fun RouteLegRef.riddenSpansOr(fallbackPoints: List<GeoPoint>): List<RiddenSpan> = riddenSpans.ifEmpty { listOf(RiddenSpan(fallbackPoints)) }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -34,6 +34,7 @@ import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.util.geoPointOrNull
+import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.runCatchingCancellable
 
 /**
@@ -143,10 +144,18 @@ class DefaultTripResultsRepository @Inject constructor(
             // "stay on board" rows do, so the two mark one ride's route changes identically. A leg with no
             // geometry contributes an empty span rather than being dropped — the spans stay aligned to the
             // ride's legs, and the map skips one it can't draw.
+            //
+            // The leg's own published colour rides along so the map can draw the span before its route loads
+            // (see [riddenSpanColorSource], #2186). Deliberately the raw parse rather than
+            // [ridePresentationColor]'s colourless-ride substitution: this stands in for the route's
+            // *published* colour until that route can state it, and the map's own route lines have never had
+            // that substitution either (#2041's remaining work), so a colourless ride resolves the same way
+            // before and after the load instead of changing colour on landing.
             val riddenSpans = (chain.leaderIndex..chain.alightIndex).map { j ->
                 RiddenSpan(
                     points = legs[j].legGeometry?.decodedPoints().orEmpty(),
                     routeId = ids[j].routeId,
+                    plannedColor = parseObaHexColor(legs[j].routeColor),
                     startsCutover = j in chain.transitionLegIndices
                 )
             }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -30,7 +30,6 @@ import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
-import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
 
@@ -44,19 +43,6 @@ class RouteSegmentHighlightTest {
     private val segment = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
 
     private fun stop(id: String, lat: Double, lon: Double) = ObaStopElement(id = id, lat = lat, lon = lon)
-
-    /** A route whose load has landed, publishing [color] — the only thing the colour rule reads off one. */
-    private fun loadedRoute(color: Int?) = object : ObaRoute {
-        override val id = "45"
-        override val shortName = "45"
-        override val longName: String? = null
-        override val description: String? = null
-        override val type = ObaRoute.TYPE_BUS
-        override val url: String? = null
-        override val color = color
-        override val textColor: Int? = null
-        override val agencyId = "agency"
-    }
 
     /** An ordinary ride: one route, so one span, cut nowhere. */
     private fun ride(points: List<GeoPoint>) = listOf(RiddenSpan(points))
@@ -212,37 +198,38 @@ class RouteSegmentHighlightTest {
         // nothing to draw from until it landed — leaving it on the caller's fallback, a pure blue.
         val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
 
-        assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loadedRoute = null))
+        assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loaded = null))
         // Nothing to stand in with either: the colour stays unstated and the renderer's default draws it.
-        assertEquals(null, riddenSpanColorSource(span.copy(plannedColor = null), loadedRoute = null))
+        assertEquals(null, riddenSpanColorSource(span.copy(plannedColor = null), loaded = null))
     }
 
     @Test
     fun riddenSpanColorSource_onceItsRouteLoads_takesTheRoutesOwnColour() {
         val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
 
-        assertEquals(0xFFD22630.toInt(), riddenSpanColorSource(span, loadedRoute(0xFFD22630.toInt())))
+        assertEquals(0xFFD22630.toInt(), riddenSpanColorSource(span, LoadedSpanRoute(0xFFD22630.toInt())))
     }
 
     @Test
-    fun riddenSpanColorSource_aLoadedRouteWithNoUsableColour_doesNotFallBackToThePlannedColour() {
-        // The corridor beneath the span is drawn from the loaded route, and states no colour for it either,
-        // so a span that kept a planned colour here would be a line its own approach couldn't match: both
-        // leave the colour unstated and take the renderer's default together.
+    fun riddenSpanColorSource_aLandedLoadWithNoUsableColour_doesNotFallBackToThePlannedColour() {
+        // The corridor beneath the span is drawn from the same landed load, and states no colour for it
+        // either, so a span that kept a planned colour here would be a line its own approach couldn't match:
+        // both leave the colour unstated and take the renderer's default together. A load that landed
+        // carrying no route at all is this case, not the pre-load one — it has nothing left to wait for.
         val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
 
-        assertEquals(null, riddenSpanColorSource(span, loadedRoute(null)))
+        assertEquals(null, riddenSpanColorSource(span, LoadedSpanRoute(publishedColor = null)))
     }
 
     @Test
     fun riddenSpanColorSource_aSpanNamingNoRoute_keepsThePlannedColourForGood() {
         // An interline leg whose route didn't resolve to an OBA id: nothing will ever load for it, and the
-        // caller hands it no route rather than the ride's shown one — which is a route it isn't ridden as.
+        // caller hands it no load rather than the ride's shown route — which is a route it isn't ridden as.
         // So the plan is its colour permanently, not for a load window, and the mid-ride change of route
         // the span exists to show survives the load instead of flattening into the leader's colour.
         val span = RiddenSpan(segment, routeId = null, plannedColor = 0xFF00A94F.toInt())
 
-        assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loadedRoute = null))
+        assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loaded = null))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -213,7 +213,7 @@ class RouteSegmentHighlightTest {
         val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
 
         assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loadedRoute = null))
-        // Nothing to stand in with either: the caller's fallback answers, as it did for the whole ride.
+        // Nothing to stand in with either: the colour stays unstated and the renderer's default draws it.
         assertEquals(null, riddenSpanColorSource(span.copy(plannedColor = null), loadedRoute = null))
     }
 
@@ -226,8 +226,9 @@ class RouteSegmentHighlightTest {
 
     @Test
     fun riddenSpanColorSource_aLoadedRouteWithNoUsableColour_doesNotFallBackToThePlannedColour() {
-        // The corridor beneath the span is drawn from the loaded route, so a span that kept a planned colour
-        // here would be a line its own approach couldn't match: both take the caller's fallback instead.
+        // The corridor beneath the span is drawn from the loaded route, and states no colour for it either,
+        // so a span that kept a planned colour here would be a line its own approach couldn't match: both
+        // leave the colour unstated and take the renderer's default together.
         val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
 
         assertEquals(null, riddenSpanColorSource(span, loadedRoute(null)))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -235,6 +235,17 @@ class RouteSegmentHighlightTest {
     }
 
     @Test
+    fun riddenSpanColorSource_aSpanNamingNoRoute_keepsThePlannedColourForGood() {
+        // An interline leg whose route didn't resolve to an OBA id: nothing will ever load for it, and the
+        // caller hands it no route rather than the ride's shown one — which is a route it isn't ridden as.
+        // So the plan is its colour permanently, not for a load window, and the mid-ride change of route
+        // the span exists to show survives the load instead of flattening into the leader's colour.
+        val span = RiddenSpan(segment, routeId = null, plannedColor = 0xFF00A94F.toInt())
+
+        assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loadedRoute = null))
+    }
+
+    @Test
     fun upstreamTo_clipsEveryVariantAtTheBoardingPoint_dropsVariantsThatNeverReachIt() {
         val trunk = RoutePolyline(color = 1, points = listOf(GeoPoint(47.58, -122.33), GeoPoint(47.66, -122.33)))
         // Reaches the boarding point up a western street instead, then branches east — a second valid

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -30,16 +30,33 @@ import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
 
-/** JVM tests for the pure trip-plan-leg segment highlighting helpers ([onSegment], [routePolylinesWithSegment]). */
+/**
+ * JVM tests for the pure trip-plan-leg segment highlighting helpers ([onSegment],
+ * [routePolylinesWithSegment], [riddenSpanColorSource]).
+ */
 class RouteSegmentHighlightTest {
 
     // A straight segment running north along a meridian.
     private val segment = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
 
     private fun stop(id: String, lat: Double, lon: Double) = ObaStopElement(id = id, lat = lat, lon = lon)
+
+    /** A route whose load has landed, publishing [color] — the only thing the colour rule reads off one. */
+    private fun loadedRoute(color: Int?) = object : ObaRoute {
+        override val id = "45"
+        override val shortName = "45"
+        override val longName: String? = null
+        override val description: String? = null
+        override val type = ObaRoute.TYPE_BUS
+        override val url: String? = null
+        override val color = color
+        override val textColor: Int? = null
+        override val agencyId = "agency"
+    }
 
     /** An ordinary ride: one route, so one span, cut nowhere. */
     private fun ride(points: List<GeoPoint>) = listOf(RiddenSpan(points))
@@ -187,6 +204,33 @@ class RouteSegmentHighlightTest {
         val result = routePolylinesWithSegment(emptyList(), spans, colorOf = { 7 })
 
         assertEquals(listOf(segment), result.map { it.points })
+    }
+
+    @Test
+    fun riddenSpanColorSource_beforeItsRouteLoads_takesThePlannedColour() {
+        // #2186: the load is a network round trip the rider spends looking at the map, and the span had
+        // nothing to draw from until it landed — leaving it on the caller's fallback, a pure blue.
+        val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
+
+        assertEquals(0xFF00A94F.toInt(), riddenSpanColorSource(span, loadedRoute = null))
+        // Nothing to stand in with either: the caller's fallback answers, as it did for the whole ride.
+        assertEquals(null, riddenSpanColorSource(span.copy(plannedColor = null), loadedRoute = null))
+    }
+
+    @Test
+    fun riddenSpanColorSource_onceItsRouteLoads_takesTheRoutesOwnColour() {
+        val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
+
+        assertEquals(0xFFD22630.toInt(), riddenSpanColorSource(span, loadedRoute(0xFFD22630.toInt())))
+    }
+
+    @Test
+    fun riddenSpanColorSource_aLoadedRouteWithNoUsableColour_doesNotFallBackToThePlannedColour() {
+        // The corridor beneath the span is drawn from the loaded route, so a span that kept a planned colour
+        // here would be a line its own approach couldn't match: both take the caller's fallback instead.
+        val span = RiddenSpan(segment, routeId = "45", plannedColor = 0xFF00A94F.toInt())
+
+        assertEquals(null, riddenSpanColorSource(span, loadedRoute(null)))
     }
 
     @Test


### PR DESCRIPTION
Fixes #2186.

## The bug

Tapping a transit leg in the directions drawer flashed the ride **pure blue** for the length of a network round trip before it settled into its route's colour.

The drill-in draws the ridden span immediately — the geometry arrives with the tap — but coloured it from the *shown route*, and that route's colour only exists once its load lands. Until then `currentRouteColor()` fell through to `DEFAULT_ROUTE_LINE_COLOR` (`0xFF0000FF`), a colour no palette on this map produces.

The ridden span turns out to be the only line with a colour to get wrong during that window: the corridor/approach is gated on `routeShape` and isn't drawn yet, vehicle markers resolve out of the poll's own references, and route mode draws no badges.

## The fix

The colour was already known — the itinerary line the rider tapped was drawn from the plan's published route colour. `RiddenSpan` now carries it (`plannedColor`), and `riddenSpanColorSource` picks the source: the span's own route once *that* route's load has landed, else the plan's.

Per span rather than per session because each span carries its *own* published colour: a stay-aboard interline rides several routes, and an interlined ride keeps each span's colour through the window instead of flattening to one. (The loads themselves land together — `loadRoute` awaits the leader and every extra in one `coroutineScope` — so the spans all flip from planned to loaded at the same moment.)

Three deliberate limits, all documented at the site:

- **Once a load lands, it answers alone**, its own missing colour included. The corridor beneath the span is drawn from that same load, so a span keeping a planned colour there would be a line its own approach couldn't match. Both leave the colour unstated and reach `RoutePolyline.resolvedColor`'s default together. The load is passed as `LoadedSpanRoute`, not as the colour it carries, so "hasn't landed" and "landed, publishes nothing" stay distinguishable at the caller — including for a response that landed with no route in its references at all.
- **A span that names no route is never coloured from the shown route.** Its route id didn't resolve, so nothing will ever load for it (it's dropped from `extraSegments` too, and so has no corridor of its own); the plan's colour is the only one it will ever have, permanently rather than for a window. Borrowing the leader's would draw the mid-ride change of route away. The drawer's undivided fallback ride, which has no route id *and* no planned colour, still draws in the shown route's colour exactly as it always has.
- **The span takes the plan's raw published colour**, not `ridePresentationColor`'s colourless-ride substitution — the map's route lines never got that substitution either (#2041's remaining work), so a colourless ride resolves the same way before and after the load rather than changing colour on landing.

`RouteFocusSegment.routeMap()` was generalized to `loadedRouteMap(id)` and shared, so a span and the corridor beneath it resolve their route through one function.

## Adjacent, not fixed here

A route that publishes **no** usable colour (e.g. every WSF ferry) drills in blue *permanently*, while the drawer badges and the itinerary line show it in the colourless-ride hue (`riddenRouteHue`). Same symptom, different cause: `RouteMapController` doesn't honour that substitution for the corridor, the ride, or its vehicles, and closing it means changing the colourless policy across all three. Worth its own issue.

## Testing

- Four new JVM cases in `RouteSegmentHighlightTest` pin the rule (pre-load → plan, landed → that route, landed-but-colourless → falls back rather than reverting to the plan, names-no-route → keeps the plan for good).
- `compileObaGoogleDebugKotlin -PwarningsAsErrors=true`, full `testObaGoogleDebugUnitTest`, and `spotlessCheck` all clean.
- **Not yet verified on a device** — the fix is traced through the code and unit-tested, but nobody has watched the tap on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route-segment coloring on trip maps.
  - Uses the correct route color for each ridden segment, including trips with multiple routes.
  - Preserves planned colors while route data is loading.
  - Avoids applying incorrect colors when loaded routes have no published color.
  - Provides safer fallback coloring for unresolved or route-less segments.

- **Tests**
  - Added coverage for loading states, route-specific colors, missing colors, and route-less segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->