### PR TITLE
Resolve a coach number from the search bar, and drill into that bus

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/ObaApiResult.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/ObaApiResult.kt
@@ -72,12 +72,18 @@ val Throwable.isNotFound: Boolean
  *
  * The body is required to decode as an envelope **whose code equals the HTTP status**, so only the OBA
  * layer's own answer is adopted: a proxy's HTML 404, or a JSON error object from something else, fails
- * that check and stays an [HttpException]. Reading the error body is safe and non-blocking — Retrofit
- * buffers it in memory before constructing the [HttpException].
+ * that check and stays an [HttpException]. Reading the error body is safe to do on the calling thread —
+ * Retrofit buffers it in memory before constructing the [HttpException], so no I/O happens here — and a
+ * body that can't be read anyway leaves the transport failure exactly as it arrived, since a body we
+ * never saw states nothing about the resource.
  */
 internal fun Throwable.asObaFailure(json: Json): Throwable {
     if (this !is HttpException) return this
-    val body = response()?.errorBody()?.string().orEmpty()
+    val body = try {
+        response()?.errorBody()?.string().orEmpty()
+    } catch (_: IOException) {
+        return this
+    }
     val envelope = try {
         json.decodeFromString<ObaEnvelope<JsonElement>>(body)
     } catch (_: SerializationException) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/ObaApiResult.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/ObaApiResult.kt
@@ -19,6 +19,7 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import org.onebusaway.android.api.contract.ListWithReferences
 import org.onebusaway.android.api.contract.ObaEnvelope
+import retrofit2.HttpException
 
 /**
  * Thrown when an OBA response carries a non-OK app-level [code] (a standard HTTP status mirrored in
@@ -40,6 +41,24 @@ fun <T> ObaEnvelope<T>.requireData(): T {
     }
     return data
 }
+
+/**
+ * True when this failure is the API's definitive "no such resource" answer rather than a transport,
+ * server or decode failure — the distinction a caller needs to tell "the server says there is none"
+ * from "we couldn't ask".
+ *
+ * An OBA server sets the HTTP status from the envelope code (`trip-for-vehicle` for an unassigned
+ * vehicle answers HTTP 404 with `{"code":404,...}`), and Retrofit raises [HttpException] on a non-2xx
+ * status before the body is ever decoded — so that is the form a 404 normally takes. [ObaApiException]
+ * is the same answer read off the decoded envelope by [requireData], which is what a response carrying
+ * the code under a 2xx status would produce; both mean not-found, so both count here.
+ */
+val Throwable.isNotFound: Boolean
+    get() = when (this) {
+        is ObaApiException -> code == HttpURLConnection.HTTP_NOT_FOUND
+        is HttpException -> code() == HttpURLConnection.HTTP_NOT_FOUND
+        else -> false
+    }
 
 /**
  * Asserts an OK app-level code, throwing [ObaApiException] otherwise — for endpoints whose response

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/ObaApiResult.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/ObaApiResult.kt
@@ -17,6 +17,9 @@ package org.onebusaway.android.api
 
 import java.io.IOException
 import java.net.HttpURLConnection
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import org.onebusaway.android.api.contract.ListWithReferences
 import org.onebusaway.android.api.contract.ObaEnvelope
 import retrofit2.HttpException
@@ -47,18 +50,41 @@ fun <T> ObaEnvelope<T>.requireData(): T {
  * server or decode failure — the distinction a caller needs to tell "the server says there is none"
  * from "we couldn't ask".
  *
- * An OBA server sets the HTTP status from the envelope code (`trip-for-vehicle` for an unassigned
- * vehicle answers HTTP 404 with `{"code":404,...}`), and Retrofit raises [HttpException] on a non-2xx
- * status before the body is ever decoded — so that is the form a 404 normally takes. [ObaApiException]
- * is the same answer read off the decoded envelope by [requireData], which is what a response carrying
- * the code under a 2xx status would produce; both mean not-found, so both count here.
+ * Only [ObaApiException] can carry that answer: it's what [requireData] raises off a decoded envelope,
+ * and what [asObaFailure] maps a non-2xx response to *once it has confirmed the body is an OBA
+ * envelope stating the same code*. A bare [HttpException] deliberately doesn't count — a 404 from a
+ * proxy, or from a deployment that doesn't serve the endpoint at all, says nothing about the resource.
  */
 val Throwable.isNotFound: Boolean
-    get() = when (this) {
-        is ObaApiException -> code == HttpURLConnection.HTTP_NOT_FOUND
-        is HttpException -> code() == HttpURLConnection.HTTP_NOT_FOUND
-        else -> false
+    get() = this is ObaApiException && code == HttpURLConnection.HTTP_NOT_FOUND
+
+/**
+ * The OBA answer behind a non-2xx response, as an [ObaApiException] — or this throwable unchanged when
+ * the response didn't come from the OBA API itself.
+ *
+ * An OBA server sets the HTTP status from the envelope code and still writes the envelope as the body
+ * (`trip-for-vehicle` for an unassigned vehicle answers HTTP 404 with
+ * `{"code":404,"currentTime":…,"text":"resource not found","version":2}`), but Retrofit raises
+ * [HttpException] on a non-2xx status before that body is ever decoded. Normalizing here — in the one
+ * place every call passes through ([org.onebusaway.android.api.net.ObaApiProvider.call]) — gives
+ * callers a single failure type to classify codes on, instead of each rediscovering that the same
+ * app-level code arrives as two different exception types.
+ *
+ * The body is required to decode as an envelope **whose code equals the HTTP status**, so only the OBA
+ * layer's own answer is adopted: a proxy's HTML 404, or a JSON error object from something else, fails
+ * that check and stays an [HttpException]. Reading the error body is safe and non-blocking — Retrofit
+ * buffers it in memory before constructing the [HttpException].
+ */
+internal fun Throwable.asObaFailure(json: Json): Throwable {
+    if (this !is HttpException) return this
+    val body = response()?.errorBody()?.string().orEmpty()
+    val envelope = try {
+        json.decodeFromString<ObaEnvelope<JsonElement>>(body)
+    } catch (_: SerializationException) {
+        null
     }
+    return if (envelope != null && envelope.code == code()) ObaApiException(envelope.code) else this
+}
 
 /**
  * Asserts an OK app-level code, throwing [ObaApiException] otherwise — for endpoints whose response

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/adapters/TripAdapters.kt
@@ -41,6 +41,24 @@ import org.onebusaway.android.util.locationOf
 
 private fun Position.toLocation(): Location = locationOf(lat, lon)
 
+/**
+ * The trip the vehicle is currently serving, or null when the status names none — the wire sends an
+ * absent active trip as `""`, and this is the one place that reads that as absent, so every consumer
+ * agrees on which trip a vehicle is on.
+ */
+internal val TripStatus.activeTripIdOrNull: String?
+    get() = activeTripId.ifBlank { null }
+
+/**
+ * Which trip this entry's vehicle is actually serving: the status's [TripStatus.activeTripId] when it
+ * names one, else the entry's own [TripDetailsEntry.tripId]. They differ during a block rollover,
+ * where the entry still names the trip the vehicle just finished — so anything keyed on "the trip the
+ * vehicle is on right now" (the trips-for-route dedup, the coach-number search) reads this, rather
+ * than each re-deciding the rule.
+ */
+internal val TripDetailsEntry.activeOrOwnTripId: String
+    get() = status?.activeTripIdOrNull ?: tripId
+
 /** Presents a [TripStatus] DTO as an [ObaTripStatus]. */
 internal class DtoTripStatus(private val dto: TripStatus) : ObaTripStatus {
     override val serviceDate: Long get() = dto.serviceDate
@@ -54,7 +72,7 @@ internal class DtoTripStatus(private val dto: TripStatus) : ObaTripStatus {
     override val position: Location? get() = dto.position?.toLocation()
 
     // Absent active-trip id reads as null, like the legacy element (callers skip on it).
-    override val activeTripId: String? get() = dto.activeTripId.ifBlank { null }
+    override val activeTripId: String? get() = dto.activeTripIdOrNull
     override val distanceAlongTrip: Double? get() = dto.distanceAlongTrip
     override val scheduledDistanceAlongTrip: Double? get() = dto.scheduledDistanceAlongTrip
     override val totalDistanceAlongTrip: Double? get() = dto.totalDistanceAlongTrip

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -232,16 +232,6 @@ data class TripDetailsEntry(
 )
 
 /**
- * Which trip this entry's vehicle is actually serving: the status's [TripStatus.activeTripId] when it
- * names one, else the entry's own [TripDetailsEntry.tripId]. They differ during a block rollover,
- * where the entry still names the trip the vehicle just finished — so anything keyed on "the trip the
- * vehicle is on right now" (the trips-for-route dedup, the coach-number search) reads this, rather
- * than each re-deciding the rule.
- */
-internal val TripDetailsEntry.activeOrOwnTripId: String
-    get() = status?.activeTripId?.ifBlank { null } ?: tripId
-
-/**
  * Real-time status for a trip. Only the fields the trip-details screen reads are modeled; times are
  * epoch millis, [scheduleDeviation] is seconds (+late/−early), [status] is the wire string (e.g.
  * "CANCELED"), and [activeTripId] is the trip the vehicle is currently serving.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -232,6 +232,16 @@ data class TripDetailsEntry(
 )
 
 /**
+ * Which trip this entry's vehicle is actually serving: the status's [TripStatus.activeTripId] when it
+ * names one, else the entry's own [TripDetailsEntry.tripId]. They differ during a block rollover,
+ * where the entry still names the trip the vehicle just finished — so anything keyed on "the trip the
+ * vehicle is on right now" (the trips-for-route dedup, the coach-number search) reads this, rather
+ * than each re-deciding the rule.
+ */
+internal val TripDetailsEntry.activeOrOwnTripId: String
+    get() = status?.activeTripId?.ifBlank { null } ?: tripId
+
+/**
  * Real-time status for a trip. Only the fields the trip-details screen reads are modeled; times are
  * epoch millis, [scheduleDeviation] is seconds (+late/−early), [status] is the wire string (e.g.
  * "CANCELED"), and [activeTripId] is the trip the vehicle is currently serving.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
@@ -122,6 +122,19 @@ interface ObaWebService {
     ): ObaEnvelope<EntryWithReferences<TripDetailsEntry>>
 
     /**
+     * trip-for-vehicle — the trip a vehicle is currently running, in the same shape as [tripDetails].
+     * [vehicleId] is the fully agency-prefixed id (`1_4531`); the coach number alone won't resolve.
+     * [includeTrip] puts the trip itself in the references (route id + headsign), which the plain
+     * status entry doesn't carry. A vehicle that isn't running a trip yields a non-OK code.
+     * {http://developer.onebusaway.org/.../api/where/methods/trip-for-vehicle.html}
+     */
+    @GET("api/where/trip-for-vehicle/{vehicleId}.json")
+    suspend fun tripForVehicle(
+        @Path("vehicleId") vehicleId: String,
+        @Query("includeTrip") includeTrip: Boolean = true
+    ): ObaEnvelope<EntryWithReferences<TripDetailsEntry>>
+
+    /**
      * arrivals-and-departures-for-stop — real-time arrivals at a stop within the next
      * [minutesAfter] minutes, with the stop/routes/trips/situations in the references.
      * {http://developer.onebusaway.org/.../api/where/methods/arrivals-and-departures-for-stop.html}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
@@ -125,7 +125,8 @@ interface ObaWebService {
      * trip-for-vehicle — the trip a vehicle is currently running, in the same shape as [tripDetails].
      * [vehicleId] is the fully agency-prefixed id (`1_4531`); the coach number alone won't resolve.
      * [includeTrip] puts the trip itself in the references (route id + headsign), which the plain
-     * status entry doesn't carry. A vehicle that isn't running a trip yields a non-OK code.
+     * status entry doesn't carry. A vehicle that isn't running a trip is answered with a 404 (status
+     * and envelope code alike), which is how that case is told apart from a lookup that simply failed.
      * {http://developer.onebusaway.org/.../api/where/methods/trip-for-vehicle.html}
      */
     @GET("api/where/trip-for-vehicle/{vehicleId}.json")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/SidecarUrls.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/SidecarUrls.kt
@@ -20,8 +20,8 @@ package org.onebusaway.android.api.contract
  * `{sidecarBaseUrl}{regionsPath}{regionId}/{resource}` — e.g.
  * `https://sidecar.onebusaway.org/api/v2/regions/1/alarms`. The one home of that shape, shared by the
  * alarms client (`TripInfoRepository`) and `PushRegistrationClient`. (The v1 sidecar endpoints —
- * weather, surveys — are a separate pre-existing idiom: each embeds the region id in its own string
- * resource via a `regionID` placeholder.)
+ * weather, surveys, alerts, vehicle search — are a separate pre-existing idiom, assembled by
+ * [sidecarV1RegionUrl].)
  *
  * [regionsPath] is the resolved `R.string.arrivals_reminders_api_endpoint` (`/api/v2/regions/`). It
  * stays a parameter because the segment lives in that string resource — overridable per brand,
@@ -33,3 +33,22 @@ fun sidecarRegionUrl(
     regionId: Long,
     resource: String
 ): String = "$sidecarBaseUrl$regionsPath$regionId/$resource"
+
+/**
+ * Assembles a **v1** sidecar endpoint URL: `{sidecarBaseUrl}{endpoint}` with [endpoint]'s `regionID`
+ * placeholder substituted — e.g. `/api/v1/regions/regionID/vehicles` + region 1 →
+ * `https://sidecar.onebusaway.org/api/v1/regions/1/vehicles`.
+ *
+ * Unlike the v2 shape, each v1 endpoint carries its whole path (with the region id embedded mid-path)
+ * in its own string resource, so what's shared is the substitution rather than the path layout. The one
+ * home of it, for weather, surveys, wide alerts and the coach-number vehicle search; [endpoint] is the
+ * caller's resolved `R.string.*_api_endpoint`, so Context stays with the caller.
+ */
+fun sidecarV1RegionUrl(
+    sidecarBaseUrl: String,
+    endpoint: String,
+    regionId: String
+): String = sidecarBaseUrl + endpoint.replace(REGION_ID_PLACEHOLDER, regionId)
+
+/** The token a v1 endpoint string resource carries where the region id goes. */
+private const val REGION_ID_PLACEHOLDER = "regionID"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/VehicleSearchWebService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/VehicleSearchWebService.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.contract
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.GET
+import retrofit2.http.Query
+import retrofit2.http.Url
+
+/**
+ * The coach-number (vehicle-ID) search client — separate from [ObaWebService] because the OBA `where`
+ * API can only look a vehicle up by its *full*, agency-prefixed id (`trip-for-vehicle/1_4531`), and a
+ * rider types the number painted on the bus (`4531`) with no idea which agency prefix it carries. The
+ * region's sidecar host indexes the region's live vehicles and does that partial match, returning the
+ * agency-qualified id the OBA API needs.
+ *
+ * Like weather/surveys the caller passes the resolved sidecar URL via [Url], so this service runs
+ * WITHOUT [ApiParamsInterceptor] and the Retrofit base URL is a throwaway. Mirrors [WeatherWebService].
+ */
+interface VehicleSearchWebService {
+
+    @GET
+    suspend fun searchVehicles(
+        @Url url: String,
+        @Query("query") query: String
+    ): List<AgencyVehicleResponse>
+}
+
+/**
+ * One partial-match hit from the sidecar's vehicle index: the operating agency plus the fully
+ * qualified vehicle id. The sidecar returns a bare JSON array (no [ObaEnvelope]), and [vehicleId] is
+ * nullable on the wire, so a hit that carries no id is dropped at the adapter.
+ *
+ * Matches the shape OBAKit's `AgencyVehicle` decodes (`id`/`name`/`vehicle_id`) — the same endpoint
+ * backs the iOS app's vehicle search.
+ */
+@Serializable
+data class AgencyVehicleResponse(
+    @SerialName("id") val agencyId: String = "",
+    @SerialName("name") val agencyName: String = "",
+    @SerialName("vehicle_id") val vehicleId: String? = null
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 import org.onebusaway.android.api.adapters.DtoRoute
 import org.onebusaway.android.api.adapters.DtoTrip
 import org.onebusaway.android.api.adapters.DtoTripDetails
+import org.onebusaway.android.api.adapters.activeOrOwnTripId
 import org.onebusaway.android.api.adapters.colorArgb
 import org.onebusaway.android.api.adapters.toObaTripSchedule
 import org.onebusaway.android.api.contract.EntryWithReferences
@@ -27,7 +28,6 @@ import org.onebusaway.android.api.contract.ListWithReferences
 import org.onebusaway.android.api.contract.ObaEnvelope
 import org.onebusaway.android.api.contract.References
 import org.onebusaway.android.api.contract.TripDetailsEntry
-import org.onebusaway.android.api.contract.activeOrOwnTripId
 import org.onebusaway.android.api.net.ObaApiProvider
 import org.onebusaway.android.api.requireData
 import org.onebusaway.android.models.ObaRoute

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/TripVehiclesDataSource.kt
@@ -27,6 +27,7 @@ import org.onebusaway.android.api.contract.ListWithReferences
 import org.onebusaway.android.api.contract.ObaEnvelope
 import org.onebusaway.android.api.contract.References
 import org.onebusaway.android.api.contract.TripDetailsEntry
+import org.onebusaway.android.api.contract.activeOrOwnTripId
 import org.onebusaway.android.api.net.ObaApiProvider
 import org.onebusaway.android.api.requireData
 import org.onebusaway.android.models.ObaRoute
@@ -68,7 +69,7 @@ private fun List<TripDetailsEntry>.dedupeByActiveTripKeepingBestFix(): List<Trip
     if (size < 2) return this
     val byKey = LinkedHashMap<String, TripDetailsEntry>(size)
     for (entry in this) {
-        val key = entry.status?.activeTripId?.ifBlank { null } ?: entry.tripId
+        val key = entry.activeOrOwnTripId
         val kept = byKey[key]
         if (kept == null || entry.fixRank() > kept.fixRank()) byKey[key] = entry
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
@@ -29,27 +29,52 @@ import org.onebusaway.android.api.contract.EntryWithReferences
 import org.onebusaway.android.api.contract.TripDetailsEntry
 import org.onebusaway.android.api.contract.VehicleSearchWebService
 import org.onebusaway.android.api.contract.activeOrOwnTripId
+import org.onebusaway.android.api.isNotFound
 import org.onebusaway.android.api.net.ObaApiProvider
 import org.onebusaway.android.api.requireData
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.runCatchingCancellable
 
 /**
- * A vehicle the region's sidecar matched on its coach number, and the trip it is running right now.
+ * A vehicle the region's sidecar matched on its coach number, and what it is doing right now.
  *
  * @param vehicleId the agency-prefixed id (`1_4531`) — the OBA key, not what's painted on the bus
  * @param coachNumber the un-prefixed number as a rider reads it off the vehicle
  * @param agencyName the operating agency's display name
- * @param trip what the vehicle is running, or null when it isn't running anything (deadheading, in
- *   the yard, or its real-time feed has gone quiet) — such a match is still reported, because a
- *   rider who typed a real coach number is better served by "not in service" than by "no results"
+ * @param assignment the ride it is running, or why there isn't one to show — a match is reported
+ *   either way, because a rider who typed a real coach number is better served by knowing the
+ *   vehicle exists than by "no results"
  */
 data class VehicleMatch(
     val vehicleId: String,
     val coachNumber: String,
     val agencyName: String,
-    val trip: VehicleTrip?
+    val assignment: VehicleAssignment
 )
+
+/**
+ * What a matched vehicle is doing, as far as `trip-for-vehicle` could tell us. [NotInService] and
+ * [Unknown] are deliberately separate: only the first is something the server actually told us, and
+ * captioning a failed lookup "not in service" would state as fact something we never asked
+ * successfully.
+ */
+sealed interface VehicleAssignment {
+
+    /** Running [trip] right now — the ride the map can drill into. */
+    data class OnTrip(val trip: VehicleTrip) : VehicleAssignment
+
+    /**
+     * The server answered that this vehicle has no trip: deadheading, in the yard, or its real-time
+     * feed has gone quiet.
+     */
+    data object NotInService : VehicleAssignment
+
+    /**
+     * The lookup didn't produce an answer — a transport, server or decode failure, or a response that
+     * names a trip its own references don't describe. The vehicle may well be in service; we don't know.
+     */
+    data object Unknown : VehicleAssignment
+}
 
 /** The live trip behind a [VehicleMatch] — enough to drill the map into the vehicle on its route. */
 data class VehicleTrip(
@@ -64,7 +89,7 @@ data class VehicleTrip(
 interface VehicleSearchDataSource {
 
     /**
-     * Vehicles whose id matches [query], each resolved to its current trip. Empty when nothing
+     * Vehicles whose id matches [query], each carrying what it is running. Empty when nothing
      * matches (including any query the sidecar considers too short to index).
      */
     suspend fun vehiclesMatching(query: String): Result<List<VehicleMatch>>
@@ -75,7 +100,8 @@ interface VehicleSearchDataSource {
  * sidecar ([VehicleSearchWebService]) turns the coach number into agency-prefixed vehicle ids, then
  * the OBA `trip-for-vehicle` endpoint turns each of those into the route + trip the map needs. The
  * second hop runs concurrently across the matches and never fails the search — a vehicle whose trip
- * can't be resolved is reported as not-in-service rather than dropped.
+ * can't be resolved is reported with an unknown assignment rather than dropped,
+ * so one flaky lookup costs neither the match nor the other matches beside it.
  *
  * A region with no sidecar host configured has no vehicle index at all, so the search fails rather
  * than returning empty: "we can't look coach numbers up here" is not the same as "no such coach".
@@ -111,7 +137,7 @@ class DefaultVehicleSearchDataSource @Inject constructor(
                             vehicleId = vehicleId,
                             coachNumber = coachNumberOf(vehicleId, hit.agencyId),
                             agencyName = hit.agencyName,
-                            trip = tripForVehicle(vehicleId)
+                            assignment = assignmentOf(vehicleId)
                         )
                     }
                 }
@@ -120,12 +146,22 @@ class DefaultVehicleSearchDataSource @Inject constructor(
     }.onFailure { Log.e(TAG, "vehiclesMatching($query) failed", it) }
 
     /**
-     * The vehicle's current trip, or null when the lookup didn't produce one — a vehicle between
-     * assignments answers with a non-OK code, which [requireData] turns into a failure here.
+     * What the vehicle is running, per `trip-for-vehicle` — see [vehicleAssignment] for the mapping.
+     * A [VehicleAssignment.Unknown] is logged with what caused it, since it's the one outcome the row
+     * can't explain to the rider.
      */
-    private suspend fun tripForVehicle(vehicleId: String): VehicleTrip? = api.call {
-        it.tripForVehicle(vehicleId).requireData().toVehicleTrip()
-    }.getOrNull()
+    private suspend fun assignmentOf(vehicleId: String): VehicleAssignment {
+        val result = api.call { it.tripForVehicle(vehicleId).requireData().toVehicleTrip() }
+        return vehicleAssignment(result).also { assignment ->
+            if (assignment != VehicleAssignment.Unknown) return@also
+            val cause = result.exceptionOrNull()
+            if (cause != null) {
+                Log.w(TAG, "trip-for-vehicle($vehicleId) failed", cause)
+            } else {
+                Log.w(TAG, "trip-for-vehicle($vehicleId) named a trip its own references don't describe")
+            }
+        }
+    }
 
     private companion object {
 
@@ -140,6 +176,20 @@ class DefaultVehicleSearchDataSource @Inject constructor(
         const val MAX_MATCHES = 5
     }
 }
+
+/**
+ * Reads a `trip-for-vehicle` outcome as an assignment. The server answers an unassigned vehicle with
+ * a 404 ([isNotFound]) — that, and only that, is [VehicleAssignment.NotInService]; every other failure
+ * (transport, server error, decode) is [VehicleAssignment.Unknown], so a lookup we never got an answer
+ * to is never captioned as one. A success with no usable trip (see [toVehicleTrip]) is unknown too:
+ * the server said the vehicle *is* on a trip, just not one it described.
+ *
+ * Pure, so it's exercised directly in JVM tests.
+ */
+internal fun vehicleAssignment(lookup: Result<VehicleTrip?>): VehicleAssignment = lookup.fold(
+    onSuccess = { trip -> trip?.let(VehicleAssignment::OnTrip) ?: VehicleAssignment.Unknown },
+    onFailure = { if (it.isNotFound) VehicleAssignment.NotInService else VehicleAssignment.Unknown }
+)
 
 /**
  * Adapts a trip-for-vehicle payload to [VehicleTrip], or null when the response names a trip that

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
@@ -21,12 +21,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.onebusaway.android.R
 import org.onebusaway.android.api.adapters.colorArgb
 import org.onebusaway.android.api.contract.EntryWithReferences
 import org.onebusaway.android.api.contract.TripDetailsEntry
 import org.onebusaway.android.api.contract.VehicleSearchWebService
+import org.onebusaway.android.api.contract.activeOrOwnTripId
 import org.onebusaway.android.api.net.ObaApiProvider
 import org.onebusaway.android.api.requireData
 import org.onebusaway.android.region.RegionRepository
@@ -85,30 +87,25 @@ class DefaultVehicleSearchDataSource @Inject constructor(
     private val api: ObaApiProvider
 ) : VehicleSearchDataSource {
 
-    override suspend fun vehiclesMatching(query: String): Result<List<VehicleMatch>> = coroutineScope {
+    override suspend fun vehiclesMatching(query: String): Result<List<VehicleMatch>> = runCatchingCancellable {
         val region = regionRepository.region.value
         val base = region?.sidecarBaseUrl
-            ?: return@coroutineScope Result.failure(IOException("No sidecar base URL for vehicle search"))
+            ?: throw IOException("No sidecar base URL for vehicle search")
         val url = base +
             context.getString(R.string.vehicles_api_endpoint)
                 .replace("regionID", region.sidecarId.toString())
 
-        runCatchingCancellable {
-            val matched = vehicleSearch.searchVehicles(url, query)
-                .filter { !it.vehicleId.isNullOrBlank() }
-            // A short query can match a lot of the fleet, and each match costs a trip-for-vehicle
-            // round trip. Cap the fan-out, and log the drop rather than let a truncated list read as
-            // the whole answer.
-            val capped = if (matched.size > MAX_MATCHES) {
-                Log.i(TAG, "vehiclesMatching($query): ${matched.size} matches, keeping the first $MAX_MATCHES")
-                matched.take(MAX_MATCHES)
-            } else {
-                matched
-            }
-            capped
-                .map { hit ->
-                    // Non-null by the filter above; the wire type keeps it optional.
-                    val vehicleId = hit.vehicleId.orEmpty()
+        val matched = vehicleSearch.searchVehicles(url, query)
+            .mapNotNull { hit -> hit.vehicleId?.takeIf { it.isNotBlank() }?.let { it to hit } }
+        // A short query can match a lot of the fleet, and each match costs a trip-for-vehicle round
+        // trip. Cap the fan-out, and log the drop rather than let a truncated list read as the whole
+        // answer.
+        if (matched.size > MAX_MATCHES) {
+            Log.i(TAG, "vehiclesMatching($query): ${matched.size} matches, keeping the first $MAX_MATCHES")
+        }
+        coroutineScope {
+            matched.take(MAX_MATCHES)
+                .map { (vehicleId, hit) ->
                     async {
                         VehicleMatch(
                             vehicleId = vehicleId,
@@ -118,9 +115,9 @@ class DefaultVehicleSearchDataSource @Inject constructor(
                         )
                     }
                 }
-                .map { it.await() }
-        }.onFailure { Log.e(TAG, "vehiclesMatching($query) failed", it) }
-    }
+                .awaitAll()
+        }
+    }.onFailure { Log.e(TAG, "vehiclesMatching($query) failed", it) }
 
     /**
      * The vehicle's current trip, or null when the lookup didn't produce one — a vehicle between
@@ -134,8 +131,13 @@ class DefaultVehicleSearchDataSource @Inject constructor(
 
         const val TAG = "VehicleSearchDataSource"
 
-        /** How many sidecar matches are kept (and given a trip-for-vehicle lookup); the rest are dropped. */
-        const val MAX_MATCHES = 10
+        /**
+         * How many sidecar matches are kept (and given a trip-for-vehicle lookup); the rest are
+         * dropped. Sized to OkHttp's default `maxRequestsPerHost` (5) so the fan-out is one wave
+         * rather than two, and so it can't fill the shared client's whole budget for the OBA host —
+         * the sibling route/stop searches go through the same client.
+         */
+        const val MAX_MATCHES = 5
     }
 }
 
@@ -144,9 +146,7 @@ class DefaultVehicleSearchDataSource @Inject constructor(
  * isn't in its own references (nothing to drill into). Pure, so it's exercised directly in JVM tests.
  */
 internal fun EntryWithReferences<TripDetailsEntry>.toVehicleTrip(): VehicleTrip? {
-    // The active trip is the one the vehicle is serving now; on a block rollover the entry's own
-    // tripId can still name the trip it just finished.
-    val tripId = entry.status?.activeTripId?.ifBlank { null } ?: entry.tripId
+    val tripId = entry.activeOrOwnTripId
     val trip = references.trip(tripId) ?: return null
     val route = references.route(trip.routeId)
     return VehicleTrip(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import android.content.Context
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.onebusaway.android.R
+import org.onebusaway.android.api.adapters.colorArgb
+import org.onebusaway.android.api.contract.EntryWithReferences
+import org.onebusaway.android.api.contract.TripDetailsEntry
+import org.onebusaway.android.api.contract.VehicleSearchWebService
+import org.onebusaway.android.api.net.ObaApiProvider
+import org.onebusaway.android.api.requireData
+import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.runCatchingCancellable
+
+/**
+ * A vehicle the region's sidecar matched on its coach number, and the trip it is running right now.
+ *
+ * @param vehicleId the agency-prefixed id (`1_4531`) — the OBA key, not what's painted on the bus
+ * @param coachNumber the un-prefixed number as a rider reads it off the vehicle
+ * @param agencyName the operating agency's display name
+ * @param trip what the vehicle is running, or null when it isn't running anything (deadheading, in
+ *   the yard, or its real-time feed has gone quiet) — such a match is still reported, because a
+ *   rider who typed a real coach number is better served by "not in service" than by "no results"
+ */
+data class VehicleMatch(
+    val vehicleId: String,
+    val coachNumber: String,
+    val agencyName: String,
+    val trip: VehicleTrip?
+)
+
+/** The live trip behind a [VehicleMatch] — enough to drill the map into the vehicle on its route. */
+data class VehicleTrip(
+    val tripId: String,
+    val routeId: String,
+    val routeShortName: String?,
+    val routeColor: Int?,
+    val headsign: String?
+)
+
+/** Resolves a rider-typed coach number to the live vehicle(s) it names. */
+interface VehicleSearchDataSource {
+
+    /**
+     * Vehicles whose id matches [query], each resolved to its current trip. Empty when nothing
+     * matches (including any query the sidecar considers too short to index).
+     */
+    suspend fun vehiclesMatching(query: String): Result<List<VehicleMatch>>
+}
+
+/**
+ * Two-hop implementation, because neither service can answer the question alone: the region's
+ * sidecar ([VehicleSearchWebService]) turns the coach number into agency-prefixed vehicle ids, then
+ * the OBA `trip-for-vehicle` endpoint turns each of those into the route + trip the map needs. The
+ * second hop runs concurrently across the matches and never fails the search — a vehicle whose trip
+ * can't be resolved is reported as not-in-service rather than dropped.
+ *
+ * A region with no sidecar host configured has no vehicle index at all, so the search fails rather
+ * than returning empty: "we can't look coach numbers up here" is not the same as "no such coach".
+ */
+class DefaultVehicleSearchDataSource @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val regionRepository: RegionRepository,
+    private val vehicleSearch: VehicleSearchWebService,
+    private val api: ObaApiProvider
+) : VehicleSearchDataSource {
+
+    override suspend fun vehiclesMatching(query: String): Result<List<VehicleMatch>> = coroutineScope {
+        val region = regionRepository.region.value
+        val base = region?.sidecarBaseUrl
+            ?: return@coroutineScope Result.failure(IOException("No sidecar base URL for vehicle search"))
+        val url = base +
+            context.getString(R.string.vehicles_api_endpoint)
+                .replace("regionID", region.sidecarId.toString())
+
+        runCatchingCancellable {
+            val matched = vehicleSearch.searchVehicles(url, query)
+                .filter { !it.vehicleId.isNullOrBlank() }
+            // A short query can match a lot of the fleet, and each match costs a trip-for-vehicle
+            // round trip. Cap the fan-out, and log the drop rather than let a truncated list read as
+            // the whole answer.
+            val capped = if (matched.size > MAX_MATCHES) {
+                Log.i(TAG, "vehiclesMatching($query): ${matched.size} matches, keeping the first $MAX_MATCHES")
+                matched.take(MAX_MATCHES)
+            } else {
+                matched
+            }
+            capped
+                .map { hit ->
+                    // Non-null by the filter above; the wire type keeps it optional.
+                    val vehicleId = hit.vehicleId.orEmpty()
+                    async {
+                        VehicleMatch(
+                            vehicleId = vehicleId,
+                            coachNumber = coachNumberOf(vehicleId, hit.agencyId),
+                            agencyName = hit.agencyName,
+                            trip = tripForVehicle(vehicleId)
+                        )
+                    }
+                }
+                .map { it.await() }
+        }.onFailure { Log.e(TAG, "vehiclesMatching($query) failed", it) }
+    }
+
+    /**
+     * The vehicle's current trip, or null when the lookup didn't produce one — a vehicle between
+     * assignments answers with a non-OK code, which [requireData] turns into a failure here.
+     */
+    private suspend fun tripForVehicle(vehicleId: String): VehicleTrip? = api.call {
+        it.tripForVehicle(vehicleId).requireData().toVehicleTrip()
+    }.getOrNull()
+
+    private companion object {
+
+        const val TAG = "VehicleSearchDataSource"
+
+        /** How many sidecar matches are kept (and given a trip-for-vehicle lookup); the rest are dropped. */
+        const val MAX_MATCHES = 10
+    }
+}
+
+/**
+ * Adapts a trip-for-vehicle payload to [VehicleTrip], or null when the response names a trip that
+ * isn't in its own references (nothing to drill into). Pure, so it's exercised directly in JVM tests.
+ */
+internal fun EntryWithReferences<TripDetailsEntry>.toVehicleTrip(): VehicleTrip? {
+    // The active trip is the one the vehicle is serving now; on a block rollover the entry's own
+    // tripId can still name the trip it just finished.
+    val tripId = entry.status?.activeTripId?.ifBlank { null } ?: entry.tripId
+    val trip = references.trip(tripId) ?: return null
+    val route = references.route(trip.routeId)
+    return VehicleTrip(
+        tripId = tripId,
+        routeId = trip.routeId,
+        routeShortName = route?.shortName?.takeIf { it.isNotBlank() },
+        routeColor = route?.colorArgb(),
+        headsign = trip.tripHeadsign?.takeIf { it.isNotBlank() }
+    )
+}
+
+/**
+ * The coach number as painted on the vehicle: the OBA id minus its `{agencyId}_` prefix. The prefix is
+ * built from the agency id the same response states rather than by splitting on the first underscore,
+ * so a vehicle id that itself contains one survives. An id that doesn't carry the prefix (a feed that
+ * doesn't follow the OBA id convention) is passed through unchanged.
+ */
+internal fun coachNumberOf(vehicleId: String, agencyId: String): String = vehicleId.removePrefix("${agencyId}_")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/VehicleSearchDataSource.kt
@@ -24,11 +24,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.onebusaway.android.R
+import org.onebusaway.android.api.adapters.activeOrOwnTripId
 import org.onebusaway.android.api.adapters.colorArgb
 import org.onebusaway.android.api.contract.EntryWithReferences
 import org.onebusaway.android.api.contract.TripDetailsEntry
 import org.onebusaway.android.api.contract.VehicleSearchWebService
-import org.onebusaway.android.api.contract.activeOrOwnTripId
+import org.onebusaway.android.api.contract.sidecarV1RegionUrl
 import org.onebusaway.android.api.isNotFound
 import org.onebusaway.android.api.net.ObaApiProvider
 import org.onebusaway.android.api.requireData
@@ -115,14 +116,22 @@ class DefaultVehicleSearchDataSource @Inject constructor(
 
     override suspend fun vehiclesMatching(query: String): Result<List<VehicleMatch>> = runCatchingCancellable {
         val region = regionRepository.region.value
-        val base = region?.sidecarBaseUrl
+        // A blank base is as much "this region has no vehicle index" as a missing one — without the
+        // guard it would build a relative URL and quietly query the throwaway Retrofit base instead.
+        val base = region?.sidecarBaseUrl?.takeIf { it.isNotBlank() }
             ?: throw IOException("No sidecar base URL for vehicle search")
-        val url = base +
-            context.getString(R.string.vehicles_api_endpoint)
-                .replace("regionID", region.sidecarId.toString())
+        val url = sidecarV1RegionUrl(
+            sidecarBaseUrl = base,
+            endpoint = context.getString(R.string.vehicles_api_endpoint),
+            regionId = region.sidecarId.toString()
+        )
 
+        // The index is external, so the same vehicle can come back twice (an agency indexed twice, a
+        // rebuild in flight); de-duplicate before the cap, so a repeat costs neither a lookup, a
+        // MAX_MATCHES slot, nor a duplicate list key.
         val matched = vehicleSearch.searchVehicles(url, query)
             .mapNotNull { hit -> hit.vehicleId?.takeIf { it.isNotBlank() }?.let { it to hit } }
+            .distinctBy { (vehicleId, _) -> vehicleId }
         // A short query can match a lot of the fleet, and each match costs a trip-for-vehicle round
         // trip. Cap the fan-out, and log the drop rather than let a truncated list read as the whole
         // answer.
@@ -212,6 +221,11 @@ internal fun EntryWithReferences<TripDetailsEntry>.toVehicleTrip(): VehicleTrip?
  * The coach number as painted on the vehicle: the OBA id minus its `{agencyId}_` prefix. The prefix is
  * built from the agency id the same response states rather than by splitting on the first underscore,
  * so a vehicle id that itself contains one survives. An id that doesn't carry the prefix (a feed that
- * doesn't follow the OBA id convention) is passed through unchanged.
+ * doesn't follow the OBA id convention) is passed through unchanged, as is any id whose hit named no
+ * agency — there is no prefix to strip then, and stripping a bare `_` would maul ids either way.
  */
-internal fun coachNumberOf(vehicleId: String, agencyId: String): String = vehicleId.removePrefix("${agencyId}_")
+internal fun coachNumberOf(vehicleId: String, agencyId: String): String = if (agencyId.isBlank()) {
+    vehicleId
+} else {
+    vehicleId.removePrefix("${agencyId}_")
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaApiProvider.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/net/ObaApiProvider.kt
@@ -22,6 +22,8 @@ import javax.inject.Singleton
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import org.onebusaway.android.api.ObaApiException
+import org.onebusaway.android.api.asObaFailure
 import org.onebusaway.android.api.contract.ObaWebService
 import org.onebusaway.android.util.runCatchingCancellable
 import retrofit2.Retrofit
@@ -50,10 +52,14 @@ class ObaApiProvider @Inject constructor(
      * [Result]. Yields [Result.failure] when there's no endpoint to contact (no current region and no
      * custom API URL) or when [block] throws (a non-OK app code, transport, or parse failure) — so the
      * common "no region is an error" callers get one uniform failure path without a try/catch.
+     *
+     * A failure the OBA layer itself stated is normalized to [ObaApiException] here (see
+     * [asObaFailure]), whichever side of the HTTP status/envelope divide it arrived on, so callers
+     * classify app-level codes on one type.
      */
     suspend fun <T> call(block: suspend (ObaWebService) -> T): Result<T> {
         val service = service() ?: return Result.failure(noEndpoint())
-        return runCatchingCancellable { block(service) }
+        return attempt { block(service) }
     }
 
     /**
@@ -62,8 +68,12 @@ class ObaApiProvider @Inject constructor(
      */
     suspend fun <T> callOrNull(block: suspend (ObaWebService) -> T): Result<T?> {
         val service = service() ?: return Result.success(null)
-        return runCatchingCancellable { block(service) }
+        return attempt { block(service) }
     }
+
+    /** Runs [block], mapping an OBA-stated failure to [ObaApiException] and keeping cancellation out. */
+    private suspend fun <T> attempt(block: suspend () -> T): Result<T> = runCatchingCancellable { block() }
+        .recoverCatching { throw it.asObaFailure(json) }
 
     /**
      * The [ObaWebService] bound to the current region's base URL, or null when there's no endpoint to

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/NetworkModule.kt
@@ -32,6 +32,7 @@ import org.onebusaway.android.api.contract.PushRegistrationWebService
 import org.onebusaway.android.api.contract.RegionsWebService
 import org.onebusaway.android.api.contract.ReminderWebService
 import org.onebusaway.android.api.contract.SurveyWebService
+import org.onebusaway.android.api.contract.VehicleSearchWebService
 import org.onebusaway.android.api.contract.WeatherWebService
 import org.onebusaway.android.api.net.ApiParamsInterceptor
 import org.onebusaway.android.api.net.JsonCharsetInterceptor
@@ -107,6 +108,14 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideWeatherWebService(json: Json): WeatherWebService = plainRetrofit(json).create(WeatherWebService::class.java)
+
+    /**
+     * The coach-number (vehicle-ID) search client. Targets the region's sidecar host via `@Url` (like
+     * weather), so it uses a plain client without [ApiParamsInterceptor].
+     */
+    @Provides
+    @Singleton
+    fun provideVehicleSearchWebService(json: Json): VehicleSearchWebService = plainRetrofit(json).create(VehicleSearchWebService::class.java)
 
     /**
      * The arrivals-reminders client. Targets the region's sidecar host via `@Url`, so like surveys

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
@@ -32,6 +32,7 @@ import org.onebusaway.android.api.data.DefaultStopsForRouteRepository
 import org.onebusaway.android.api.data.DefaultSurveyDataSource
 import org.onebusaway.android.api.data.DefaultTripDetailsDataSource
 import org.onebusaway.android.api.data.DefaultTripVehiclesDataSource
+import org.onebusaway.android.api.data.DefaultVehicleSearchDataSource
 import org.onebusaway.android.api.data.LocationSearchDataSource
 import org.onebusaway.android.api.data.MapDataSource
 import org.onebusaway.android.api.data.NearbyArrivalsDataSource
@@ -42,6 +43,7 @@ import org.onebusaway.android.api.data.StopsForRouteRepository
 import org.onebusaway.android.api.data.SurveyDataSource
 import org.onebusaway.android.api.data.TripDetailsDataSource
 import org.onebusaway.android.api.data.TripVehiclesDataSource
+import org.onebusaway.android.api.data.VehicleSearchDataSource
 import org.onebusaway.android.database.oba.RouteFavorites
 import org.onebusaway.android.database.oba.RouteFavoritesRepository
 import org.onebusaway.android.extrapolation.data.DefaultTripObservationFetcher
@@ -183,6 +185,11 @@ abstract class RepositoryModule {
     abstract fun bindTripVehiclesDataSource(
         impl: DefaultTripVehiclesDataSource
     ): TripVehiclesDataSource
+
+    @Binds
+    abstract fun bindVehicleSearchDataSource(
+        impl: DefaultVehicleSearchDataSource
+    ): VehicleSearchDataSource
 
     @Binds
     abstract fun bindSearchResultsRepository(impl: DefaultSearchResultsRepository): SearchResultsRepository

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/Region.kt
@@ -89,8 +89,8 @@ data class Region(
      * *is* the directory's id); the distinction exists only for custom regions (#2165).
      *
      * Every sidecar endpoint that embeds a region id goes through this: alarms and push registrations
-     * (v2, via `sidecarRegionUrl`), and weather, studies and wide alerts (v1, via their `regionID`
-     * placeholders).
+     * (v2, via `sidecarRegionUrl`), and weather, studies, wide alerts and coach-number search (v1, via
+     * their `regionID` placeholders).
      */
     val sidecarId: Long get() = sidecarRegionId ?: id
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -126,14 +126,11 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
                     navController.revealStopOnMap(stop.id, stop.latitude, stop.longitude)
                 },
                 // A coach-number hit drills into the ride that vehicle is running — the same
-                // route-mode-with-a-focused-vehicle view an arrivals ETA-pill tap opens. Only a
-                // vehicle with a resolved ride is clickable, so the null branch never fires.
-                onVehicleShowOnMap = { vehicle ->
-                    vehicle.ride?.let { ride ->
-                        navController.revealRouteOnMap(
-                            ShowRouteRequest(routeId = ride.routeId, focusTripId = ride.tripId)
-                        )
-                    }
+                // route-mode-with-a-focused-vehicle view an arrivals ETA-pill tap opens.
+                onVehicleShowOnMap = { ride ->
+                    navController.revealRouteOnMap(
+                        ShowRouteRequest(routeId = ride.routeId, focusTripId = ride.tripId)
+                    )
                 }
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nav/ExtraDestinations.kt
@@ -29,6 +29,7 @@ import androidx.navigation.navArgument
 import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.DatabaseEntryPoint
 import org.onebusaway.android.app.di.DonationsEntryPoint
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.home.donation.DonationLearnMoreScreen
@@ -123,6 +124,16 @@ fun NavGraphBuilder.extraDestinations(navController: NavHostController) {
                 },
                 onStopShowOnMap = { stop ->
                     navController.revealStopOnMap(stop.id, stop.latitude, stop.longitude)
+                },
+                // A coach-number hit drills into the ride that vehicle is running — the same
+                // route-mode-with-a-focused-vehicle view an arrivals ETA-pill tap opens. Only a
+                // vehicle with a resolved ride is clickable, so the null branch never fires.
+                onVehicleShowOnMap = { vehicle ->
+                    vehicle.ride?.let { ride ->
+                        navController.revealRouteOnMap(
+                            ShowRouteRequest(routeId = ride.routeId, focusTripId = ride.tripId)
+                        )
+                    }
                 }
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/weather/WeatherRepository.kt
@@ -21,6 +21,7 @@ import java.io.IOException
 import javax.inject.Inject
 import org.onebusaway.android.R
 import org.onebusaway.android.api.contract.WeatherWebService
+import org.onebusaway.android.api.contract.sidecarV1RegionUrl
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.runCatchingCancellable
 
@@ -52,9 +53,11 @@ class DefaultWeatherRepository @Inject constructor(
     override suspend fun currentForecast(regionId: Long): Result<WeatherData> = runCatchingCancellable {
         val base = regionRepository.region.value?.sidecarBaseUrl
             ?: throw IOException("No sidecar base URL for region $regionId")
-        val url = base +
-            context.getString(R.string.weather_api_endpoint)
-                .replace("regionID", regionId.toString())
+        val url = sidecarV1RegionUrl(
+            sidecarBaseUrl = base,
+            endpoint = context.getString(R.string.weather_api_endpoint),
+            regionId = regionId.toString()
+        )
         val forecast = weatherService.getWeather(url).current_forecast
             ?: throw IOException("No weather forecast for region $regionId")
         WeatherData(forecast.icon ?: "", forecast.temperature, forecast.summary)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultItem.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultItem.kt
@@ -56,15 +56,32 @@ sealed interface SearchResultItem {
      * @param id the agency-prefixed OBA vehicle id (`1_4531`), used only as the row key
      * @param coachNumber the number as a rider reads it off the vehicle, shown as the row's title
      * @param agency the operating agency's display name
-     * @param ride what the vehicle is running, or null when it isn't running anything right now —
-     *   which makes the row unselectable rather than hiding the match
+     * @param status what it is running, or why there's nothing to open — anything but [Status.OnRide]
+     *   makes the row unselectable rather than hiding the match
      */
     data class Vehicle(
         val id: String,
         val coachNumber: String,
         val agency: String,
-        val ride: Ride?
+        val status: Status
     ) : SearchResultItem {
+
+        /**
+         * What the row can say about the vehicle. The two rideless cases stay distinct because they
+         * caption differently: the server telling us a coach is off duty is not the same as our
+         * failing to ask it.
+         */
+        sealed interface Status {
+
+            /** On [ride] — the row opens the map on it. */
+            data class OnRide(val ride: Ride) : Status
+
+            /** The server says it isn't running a trip right now. */
+            data object NotInService : Status
+
+            /** Its status couldn't be looked up, so the row reports the match and nothing more. */
+            data object Unknown : Status
+        }
 
         /**
          * The ride a matched vehicle is on: the ids the map needs to drill into it, plus the labels

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultItem.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultItem.kt
@@ -16,8 +16,10 @@
 package org.onebusaway.android.ui.searchresults
 
 /**
- * One row of the combined search results list — a matching route or stop. The screen renders
- * these into a single heterogeneous list (routes first, then stops), matching the legacy screen.
+ * One row of the combined search results list — a matching route, stop, or vehicle. The screen
+ * renders these into a single heterogeneous list (routes first, then stops, then vehicles; the first
+ * two orderings match the legacy screen, and coach-number hits come last so a numeric query still
+ * leads with the route/stop it names).
  */
 sealed interface SearchResultItem {
 
@@ -46,4 +48,38 @@ sealed interface SearchResultItem {
         val latitude: Double,
         val longitude: Double
     ) : SearchResultItem
+
+    /**
+     * A vehicle matched by its coach number — the number painted on the bus, which riders use to
+     * find a specific vehicle (e.g. to meet someone riding it).
+     *
+     * @param id the agency-prefixed OBA vehicle id (`1_4531`), used only as the row key
+     * @param coachNumber the number as a rider reads it off the vehicle, shown as the row's title
+     * @param agency the operating agency's display name
+     * @param ride what the vehicle is running, or null when it isn't running anything right now —
+     *   which makes the row unselectable rather than hiding the match
+     */
+    data class Vehicle(
+        val id: String,
+        val coachNumber: String,
+        val agency: String,
+        val ride: Ride?
+    ) : SearchResultItem {
+
+        /**
+         * The ride a matched vehicle is on: the ids the map needs to drill into it, plus the labels
+         * that let a rider recognize it in the list before tapping.
+         *
+         * @param routeShortName the route's badge text, or null when unknown
+         * @param routeColor the route's GTFS color as an Android ARGB int, or null when unset
+         * @param headsign where the vehicle is headed, or null when unknown
+         */
+        data class Ride(
+            val routeId: String,
+            val tripId: String,
+            val routeShortName: String?,
+            val routeColor: Int?,
+            val headsign: String?
+        )
+    }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultItem.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultItem.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.ui.searchresults
 
+import org.onebusaway.android.api.data.VehicleAssignment
+
 /**
  * One row of the combined search results list — a matching route, stop, or vehicle. The screen
  * renders these into a single heterogeneous list (routes first, then stops, then vehicles; the first
@@ -53,50 +55,21 @@ sealed interface SearchResultItem {
      * A vehicle matched by its coach number — the number painted on the bus, which riders use to
      * find a specific vehicle (e.g. to meet someone riding it).
      *
+     * [assignment] is the data layer's [VehicleAssignment] as-is: it already carries exactly what the
+     * row renders (the ride, or which of the two rideless cases this is — the server's own "no trip"
+     * answer captions differently from a lookup that never got one), so mirroring it into a parallel
+     * UI enum would only add a hand-synced copy to keep in step.
+     *
      * @param id the agency-prefixed OBA vehicle id (`1_4531`), used only as the row key
      * @param coachNumber the number as a rider reads it off the vehicle, shown as the row's title
      * @param agency the operating agency's display name
-     * @param status what it is running, or why there's nothing to open — anything but [Status.OnRide]
-     *   makes the row unselectable rather than hiding the match
+     * @param assignment what it is running; anything but [VehicleAssignment.OnTrip] makes the row
+     *   unselectable rather than hiding the match
      */
     data class Vehicle(
         val id: String,
         val coachNumber: String,
         val agency: String,
-        val status: Status
-    ) : SearchResultItem {
-
-        /**
-         * What the row can say about the vehicle. The two rideless cases stay distinct because they
-         * caption differently: the server telling us a coach is off duty is not the same as our
-         * failing to ask it.
-         */
-        sealed interface Status {
-
-            /** On [ride] — the row opens the map on it. */
-            data class OnRide(val ride: Ride) : Status
-
-            /** The server says it isn't running a trip right now. */
-            data object NotInService : Status
-
-            /** Its status couldn't be looked up, so the row reports the match and nothing more. */
-            data object Unknown : Status
-        }
-
-        /**
-         * The ride a matched vehicle is on: the ids the map needs to drill into it, plus the labels
-         * that let a rider recognize it in the list before tapping.
-         *
-         * @param routeShortName the route's badge text, or null when unknown
-         * @param routeColor the route's GTFS color as an Android ARGB int, or null when unset
-         * @param headsign where the vehicle is headed, or null when unknown
-         */
-        data class Ride(
-            val routeId: String,
-            val tripId: String,
-            val routeShortName: String?,
-            val routeColor: Int?,
-            val headsign: String?
-        )
-    }
+        val assignment: VehicleAssignment
+    ) : SearchResultItem
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.onebusaway.android.api.data.LocationSearchDataSource
 import org.onebusaway.android.api.data.RoutesNearResult
+import org.onebusaway.android.api.data.VehicleMatch
+import org.onebusaway.android.api.data.VehicleSearchDataSource
 import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.database.oba.StopUserInfo
@@ -33,42 +35,49 @@ import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.util.routeDisplayNames
 import org.onebusaway.android.util.runCatchingCancellable
 
-/** Searches routes and stops near the user and combines them into one result list. */
+/** Searches routes and stops near the user, plus vehicles by coach number, into one result list. */
 interface SearchResultsRepository {
 
     suspend fun search(query: String): Result<List<SearchResultItem>>
 }
 
 /**
- * Default implementation over the api [LocationSearchDataSource]. Runs the routes-for-location
- * and stops-for-location requests in parallel (matching the legacy screen's single combined loader)
- * and merges them routes-first. All Android statics are quarantined here so [SearchResultsViewModel]
- * stays JVM-testable.
+ * Default implementation over the api [LocationSearchDataSource] and [VehicleSearchDataSource]. Runs
+ * the routes-for-location, stops-for-location and coach-number searches in parallel (matching the
+ * legacy screen's single combined loader) and merges them routes-first, then stops, then vehicles.
+ * All Android statics are quarantined here so [SearchResultsViewModel] stays JVM-testable.
+ *
+ * The vehicle search is deliberately not gated on the query "looking like" a coach number — the
+ * region's vehicle index decides what matches, so a route/stop query simply comes back empty.
  */
 class DefaultSearchResultsRepository @Inject constructor(
     private val searchCenter: SearchCenter,
     private val search: LocationSearchDataSource,
+    private val vehicleSearch: VehicleSearchDataSource,
     private val stopDao: StopDao,
     private val importGate: ImportGate
 ) : SearchResultsRepository {
 
     override suspend fun search(query: String): Result<List<SearchResultItem>> = coroutineScope {
+        // Only the near-me searches need a location; a coach number resolves without one, so a
+        // missing center fails those two rather than the whole search.
         val center = searchCenter.current()
-            ?: return@coroutineScope Result.failure(IOException("No search location available"))
 
         // Each search resolves a non-OK code / transport failure to Result.failure (requireData).
         // runCatchingCancellable keeps a cancelled search out of that Result.failure, so cancellation
-        // propagates through await() and cancels the sibling search too.
-        val routes = async { runCatchingCancellable { searchRoutes(query, center) } }
-        val stops = async { runCatchingCancellable { searchStops(query, center) } }
+        // propagates through await() and cancels the sibling searches too.
+        val routes = async { nearMe(center) { runCatchingCancellable { searchRoutes(query, it) } } }
+        val stops = async { nearMe(center) { runCatchingCancellable { searchStops(query, it) } } }
+        val vehicles = async { vehicleSearch.vehiclesMatching(query) }
         val routeResult = routes.await()
         val stopResult = stops.await()
+        val vehicleResult = vehicles.await()
 
-        // A true failure only when BOTH searches failed; otherwise show whatever came back.
-        if (routeResult.isFailure && stopResult.isFailure) {
+        // A true failure only when EVERY search failed; otherwise show whatever came back.
+        val results = listOf(routeResult, stopResult, vehicleResult)
+        if (results.all { it.isFailure }) {
             return@coroutineScope Result.failure(
-                routeResult.exceptionOrNull() ?: stopResult.exceptionOrNull()
-                    ?: IOException("Search failed")
+                results.firstNotNullOfOrNull { it.exceptionOrNull() } ?: IOException("Search failed")
             )
         }
 
@@ -82,9 +91,14 @@ class DefaultSearchResultsRepository @Inject constructor(
                 result.routes.forEach { add(toRoute(it, result.agencyNames)) }
             }
             stopResult.getOrNull()?.forEach { add(toStop(it, userInfo[it.id])) }
+            vehicleResult.getOrNull()?.forEach { add(toVehicle(it)) }
         }
         Result.success(items)
     }
+
+    /** Runs a location-scoped [lookup], or reports the missing center as that lookup's failure. */
+    private suspend fun <T> nearMe(center: Location?, lookup: suspend (Location) -> Result<T>): Result<T> = center?.let { lookup(it) }
+        ?: Result.failure(IOException("No search location available"))
 
     /** Searches around the user, widening to the region's default center when nothing matches. */
     private suspend fun searchRoutes(query: String, center: Location): RoutesNearResult {
@@ -114,6 +128,21 @@ class DefaultSearchResultsRepository @Inject constructor(
             agency = agencyNames[route.agencyId]
         )
     }
+
+    private fun toVehicle(match: VehicleMatch) = SearchResultItem.Vehicle(
+        id = match.vehicleId,
+        coachNumber = match.coachNumber,
+        agency = match.agencyName,
+        ride = match.trip?.let {
+            SearchResultItem.Vehicle.Ride(
+                routeId = it.routeId,
+                tripId = it.tripId,
+                routeShortName = it.routeShortName,
+                routeColor = it.routeColor,
+                headsign = it.headsign
+            )
+        }
+    )
 
     private fun toStop(stop: ObaStop, userInfo: StopUserInfo?) = SearchResultItem.Stop(
         id = stop.id,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.onebusaway.android.api.data.LocationSearchDataSource
 import org.onebusaway.android.api.data.RoutesNearResult
+import org.onebusaway.android.api.data.VehicleAssignment
 import org.onebusaway.android.api.data.VehicleMatch
 import org.onebusaway.android.api.data.VehicleSearchDataSource
 import org.onebusaway.android.database.oba.ImportGate
@@ -148,14 +149,19 @@ class DefaultSearchResultsRepository @Inject constructor(
         id = match.vehicleId,
         coachNumber = match.coachNumber,
         agency = match.agencyName,
-        ride = match.trip?.let {
-            SearchResultItem.Vehicle.Ride(
-                routeId = it.routeId,
-                tripId = it.tripId,
-                routeShortName = it.routeShortName,
-                routeColor = it.routeColor,
-                headsign = it.headsign
+        status = when (val assignment = match.assignment) {
+            is VehicleAssignment.OnTrip -> SearchResultItem.Vehicle.Status.OnRide(
+                SearchResultItem.Vehicle.Ride(
+                    routeId = assignment.trip.routeId,
+                    tripId = assignment.trip.tripId,
+                    routeShortName = assignment.trip.routeShortName,
+                    routeColor = assignment.trip.routeColor,
+                    headsign = assignment.trip.headsign
+                )
             )
+
+            VehicleAssignment.NotInService -> SearchResultItem.Vehicle.Status.NotInService
+            VehicleAssignment.Unknown -> SearchResultItem.Vehicle.Status.Unknown
         }
     )
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -63,11 +63,8 @@ class DefaultSearchResultsRepository @Inject constructor(
         // missing center fails those two rather than the whole search.
         val center = searchCenter.current()
 
-        // Each search resolves a non-OK code / transport failure to Result.failure (requireData).
-        // runCatchingCancellable keeps a cancelled search out of that Result.failure, so cancellation
-        // propagates through await() and cancels the sibling searches too.
-        val routes = async { nearMe(center) { runCatchingCancellable { searchRoutes(query, it) } } }
-        val stops = async { nearMe(center) { runCatchingCancellable { searchStops(query, it) } } }
+        val routes = async { nearMe(center) { searchRoutes(query, it) } }
+        val stops = async { nearMe(center) { searchStops(query, it) } }
         val vehicles = async { vehicleSearch.vehiclesMatching(query) }
         val routeResult = routes.await()
         val stopResult = stops.await()
@@ -81,24 +78,42 @@ class DefaultSearchResultsRepository @Inject constructor(
             )
         }
 
-        // The favourite/custom-name enrichment is best-effort: a DB hiccup here must not fail a search
-        // that already has route/stop results, so treat it as a soft miss (empty map) like the lookups.
-        importGate.awaitReady()
-        val userInfo = runCatchingCancellable { stopDao.userInfoMap().toStopUserInfoMap() }
-            .getOrDefault(emptyMap())
+        val matchedStops = stopResult.getOrNull().orEmpty()
         val items = buildList {
             routeResult.getOrNull()?.let { result ->
                 result.routes.forEach { add(toRoute(it, result.agencyNames)) }
             }
-            stopResult.getOrNull()?.forEach { add(toStop(it, userInfo[it.id])) }
+            val userInfo = stopUserInfo(matchedStops)
+            matchedStops.forEach { add(toStop(it, userInfo[it.id])) }
             vehicleResult.getOrNull()?.forEach { add(toVehicle(it)) }
         }
         Result.success(items)
     }
 
-    /** Runs a location-scoped [lookup], or reports the missing center as that lookup's failure. */
-    private suspend fun <T> nearMe(center: Location?, lookup: suspend (Location) -> Result<T>): Result<T> = center?.let { lookup(it) }
-        ?: Result.failure(IOException("No search location available"))
+    /**
+     * Favourite/custom-name info for [stops], or an empty map when there are none to enrich — a
+     * coach-number-only (or location-less) search then skips the import-gate await and the query
+     * entirely. Best-effort otherwise: a DB hiccup must not fail a search that already has results,
+     * so it's a soft miss (empty map) like the lookups.
+     */
+    private suspend fun stopUserInfo(stops: List<ObaStop>): Map<String, StopUserInfo> {
+        if (stops.isEmpty()) return emptyMap()
+        importGate.awaitReady()
+        return runCatchingCancellable { stopDao.userInfoMap().toStopUserInfoMap() }
+            .getOrDefault(emptyMap())
+    }
+
+    /**
+     * Runs a location-scoped [lookup], or reports the missing center as that lookup's failure. The
+     * lookup resolves a non-OK code / transport failure to Result.failure (requireData);
+     * runCatchingCancellable keeps a cancelled search out of that Result.failure, so cancellation
+     * propagates through await() and cancels the sibling searches too.
+     */
+    private suspend fun <T> nearMe(center: Location?, lookup: suspend (Location) -> T): Result<T> = if (center == null) {
+        Result.failure(IOException("No search location available"))
+    } else {
+        runCatchingCancellable { lookup(center) }
+    }
 
     /** Searches around the user, widening to the region's default center when nothing matches. */
     private suspend fun searchRoutes(query: String, center: Location): RoutesNearResult {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsRepository.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.onebusaway.android.api.data.LocationSearchDataSource
 import org.onebusaway.android.api.data.RoutesNearResult
-import org.onebusaway.android.api.data.VehicleAssignment
 import org.onebusaway.android.api.data.VehicleMatch
 import org.onebusaway.android.api.data.VehicleSearchDataSource
 import org.onebusaway.android.database.oba.ImportGate
@@ -71,9 +70,13 @@ class DefaultSearchResultsRepository @Inject constructor(
         val stopResult = stops.await()
         val vehicleResult = vehicles.await()
 
-        // A true failure only when EVERY search failed; otherwise show whatever came back.
-        val results = listOf(routeResult, stopResult, vehicleResult)
-        if (results.all { it.isFailure }) {
+        // A true failure when both near-me legs failed and the vehicle leg has nothing to put in their
+        // place. The vehicle leg answering "no coach by that name" is not an answer about the routes and
+        // stops we couldn't reach, so an empty vehicle success must not turn an outage into the
+        // no-results screen (which offers no retry) — only actual vehicle hits do.
+        val matchedVehicles = vehicleResult.getOrNull().orEmpty()
+        if (routeResult.isFailure && stopResult.isFailure && matchedVehicles.isEmpty()) {
+            val results = listOf(routeResult, stopResult, vehicleResult)
             return@coroutineScope Result.failure(
                 results.firstNotNullOfOrNull { it.exceptionOrNull() } ?: IOException("Search failed")
             )
@@ -86,7 +89,7 @@ class DefaultSearchResultsRepository @Inject constructor(
             }
             val userInfo = stopUserInfo(matchedStops)
             matchedStops.forEach { add(toStop(it, userInfo[it.id])) }
-            vehicleResult.getOrNull()?.forEach { add(toVehicle(it)) }
+            matchedVehicles.forEach { add(toVehicle(it)) }
         }
         Result.success(items)
     }
@@ -149,20 +152,7 @@ class DefaultSearchResultsRepository @Inject constructor(
         id = match.vehicleId,
         coachNumber = match.coachNumber,
         agency = match.agencyName,
-        status = when (val assignment = match.assignment) {
-            is VehicleAssignment.OnTrip -> SearchResultItem.Vehicle.Status.OnRide(
-                SearchResultItem.Vehicle.Ride(
-                    routeId = assignment.trip.routeId,
-                    tripId = assignment.trip.tripId,
-                    routeShortName = assignment.trip.routeShortName,
-                    routeColor = assignment.trip.routeColor,
-                    headsign = assignment.trip.headsign
-                )
-            )
-
-            VehicleAssignment.NotInService -> SearchResultItem.Vehicle.Status.NotInService
-            VehicleAssignment.Unknown -> SearchResultItem.Vehicle.Status.Unknown
-        }
+        assignment = match.assignment
     )
 
     private fun toStop(stop: ObaStop, userInfo: StopUserInfo?) = SearchResultItem.Stop(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -154,19 +154,21 @@ private fun StopResultRow(
 
 /**
  * A matched vehicle: its coach number as the title, with the ride it is running (route badge +
- * headsign) beneath, or the operating agency when it isn't running one. A vehicle between
- * assignments has no ride to open, so the row reports the match but isn't clickable.
+ * headsign) beneath, or — when there is no ride to show — why not, over the operating agency. Only a
+ * ride is something to open, so the other two rows report the match without being clickable, and they
+ * caption differently: "not in service" is the server's answer, and is not claimed for a status we
+ * couldn't look up.
  */
 @Composable
 private fun VehicleResultRow(
     vehicle: SearchResultItem.Vehicle,
     onShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
 ) {
-    val ride = vehicle.ride
+    val status = vehicle.status
+    val ride = (status as? SearchResultItem.Vehicle.Status.OnRide)?.ride
     ResultRow(
         painter = painterResource(R.drawable.ic_bus),
         contentDescription = stringResource(R.string.search_result_coach_icon),
-        // Only a resolved ride is something to open, so the unactionable row simply isn't clickable.
         onClick = ride?.let { { onShowOnMap(it) } }
     ) {
         Column(Modifier.weight(1f)) {
@@ -185,7 +187,13 @@ private fun VehicleResultRow(
                 )
             } else {
                 Text(
-                    text = stringResource(R.string.search_result_coach_not_in_service),
+                    text = stringResource(
+                        if (status is SearchResultItem.Vehicle.Status.NotInService) {
+                            R.string.search_result_coach_not_in_service
+                        } else {
+                            R.string.search_result_coach_status_unavailable
+                        }
+                    ),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -203,7 +211,7 @@ private fun VehicleResultRow(
  * A combined-search list row: a leading result-type glyph (a route, stop or vehicle marker in a
  * consistent tinted column, so they're distinguishable at a glance), the type-specific [content], and
  * a trailing divider. The whole row is clickable via [onClick]; a null [onClick] is a row with
- * nothing to open (a matched vehicle that isn't running a trip).
+ * nothing to open (a matched vehicle with no ride behind it).
  */
 @Composable
 private fun ResultRow(
@@ -256,19 +264,27 @@ private fun SearchResultsScreenSuccessPreview() {
                         id = "1_4531",
                         coachNumber = "4531",
                         agency = "King County Metro",
-                        ride = SearchResultItem.Vehicle.Ride(
-                            routeId = "1_100263",
-                            tripId = "1_800587510",
-                            routeShortName = "7",
-                            routeColor = 0xFDB71A.toInt(),
-                            headsign = "Prentice St Via Rainier Ave S"
+                        status = SearchResultItem.Vehicle.Status.OnRide(
+                            SearchResultItem.Vehicle.Ride(
+                                routeId = "1_100263",
+                                tripId = "1_800587510",
+                                routeShortName = "7",
+                                routeColor = 0xFDB71A.toInt(),
+                                headsign = "Prentice St Via Rainier Ave S"
+                            )
                         )
                     ),
                     SearchResultItem.Vehicle(
                         id = "1_4532",
                         coachNumber = "4532",
                         agency = "King County Metro",
-                        ride = null
+                        status = SearchResultItem.Vehicle.Status.NotInService
+                    ),
+                    SearchResultItem.Vehicle(
+                        id = "1_4533",
+                        coachNumber = "4533",
+                        agency = "King County Metro",
+                        status = SearchResultItem.Vehicle.Status.Unknown
                     )
                 )
             ),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -55,7 +55,8 @@ fun SearchResultsRoute(
     viewModel: SearchResultsViewModel,
     onBack: () -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
-    onStopShowOnMap: (SearchResultItem.Stop) -> Unit
+    onStopShowOnMap: (SearchResultItem.Stop) -> Unit,
+    onVehicleShowOnMap: (SearchResultItem.Vehicle) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     SearchResultsScreen(
@@ -64,7 +65,8 @@ fun SearchResultsRoute(
         onRetry = viewModel::retry,
         onBack = onBack,
         onRouteShowOnMap = onRouteShowOnMap,
-        onStopShowOnMap = onStopShowOnMap
+        onStopShowOnMap = onStopShowOnMap,
+        onVehicleShowOnMap = onVehicleShowOnMap
     )
 }
 
@@ -76,18 +78,20 @@ fun SearchResultsScreen(
     onRetry: () -> Unit,
     onBack: () -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
-    onStopShowOnMap: (SearchResultItem.Stop) -> Unit
+    onStopShowOnMap: (SearchResultItem.Stop) -> Unit,
+    onVehicleShowOnMap: (SearchResultItem.Vehicle) -> Unit
 ) {
     ListScreenScaffold(
         title = title,
         onBack = onBack,
         state = state,
         onRetry = onRetry,
-        // Route and stop ids share no namespace, so prefix to keep keys unique
+        // Route, stop and vehicle ids share no namespace, so prefix to keep keys unique
         itemKey = { item ->
             when (item) {
                 is SearchResultItem.Route -> "r:${item.id}"
                 is SearchResultItem.Stop -> "s:${item.id}"
+                is SearchResultItem.Vehicle -> "v:${item.id}"
             }
         },
         emptyContent = {
@@ -104,6 +108,7 @@ fun SearchResultsScreen(
         when (item) {
             is SearchResultItem.Route -> RouteResultRow(item, onRouteShowOnMap)
             is SearchResultItem.Stop -> StopResultRow(item, onStopShowOnMap)
+            is SearchResultItem.Vehicle -> VehicleResultRow(item, onVehicleShowOnMap)
         }
     }
 }
@@ -148,22 +153,69 @@ private fun StopResultRow(
 }
 
 /**
- * A combined-search list row: a leading result-type glyph (a route or stop marker in a consistent
- * tinted column, so the two are distinguishable at a glance), the type-specific [content], and a
- * trailing divider. The whole row is clickable via [onClick].
+ * A matched vehicle: its coach number as the title, with the ride it is running (route badge +
+ * headsign) beneath, or the operating agency when it isn't running one. A vehicle between
+ * assignments has no ride to open, so the row reports the match but isn't clickable.
+ */
+@Composable
+private fun VehicleResultRow(
+    vehicle: SearchResultItem.Vehicle,
+    onShowOnMap: (SearchResultItem.Vehicle) -> Unit
+) {
+    val ride = vehicle.ride
+    ResultRow(
+        painter = painterResource(R.drawable.ic_bus),
+        contentDescription = stringResource(R.string.search_result_coach_icon),
+        onClick = if (ride != null) ({ onShowOnMap(vehicle) }) else null
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.search_result_coach, vehicle.coachNumber),
+                style = MaterialTheme.typography.bodyLarge
+            )
+            if (ride != null) {
+                // The route badge reads the same here as on an arrivals row, so a rider recognizes the
+                // ride before tapping into it; the headsign line is dropped when the feed omits it.
+                RouteRowContent(
+                    shortName = ride.routeShortName.orEmpty(),
+                    longName = ride.headsign,
+                    routeColor = ride.routeColor,
+                    agency = vehicle.agency
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.search_result_coach_not_in_service),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = vehicle.agency,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A combined-search list row: a leading result-type glyph (a route, stop or vehicle marker in a
+ * consistent tinted column, so they're distinguishable at a glance), the type-specific [content], and
+ * a trailing divider. The whole row is clickable via [onClick]; a null [onClick] is a row with
+ * nothing to open (a matched vehicle that isn't running a trip).
  */
 @Composable
 private fun ResultRow(
     painter: Painter,
     contentDescription: String,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
     content: @Composable RowScope.() -> Unit
 ) {
     Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -198,13 +250,32 @@ private fun SearchResultsScreenSuccessPreview() {
                     ),
                     SearchResultItem.Route("1_40", "40", "Downtown - Northgate", null),
                     SearchResultItem.Stop("1_100", "Broadway & E Denny Way", "S", true, 47.6, -122.3),
-                    SearchResultItem.Stop("1_101", "Stop with no direction", "", false, 47.6, -122.3)
+                    SearchResultItem.Stop("1_101", "Stop with no direction", "", false, 47.6, -122.3),
+                    SearchResultItem.Vehicle(
+                        id = "1_4531",
+                        coachNumber = "4531",
+                        agency = "King County Metro",
+                        ride = SearchResultItem.Vehicle.Ride(
+                            routeId = "1_100263",
+                            tripId = "1_800587510",
+                            routeShortName = "7",
+                            routeColor = 0xFDB71A.toInt(),
+                            headsign = "Prentice St Via Rainier Ave S"
+                        )
+                    ),
+                    SearchResultItem.Vehicle(
+                        id = "1_4532",
+                        coachNumber = "4532",
+                        agency = "King County Metro",
+                        ride = null
+                    )
                 )
             ),
             onRetry = {},
             onBack = {},
             onRouteShowOnMap = {},
-            onStopShowOnMap = {}
+            onStopShowOnMap = {},
+            onVehicleShowOnMap = {}
         )
     }
 }
@@ -219,7 +290,8 @@ private fun SearchResultsScreenEmptyPreview() {
             onRetry = {},
             onBack = {},
             onRouteShowOnMap = {},
-            onStopShowOnMap = {}
+            onStopShowOnMap = {},
+            onVehicleShowOnMap = {}
         )
     }
 }
@@ -234,7 +306,8 @@ private fun SearchResultsScreenLoadingPreview() {
             onRetry = {},
             onBack = {},
             onRouteShowOnMap = {},
-            onStopShowOnMap = {}
+            onStopShowOnMap = {},
+            onVehicleShowOnMap = {}
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.onebusaway.android.R
+import org.onebusaway.android.api.data.VehicleAssignment
+import org.onebusaway.android.api.data.VehicleTrip
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.components.ListScreenScaffold
 import org.onebusaway.android.ui.compose.components.RouteRowContent
@@ -56,7 +58,7 @@ fun SearchResultsRoute(
     onBack: () -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
     onStopShowOnMap: (SearchResultItem.Stop) -> Unit,
-    onVehicleShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
+    onVehicleShowOnMap: (VehicleTrip) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     SearchResultsScreen(
@@ -79,7 +81,7 @@ fun SearchResultsScreen(
     onBack: () -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
     onStopShowOnMap: (SearchResultItem.Stop) -> Unit,
-    onVehicleShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
+    onVehicleShowOnMap: (VehicleTrip) -> Unit
 ) {
     ListScreenScaffold(
         title = title,
@@ -162,10 +164,10 @@ private fun StopResultRow(
 @Composable
 private fun VehicleResultRow(
     vehicle: SearchResultItem.Vehicle,
-    onShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
+    onShowOnMap: (VehicleTrip) -> Unit
 ) {
-    val status = vehicle.status
-    val ride = (status as? SearchResultItem.Vehicle.Status.OnRide)?.ride
+    val assignment = vehicle.assignment
+    val ride = (assignment as? VehicleAssignment.OnTrip)?.trip
     ResultRow(
         painter = painterResource(R.drawable.ic_bus),
         contentDescription = stringResource(R.string.search_result_coach_icon),
@@ -188,7 +190,7 @@ private fun VehicleResultRow(
             } else {
                 Text(
                     text = stringResource(
-                        if (status is SearchResultItem.Vehicle.Status.NotInService) {
+                        if (assignment == VehicleAssignment.NotInService) {
                             R.string.search_result_coach_not_in_service
                         } else {
                             R.string.search_result_coach_status_unavailable
@@ -211,7 +213,9 @@ private fun VehicleResultRow(
  * A combined-search list row: a leading result-type glyph (a route, stop or vehicle marker in a
  * consistent tinted column, so they're distinguishable at a glance), the type-specific [content], and
  * a trailing divider. The whole row is clickable via [onClick]; a null [onClick] is a row with
- * nothing to open (a matched vehicle with no ride behind it).
+ * nothing to open (a matched vehicle with no ride behind it) — kept `clickable(enabled = false)`
+ * rather than un-clickable, so it still merges its glyph, title and caption into one focusable node
+ * like every neighbouring row, and announces itself as disabled instead of as four loose fragments.
  */
 @Composable
 private fun ResultRow(
@@ -224,7 +228,7 @@ private fun ResultRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+                .clickable(enabled = onClick != null) { onClick?.invoke() }
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -264,10 +268,10 @@ private fun SearchResultsScreenSuccessPreview() {
                         id = "1_4531",
                         coachNumber = "4531",
                         agency = "King County Metro",
-                        status = SearchResultItem.Vehicle.Status.OnRide(
-                            SearchResultItem.Vehicle.Ride(
-                                routeId = "1_100263",
+                        assignment = VehicleAssignment.OnTrip(
+                            VehicleTrip(
                                 tripId = "1_800587510",
+                                routeId = "1_100263",
                                 routeShortName = "7",
                                 routeColor = 0xFDB71A.toInt(),
                                 headsign = "Prentice St Via Rainier Ave S"
@@ -278,13 +282,13 @@ private fun SearchResultsScreenSuccessPreview() {
                         id = "1_4532",
                         coachNumber = "4532",
                         agency = "King County Metro",
-                        status = SearchResultItem.Vehicle.Status.NotInService
+                        assignment = VehicleAssignment.NotInService
                     ),
                     SearchResultItem.Vehicle(
                         id = "1_4533",
                         coachNumber = "4533",
                         agency = "King County Metro",
-                        status = SearchResultItem.Vehicle.Status.Unknown
+                        assignment = VehicleAssignment.Unknown
                     )
                 )
             ),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/searchresults/SearchResultsScreen.kt
@@ -56,7 +56,7 @@ fun SearchResultsRoute(
     onBack: () -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
     onStopShowOnMap: (SearchResultItem.Stop) -> Unit,
-    onVehicleShowOnMap: (SearchResultItem.Vehicle) -> Unit
+    onVehicleShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     SearchResultsScreen(
@@ -79,7 +79,7 @@ fun SearchResultsScreen(
     onBack: () -> Unit,
     onRouteShowOnMap: (SearchResultItem.Route) -> Unit,
     onStopShowOnMap: (SearchResultItem.Stop) -> Unit,
-    onVehicleShowOnMap: (SearchResultItem.Vehicle) -> Unit
+    onVehicleShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
 ) {
     ListScreenScaffold(
         title = title,
@@ -160,13 +160,14 @@ private fun StopResultRow(
 @Composable
 private fun VehicleResultRow(
     vehicle: SearchResultItem.Vehicle,
-    onShowOnMap: (SearchResultItem.Vehicle) -> Unit
+    onShowOnMap: (SearchResultItem.Vehicle.Ride) -> Unit
 ) {
     val ride = vehicle.ride
     ResultRow(
         painter = painterResource(R.drawable.ic_bus),
         contentDescription = stringResource(R.string.search_result_coach_icon),
-        onClick = if (ride != null) ({ onShowOnMap(vehicle) }) else null
+        // Only a resolved ride is something to open, so the unactionable row simply isn't clickable.
+        onClick = ride?.let { { onShowOnMap(it) } }
     ) {
         Column(Modifier.weight(1f)) {
             Text(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/survey/SurveyViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
 import org.onebusaway.android.R
+import org.onebusaway.android.api.contract.sidecarV1RegionUrl
 import org.onebusaway.android.api.data.SurveyDataSource
 import org.onebusaway.android.app.di.AppScope
 import org.onebusaway.android.database.survey.SurveyRepository
@@ -296,9 +297,11 @@ class SurveyViewModel @Inject constructor(
     private fun studyUrl(): String? {
         val region = regionRepository.region.value ?: return null
         val base = region.sidecarBaseUrl ?: return null
-        return base +
-            context.getString(R.string.studies_api_endpoint)
-                .replace("regionID", region.sidecarId.toString())
+        return sidecarV1RegionUrl(
+            sidecarBaseUrl = base,
+            endpoint = context.getString(R.string.studies_api_endpoint),
+            regionId = region.sidecarId.toString()
+        )
     }
 
     private fun submitUrl(hero: Boolean): String {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.kt
@@ -11,6 +11,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
+import org.onebusaway.android.api.contract.sidecarV1RegionUrl
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.WallTime
@@ -91,9 +92,11 @@ class GtfsAlerts @Inject constructor(
             context.getString(R.string.preferences_display_test_alerts),
             false
         )
-        return (baseUrl + context.getString(R.string.alerts_api_endpoint))
-            .replace("regionID", regionId)
-            .let { if (testAlert) "$it?test=1" else it }
+        return sidecarV1RegionUrl(
+            sidecarBaseUrl = baseUrl,
+            endpoint = context.getString(R.string.alerts_api_endpoint),
+            regionId = regionId
+        ).let { if (testAlert) "$it?test=1" else it }
     }
 
     private companion object {

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -76,6 +76,9 @@
     <!-- Weather API URL -->
     <string name="weather_api_endpoint">/api/v1/regions/regionID/weather.json</string>
 
+    <!-- Vehicle (coach number) search API URL -->
+    <string name="vehicles_api_endpoint">/api/v1/regions/regionID/vehicles</string>
+
     <!-- GET Survey API URL -->
     <string name="studies_api_endpoint">/api/v1/regions/regionID/surveys.json</string>
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="direction_nw">Northwest bound</string>
     <string name="direction_none"></string>
     <string name="browser_error">Unable to launch browser.</string>
-    <string name="search_hint">Search stop or route IDs</string>
+    <string name="search_hint">Search stops, routes or coach numbers</string>
     <string name="checkmark_description">Selection checkmark</string>
 
     <!--  Option strings -->
@@ -449,6 +449,13 @@
     <string name="search_route_hint">Enter a route name/number</string>
     <string name="route_shortcut">Route</string>
     <string name="stop_shortcut">Stop</string>
+    <!-- A coach-number search hit. %1$s is the number painted on the vehicle, e.g. "Coach 4531". -->
+    <string name="search_result_coach">Coach %1$s</string>
+    <!-- Names the leading glyph on a coach-number search result, for screen readers. -->
+    <string name="search_result_coach_icon">Vehicle</string>
+    <!-- Shown under a matched coach number when the vehicle isn't running a trip right now, so
+         there is no ride to open. -->
+    <string name="search_result_coach_not_in_service">Not in service</string>
     <string name="recent_stops_shortcut">Recent Stops</string>
     <string name="recent_routes_shortcut">Recent Routes</string>
     <string name="starred_stops_shortcut">Starred Stops</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="direction_nw">Northwest bound</string>
     <string name="direction_none"></string>
     <string name="browser_error">Unable to launch browser.</string>
-    <string name="search_hint">Search stops, routes or coach numbers</string>
+    <string name="search_hint">Search stop or route IDs</string>
     <string name="checkmark_description">Selection checkmark</string>
 
     <!--  Option strings -->

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -453,9 +453,12 @@
     <string name="search_result_coach">Coach %1$s</string>
     <!-- Names the leading glyph on a coach-number search result, for screen readers. -->
     <string name="search_result_coach_icon">Vehicle</string>
-    <!-- Shown under a matched coach number when the vehicle isn't running a trip right now, so
-         there is no ride to open. -->
+    <!-- Shown under a matched coach number when the server says the vehicle isn't running a trip
+         right now, so there is no ride to open. -->
     <string name="search_result_coach_not_in_service">Not in service</string>
+    <!-- Shown under a matched coach number when looking up what the vehicle is running failed, so
+         the app can't say whether it is in service. -->
+    <string name="search_result_coach_status_unavailable">Status unavailable</string>
     <string name="recent_stops_shortcut">Recent Stops</string>
     <string name="recent_routes_shortcut">Recent Routes</string>
     <string name="starred_stops_shortcut">Starred Stops</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/ObaFailureTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/ObaFailureTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api
+
+import java.io.IOException
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+/**
+ * Which non-2xx responses count as the OBA layer's own answer. The distinction matters because
+ * [isNotFound] is read as "the server says there is no such resource" — so a 404 that OBA didn't write
+ * (a proxy's, or a deployment that doesn't serve the endpoint) must not be adopted as one.
+ */
+class ObaFailureTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    @Test
+    fun anObaEnvelopeBodyBecomesAnObaApiException() {
+        // Verbatim from api.pugetsound.onebusaway.org for an unassigned vehicle: the envelope is the
+        // body, and the HTTP status mirrors its code.
+        val failure = httpError(404, """{"code":404,"currentTime":1786250725829,"text":"resource not found","version":2}""")
+
+        val normalized = failure.asObaFailure(json)
+
+        assertEquals(404, (normalized as ObaApiException).code)
+        assertTrue(normalized.isNotFound)
+    }
+
+    @Test
+    fun aBodyThatIsntAnObaEnvelopeStaysTransport() {
+        // A fronting proxy's 404 for a path the OBA deployment never saw.
+        val proxy = httpError(404, "<html><body>404 Not Found</body></html>")
+        val empty = httpError(404, "")
+        // JSON, but from something else — no envelope code, so nothing states the resource is missing.
+        val otherJson = httpError(404, """{"error":"not found"}""")
+
+        listOf(proxy, empty, otherJson).forEach { failure ->
+            // One call per failure: reading the body consumes it, as it would in production.
+            val normalized = failure.asObaFailure(json)
+            assertSame(failure, normalized)
+            assertFalse(normalized.isNotFound)
+        }
+    }
+
+    @Test
+    fun anEnvelopeCodeThatContradictsTheStatusIsNotAdopted() {
+        // A body whose code doesn't match the status it arrived under isn't this response's answer.
+        val failure = httpError(502, """{"code":404,"text":"resource not found","version":2}""")
+
+        assertSame(failure, failure.asObaFailure(json))
+    }
+
+    @Test
+    fun aNonHttpFailurePassesThrough() {
+        val failure = IOException("connection reset")
+
+        assertSame(failure, failure.asObaFailure(json))
+    }
+
+    @Test
+    fun onlyA404CountsAsNotFound() {
+        assertTrue(ObaApiException(404).isNotFound)
+        assertFalse(ObaApiException(500).isNotFound)
+        assertFalse(IOException("connection reset").isNotFound)
+    }
+
+    private fun httpError(code: Int, body: String) = HttpException(
+        Response.error<Unit>(code, body.toResponseBody("application/json".toMediaType()))
+    )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/ObaFailureTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/ObaFailureTest.kt
@@ -17,8 +17,11 @@ package org.onebusaway.android.api
 
 import java.io.IOException
 import kotlinx.serialization.json.Json
+import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.BufferedSource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
@@ -71,6 +74,24 @@ class ObaFailureTest {
     fun anEnvelopeCodeThatContradictsTheStatusIsNotAdopted() {
         // A body whose code doesn't match the status it arrived under isn't this response's answer.
         val failure = httpError(502, """{"code":404,"text":"resource not found","version":2}""")
+
+        assertSame(failure, failure.asObaFailure(json))
+    }
+
+    @Test
+    fun aBodyThatCantBeReadLeavesTheFailureAlone() {
+        val failure = HttpException(
+            Response.error<Unit>(
+                404,
+                object : ResponseBody() {
+                    override fun contentType(): MediaType = "application/json".toMediaType()
+
+                    override fun contentLength(): Long = -1
+
+                    override fun source(): BufferedSource = throw IOException("stream closed")
+                }
+            )
+        )
 
         assertSame(failure, failure.asObaFailure(json))
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/VehicleSearchDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/VehicleSearchDecodeTest.kt
@@ -68,6 +68,9 @@ class VehicleSearchDecodeTest {
         assertEquals("103_897453", coachNumberOf("40_103_897453", "40"))
         // An id that doesn't carry the OBA agency prefix is passed through rather than guessed at.
         assertEquals("4531", coachNumberOf("4531", "1"))
+        // A hit that named no agency has no prefix to strip — not a bare "_" to strip either.
+        assertEquals("1_4531", coachNumberOf("1_4531", ""))
+        assertEquals("_4531", coachNumberOf("_4531", ""))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/VehicleSearchDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/VehicleSearchDecodeTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.api.contract.AgencyVehicleResponse
+import org.onebusaway.android.api.contract.EntryWithReferences
+import org.onebusaway.android.api.contract.ObaEnvelope
+import org.onebusaway.android.api.contract.TripDetailsEntry
+import org.onebusaway.android.api.data.coachNumberOf
+import org.onebusaway.android.api.data.toVehicleTrip
+
+/**
+ * Covers the two hops of a coach-number search: the region sidecar's partial-match array (bare JSON,
+ * snake_case, so [AgencyVehicleResponse] carries `@SerialName`s) and the OBA `trip-for-vehicle`
+ * envelope that turns the matched id into the route + trip the map drills into. Both bodies mirror
+ * live Puget Sound payloads.
+ */
+class VehicleSearchDecodeTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    @Test
+    fun decodesSidecarVehicleMatches() {
+        val body = """
+            [
+              {"id":"1","name":"Metro Transit","vehicle_id":"1_4531"},
+              {"id":"19","name":"Intercity Transit","vehicle_id":"19_453"},
+              {"id":"40","name":"Sound Transit"}
+            ]
+        """.trimIndent()
+
+        val matches = json.decodeFromString<List<AgencyVehicleResponse>>(body)
+
+        assertEquals(3, matches.size)
+        assertEquals("1", matches[0].agencyId)
+        assertEquals("Metro Transit", matches[0].agencyName)
+        assertEquals("1_4531", matches[0].vehicleId)
+        assertEquals("19_453", matches[1].vehicleId)
+        // The sidecar can name an agency with no live vehicle id; the adapter drops those.
+        assertNull(matches[2].vehicleId)
+    }
+
+    @Test
+    fun coachNumberStripsTheAgencyPrefix() {
+        assertEquals("4531", coachNumberOf("1_4531", "1"))
+        assertEquals("453", coachNumberOf("19_453", "19"))
+        // Only the stated agency's prefix comes off, so an underscore inside the number survives.
+        assertEquals("103_897453", coachNumberOf("40_103_897453", "40"))
+        // An id that doesn't carry the OBA agency prefix is passed through rather than guessed at.
+        assertEquals("4531", coachNumberOf("4531", "1"))
+    }
+
+    @Test
+    fun tripForVehicleResolvesTheActiveTripsRouteAndHeadsign() {
+        val trip = json.decodeFromString<ObaEnvelope<EntryWithReferences<TripDetailsEntry>>>(TRIP_FOR_VEHICLE)
+            .requireData()
+            .toVehicleTrip()
+
+        assertEquals("1_800587510", trip?.tripId)
+        assertEquals("1_100263", trip?.routeId)
+        assertEquals("7", trip?.routeShortName)
+        assertEquals("Prentice St Via Rainier Ave S", trip?.headsign)
+        // The fixture carries no route color: colorArgb() parses via android.graphics.Color, which
+        // isn't available to a JVM test. It's an unmodified pass-through of the shared route parser.
+        assertNull(trip?.routeColor)
+    }
+
+    @Test
+    fun tripForVehiclePrefersTheActiveTripOverTheEntrysOwn() {
+        // A block rollover: the entry still names the finished trip, while status names the new one.
+        val body = TRIP_FOR_VEHICLE.replace("\"tripId\": \"1_800587510\"", "\"tripId\": \"1_800587509\"")
+
+        val trip = json.decodeFromString<ObaEnvelope<EntryWithReferences<TripDetailsEntry>>>(body)
+            .requireData()
+            .toVehicleTrip()
+
+        assertEquals("1_800587510", trip?.tripId)
+    }
+
+    @Test
+    fun tripForVehicleWithoutTheTripInReferencesIsNotARide() {
+        // includeTrip omitted (or an inconsistent response): nothing to drill into.
+        val body = TRIP_FOR_VEHICLE.replace("\"trips\":", "\"unusedTrips\":")
+
+        val trip = json.decodeFromString<ObaEnvelope<EntryWithReferences<TripDetailsEntry>>>(body)
+            .requireData()
+            .toVehicleTrip()
+
+        assertNull(trip)
+    }
+
+    private companion object {
+
+        val TRIP_FOR_VEHICLE = """
+            {
+              "code": 200,
+              "currentTime": 1786127569099,
+              "version": 2,
+              "data": {
+                "entry": {
+                  "serviceDate": 1786086000000,
+                  "status": {
+                    "activeTripId": "1_800587510",
+                    "phase": "in_progress",
+                    "predicted": true,
+                    "vehicleId": "1_4531"
+                  },
+                  "tripId": "1_800587510"
+                },
+                "references": {
+                  "agencies": [{"id": "1", "name": "Metro Transit"}],
+                  "routes": [
+                    {
+                      "agencyId": "1", "id": "1_100263",
+                      "longName": "", "shortName": "7", "type": 3
+                    }
+                  ],
+                  "stops": [],
+                  "situations": [],
+                  "trips": [
+                    {
+                      "blockId": "1_8127845", "directionId": "0", "id": "1_800587510",
+                      "routeId": "1_100263", "shapeId": "1_21007015",
+                      "tripHeadsign": "Prentice St Via Rainier Ave S"
+                    }
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/VehicleAssignmentTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/VehicleAssignmentTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.api.ObaApiException
+import retrofit2.HttpException
+import retrofit2.Response
+
+/**
+ * How a `trip-for-vehicle` outcome becomes a coach-number row's caption. The distinction under test is
+ * that only the server's own 404 means "not in service" — every other failure leaves the assignment
+ * unknown, so a lookup that never got an answer is never rendered as one.
+ */
+class VehicleAssignmentTest {
+
+    @Test
+    fun aResolvedTripIsTheRide() {
+        val trip = VehicleTrip(
+            tripId = "1_800587510",
+            routeId = "1_100263",
+            routeShortName = "7",
+            routeColor = null,
+            headsign = "Prentice St Via Rainier Ave S"
+        )
+
+        assertEquals(VehicleAssignment.OnTrip(trip), vehicleAssignment(Result.success(trip)))
+    }
+
+    @Test
+    fun theServers404IsNotInService() {
+        // How an unassigned vehicle actually answers: OBA sets the HTTP status from the envelope code,
+        // so Retrofit raises this before the body is decoded.
+        assertEquals(VehicleAssignment.NotInService, vehicleAssignment(Result.failure(httpError(404))))
+        // The same answer read off a decoded envelope, which is what requireData raises.
+        assertEquals(VehicleAssignment.NotInService, vehicleAssignment(Result.failure(ObaApiException(404))))
+    }
+
+    @Test
+    fun aFailedLookupIsUnknownRatherThanNotInService() {
+        listOf(
+            SocketTimeoutException("timeout"),
+            IOException("connection reset"),
+            httpError(500),
+            ObaApiException(500),
+            IllegalArgumentException("malformed body")
+        ).forEach { failure ->
+            assertEquals(
+                "$failure should leave the assignment unknown",
+                VehicleAssignment.Unknown,
+                vehicleAssignment(Result.failure(failure))
+            )
+        }
+    }
+
+    @Test
+    fun aTripTheResponseDoesntDescribeIsUnknown() {
+        // The server said the vehicle is on a trip; its references just didn't say which. That's not
+        // grounds for reporting the coach as off duty.
+        assertEquals(VehicleAssignment.Unknown, vehicleAssignment(Result.success(null)))
+    }
+
+    private fun httpError(code: Int) = HttpException(
+        Response.error<Unit>(code, "".toResponseBody("application/json".toMediaType()))
+    )
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/data/VehicleAssignmentTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/data/VehicleAssignmentTest.kt
@@ -47,10 +47,8 @@ class VehicleAssignmentTest {
 
     @Test
     fun theServers404IsNotInService() {
-        // How an unassigned vehicle actually answers: OBA sets the HTTP status from the envelope code,
-        // so Retrofit raises this before the body is decoded.
-        assertEquals(VehicleAssignment.NotInService, vehicleAssignment(Result.failure(httpError(404))))
-        // The same answer read off a decoded envelope, which is what requireData raises.
+        // The one form that means it: an ObaApiException(404), which is either what requireData raises
+        // off a decoded envelope or what ObaApiProvider normalizes an OBA-stated HTTP 404 into.
         assertEquals(VehicleAssignment.NotInService, vehicleAssignment(Result.failure(ObaApiException(404))))
     }
 
@@ -59,6 +57,9 @@ class VehicleAssignmentTest {
         listOf(
             SocketTimeoutException("timeout"),
             IOException("connection reset"),
+            // A bare HTTP 404 the OBA layer never claimed — a proxy, or a deployment that doesn't serve
+            // trip-for-vehicle at all. Not grounds for reporting the coach off duty.
+            httpError(404),
             httpError(500),
             ObaApiException(500),
             IllegalArgumentException("malformed body")


### PR DESCRIPTION
Closes #2193.

Typing the number painted on a bus into the map's search field now finds that vehicle and, on tap, opens the ride it is running — the same route-mode-with-a-focused-vehicle view an arrivals ETA-pill tap opens (`ShowRouteRequest(routeId, focusTripId = tripId)`). It's the fastest way to answer "which bus is my friend on", and it costs no screen or attention space: it's a third result type in the existing combined search list.

## Why two hops

Neither service can resolve a coach number alone:

- The OBA `where` API only looks a vehicle up by its **full agency-prefixed id** (`trip-for-vehicle/1_4531`), and a rider has no idea which prefix their coach carries.
- The region's **sidecar** indexes the live fleet and does the partial match: `GET {sidecarBaseUrl}/api/v1/regions/{id}/vehicles?query=4531` → `[{"id":"1","name":"Metro Transit","vehicle_id":"1_4531"}]`.

So the new `VehicleSearchDataSource` does sidecar-match → one `trip-for-vehicle` per hit (concurrently) for the route + trip. This is the same endpoint pair [OBAKit's vehicle search](https://github.com/OneBusAway/onebusaway-ios/blob/main/OBAKit/Search/SearchRequest.swift) uses on iOS (`ObacoAPIService.getVehicles(matching:)` → `RESTAPIService.getVehicle`).

## Notes for review

- **No client-side guess about what a coach number looks like.** The vehicle leg runs on every query alongside routes/stops; the region's index decides what matches, so a route/stop query just comes back empty. (Puget Sound's index declines queries under 3 characters, so short route numbers produce no noise.) Vehicle hits sort last, so a numeric query still leads with the route or stop it names.
- **The coach number is stripped using the agency id the same response states** (`vehicleId.removePrefix("${agencyId}_")`), not by splitting on the first underscore — an id that itself contains one survives.
- **Two consequences of adding a third leg to `DefaultSearchResultsRepository`:**
  - Only the near-me legs need a location, so a missing search center now fails *those two* rather than the whole search, and a coach number still resolves. The search reports failure when both near-me legs failed and the vehicle leg matched nothing — an *empty* vehicle success is not an answer about the routes and stops we couldn't reach, so an OBA outage still reaches the error+retry state rather than "no results".
  - A matched vehicle with no ride behind it is reported rather than dropped — a rider who typed a real coach number is better served by that than by "no results" — and its row isn't clickable, since there's no ride to open. The two rideless cases caption differently: **"Not in service"** is only the server's own answer — `trip-for-vehicle` 404, which OBA mirrors into the HTTP status *and* still writes as the envelope body, so `ObaApiProvider` adopts it as an `ObaApiException(404)` only after decoding that body and finding it states the same code (a proxy's or a wrong-deployment 404 stays a plain failure) — while a lookup that failed — transport, 500, decode, or a 200 naming a trip its own references don't describe — reads **"Status unavailable"** and is logged with its cause. That keeps one flaky lookup from costing the match or its siblings in the fan-out, without stating a status we never got.
- **A region with no sidecar host** has no vehicle index, so that leg fails rather than returning empty ("we can't look coach numbers up here" is not "no such coach").
- **Fan-out is capped** at 5 trip-for-vehicle lookups per search (OkHttp's default `maxRequestsPerHost`, so it's one wave and can't fill the shared client's budget for the OBA host), de-duplicated by vehicle id first, and the drop is logged rather than silently truncating.

## Testing

- `ObaFailureTest` (new) covers the non-2xx → `ObaApiException` normalization: the live Puget Sound 404 envelope, a proxy's HTML 404, a non-OBA JSON body, and a body whose code contradicts the status.
- `VehicleSearchDecodeTest` (new) covers the sidecar array decode, the agency-prefix strip, and the `trip-for-vehicle` → ride adapter (including the block-rollover `activeTripId` preference and the no-trip-in-references case). The route-color assert is a null-color fixture: `colorArgb()` goes through `android.graphics.Color`, which a JVM test can't reach.
- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest compileObaGoogleDebugAndroidTestKotlin spotlessCheck -PwarningsAsErrors=true` — green.
- Both endpoints verified by hand against live Puget Sound data: `?query=4531` → `1_4531`, which `trip-for-vehicle` resolves to trip `1_800587510` on route 7 "Prentice St Via Rainier Ave S".
- Not yet exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search now finds vehicles by coach number alongside routes and stops.
  - Vehicle results show agency, coach number, service status, and trip details when available.
  - Active vehicles can open their route and trip on the map.
  - Vehicles without an active trip remain visible but cannot be selected.
- **Bug Fixes**
  - Improved handling of service-unavailable responses and API errors.
  - Standardized sidecar URL handling.
- **Localization**
  - Added labels for vehicle status and coach-number results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
