### PR TITLE
Show the timetable time struck through in the ETA pill (#2167)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripCorrectedClockRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripCorrectedClockRenderTest.kt
@@ -19,7 +19,9 @@ import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
@@ -94,14 +96,12 @@ class EtaStripCorrectedClockRenderTest {
     }
 
     @Test
-    fun aPillOnItsTimetableTimeHasNothingToStrikeThrough() {
+    fun aPillOnItsTimetableTimeDrawsOneClockLine() {
         setContent(etaMinutes = 6, deviationMinutes = 0)
 
-        composeRule.onNodeWithText(clockAt(6)).assertIsDisplayed()
-        composeRule
-            .onNodeWithContentDescription(
-                context.getString(R.string.stop_info_clock_corrected, clockAt(6), clockAt(6))
-            )
-            .assertDoesNotExist()
+        // Exactly one line carrying that time, not two identical ones — the failure mode of striking a
+        // time through and replacing it with itself, which is why the rule compares formatted strings.
+        // The unmerged tree, since the clickable pill merges its children's text into one node.
+        composeRule.onAllNodesWithText(clockAt(6), useUnmergedTree = true).assertCountEquals(1)
     }
 }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripCorrectedClockRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripCorrectedClockRenderTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.arrivals.components.EtaStrip
+import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.util.DisplayFormat
+
+/**
+ * The ETA pill's struck-through timetable time (#2167), end to end: a real [EtaStrip] over real
+ * [org.onebusaway.android.ui.arrivals.ArrivalInfo]s, so the whole path — the model's `scheduledTime`,
+ * the formatted-string rule, the pill's two clock lines — is exercised rather than the composable in
+ * isolation.
+ *
+ * The two things worth pinning on a device: a corrected pill really draws *both* times (its extra line
+ * has to fit the height the strip measured for it, or it would be clipped away), and the correction is
+ * spoken, since a strikethrough says nothing to a screen reader.
+ */
+class EtaStripCorrectedClockRenderTest {
+
+    // Unconfined composition — see createUnconfinedComposeRule (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context: Context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    /** previewArrival anchors serverNow at 0, so a pill's clock time is just its ETA in minutes past
+     *  the epoch — formatted through the same helper the pill uses, so this matches whatever locale and
+     *  12h/24h setting the test device is in. */
+    private fun clockAt(minutes: Long) = DisplayFormat.formatTime(context, minutes * 60_000L)
+
+    /** A strip holding one trip: [etaMinutes] out, running [deviationMinutes] behind its timetable. */
+    private fun setContent(etaMinutes: Long, deviationMinutes: Long) = composeRule.setContent {
+        Box(Modifier.width(320.dp)) {
+            EtaStrip(
+                trips = listOf(
+                    previewArrival(
+                        "8",
+                        "Rainier Beach",
+                        etaMinutes = etaMinutes,
+                        scheduleDeviationMinutes = deviationMinutes
+                    )
+                ),
+                actionsFor = { null },
+                callbacks = previewRowCallbacks()
+            )
+        }
+    }
+
+    @Test
+    fun latePillDrawsItsTimetableTimeAboveTheTimeNowExpected() {
+        setContent(etaMinutes = 6, deviationMinutes = 4)
+
+        composeRule.onNodeWithText(clockAt(2)).assertIsDisplayed()
+        composeRule.onNodeWithText(clockAt(6)).assertIsDisplayed()
+    }
+
+    @Test
+    fun theCorrectionIsSpokenSinceItsStrikethroughIsNot() {
+        setContent(etaMinutes = 6, deviationMinutes = 4)
+
+        composeRule
+            .onNodeWithContentDescription(
+                context.getString(R.string.stop_info_clock_corrected, clockAt(2), clockAt(6))
+            )
+            .assertExists()
+    }
+
+    @Test
+    fun aPillOnItsTimetableTimeHasNothingToStrikeThrough() {
+        setContent(etaMinutes = 6, deviationMinutes = 0)
+
+        composeRule.onNodeWithText(clockAt(6)).assertIsDisplayed()
+        composeRule
+            .onNodeWithContentDescription(
+                context.getString(R.string.stop_info_clock_corrected, clockAt(6), clockAt(6))
+            )
+            .assertDoesNotExist()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalInfo.kt
@@ -48,6 +48,17 @@ class ArrivalInfo(
 
     val displayTime: ServerTime
 
+    /**
+     * The timetable time behind [displayTime]: the same arrival-vs-departure choice [displayTime]
+     * makes (see the init block), before any prediction corrects it. Equal to [displayTime] whenever
+     * the server gave no usable prediction, so a surface can always compare the two.
+     *
+     * Exposed so the clock-time surfaces can show the correction itself rather than only its
+     * consequences — see
+     * [arrivalClock][org.onebusaway.android.ui.arrivals.components.arrivalClock] (#2167).
+     */
+    val scheduledTime: ServerTime
+
     val statusText: String
 
     val timeText: String
@@ -206,6 +217,7 @@ class ArrivalInfo(
         // timestamp from "now" and render garbage (~ -29,718,596 min).
         val hasPrediction = data.predicted && predictedTime != null
 
+        scheduledTime = scheduled
         if (hasPrediction) {
             predicted = true
             displayTime = predictedTime

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTime.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals.components
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.util.DisplayFormat
+
+// The one place the app decides *and draws* "this bus is no longer coming at its timetable time"
+// (issue #2167, parity with onebusaway-ios#1224/#1237). Every surface that prints a clock time for an
+// arrival should read its pair from [arrivalClock] and draw it with [CorrectedClockTime], so the rule
+// and the words live here rather than being re-derived per call site.
+
+/**
+ * An arrival's clock time as a rider should read it: the time it is now [expected] at, and — when a
+ * prediction moved it — the timetable time that prediction [corrects], to be shown struck through.
+ * [corrects] is null when there is nothing to correct, which is the common case.
+ */
+internal data class ArrivalClock(val expected: String, val corrects: String?)
+
+/**
+ * This arrival's [ArrivalClock], formatted for the current locale/12h-24h setting.
+ *
+ * The decision is made on the **formatted strings**, not the instants behind them — the same choice
+ * onebusaway-ios made, and for two reasons that pull in opposite directions:
+ *
+ * - A prediction a few seconds off the timetable would otherwise render `10:42 AM 10:42 AM`, striking
+ *   through a time and replacing it with itself.
+ * - A trip inside the ±90s on-time band ([org.onebusaway.android.util.ScheduleDeviation.ON_TIME_BAND])
+ *   can still land on a different clock minute, and that rider's time genuinely needs correcting even
+ *   though the app calls the trip on time. A "strike through only when late" rule would miss it.
+ *
+ * Both fall out of comparing what is actually printed, so there is no threshold to pick here.
+ */
+internal fun ArrivalInfo.arrivalClock(context: Context): ArrivalClock = arrivalClockOf(
+    expected = DisplayFormat.formatTime(context, displayTime.epochMs),
+    scheduled = DisplayFormat.formatTime(context, scheduledTime.epochMs)
+)
+
+/** The formatted-string rule itself, split out so it is testable without a `Context`. */
+@VisibleForTesting
+internal fun arrivalClockOf(expected: String, scheduled: String): ArrivalClock = ArrivalClock(
+    expected = expected,
+    corrects = scheduled.takeIf { it != expected }
+)
+
+/** How much fainter the struck timetable time is drawn than the time that replaced it — present, but
+ *  clearly the superseded one of the two. Applied to [CorrectedClockTime]'s own [Color], so it works
+ *  the same on the pill's white-on-fill text as on a surface-coloured caller. */
+private const val CORRECTED_ALPHA = 0.75f
+
+/** The gap between the struck line and the time below it. Zero: [style]'s trimmed line boxes already
+ *  sit flush, and these two are one reading rather than two lines of text. */
+private val CORRECTED_LINE_SPACING = 0.dp
+
+/**
+ * A clock time, with the timetable time it corrects struck through directly above it when there is
+ * one ([ArrivalClock.corrects]) — `~~10:42 AM~~` over `10:47 AM`. With nothing to correct this is
+ * exactly the plain single [Text] it replaced, adding no layout node of its own.
+ *
+ * A strikethrough is inaudible, so the corrected pair merges into one spoken phrase — "Scheduled
+ * 10:42 AM, now expected 10:47 AM" — rather than leaving a screen reader to read two bare times in a
+ * row and imply nothing about their relationship.
+ *
+ * [canceled] strikes the whole thing through, as a canceled trip's other text is; the timetable line
+ * is struck either way.
+ */
+@Composable
+internal fun CorrectedClockTime(
+    clock: ArrivalClock,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    style: TextStyle = LocalTextStyle.current,
+    canceled: Boolean = false
+) {
+    val canceledDecoration = if (canceled) TextDecoration.LineThrough else null
+    val corrects = clock.corrects
+    if (corrects == null) {
+        Text(
+            text = clock.expected,
+            modifier = modifier,
+            color = color,
+            fontSize = fontSize,
+            textDecoration = canceledDecoration,
+            style = style
+        )
+        return
+    }
+    val spoken = stringResource(R.string.stop_info_clock_corrected, corrects, clock.expected)
+    Column(
+        modifier = modifier.semantics(mergeDescendants = true) { contentDescription = spoken },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(CORRECTED_LINE_SPACING)
+    ) {
+        Text(
+            text = corrects,
+            color = if (color.isSpecified) color.copy(alpha = color.alpha * CORRECTED_ALPHA) else color,
+            fontSize = fontSize,
+            textDecoration = TextDecoration.LineThrough,
+            style = style
+        )
+        Text(
+            text = clock.expected,
+            color = color,
+            fontSize = fontSize,
+            textDecoration = canceledDecoration,
+            style = style
+        )
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTime.kt
@@ -17,37 +17,37 @@ package org.onebusaway.android.ui.arrivals.components
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.isSpecified
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.util.DisplayFormat
 
 // The one place the app decides *and draws* "this bus is no longer coming at its timetable time"
-// (issue #2167, parity with onebusaway-ios#1224/#1237). Every surface that prints a clock time for an
-// arrival should read its pair from [arrivalClock] and draw it with [CorrectedClockTime], so the rule
-// and the words live here rather than being re-derived per call site.
+// (issue #2167, parity with onebusaway-ios#1224/#1237), so every surface that prints a clock time for
+// an arrival can take both from here rather than re-deriving them.
 
 /**
  * An arrival's clock time as a rider should read it: the time it is now [expected] at, and — when a
  * prediction moved it — the timetable time that prediction [corrects], to be shown struck through.
  * [corrects] is null when there is nothing to correct, which is the common case.
+ *
+ * A plain display pair, not a validated one: [arrivalClockOf] is the canonical producer and will never
+ * hand back a [corrects] equal to [expected], but the constructor doesn't enforce that, so a caller
+ * building one by hand (the strip's measured-only reference pill) can.
  */
-internal data class ArrivalClock(val expected: String, val corrects: String?)
+internal data class ArrivalClock(val expected: String, val corrects: String? = null)
 
 /**
  * This arrival's [ArrivalClock], formatted for the current locale/12h-24h setting.
@@ -63,10 +63,13 @@ internal data class ArrivalClock(val expected: String, val corrects: String?)
  *
  * Both fall out of comparing what is actually printed, so there is no threshold to pick here.
  */
-internal fun ArrivalInfo.arrivalClock(context: Context): ArrivalClock = arrivalClockOf(
-    expected = DisplayFormat.formatTime(context, displayTime.epochMs),
-    scheduled = DisplayFormat.formatTime(context, scheduledTime.epochMs)
-)
+internal fun ArrivalInfo.arrivalClock(context: Context): ArrivalClock {
+    val expected = DisplayFormat.formatTime(context, displayTime.epochMs)
+    // Without a usable prediction the two are the same instant, so the second format call is a
+    // guaranteed-identical string — skip it rather than pay for it on every scheduled-only arrival.
+    if (scheduledTime == displayTime) return ArrivalClock(expected)
+    return arrivalClockOf(expected = expected, scheduled = DisplayFormat.formatTime(context, scheduledTime.epochMs))
+}
 
 /** The formatted-string rule itself, split out so it is testable without a `Context`. */
 @VisibleForTesting
@@ -76,13 +79,8 @@ internal fun arrivalClockOf(expected: String, scheduled: String): ArrivalClock =
 )
 
 /** How much fainter the struck timetable time is drawn than the time that replaced it — present, but
- *  clearly the superseded one of the two. Applied to [CorrectedClockTime]'s own [Color], so it works
- *  the same on the pill's white-on-fill text as on a surface-coloured caller. */
+ *  clearly the superseded one of the two. */
 private const val CORRECTED_ALPHA = 0.75f
-
-/** The gap between the struck line and the time below it. Zero: [style]'s trimmed line boxes already
- *  sit flush, and these two are one reading rather than two lines of text. */
-private val CORRECTED_LINE_SPACING = 0.dp
 
 /**
  * A clock time, with the timetable time it corrects struck through directly above it when there is
@@ -94,18 +92,19 @@ private val CORRECTED_LINE_SPACING = 0.dp
  * row and imply nothing about their relationship.
  *
  * [canceled] strikes the whole thing through, as a canceled trip's other text is; the timetable line
- * is struck either way.
+ * is struck either way. It's the trip's state rather than a [TextDecoration] because this composable
+ * already owns one strikethrough of its own, and only it can say how the two compose.
  */
 @Composable
 internal fun CorrectedClockTime(
     clock: ArrivalClock,
+    color: Color,
+    fontSize: TextUnit,
+    style: TextStyle,
     modifier: Modifier = Modifier,
-    color: Color = Color.Unspecified,
-    fontSize: TextUnit = TextUnit.Unspecified,
-    style: TextStyle = LocalTextStyle.current,
     canceled: Boolean = false
 ) {
-    val canceledDecoration = if (canceled) TextDecoration.LineThrough else null
+    val canceledDecoration = strikeThroughIf(canceled)
     val corrects = clock.corrects
     if (corrects == null) {
         Text(
@@ -118,15 +117,21 @@ internal fun CorrectedClockTime(
         )
         return
     }
-    val spoken = stringResource(R.string.stop_info_clock_corrected, corrects, clock.expected)
+    val context = LocalContext.current
+    // Held across recompositions: a corrected pill recomposes on every ETA rollover, and this is a
+    // getString + format each time. It only changes when a fresh poll brings a new pair.
+    val spoken = remember(clock, context) {
+        context.getString(R.string.stop_info_clock_corrected, corrects, clock.expected)
+    }
+    // No verticalArrangement: [style]'s trimmed line boxes already sit flush, which is what these two
+    // want — they are one reading, not two lines of text.
     Column(
         modifier = modifier.semantics(mergeDescendants = true) { contentDescription = spoken },
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(CORRECTED_LINE_SPACING)
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = corrects,
-            color = if (color.isSpecified) color.copy(alpha = color.alpha * CORRECTED_ALPHA) else color,
+            color = color.copy(alpha = color.alpha * CORRECTED_ALPHA),
             fontSize = fontSize,
             textDecoration = TextDecoration.LineThrough,
             style = style

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -623,7 +623,9 @@ internal fun OnMapIndicator(color: Color, modifier: Modifier = Modifier) {
     )
 }
 
-private fun strikeThroughIf(canceled: Boolean): TextDecoration = if (canceled) TextDecoration.LineThrough else TextDecoration.None
+/** The package's one "a canceled trip's text is struck through" rule — the flat row, the ETA pill and
+ *  its clock lines all read it, so they can't drift apart. */
+internal fun strikeThroughIf(canceled: Boolean): TextDecoration = if (canceled) TextDecoration.LineThrough else TextDecoration.None
 
 /**
  * Renders [DisplayFormat.formatEtaParts] output as a single [AnnotatedString] — not separate Text

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -66,7 +66,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
@@ -163,13 +162,21 @@ internal fun EtaStrip(
     // this would otherwise re-run the caller's lambda over every trip on each of those ticks. It only
     // changes when the trips or the badge source do.
     val hasRouteBadges = remember(trips, routeBadgeFor) { trips.any { routeBadgeFor(it) != null } }
-    // Whether any pill in this strip carries a struck-through timetable time (#2167), which makes it a
-    // clock line taller than its neighbours. The reference pill below has to match the strip's tallest
-    // variant or that pill would be measured short and clipped — and it's per-strip, so a strip where
-    // nothing was corrected keeps exactly the height it had. Remembered for the same reason as above:
-    // the live clock recomposes this body every second, but the answer only moves on a fresh poll.
+    // Every pill's clock time, formatted once here for the whole strip rather than per pill: the
+    // reference pill below needs the same answer the pills do (see referenceClock), and formatting is a
+    // locale-aware DateUtils round trip. Remembered for the same reason as above — the live clock
+    // recomposes this body every second, but these only move when a poll brings new trips.
     val context = LocalContext.current
-    val hasCorrectedClock = remember(trips, context) { trips.any { it.arrivalClock(context).corrects != null } }
+    val clocks = remember(trips, context) { trips.map { it.arrivalClock(context) } }
+    // The tallest pill variant this strip needs. A pill carrying a struck-through timetable time
+    // (#2167) is one clock line taller than its neighbours, and the reference pill has to match the
+    // strip's tallest or the taller pill would be measured short and clipped. Per-strip, so a strip
+    // where nothing was corrected keeps exactly the height it had.
+    val referenceClock = remember(clocks) {
+        // Measured for height only, so the times themselves are arbitrary; all that matters is whether
+        // there are one or two clock lines.
+        ArrivalClock(expected = "0:00", corrects = "0:01".takeIf { clocks.any { clock -> clock.corrects != null } })
+    }
     // Where the marker's moment falls among these departures. Remembered for the same reason: the live
     // clock recomposes this body every second, but the answer only moves when a poll brings new trips.
     val markerIndex = remember(trips, marker) { marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } }
@@ -215,9 +222,7 @@ internal fun EtaStrip(
                     eta = 10,
                     color = Color.Transparent,
                     predicted = false,
-                    // Measured for height only, so the times themselves are arbitrary; all that
-                    // matters is whether there are one or two clock lines.
-                    clock = ArrivalClock(expected = "0:00", corrects = if (hasCorrectedClock) "0:00" else null),
+                    clock = referenceClock,
                     routeBadge = if (hasRouteBadges) RouteBadge("00", null) else null
                 )
             }
@@ -250,6 +255,7 @@ internal fun EtaStrip(
                     MarkedItem(marker?.takeIf { markerIndex == index }) {
                         EtaPillWithMenu(
                             trip = trip,
+                            clock = clocks[index],
                             liveNow = liveNow,
                             actions = actionsFor(trip),
                             callbacks = callbacks,
@@ -406,10 +412,13 @@ private fun ReferencePillHeightFrame(
 
 /** A single ETA pill with its long-press per-trip menu. Tap focuses the vehicle; long-press opens
  *  the menu (trip details / reminder / report). [liveNow] is the strip's one shared ticking clock
- *  (issue #1781) — counts this pill down between polls rather than freezing at the poll-time eta. */
+ *  (issue #1781) — counts this pill down between polls rather than freezing at the poll-time eta.
+ *  [clock] is this trip's entry in the strip's once-per-poll formatted clock times (see EtaStrip),
+ *  passed in rather than derived here because this composable recomposes every second. */
 @Composable
 private fun EtaPillWithMenu(
     trip: ArrivalInfo,
+    clock: ArrivalClock,
     liveNow: ServerTime,
     actions: ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
@@ -417,11 +426,6 @@ private fun EtaPillWithMenu(
     routeBadge: RouteBadge? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
-    // trip.displayTime only changes on a fresh poll, but liveNow (and so this composable) recomposes
-    // every second (issue #1781's ticker) — memoize so the locale-aware format calls don't re-run on
-    // every tick.
-    val context = LocalContext.current
-    val clock = remember(trip.displayTime, trip.scheduledTime, context) { trip.arrivalClock(context) }
     // fillMaxHeight here and on the pill so the colored Surface stretches to the strip's tallest pill
     // (the strip fixes its row height to the tallest pill via ReferencePillHeightFrame — see
     // EtaStrip), levelling the shorter single-line NOW pill up to its neighbours.
@@ -512,7 +516,7 @@ internal fun EtaPill(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null
 ) {
-    val decoration = if (canceled) TextDecoration.LineThrough else null
+    val decoration = strikeThroughIf(canceled)
     val shape = RoundedCornerShape(8.dp)
     val numberSize = 28.sp
     // "NOW" reads a touch too urgent at the full number size, so its glyph is dialed back slightly —
@@ -732,10 +736,6 @@ private fun EtaStripFitsPreview() {
     )
 }
 
-/** An uncorrected pill clock — the timetable time and the expected time format the same, so there is
- *  nothing to strike through. The preview shorthand for [ArrivalClock]. */
-private fun previewClock(time: String) = ArrivalClock(expected = time, corrects = null)
-
 /** A gallery of individual [EtaPill] states (not the strip): recent-past, "Now", the lateness
  *  colors, a canceled pill, the corrected clock (#2167), and the past-an-hour "Xhr Ymin" form. */
 @Preview(showBackground = true)
@@ -749,8 +749,8 @@ private fun EtaPillVariantsPreview() {
                 verticalAlignment = Alignment.Bottom
             ) {
                 // A recent-past arrival: same size as the upcoming ones — negative ETAs aren't shrunk.
-                EtaPill(-3, colorResource(R.color.stop_info_delayed_fill), predicted = true, clock = previewClock("2:57pm"))
-                EtaPill(0, colorResource(R.color.stop_info_ontime_fill), predicted = true, clock = previewClock("3:00pm"))
+                EtaPill(-3, colorResource(R.color.stop_info_delayed_fill), predicted = true, clock = ArrivalClock("2:57pm"))
+                EtaPill(0, colorResource(R.color.stop_info_ontime_fill), predicted = true, clock = ArrivalClock("3:00pm"))
                 // Late, and so showing the timetable time it corrects struck through above (#2167).
                 EtaPill(
                     5,
@@ -758,18 +758,18 @@ private fun EtaPillVariantsPreview() {
                     predicted = true,
                     clock = ArrivalClock(expected = "3:05pm", corrects = "3:00pm")
                 )
-                EtaPill(12, colorResource(R.color.stop_info_early_fill), predicted = true, clock = previewClock("3:12pm"))
-                EtaPill(22, colorResource(R.color.stop_info_scheduled_fill), predicted = false, clock = previewClock("3:22pm"))
+                EtaPill(12, colorResource(R.color.stop_info_early_fill), predicted = true, clock = ArrivalClock("3:12pm"))
+                EtaPill(22, colorResource(R.color.stop_info_scheduled_fill), predicted = false, clock = ArrivalClock("3:22pm"))
                 EtaPill(
                     8,
                     colorResource(R.color.stop_info_scheduled_fill),
                     predicted = false,
                     canceled = true,
-                    clock = previewClock("3:08pm")
+                    clock = ArrivalClock("3:08pm")
                 )
                 // Past an hour: the number switches to hours, the leftover minutes fold into the label (#1777).
-                EtaPill(83, colorResource(R.color.stop_info_scheduled_fill), predicted = true, clock = previewClock("4:23pm"))
-                EtaPill(125, colorResource(R.color.stop_info_early_fill), predicted = false, clock = previewClock("5:05pm"))
+                EtaPill(83, colorResource(R.color.stop_info_scheduled_fill), predicted = true, clock = ArrivalClock("4:23pm"))
+                EtaPill(125, colorResource(R.color.stop_info_early_fill), predicted = false, clock = ArrivalClock("5:05pm"))
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -163,6 +163,13 @@ internal fun EtaStrip(
     // this would otherwise re-run the caller's lambda over every trip on each of those ticks. It only
     // changes when the trips or the badge source do.
     val hasRouteBadges = remember(trips, routeBadgeFor) { trips.any { routeBadgeFor(it) != null } }
+    // Whether any pill in this strip carries a struck-through timetable time (#2167), which makes it a
+    // clock line taller than its neighbours. The reference pill below has to match the strip's tallest
+    // variant or that pill would be measured short and clipped — and it's per-strip, so a strip where
+    // nothing was corrected keeps exactly the height it had. Remembered for the same reason as above:
+    // the live clock recomposes this body every second, but the answer only moves on a fresh poll.
+    val context = LocalContext.current
+    val hasCorrectedClock = remember(trips, context) { trips.any { it.arrivalClock(context).corrects != null } }
     // Where the marker's moment falls among these departures. Remembered for the same reason: the live
     // clock recomposes this body every second, but the answer only moves when a poll brings new trips.
     val markerIndex = remember(trips, marker) { marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } }
@@ -200,14 +207,17 @@ internal fun EtaStrip(
         ReferencePillHeightFrame(
             modifier = Modifier.weight(1f),
             reference = {
-                // An invisible tallest-variant pill (two-line ETA + clock subline), measured to size
-                // the row and never placed — so it's never drawn, takes no input, adds no semantics.
-                // Constant params, so it never recomposes on the live clock tick.
+                // An invisible tallest-variant pill (ETA + clock subline, plus the struck timetable
+                // line when any pill here has one), measured to size the row and never placed — so
+                // it's never drawn, takes no input, adds no semantics. Constant params, so it never
+                // recomposes on the live clock tick.
                 EtaPill(
                     eta = 10,
                     color = Color.Transparent,
                     predicted = false,
-                    clockTime = "0:00",
+                    // Measured for height only, so the times themselves are arbitrary; all that
+                    // matters is whether there are one or two clock lines.
+                    clock = ArrivalClock(expected = "0:00", corrects = if (hasCorrectedClock) "0:00" else null),
                     routeBadge = if (hasRouteBadges) RouteBadge("00", null) else null
                 )
             }
@@ -408,12 +418,10 @@ private fun EtaPillWithMenu(
 ) {
     var expanded by remember { mutableStateOf(false) }
     // trip.displayTime only changes on a fresh poll, but liveNow (and so this composable) recomposes
-    // every second (issue #1781's ticker) — memoize so the locale-aware format call doesn't re-run on
+    // every second (issue #1781's ticker) — memoize so the locale-aware format calls don't re-run on
     // every tick.
     val context = LocalContext.current
-    val clockTime = remember(trip.displayTime, context) {
-        DisplayFormat.formatTime(context, trip.displayTime.epochMs)
-    }
+    val clock = remember(trip.displayTime, trip.scheduledTime, context) { trip.arrivalClock(context) }
     // fillMaxHeight here and on the pill so the colored Surface stretches to the strip's tallest pill
     // (the strip fixes its row height to the tallest pill via ReferencePillHeightFrame — see
     // EtaStrip), levelling the shorter single-line NOW pill up to its neighbours.
@@ -427,7 +435,7 @@ private fun EtaPillWithMenu(
             predicted = trip.predicted,
             onMap = trip.vehicleOnMap,
             canceled = trip.status == Status.CANCELED,
-            clockTime = clockTime,
+            clock = clock,
             routeBadge = routeBadge,
             onClick = { callbacks.onEtaClick(trip) },
             onLongClick = { expanded = true }
@@ -477,8 +485,9 @@ private val PILL_BADGE_MAX_WIDTH = 72.dp
 /**
  * The prominent white-on-lateness ETA pill — one per trip in a route row's strip (and the Home legend
  * dialog, which passes no clicks). [onClick] taps focus that trip's vehicle + stop; [onLongClick]
- * opens the trip menu; [canceled] strikes the text through. [clockTime] is the small "1:10pm"-style
- * clock time shown below the ETA (issue #1786); null omits that line (e.g. the Home legend's
+ * opens the trip menu; [canceled] strikes the text through. [clock] is the small "1:10pm"-style
+ * clock time shown below the ETA (issue #1786) — with the timetable time it corrects struck through
+ * above it when there is one (#2167); null omits those lines entirely (e.g. the Home legend's
  * illustrative pills, which aren't tied to a real arrival time). The "NOW" pill ([eta] == 0) always
  * omits it too — it's a single centered label — so it's shorter by content; the strip levels it back
  * to its neighbours' height with fillMaxHeight (see EtaStrip's ReferencePillHeightFrame / EtaPillWithMenu).
@@ -499,7 +508,7 @@ internal fun EtaPill(
     // (a drawn vehicle is always real-time), so it wins when both would apply.
     onMap: Boolean = false,
     canceled: Boolean = false,
-    clockTime: String? = null,
+    clock: ArrivalClock? = null,
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null
 ) {
@@ -598,13 +607,15 @@ internal fun EtaPill(
                 // The NOW pill (etaParts == null) drops the clock subline — it's a single centered
                 // label, stretched to its neighbours' height by fillMaxHeight rather than by a second
                 // line of its own.
-                if (clockTime != null && etaParts != null) {
-                    Text(
-                        text = clockTime,
+                if (clock != null && etaParts != null) {
+                    CorrectedClockTime(
+                        clock = clock,
                         fontSize = clockTimeSize,
                         color = Color.White.copy(alpha = 0.8f),
-                        textDecoration = decoration,
-                        style = remember(baseTextStyle, clockTimeSize) { tightLineStyle(baseTextStyle, clockTimeSize) }
+                        // Same trim the ETA line gets, so a corrected pill's two clock lines stack as
+                        // tightly as the single line did rather than gaining a line box each.
+                        style = remember(baseTextStyle, clockTimeSize) { tightLineStyle(baseTextStyle, clockTimeSize) },
+                        canceled = canceled
                     )
                 }
             }
@@ -695,6 +706,20 @@ private fun EtaStripMarkedPreview() {
     )
 }
 
+@Preview(showBackground = true, widthDp = 240, name = "EtaStrip · corrected clock time")
+@Composable
+private fun EtaStripCorrectedPreview() {
+    // The first bus is running 4 minutes behind its timetable, so its pill strikes the scheduled time
+    // through above the one it's now expected at (#2167). The second is on its timetable time and
+    // shows one clock line — levelled to its neighbour's height by the strip, as the NOW pill is.
+    EtaStripPreviewFrame(
+        trips = listOf(
+            previewArrival("8", "Rainier Beach", etaMinutes = 6, scheduleDeviationMinutes = 4, tripId = "trip_1"),
+            previewArrival("8", "Rainier Beach", etaMinutes = 14, tripId = "trip_2")
+        )
+    )
+}
+
 @Preview(showBackground = true, widthDp = 240, name = "EtaStrip · fits (no chevron)")
 @Composable
 private fun EtaStripFitsPreview() {
@@ -707,8 +732,12 @@ private fun EtaStripFitsPreview() {
     )
 }
 
+/** An uncorrected pill clock — the timetable time and the expected time format the same, so there is
+ *  nothing to strike through. The preview shorthand for [ArrivalClock]. */
+private fun previewClock(time: String) = ArrivalClock(expected = time, corrects = null)
+
 /** A gallery of individual [EtaPill] states (not the strip): recent-past, "Now", the lateness
- *  colors, a canceled pill, and the past-an-hour "Xhr Ymin" form. */
+ *  colors, a canceled pill, the corrected clock (#2167), and the past-an-hour "Xhr Ymin" form. */
 @Preview(showBackground = true)
 @Composable
 private fun EtaPillVariantsPreview() {
@@ -720,21 +749,27 @@ private fun EtaPillVariantsPreview() {
                 verticalAlignment = Alignment.Bottom
             ) {
                 // A recent-past arrival: same size as the upcoming ones — negative ETAs aren't shrunk.
-                EtaPill(-3, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "2:57pm")
-                EtaPill(0, colorResource(R.color.stop_info_ontime_fill), predicted = true, clockTime = "3:00pm")
-                EtaPill(5, colorResource(R.color.stop_info_delayed_fill), predicted = true, clockTime = "3:05pm")
-                EtaPill(12, colorResource(R.color.stop_info_early_fill), predicted = true, clockTime = "3:12pm")
-                EtaPill(22, colorResource(R.color.stop_info_scheduled_fill), predicted = false, clockTime = "3:22pm")
+                EtaPill(-3, colorResource(R.color.stop_info_delayed_fill), predicted = true, clock = previewClock("2:57pm"))
+                EtaPill(0, colorResource(R.color.stop_info_ontime_fill), predicted = true, clock = previewClock("3:00pm"))
+                // Late, and so showing the timetable time it corrects struck through above (#2167).
+                EtaPill(
+                    5,
+                    colorResource(R.color.stop_info_delayed_fill),
+                    predicted = true,
+                    clock = ArrivalClock(expected = "3:05pm", corrects = "3:00pm")
+                )
+                EtaPill(12, colorResource(R.color.stop_info_early_fill), predicted = true, clock = previewClock("3:12pm"))
+                EtaPill(22, colorResource(R.color.stop_info_scheduled_fill), predicted = false, clock = previewClock("3:22pm"))
                 EtaPill(
                     8,
                     colorResource(R.color.stop_info_scheduled_fill),
                     predicted = false,
                     canceled = true,
-                    clockTime = "3:08pm"
+                    clock = previewClock("3:08pm")
                 )
                 // Past an hour: the number switches to hours, the leftover minutes fold into the label (#1777).
-                EtaPill(83, colorResource(R.color.stop_info_scheduled_fill), predicted = true, clockTime = "4:23pm")
-                EtaPill(125, colorResource(R.color.stop_info_early_fill), predicted = false, clockTime = "5:05pm")
+                EtaPill(83, colorResource(R.color.stop_info_scheduled_fill), predicted = true, clock = previewClock("4:23pm"))
+                EtaPill(125, colorResource(R.color.stop_info_early_fill), predicted = false, clock = previewClock("5:05pm"))
             }
         }
     }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -216,6 +216,9 @@
     <string name="stop_info_time_departing_at">Departing at %1s</string>
     <string name="stop_info_time_arrived_at">Arrived at %1s</string>
     <string name="stop_info_time_departed_at">Departed at %1s</string>
+    <!-- Spoken form of a corrected clock time, whose strikethrough a screen reader cannot convey:
+         %1$s is the struck-through timetable time, %2$s the time now expected. -->
+    <string name="stop_info_clock_corrected">Scheduled %1$s, now expected %2$s</string>
 
     <plurals name="stop_info_frequency_from">
         <item quantity="one">Every %1$d min from %2$s</item>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -250,7 +250,7 @@ class ArrivalInfoTest {
 
     @Test
     fun `scheduledTime keeps the timetable time a prediction moved`() {
-        val info = infoFor(arrival(predicted = true, predictedArrivalTime = 1_783_119_500_000L))
+        val info = genuinePrediction
 
         assertEquals(scheduledArrival, info.scheduledTime.epochMs)
         assertEquals(1_783_119_500_000L, info.displayTime.epochMs)
@@ -260,10 +260,9 @@ class ArrivalInfoTest {
     fun `scheduledTime equals displayTime when there is no usable prediction`() {
         // Including the closed-stop sentinel, which normalizes to no prediction: the two agree, so
         // nothing is struck through.
-        assertEquals(
-            infoFor(arrival(predicted = false, predictedArrivalTime = 0L)).displayTime,
-            infoFor(arrival(predicted = false, predictedArrivalTime = 0L)).scheduledTime
-        )
+        val unpredicted = infoFor(arrival(predicted = false, predictedArrivalTime = 0L))
+        assertEquals(unpredicted.displayTime, unpredicted.scheduledTime)
+
         val suppressed = infoFor(arrival(predicted = true, predictedArrivalTime = -1L))
         assertEquals(suppressed.displayTime, suppressed.scheduledTime)
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalInfoTest.kt
@@ -241,6 +241,51 @@ class ArrivalInfoTest {
         assertEquals(R.color.stop_info_early_fill, deviating(-91).fillColor)
         assertEquals(R.color.stop_info_scheduled_fill, deviating(600, predicted = false).fillColor)
     }
+
+    // --- The timetable time behind displayTime (#2167) --------------------------------------------
+    //
+    // The clock surfaces print the correction — the struck-through scheduled time over the expected
+    // one — so scheduledTime has to be the *same* arrival-vs-departure choice displayTime made, and
+    // has to survive a prediction rather than being overwritten by it.
+
+    @Test
+    fun `scheduledTime keeps the timetable time a prediction moved`() {
+        val info = infoFor(arrival(predicted = true, predictedArrivalTime = 1_783_119_500_000L))
+
+        assertEquals(scheduledArrival, info.scheduledTime.epochMs)
+        assertEquals(1_783_119_500_000L, info.displayTime.epochMs)
+    }
+
+    @Test
+    fun `scheduledTime equals displayTime when there is no usable prediction`() {
+        // Including the closed-stop sentinel, which normalizes to no prediction: the two agree, so
+        // nothing is struck through.
+        assertEquals(
+            infoFor(arrival(predicted = false, predictedArrivalTime = 0L)).displayTime,
+            infoFor(arrival(predicted = false, predictedArrivalTime = 0L)).scheduledTime
+        )
+        val suppressed = infoFor(arrival(predicted = true, predictedArrivalTime = -1L))
+        assertEquals(suppressed.displayTime, suppressed.scheduledTime)
+    }
+
+    @Test
+    fun `at the first stop scheduledTime is the scheduled departure`() {
+        // stopSequence 0 makes this a departure, and displayTime follows the departure pair — the
+        // timetable time has to follow it there, not stay on the (unused) arrival time.
+        val info = infoFor(
+            FakeArrivalData(
+                predicted = true,
+                predictedArrivalTime = ServerTime(scheduledArrival),
+                scheduledArrivalTime = ServerTime(scheduledArrival),
+                stopSequence = 0,
+                scheduledDepartureTime = ServerTime(scheduledArrival + 120_000L),
+                predictedDepartureTime = ServerTime(scheduledArrival + 300_000L)
+            )
+        )
+
+        assertEquals(scheduledArrival + 120_000L, info.scheduledTime.epochMs)
+        assertEquals(scheduledArrival + 300_000L, info.displayTime.epochMs)
+    }
 }
 
 /** Minimal [ArrivalData] stub; only the arrival-time fields matter for these ETA assertions. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * When a clock time shows the timetable time it corrects, struck through (#2167).
+ *
+ * The whole rule is "do the two *formatted* times differ", which is why it is worth pinning: the
+ * tempting alternatives — compare the instants, or strike through only when the trip is late — are
+ * each wrong at one end, and the cases below are exactly those two ends.
+ */
+class ArrivalClockTest {
+
+    @Test
+    fun `a prediction that formats the same as the timetable corrects nothing`() {
+        // A prediction seconds off the timetable prints the identical clock time. Comparing the
+        // instants instead would strike "10:42 AM" through and replace it with "10:42 AM".
+        val clock = arrivalClockOf(expected = "10:42 AM", scheduled = "10:42 AM")
+
+        assertEquals("10:42 AM", clock.expected)
+        assertNull("nothing to strike through", clock.corrects)
+    }
+
+    @Test
+    fun `a prediction on a different clock minute corrects the timetable time`() {
+        val clock = arrivalClockOf(expected = "10:47 AM", scheduled = "10:42 AM")
+
+        assertEquals("10:47 AM", clock.expected)
+        assertEquals("10:42 AM", clock.corrects)
+    }
+
+    @Test
+    fun `an on-time trip still corrects a time that lands on the next minute`() {
+        // Inside the +-90s ON_TIME_BAND, so the app calls this trip on time and colours it green — but
+        // the rider's timetable said 10:42 and the bus is now due at 10:43, and that is the whole
+        // point of printing the correction. A "strike through only when late" rule would miss it.
+        val clock = arrivalClockOf(expected = "10:43 AM", scheduled = "10:42 AM")
+
+        assertEquals("10:42 AM", clock.corrects)
+    }
+
+    @Test
+    fun `an early prediction corrects the timetable time too`() {
+        // Not just lateness: a bus running ahead of its timetable moves the rider's time as much as a
+        // late one does.
+        val clock = arrivalClockOf(expected = "10:38 AM", scheduled = "10:42 AM")
+
+        assertEquals("10:42 AM", clock.corrects)
+    }
+}


### PR DESCRIPTION
Closes #2167. Parity with onebusaway-ios [#1224](https://github.com/OneBusAway/onebusaway-ios/pull/1224) / [#1237](https://github.com/OneBusAway/onebusaway-ios/pull/1237) — the presentation half, which is the part we didn't already have.

A late bus's pill said `5 min` over `10:47 AM` and left the rider to infer that their 10:42 timetable time had moved. The colour and the "5 min late" status label both say *that* a correction happened; neither says *what it corrected*. Now the pill prints it: the scheduled time struck through directly above the time the bus is now expected at.

```
   5 min          ~~10:42 AM~~
  10:47 AM   →      10:47 AM
```

### The rule is on the formatted strings, not the instants

The same choice iOS made, and it's the whole design — the two tempting alternatives are each wrong at one end:

- **Comparing the instants** renders `~~10:42 AM~~ 10:42 AM` for a prediction a few seconds off the timetable — striking a time through and replacing it with itself.
- **Striking through only when late** misses a trip inside the ±90s `ON_TIME_BAND` that still lands on a different clock minute. We call that trip on time and paint it green, but the rider's time moved and that is exactly what this is for.

Both fall out of comparing what is actually printed, so there is no threshold picked here. `ArrivalClockTest` pins both ends.

### Shape

Per #1237's lesson, the decision and the drawing live in one place (`ui/arrivals/components/ArrivalClockTime.kt`) rather than at each call site. The rule is a plain `Context`-only function separate from the composable, deliberately: the starred-stop badge builds its text in a repository, not a composable, so a Compose-only helper would have been unreachable there.

`ArrivalInfo` gained `scheduledTime` — the same arrival-vs-departure choice `displayTime` makes, before the prediction — so a surface can always compare the two. It stays a `ServerTime`; the only `.epochMs` unwrap is at the `DisplayFormat` boundary.

**A strikethrough is inaudible**, so a corrected pair merges into one spoken phrase: "Scheduled 10:42 AM, now expected 10:47 AM".

### Height

The strip's reference pill grows the extra clock line only when some pill in *that* strip has one, so a strip where nothing was corrected keeps exactly the height it had. That's the mechanism `hasRouteBadges` already uses for the same kind of question.

### Scope left for later

- **Arrival rows** (today only the report-a-problem picker) show a pre-baked sentence, `"Arriving at 10:47 AM"`. Adopting the correction there means unbaking `timeText` into parts — a model change, not another composable. This change doesn't make that harder.
- **Starred-stop / My Lists badges** show no clock time at all (`8 · 5 min`), so there's nothing to correct there yet.

### Translation

One new string, `stop_info_clock_corrected` ("Scheduled %1\$s, now expected %2\$s") — the only place the correction is spoken.

### Testing

- `ArrivalClockTest` (JVM) — the formatted-string rule, including the on-time-band and early-bus ends.
- `ArrivalInfoTest` — `scheduledTime` survives a prediction, collapses to `displayTime` without one (including the closed-stop sentinel), and follows the departure pair at the first stop.
- `EtaStripCorrectedClockRenderTest` (instrumented) — a real strip over real `ArrivalInfo`s: both times drawn, the correction spoken, and an uncorrected pill drawing one clock line rather than two identical ones.

Verified on a device at production geometry: ETA numbers stay baseline-aligned across the strip, corrected pills gain a struck line, uncorrected neighbours stay level. Full strip render suite (9 tests) passes on device; unit tests, `spotlessCheck`, and `-PwarningsAsErrors=true` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Arrival displays now show corrected times with the original timetable time and expected time.
  - Corrected times include visual strikethrough treatment and accessible screen-reader descriptions.
  - Cancellation styling remains supported alongside corrected-time displays.

- **Bug Fixes**
  - Improved handling of predicted, scheduled, early, and next-minute arrival times.
  - On-time arrivals now display a single clock value without unnecessary correction details.

- **Tests**
  - Added coverage for corrected-time rendering, accessibility announcements, cancellation styling, and scheduled-time selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->