### PR TITLE
Solve extrapolated position quantiles in closed form (#2190)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistribution.kt
@@ -15,16 +15,6 @@
  */
 package org.onebusaway.android.extrapolation.math.prob
 
-/**
- * Bisection steps used to invert the CDF.
- *
- * The bracket is the whole remaining schedule, at most ~1800s, so 20 halvings resolve the answer to
- * under 2ms of schedule time — a couple of centimetres of road. Every extra step costs an
- * incomplete-gamma evaluation on a path that runs per vehicle per frame, and buys resolution far
- * below anything drawable.
- */
-private const val QUANTILE_ITERATIONS = 20
-
 /** Central-difference step for [FirstPassageDistribution.pdf], as a fraction of the profile's extent. */
 private const val PDF_STEP_FRACTION = 1e-4
 
@@ -73,17 +63,17 @@ class FirstPassageDistribution(
             "knot arrays must be the same length, were ${scheduleSeconds.size} and ${distances.size}"
         }
         require(scheduleSeconds.size >= 2) { "at least 2 knots are required" }
-        // An infinite knot stays non-decreasing, so it survives the check below and reaches the
-        // bisection as a bracket that halves to itself. NaN would fail that check, but as a knot
+        // An infinite knot stays non-decreasing, so it survives the check below and reaches
+        // interpolate() as a span it cannot divide by. NaN would fail that check, but as a knot
         // that "steps back" rather than as what it is.
         for (i in scheduleSeconds.indices) {
             require(scheduleSeconds[i].isFinite() && distances[i].isFinite()) {
                 "knots must be finite, but knot $i is (${scheduleSeconds[i]}, ${distances[i]})"
             }
         }
-        // Both readings of the profile -- interpolate() and the quantile bisection -- assume it only
-        // ever goes forward. A knot that steps back reads as a plausible position rather than as an
-        // error, so check it here instead of letting it out silently.
+        // Reading the profile -- in either direction -- assumes it only ever goes forward. A knot
+        // that steps back reads as a plausible position rather than as an error, so check it here
+        // instead of letting it out silently.
         for (i in 1 until scheduleSeconds.size) {
             require(scheduleSeconds[i] >= scheduleSeconds[i - 1] && distances[i] >= distances[i - 1]) {
                 "knots must be non-decreasing, but knot $i steps back"
@@ -106,8 +96,8 @@ class FirstPassageDistribution(
      * the further ahead you look, the less likely it has got there.
      *
      * Only the *shape* varies with [tau], so this calls the incomplete-gamma kernel directly rather
-     * than building a [GammaDistribution] per evaluation: quantile inversion runs this 20 times, per
-     * vehicle, per frame.
+     * than building a [GammaDistribution] per evaluation: the map's uncertainty band and the
+     * trajectory view's density read it through [pdf] tens to hundreds of times per frame.
      */
     private fun reached(tau: Double): Double {
         // No ground takes no time, so it is certainly covered. (A zero gamma shape is not a
@@ -123,20 +113,24 @@ class FirstPassageDistribution(
         return (1.0 - reached(interpolate(distances, scheduleSeconds, x))).coerceIn(0.0, 1.0)
     }
 
+    /**
+     * Solved rather than searched for. `1 - reached(tau) = p` is `P(m*tau/theta, dt/theta) = 1 - p`,
+     * so the answer in schedule time is
+     *
+     *     tau = A(1 - p, dt/theta) * theta / m
+     *
+     * where `A` inverts the incomplete gamma in its *shape* — a curve that knows nothing about
+     * theta, the travel multiplier or the schedule, and is therefore shared across every vehicle
+     * (see [IncompleteGammaShape]). Answering in schedule time rather than distance keeps it
+     * well-behaved across dwell plateaus, where a whole range of schedule times maps to one
+     * distance; [interpolate] then clamps `tau` past the end of the profile to its last knot.
+     */
     override fun quantile(p: Double): Double {
         if (p.isNaN()) return Double.NaN
         if (p <= 0.0) return distances.first()
         if (p >= 1.0) return distances.last()
-        // 1 - reached() increases in tau, so this bisects cleanly. Searching in schedule time
-        // rather than distance keeps it well-behaved across dwell plateaus, where a whole range
-        // of schedule times maps to one distance.
-        var lo = 0.0
-        var hi = scheduleSeconds.last()
-        repeat(QUANTILE_ITERATIONS) {
-            val mid = (lo + hi) / 2
-            if (1.0 - reached(mid) < p) lo = mid else hi = mid
-        }
-        return interpolate(scheduleSeconds, distances, (lo + hi) / 2)
+        val shape = IncompleteGammaShape.shapeFor(1.0 - p, elapsedOverTheta)
+        return interpolate(scheduleSeconds, distances, shape * theta / meanTravelMultiplier)
     }
 
     /**
@@ -161,8 +155,9 @@ class FirstPassageDistribution(
     /**
      * Mean position, by midpoint quadrature over the quantile function. No consumer of an
      * extrapolated distance reads the mean — the map, the band and the trajectory view all work in
-     * quantiles — so the approximation buys simplicity at no cost. It is `lazy` because each sample
-     * costs a quantile inversion; nothing currently triggers it.
+     * quantiles — so the approximation buys simplicity at no cost. It is `lazy` because its samples
+     * sweep 64 distinct quantiles, which is wider than [IncompleteGammaShape] keeps tables for;
+     * nothing currently triggers it.
      */
     override val mean: Double by lazy(LazyThreadSafetyMode.NONE) {
         var sum = 0.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistribution.kt
@@ -129,9 +129,11 @@ class FirstPassageDistribution(
         if (p.isNaN()) return Double.NaN
         if (p <= 0.0) return distances.first()
         if (p >= 1.0) return distances.last()
-        val shape = IncompleteGammaShape.shapeFor(1.0 - p, elapsedOverTheta)
-        return interpolate(scheduleSeconds, distances, shape * theta / meanTravelMultiplier)
+        return positionAtShape(IncompleteGammaShape.shapeFor(1.0 - p, elapsedOverTheta))
     }
+
+    /** Where a gamma [shape] worth of schedule time puts the vehicle, clamped to the profile. */
+    private fun positionAtShape(shape: Double) = interpolate(scheduleSeconds, distances, shape * theta / meanTravelMultiplier)
 
     /**
      * Density at [x], by central difference on the CDF.
@@ -155,14 +157,18 @@ class FirstPassageDistribution(
     /**
      * Mean position, by midpoint quadrature over the quantile function. No consumer of an
      * extrapolated distance reads the mean — the map, the band and the trajectory view all work in
-     * quantiles — so the approximation buys simplicity at no cost. It is `lazy` because its samples
-     * sweep 64 distinct quantiles, which is wider than [IncompleteGammaShape] keeps tables for;
-     * nothing currently triggers it.
+     * quantiles — so the approximation buys simplicity at no cost. It is `lazy` because the sweep is
+     * genuinely expensive; nothing currently triggers it.
+     *
+     * The samples go through [IncompleteGammaShape.solveShapeFor] rather than [quantile]: 64 distinct
+     * levels through the shared tables would evict every level the map draws, so a mean here would
+     * slow the next frame down there.
      */
     override val mean: Double by lazy(LazyThreadSafetyMode.NONE) {
         var sum = 0.0
         for (i in 0 until MEAN_SAMPLES) {
-            sum += quantile((i + 0.5) / MEAN_SAMPLES)
+            val level = 1.0 - (i + 0.5) / MEAN_SAMPLES
+            sum += positionAtShape(IncompleteGammaShape.solveShapeFor(level, elapsedOverTheta))
         }
         sum / MEAN_SAMPLES
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/GammaDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/GammaDistribution.kt
@@ -61,8 +61,9 @@ class GammaDistribution(val alpha: Double, val scale: Double) : ProbDistribution
         /**
          * The regularized lower incomplete gamma P(a, x) — the gamma CDF's kernel, in the
          * normalized coordinates where scale has already been divided out. Exposed because
-         * [FirstPassageDistribution] root-finds over the *shape*, so it evaluates this thousands
-         * of times per second with a fixed x; going through a [GammaDistribution] instance would
+         * [FirstPassageDistribution] varies the *shape* at a fixed x, so it evaluates this
+         * thousands of times per second — and because [IncompleteGammaShape] root-finds over the
+         * shape to tabulate that inverse. Going through a [GammaDistribution] instance would
          * allocate one per evaluation.
          */
         internal fun regularizedGammaP(a: Double, x: Double): Double {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShape.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShape.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation.math.prob
+
+import kotlin.math.exp
+import kotlin.math.floor
+import kotlin.math.ln
+
+/**
+ * Argument range the tables cover. [FirstPassageDistribution] queries at `x = elapsed / theta`:
+ * elapsed runs to the 15-minute extrapolation horizon and [org.onebusaway.android.extrapolation.DeviationModel]
+ * holds theta in 22..146s, so real queries land in `(0, 41]`. The bounds here leave six times that
+ * headroom above and reach down to a couple of milliseconds elapsed below; anything outside is
+ * solved directly rather than clamped, so the range is a performance boundary, not a domain limit.
+ */
+private const val X_MIN = 1e-4
+private const val X_MAX = 256.0
+
+/**
+ * Nodes spanning [X_MIN]..[X_MAX], plus [PAD] off each end so the interpolation stencil is interior
+ * everywhere in the covered range — otherwise the first and last cells extrapolate from a clamped
+ * stencil, which is where the error would concentrate.
+ *
+ * `ln(shape)` against `ln(x)` is a gentle monotone curve — slope about a tenth at the low end,
+ * rising to 1 — so cubic interpolation over 1024 log-spaced nodes holds the worst relative error
+ * below 4e-7 over the whole range, and below 1e-8 at every quantile the app actually asks for. In
+ * schedule time that is under a millisecond at the horizon, against the ~2ms the 20-step bisection
+ * left. Each table costs 8KB.
+ */
+private const val NODE_COUNT = 1024
+private const val PAD = 2
+private const val TABLE_SIZE = NODE_COUNT + 2 * PAD
+private val LN_X_STEP = (ln(X_MAX) - ln(X_MIN)) / (NODE_COUNT - 1)
+private val LN_X_BASE = ln(X_MIN) - PAD * LN_X_STEP
+
+/**
+ * Bracket for the direct solve. `P(1e-12, x)` is 1 to within 1e-11 and `P(1e4, 256)` underflows to
+ * zero, so this brackets every level; 60 halvings of the 37-nat span resolve the shape to ~1e-15
+ * relative, well past what the incomplete gamma itself carries.
+ */
+private const val SHAPE_FLOOR = 1e-12
+private const val SHAPE_CEILING = 1e4
+private const val SOLVE_ITERATIONS = 60
+
+/**
+ * Levels held at once. Seven distinct quantiles are drawn (the marker's median, the band's edges,
+ * the fast estimate, and the trajectory view's density window and separators), so the working set
+ * fits with room to spare. [ProbDistribution.mean]'s quadrature would sweep past it, which is why
+ * eviction is round-robin and entries fill lazily: churn costs a solve, not a table.
+ */
+private const val CACHE_SIZE = 16
+
+/**
+ * Inverts the regularized incomplete gamma in its **shape**: given a level and an argument `x`,
+ * the shape `a` with `P(a, x) = level`.
+ *
+ * [FirstPassageDistribution] needs this because its CDF varies the gamma's shape while holding its
+ * argument fixed — it asks how far along the schedule a vehicle has got, and schedule time enters
+ * as the shape. `P` is strictly decreasing in the shape, from 1 as `a -> 0` to 0 as `a -> inf`, so
+ * the inverse exists and is single-valued.
+ *
+ * The curve is worth tabulating because it depends on **nothing else**: not the dispersion, not the
+ * travel multiplier, not the schedule. Those all fold into `x` and into scaling the answer back out,
+ * leaving one two-argument function shared by every vehicle on the map. So a lookup with a cubic
+ * interpolation replaces a root search that cost twenty incomplete-gamma evaluations per quantile,
+ * per vehicle, per frame.
+ *
+ * Tables fill lazily, one node at a time, so nothing pays for a range it never queries and there is
+ * no build-time hitch on the first frame. The whole entry point is synchronized: the fill is a
+ * write to shared state, and an uncontended monitor costs a rounding error against the search this
+ * removes.
+ */
+internal object IncompleteGammaShape {
+
+    /** Cache keys. Initialized to NaN, which never equals a level, so an empty slot cannot hit. */
+    private val levels = DoubleArray(CACHE_SIZE) { Double.NaN }
+
+    /** `ln(shape)` per node, NaN where not yet solved. Parallel to [levels]. */
+    private val tables = arrayOfNulls<DoubleArray>(CACHE_SIZE)
+
+    /** Next slot to overwrite. */
+    private var nextSlot = 0
+
+    /**
+     * The shape `a` with `P(a, [x]) = [level]`, for `x >= 0`.
+     *
+     * A [level] at or outside `(0, 1)` has no solution — `P` never reaches either end — and comes
+     * back clamped to the bracket, which is the limit the caller wants: shape 0 for a certainty and
+     * an effectively unbounded shape for an impossibility.
+     */
+    @Synchronized
+    fun shapeFor(level: Double, x: Double): Double {
+        // P(a, 0) is 0 whatever the shape, so no positive level is attained; the limiting shape is 0.
+        if (x <= 0.0) return 0.0
+        if (x < X_MIN || x > X_MAX) return solve(level, x)
+
+        val table = tableFor(level)
+        val u = (ln(x) - LN_X_BASE) / LN_X_STEP
+        val i = floor(u).toInt().coerceIn(1, TABLE_SIZE - 3)
+        return exp(
+            catmullRom(
+                node(table, level, i - 1),
+                node(table, level, i),
+                node(table, level, i + 1),
+                node(table, level, i + 2),
+                u - i
+            )
+        )
+    }
+
+    /** [level]'s table, evicting round-robin on a miss. */
+    private fun tableFor(level: Double): DoubleArray {
+        for (slot in 0 until CACHE_SIZE) {
+            if (levels[slot] == level) return tables[slot]!!
+        }
+        val fresh = DoubleArray(TABLE_SIZE) { Double.NaN }
+        levels[nextSlot] = level
+        tables[nextSlot] = fresh
+        nextSlot = (nextSlot + 1) % CACHE_SIZE
+        return fresh
+    }
+
+    /** `ln(shape)` at node [i], solving and storing it the first time it is asked for. */
+    private fun node(table: DoubleArray, level: Double, i: Int): Double {
+        val cached = table[i]
+        if (!cached.isNaN()) return cached
+        val solved = ln(solve(level, exp(LN_X_BASE + i * LN_X_STEP)))
+        table[i] = solved
+        return solved
+    }
+
+    /**
+     * Bisects `ln(shape)` for `P(shape, [x]) = [level]`. Geometric rather than linear because the
+     * answer spans twelve orders of magnitude across the tabulated range, and only its relative
+     * precision matters — the caller scales it by theta.
+     *
+     * This is the cold path: it runs once per table node, and directly only for arguments outside
+     * the tabulated range.
+     */
+    private fun solve(level: Double, x: Double): Double {
+        var lo = ln(SHAPE_FLOOR)
+        var hi = ln(SHAPE_CEILING)
+        repeat(SOLVE_ITERATIONS) {
+            val mid = (lo + hi) / 2
+            if (GammaDistribution.regularizedGammaP(exp(mid), x) > level) lo = mid else hi = mid
+        }
+        return exp((lo + hi) / 2)
+    }
+
+    /**
+     * Catmull-Rom through four consecutive nodes, at fraction [f] of the way from [p1] to [p2].
+     * Chosen over linear interpolation because it costs a handful of multiplies and buys a couple
+     * of hundred times the accuracy on this curve at the same node count.
+     */
+    private fun catmullRom(p0: Double, p1: Double, p2: Double, p3: Double, f: Double): Double = p1 + 0.5 * f * ((p2 - p0) + f * ((2 * p0 - 5 * p1 + 4 * p2 - p3) + f * (3 * (p1 - p2) + p3 - p0)))
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShape.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShape.kt
@@ -36,15 +36,14 @@ private const val X_MAX = 256.0
  *
  * `ln(shape)` against `ln(x)` is a gentle monotone curve — slope about a tenth at the low end,
  * rising to 1 — so cubic interpolation over 1024 log-spaced nodes holds the worst relative error
- * below 4e-7 over the whole range, and below 1e-8 at every quantile the app actually asks for. In
- * schedule time that is under a millisecond at the horizon, against the ~2ms the 20-step bisection
- * left. Each table costs 8KB.
+ * to 3.4e-7, at the 0.999 level where the curve is steepest; the marker's median and the band's
+ * edges sit nearer 1e-9. In schedule time even the worst is under a millisecond at the horizon,
+ * against the ~2ms the 20-step bisection left. Halving the node count costs a factor of eight, and
+ * the error is pinned by `IncompleteGammaShapeTest`. Each table costs 8KB.
  */
 private const val NODE_COUNT = 1024
 private const val PAD = 2
 private const val TABLE_SIZE = NODE_COUNT + 2 * PAD
-private val LN_X_STEP = (ln(X_MAX) - ln(X_MIN)) / (NODE_COUNT - 1)
-private val LN_X_BASE = ln(X_MIN) - PAD * LN_X_STEP
 
 /**
  * Bracket for the direct solve. `P(1e-12, x)` is 1 to within 1e-11 and `P(1e4, 256)` underflows to
@@ -58,8 +57,11 @@ private const val SOLVE_ITERATIONS = 60
 /**
  * Levels held at once. Seven distinct quantiles are drawn (the marker's median, the band's edges,
  * the fast estimate, and the trajectory view's density window and separators), so the working set
- * fits with room to spare. [ProbDistribution.mean]'s quadrature would sweep past it, which is why
- * eviction is round-robin and entries fill lazily: churn costs a solve, not a table.
+ * fits with room to spare and round-robin eviction never reaches a live level.
+ *
+ * Deliberately parallel arrays rather than the codebase's `BoundedLruCache`: that is a
+ * `LinkedHashMap`, so every lookup would box the `Double` level on a path that runs per vehicle per
+ * frame. A flat scan of sixteen doubles is a handful of compares and allocates nothing.
  */
 private const val CACHE_SIZE = 16
 
@@ -79,11 +81,16 @@ private const val CACHE_SIZE = 16
  * per vehicle, per frame.
  *
  * Tables fill lazily, one node at a time, so nothing pays for a range it never queries and there is
- * no build-time hitch on the first frame. The whole entry point is synchronized: the fill is a
- * write to shared state, and an uncontended monitor costs a rounding error against the search this
- * removes.
+ * no build-time hitch on the first frame. [shapeFor] is synchronized because that fill writes shared
+ * state; the monitor is a fifth of the call's ~90ns, which is still a fraction of the twenty gamma
+ * evaluations it replaces, and both callers are on the UI thread so it is never contended.
  */
 internal object IncompleteGammaShape {
+
+    /** Node spacing and origin, in `ln(x)`. Held here rather than at file scope: a top-level
+     * non-const `val` compiles to a synthetic accessor, and these are read four times per call. */
+    private val lnStep = (ln(X_MAX) - ln(X_MIN)) / (NODE_COUNT - 1)
+    private val lnBase = ln(X_MIN) - PAD * lnStep
 
     /** Cache keys. Initialized to NaN, which never equals a level, so an empty slot cannot hit. */
     private val levels = DoubleArray(CACHE_SIZE) { Double.NaN }
@@ -97,9 +104,11 @@ internal object IncompleteGammaShape {
     /**
      * The shape `a` with `P(a, [x]) = [level]`, for `x >= 0`.
      *
-     * A [level] at or outside `(0, 1)` has no solution — `P` never reaches either end — and comes
-     * back clamped to the bracket, which is the limit the caller wants: shape 0 for a certainty and
-     * an effectively unbounded shape for an impossibility.
+     * No production caller passes a [level] outside `(0, 1)` — [FirstPassageDistribution.quantile]
+     * short-circuits `p <= 0` and `p >= 1` first — and there is no solution there anyway, since `P`
+     * reaches neither end. Such a level runs the bisection to whichever end of its bracket it can,
+     * which is the limit a caller would want: no shape at all for a certainty, and an effectively
+     * unbounded one for an impossibility.
      */
     @Synchronized
     fun shapeFor(level: Double, x: Double): Double {
@@ -108,7 +117,7 @@ internal object IncompleteGammaShape {
         if (x < X_MIN || x > X_MAX) return solve(level, x)
 
         val table = tableFor(level)
-        val u = (ln(x) - LN_X_BASE) / LN_X_STEP
+        val u = (ln(x) - lnBase) / lnStep
         val i = floor(u).toInt().coerceIn(1, TABLE_SIZE - 3)
         return exp(
             catmullRom(
@@ -120,6 +129,16 @@ internal object IncompleteGammaShape {
             )
         )
     }
+
+    /**
+     * As [shapeFor], but solved directly, touching no table.
+     *
+     * For callers that sweep many levels once — [ProbDistribution.mean]'s quadrature takes 64 — where
+     * going through the cache would allocate a table per level and evict every level the map draws,
+     * leaving the next frame to refill nodes it had already paid for. A single solve is ~20us, which
+     * is the right price for a cold sweep and the wrong one for a frame.
+     */
+    fun solveShapeFor(level: Double, x: Double): Double = if (x <= 0.0) 0.0 else solve(level, x)
 
     /** [level]'s table, evicting round-robin on a miss. */
     private fun tableFor(level: Double): DoubleArray {
@@ -137,7 +156,7 @@ internal object IncompleteGammaShape {
     private fun node(table: DoubleArray, level: Double, i: Int): Double {
         val cached = table[i]
         if (!cached.isNaN()) return cached
-        val solved = ln(solve(level, exp(LN_X_BASE + i * LN_X_STEP)))
+        val solved = ln(solve(level, exp(lnBase + i * lnStep)))
         table[i] = solved
         return solved
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistributionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistributionTest.kt
@@ -229,15 +229,22 @@ class FirstPassageDistributionTest {
         }
     }
 
-    /** Inverts [FirstPassageDistribution.cdf] the slow way: bisect distance until it brackets [p]. */
-    private fun searchQuantile(dist: FirstPassageDistribution, p: Double): Double {
-        var lo = distances.first()
-        var hi = distances.last()
-        repeat(60) {
-            val mid = (lo + hi) / 2
-            if (dist.cdf(mid) < p) lo = mid else hi = mid
+    /** Inverts [FirstPassageDistribution.cdf] the slow way, with the package's own root-finder. */
+    private fun searchQuantile(dist: FirstPassageDistribution, p: Double) = bisect(dist::cdf, p, distances.last())
+
+    @Test
+    fun `the mean matches the same quadrature taken through the quantiles`() {
+        // The mean's samples deliberately bypass the shared quantile tables, so that a 64-level
+        // sweep can't evict the levels the map draws. It must still land where the equivalent sweep
+        // through quantile() does.
+        val dist = at(120.0)
+        val samples = 64
+        var sum = 0.0
+        for (i in 0 until samples) {
+            sum += dist.quantile((i + 0.5) / samples)
         }
-        return (lo + hi) / 2
+        assertEquals(sum / samples, dist.mean, QUANTILE_TOLERANCE_M)
+        assertTrue("mean ${dist.mean} out of range", dist.mean > distances.first() && dist.mean < distances.last())
     }
 
     // --- Dwells ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistributionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistributionTest.kt
@@ -23,11 +23,11 @@ import org.junit.Test
 private const val THETA = 25.236
 
 /**
- * Quantiles are found by bisecting the remaining schedule, so they carry that search's residue.
- * A centimetre is far below anything drawable and comfortably above the residue the iteration
- * count guarantees — asserting tighter would be pinning the constant, not the behaviour.
+ * Quantiles come from a tabulated inverse, so they carry its interpolation residue. A centimetre is
+ * far below anything drawable and orders of magnitude above the residue the table guarantees —
+ * asserting tighter would be pinning the table's resolution, not the behaviour.
  */
-private const val SEARCH_TOLERANCE_M = 0.01
+private const val QUANTILE_TOLERANCE_M = 0.01
 
 class FirstPassageDistributionTest {
 
@@ -66,8 +66,8 @@ class FirstPassageDistributionTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun `an infinite knot is rejected`() {
-        // It is non-decreasing, so only a finiteness check catches it before the quantile
-        // bisection inherits it as an unhalvable bracket.
+        // It is non-decreasing, so only a finiteness check catches it before the profile reads as
+        // a segment of infinite extent that every position falls at the start of.
         FirstPassageDistribution(
             60.0,
             doubleArrayOf(0.0, 100.0, Double.POSITIVE_INFINITY),
@@ -172,7 +172,7 @@ class FirstPassageDistributionTest {
     @Test
     fun `the vehicle never runs past the end of the schedule`() {
         val dist = at(3600.0)
-        assertEquals(2000.0, dist.quantile(0.999), SEARCH_TOLERANCE_M)
+        assertEquals(2000.0, dist.quantile(0.999), QUANTILE_TOLERANCE_M)
         assertEquals(1.0, dist.cdf(2000.0), 0.0)
         assertEquals(0.0, dist.pdf(2000.0), 0.0)
     }
@@ -180,8 +180,8 @@ class FirstPassageDistributionTest {
     @Test
     fun `at the anchor instant the vehicle is exactly where it was seen`() {
         val dist = at(0.0)
-        assertEquals(0.0, dist.quantile(0.5), SEARCH_TOLERANCE_M)
-        assertEquals(0.0, dist.quantile(0.99), SEARCH_TOLERANCE_M)
+        assertEquals(0.0, dist.quantile(0.5), QUANTILE_TOLERANCE_M)
+        assertEquals(0.0, dist.quantile(0.99), QUANTILE_TOLERANCE_M)
         assertEquals(0.0, dist.cdf(-1e-9), 0.0)
     }
 
@@ -200,6 +200,44 @@ class FirstPassageDistributionTest {
         // The tail beyond the last knot is an atom carrying the rest of the mass.
         val atom = 1.0 - dist.cdf(2000.0 - 1e-6)
         assertEquals(1.0, sum + atom, 0.02)
+    }
+
+    // --- The closed-form quantile agrees with searching for it ---
+
+    @Test
+    fun `quantiles match inverting the cdf by search`() {
+        // The shipped quantile solves for the schedule time directly; this searches the CDF for
+        // the same crossing, which is what it replaced. Swept over the dispersion and
+        // travel-multiplier range DeviationModel spans, the whole extrapolation horizon, and the
+        // quantiles the app draws.
+        for (theta in listOf(22.0, 50.0, 146.0)) {
+            for (multiplier in listOf(1.02, 1.35)) {
+                for (dtSec in listOf(1.0, 5.0, 30.0, 90.0, 300.0, 600.0, 900.0)) {
+                    val dist =
+                        FirstPassageDistribution(dtSec, scheduleSeconds, distances, theta, multiplier)
+                    for (p in listOf(0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999)) {
+                        val searched = searchQuantile(dist, p)
+                        assertEquals(
+                            "theta=$theta m=$multiplier dt=$dtSec p=$p",
+                            searched,
+                            dist.quantile(p),
+                            QUANTILE_TOLERANCE_M
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /** Inverts [FirstPassageDistribution.cdf] the slow way: bisect distance until it brackets [p]. */
+    private fun searchQuantile(dist: FirstPassageDistribution, p: Double): Double {
+        var lo = distances.first()
+        var hi = distances.last()
+        repeat(60) {
+            val mid = (lo + hi) / 2
+            if (dist.cdf(mid) < p) lo = mid else hi = mid
+        }
+        return (lo + hi) / 2
     }
 
     // --- Dwells ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShapeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShapeTest.kt
@@ -26,19 +26,19 @@ import org.junit.Test
 private val LEVELS = doubleArrayOf(0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999)
 
 /**
- * How far the tabulated inverse may sit from a direct solve, relatively. The interpolation's own
- * worst case over the tabulated range is 4e-7 (at level 0.999, the steepest curve of the set), so
- * this leaves an order of magnitude of headroom without being so loose it would miss a table that
- * had stopped being interpolated at all.
+ * How far the tabulated inverse may sit from a direct solve, relatively. This is deliberately close
+ * to the interpolation's measured worst case — 3.4e-7, at level 0.999 where the curve is steepest —
+ * so that it pins the figure `IncompleteGammaShape` documents to justify its node count, rather than
+ * merely catching a table that had stopped being interpolated at all.
  */
-private const val TABLE_TOLERANCE = 5e-6
+private const val TABLE_TOLERANCE = 1e-6
 
 class IncompleteGammaShapeTest {
 
     /**
-     * Independent, deliberately slow inversion: bisect the shape until the bracket is closed to
-     * machine precision. Same kernel as the tabulated path — this pins the *interpolation*, not the
-     * incomplete gamma, which [GammaDistributionTest] covers.
+     * The same geometric bisection the production solver runs, but to convergence rather than to a
+     * fixed 60 steps. Sharing the kernel is the point: it pins the *interpolation* and nothing else,
+     * leaving the incomplete gamma itself to [GammaDistributionTest].
      */
     private fun reference(level: Double, x: Double): Double {
         var lo = ln(1e-12)
@@ -53,12 +53,10 @@ class IncompleteGammaShapeTest {
     /** Log-spaced arguments, deliberately offset so they land between table nodes. */
     private fun sampleArguments(count: Int, min: Double = 1e-4, max: Double = 256.0) = (0 until count).map { exp(ln(min) + (ln(max) - ln(min)) * (it + 0.5) / count) }
 
-    // --- Agreement with a direct solve ---
-
-    @Test
-    fun `matches a direct solve across the tabulated range`() {
+    /** Every level, against [reference], at each of [xs]. */
+    private fun assertMatchesReference(xs: Iterable<Double>) {
         for (level in LEVELS) {
-            for (x in sampleArguments(200)) {
+            for (x in xs) {
                 val expected = reference(level, x)
                 val actual = IncompleteGammaShape.shapeFor(level, x)
                 assertTrue(
@@ -68,36 +66,24 @@ class IncompleteGammaShapeTest {
             }
         }
     }
+
+    // --- Agreement with a direct solve ---
+
+    @Test
+    fun `matches a direct solve across the tabulated range`() = assertMatchesReference(sampleArguments(200))
 
     @Test
     fun `matches a direct solve at the edges of the tabulated range`() {
         // Where the interpolation stencil is most nearly one-sided, and (at the low end) where the
         // curve is steepest in the argument.
-        val edges = listOf(1e-4, 1.02e-4, 1.1e-4, 2e-4, 200.0, 255.0, 255.99, 256.0)
-        for (level in LEVELS) {
-            for (x in edges) {
-                val expected = reference(level, x)
-                val actual = IncompleteGammaShape.shapeFor(level, x)
-                assertTrue(
-                    "level=$level x=$x expected $expected but got $actual",
-                    abs(actual - expected) <= TABLE_TOLERANCE * expected
-                )
-            }
-        }
+        assertMatchesReference(listOf(1e-4, 1.02e-4, 1.1e-4, 2e-4, 200.0, 255.0, 255.99, 256.0))
     }
 
     @Test
-    fun `solves directly outside the tabulated range`() {
-        for (level in LEVELS) {
-            for (x in listOf(1e-7, 1e-5, 9.9e-5, 300.0, 1000.0, 5000.0)) {
-                val expected = reference(level, x)
-                val actual = IncompleteGammaShape.shapeFor(level, x)
-                assertTrue(
-                    "level=$level x=$x expected $expected but got $actual",
-                    abs(actual - expected) <= TABLE_TOLERANCE * expected
-                )
-            }
-        }
+    fun `an argument outside the tabulated range is solved rather than clamped`() {
+        // Below X_MIN and above X_MAX there is no table to read, so these exercise the direct path
+        // and pin that it stays exact instead of pinning the ends of the table.
+        assertMatchesReference(listOf(1e-7, 1e-5, 9.9e-5, 300.0, 1000.0, 5000.0))
     }
 
     // --- Against closed forms ---
@@ -175,6 +161,21 @@ class IncompleteGammaShapeTest {
     }
 
     // --- Cache behaviour ---
+
+    @Test
+    fun `the uncached solve agrees with the tabulated one`() {
+        for (level in LEVELS) {
+            for (x in listOf(0.01, 1.0, 12.5, 41.0)) {
+                val tabulated = IncompleteGammaShape.shapeFor(level, x)
+                val solved = IncompleteGammaShape.solveShapeFor(level, x)
+                assertTrue(
+                    "level=$level x=$x tabulated $tabulated but solved $solved",
+                    abs(solved - tabulated) <= TABLE_TOLERANCE * tabulated
+                )
+            }
+        }
+        assertEquals(0.0, IncompleteGammaShape.solveShapeFor(0.5, 0.0), 0.0)
+    }
 
     @Test
     fun `answers survive being evicted from the table cache`() {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShapeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShapeTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation.math.prob
+
+import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.ln
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Quantile levels the app draws, plus the extremes of the trajectory view's density window. */
+private val LEVELS = doubleArrayOf(0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999)
+
+/**
+ * How far the tabulated inverse may sit from a direct solve, relatively. The interpolation's own
+ * worst case over the tabulated range is 4e-7 (at level 0.999, the steepest curve of the set), so
+ * this leaves an order of magnitude of headroom without being so loose it would miss a table that
+ * had stopped being interpolated at all.
+ */
+private const val TABLE_TOLERANCE = 5e-6
+
+class IncompleteGammaShapeTest {
+
+    /**
+     * Independent, deliberately slow inversion: bisect the shape until the bracket is closed to
+     * machine precision. Same kernel as the tabulated path — this pins the *interpolation*, not the
+     * incomplete gamma, which [GammaDistributionTest] covers.
+     */
+    private fun reference(level: Double, x: Double): Double {
+        var lo = ln(1e-12)
+        var hi = ln(1e4)
+        repeat(100) {
+            val mid = (lo + hi) / 2
+            if (GammaDistribution.regularizedGammaP(exp(mid), x) > level) lo = mid else hi = mid
+        }
+        return exp((lo + hi) / 2)
+    }
+
+    /** Log-spaced arguments, deliberately offset so they land between table nodes. */
+    private fun sampleArguments(count: Int, min: Double = 1e-4, max: Double = 256.0) = (0 until count).map { exp(ln(min) + (ln(max) - ln(min)) * (it + 0.5) / count) }
+
+    // --- Agreement with a direct solve ---
+
+    @Test
+    fun `matches a direct solve across the tabulated range`() {
+        for (level in LEVELS) {
+            for (x in sampleArguments(200)) {
+                val expected = reference(level, x)
+                val actual = IncompleteGammaShape.shapeFor(level, x)
+                assertTrue(
+                    "level=$level x=$x expected $expected but got $actual",
+                    abs(actual - expected) <= TABLE_TOLERANCE * expected
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `matches a direct solve at the edges of the tabulated range`() {
+        // Where the interpolation stencil is most nearly one-sided, and (at the low end) where the
+        // curve is steepest in the argument.
+        val edges = listOf(1e-4, 1.02e-4, 1.1e-4, 2e-4, 200.0, 255.0, 255.99, 256.0)
+        for (level in LEVELS) {
+            for (x in edges) {
+                val expected = reference(level, x)
+                val actual = IncompleteGammaShape.shapeFor(level, x)
+                assertTrue(
+                    "level=$level x=$x expected $expected but got $actual",
+                    abs(actual - expected) <= TABLE_TOLERANCE * expected
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `solves directly outside the tabulated range`() {
+        for (level in LEVELS) {
+            for (x in listOf(1e-7, 1e-5, 9.9e-5, 300.0, 1000.0, 5000.0)) {
+                val expected = reference(level, x)
+                val actual = IncompleteGammaShape.shapeFor(level, x)
+                assertTrue(
+                    "level=$level x=$x expected $expected but got $actual",
+                    abs(actual - expected) <= TABLE_TOLERANCE * expected
+                )
+            }
+        }
+    }
+
+    // --- Against closed forms ---
+
+    @Test
+    fun `recovers the shapes whose incomplete gamma is elementary`() {
+        // P(1, x) = 1 - exp(-x), and P(2, x) = 1 - exp(-x) * (1 + x). Asking for the level those
+        // produce must give back the shape that produced it. Held to moderate x: past x ~ 36 the
+        // level rounds to 1.0 and the test would be measuring double precision, not the inverse.
+        for (x in sampleArguments(100, min = 1e-2, max = 10.0)) {
+            assertEquals("shape 1 at x=$x", 1.0, IncompleteGammaShape.shapeFor(1 - exp(-x), x), 1e-5)
+            assertEquals("shape 2 at x=$x", 2.0, IncompleteGammaShape.shapeFor(1 - exp(-x) * (1 + x), x), 2e-5)
+        }
+    }
+
+    @Test
+    fun `the median shape approaches the classic gamma-median result`() {
+        // The median of Gamma(a, 1) is a - 1/3 + O(1/a), so inverting at level 0.5 gives x + 1/3.
+        // The tolerance is that remainder — 0.004 at x = 5, shrinking as 1/x from there — not the
+        // table's error, which is nine orders of magnitude smaller.
+        for (x in listOf(5.0, 10.0, 20.0, 41.0, 100.0)) {
+            assertEquals("x=$x", x + 1.0 / 3.0, IncompleteGammaShape.shapeFor(0.5, x), 5e-3)
+        }
+    }
+
+    // --- Structure ---
+
+    @Test
+    fun `the shape round-trips through the incomplete gamma`() {
+        for (level in LEVELS) {
+            for (x in sampleArguments(100)) {
+                val shape = IncompleteGammaShape.shapeFor(level, x)
+                assertEquals("level=$level x=$x", level, GammaDistribution.regularizedGammaP(shape, x), 1e-5)
+            }
+        }
+    }
+
+    @Test
+    fun `the shape rises with the argument and falls with the level`() {
+        for (level in LEVELS) {
+            var previous = Double.NEGATIVE_INFINITY
+            for (x in sampleArguments(600)) {
+                val shape = IncompleteGammaShape.shapeFor(level, x)
+                assertTrue("level=$level went backwards at x=$x", shape >= previous)
+                previous = shape
+            }
+        }
+        for (x in listOf(0.01, 1.0, 10.0, 41.0)) {
+            var previous = Double.POSITIVE_INFINITY
+            for (level in LEVELS) {
+                val shape = IncompleteGammaShape.shapeFor(level, x)
+                assertTrue("x=$x rose at level=$level", shape <= previous)
+                previous = shape
+            }
+        }
+    }
+
+    // --- Degenerate arguments ---
+
+    @Test
+    fun `a zero argument has no shape at all`() {
+        // P(a, 0) is 0 for every shape, so nothing has been covered and the limiting shape is 0.
+        assertEquals(0.0, IncompleteGammaShape.shapeFor(0.5, 0.0), 0.0)
+        assertEquals(0.0, IncompleteGammaShape.shapeFor(0.999, 0.0), 0.0)
+    }
+
+    @Test
+    fun `unattainable levels resolve to the limiting shape`() {
+        // P never reaches 1 or 0, so these have no solution. Certainty bottoms out at a shape of
+        // nothing; impossibility runs out to a shape with no mass at x at all.
+        assertTrue(IncompleteGammaShape.shapeFor(1.0, 10.0) <= 1e-11)
+        val unreachable = IncompleteGammaShape.shapeFor(0.0, 10.0)
+        assertTrue("got $unreachable", unreachable > 100.0)
+        assertTrue(GammaDistribution.regularizedGammaP(unreachable, 10.0) < 1e-300)
+    }
+
+    // --- Cache behaviour ---
+
+    @Test
+    fun `answers survive being evicted from the table cache`() {
+        val before = IncompleteGammaShape.shapeFor(0.5, 7.5)
+        // More distinct levels than the cache holds, so 0.5's table is certainly evicted.
+        for (i in 1..64) {
+            IncompleteGammaShape.shapeFor(i / 65.0, 7.5)
+        }
+        assertEquals(before, IncompleteGammaShape.shapeFor(0.5, 7.5), 0.0)
+    }
+}


### PR DESCRIPTION
`FirstPassageDistribution.quantile()` inverted its CDF by bisection — 20 halvings of the remaining schedule, each an incomplete-gamma evaluation — on the map's per-frame vehicle sampler.

### The identity

`reached(tau)` is `regularizedGammaP(m·tau/θ, dt/θ)`. With `a = m·tau/θ` and `z = dt/θ`, solving `1 − reached(tau) = p` is just

```
P(a, z) = 1 − p        →        a = A(1 − p, z)
```

`A` inverts the incomplete gamma in its **shape**, and depends on neither `theta`, nor the travel multiplier, nor the schedule — those fold into `z` and into scaling the answer back out. One curve, shared by every vehicle on the map. `tau = A(1 − p, z)·θ/m` then goes to the same `interpolate(scheduleSeconds, distances, tau)` as before, which still clamps past the end of the profile.

### The lookup

New `IncompleteGammaShape` tabulates `ln(shape)` against `ln(x)` — a gentle monotone curve, slope ~0.1 at the low end rising to 1 — over 1024 log-spaced nodes per level, read with a Catmull-Rom interpolation.

- **Lazy per node.** Nodes solve on first touch, so nothing pays for a range it never queries and there is no table-build hitch on the first frame.
- **Not a domain limit.** Arguments outside the tabulated `[1e-4, 256]` fall through to the direct solve. Real queries land in `(0, 41]` (15-minute horizon over `DeviationModel`'s 22–146s dispersion), so the range is a performance boundary with headroom, not a clamp.
- **Bounded cache.** 16 levels, round-robin; the app draws seven. `mean`'s 64-sample quadrature sweeps past it, which is why eviction is cheap — churn costs a solve, not a table.
- The whole entry point is `@Synchronized`: the lazy fill writes shared state, and an uncontended monitor is a rounding error against the search this removes.

### Accuracy

Worst relative error against a direct high-precision solve is **4e-7** over the whole tabulated range (at level 0.999, the steepest curve of the set) and **below 1e-8** at every quantile the app actually draws. In schedule time that is under a millisecond at the horizon, against the ~2ms residue the 20-step bisection left.

### Speed

Measured on a desktop JVM over 256 distributions spanning the dispersion range: `median()` goes **5.9 µs → 91 ns** (~65×), i.e. a quantile now costs less than *half of a single* incomplete-gamma evaluation, where it used to cost twenty. No allocation. ART is slower again in the same proportion.

### Tests

- `IncompleteGammaShapeTest` — agreement with a direct solve across the range, at its edges, and outside it; the elementary shapes (`P(1,x) = 1−e⁻ˣ`, `P(2,x) = 1−e⁻ˣ(1+x)`) recovered exactly; the classic `A(0.5, x) ≈ x + 1/3` gamma-median result; monotonicity in both arguments; degenerate arguments and unattainable levels; and survival of cache eviction.
- `FirstPassageDistributionTest` gains the sweep from the issue — θ ∈ {22, 50, 146} × m ∈ {1.02, 1.35} × dt ∈ [1, 900]s × p ∈ {0.001 … 0.999} — asserting the closed form matches searching the CDF for the same crossing, to a centimetre.

Full `obaGoogle` unit suite, both flavours' Kotlin compile under `-PwarningsAsErrors=true`, and `spotlessCheck` all pass.

Closes #2190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved probability-based travel-time and distance quantile calculations through more direct mathematical inversion.
  - Increased accuracy and consistency across a wider range of dispersion, elapsed-time, and probability values.
  - Improved handling of boundary, unreachable, and out-of-range inputs.
  - Reduced repeated iterative calculations for more efficient results.
  - Improved agreement between mean and quantile-based calculations.

- **Documentation**
  - Clarified usage guidance, calculation behavior, and validation expectations for probability estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->