### PR TITLE
Shrink a focused stop's route labels with the zoom

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -339,9 +339,8 @@ class GoogleMapRenderer(
 
     /**
      * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102, #2195). A label
-     * on the fixed profile resolves to the same scale either side of the move and is left alone, as is a
-     * scheduled one whose camera stayed within a flat end of its ramp or moved less than one quantization
-     * step (see [RouteBadgeScaleProfile.scaleAt]).
+     * whose camera stayed within a flat end of its ramp, or moved less than one quantization step, resolves
+     * to the same scale either side of the move and is left alone (see [RouteBadgeScaleProfile.scaleAt]).
      */
     private fun updateRouteBadgeScale(zoom: Float) {
         val previous = renderedBadgeZoom
@@ -919,7 +918,14 @@ class GoogleMapRenderer(
         // handful of route colors, times a few route types, plus the fast-estimate + dot icons
         // — so descriptors are reused as vehicles turn, not thrashed. Bounded so a long, varied session
         // can't grow it without limit (evicting a still-shown icon just re-wraps it on next request).
-        private const val DESCRIPTOR_CACHE_SIZE = 256
+        //
+        // Route labels share this cache, and since #2195 they are the larger half of it: every label on the
+        // map now takes a zoom schedule, so a busy stop's dozen adjacency labels can each be asked for at
+        // any of the nine sizes [RouteBadgeScaleProfile.scaleAt]'s sixteenths quantize the ramp to. Sized to
+        // hold that alongside the vehicles rather than letting a zoom-out sweep evict the icons the ~20Hz
+        // vehicle re-stamp depends on. The maplibre flavor gives its labels a cache of their own, so its
+        // BADGE_ICON_CACHE_SIZE covers only the labels.
+        private const val DESCRIPTOR_CACHE_SIZE = 384
     }
 }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -338,10 +338,10 @@ class GoogleMapRenderer(
     }
 
     /**
-     * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102). A label on the
-     * fixed profile — every one but a directions itinerary's — resolves to the same scale either side of
-     * the move and is left alone, as is a scheduled one whose camera stayed within a flat end of its ramp
-     * or moved less than one quantization step (see [RouteBadgeScaleProfile.scaleAt]).
+     * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102, #2195). A label
+     * on the fixed profile resolves to the same scale either side of the move and is left alone, as is a
+     * scheduled one whose camera stayed within a flat end of its ramp or moved less than one quantization
+     * step (see [RouteBadgeScaleProfile.scaleAt]).
      */
     private fun updateRouteBadgeScale(zoom: Float) {
         val previous = renderedBadgeZoom

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -25,8 +25,8 @@ import org.onebusaway.android.map.layout.RouteBadgeRequest
 import org.onebusaway.android.map.layout.placeRouteBadges
 import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
-import org.onebusaway.android.map.render.ITINERARY_ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
@@ -245,8 +245,9 @@ internal data class ItinerarySubstitute(val route: InterchangeableRoute, val rou
  * which is what a label on this view must never do: the rider is reading a trip, and a stray tap must not
  * trade the whole itinerary for one route (see [RouteBadgeTap]).
  *
- * These are also the map's only labels that follow the zoom (#2102), receding with the lines they name
- * rather than holding a fixed pixel size — see [ITINERARY_ROUTE_BADGE_SCALE_PROFILE].
+ * These follow the zoom (#2102), receding with the lines they name rather than holding a fixed pixel size
+ * — on the same schedule a focused stop's adjacency labels took later (#2195), see
+ * [ROUTE_BADGE_SCALE_PROFILE].
  */
 internal fun itineraryRouteBadges(
     legs: List<ItineraryDrawableLeg>,
@@ -278,7 +279,7 @@ internal fun itineraryRouteBadges(
                 routes = ride.badgedRoutes(palette),
                 paths = ridden.map { RouteBadgePath(it.drawable.points) },
                 tap = RouteBadgeTap.FocusItineraryRide(ridden.mapTo(mutableSetOf()) { it.drawable.index }),
-                scale = ITINERARY_ROUTE_BADGE_SCALE_PROFILE
+                scale = ROUTE_BADGE_SCALE_PROFILE
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -26,7 +26,6 @@ import org.onebusaway.android.map.layout.placeRouteBadges
 import org.onebusaway.android.map.render.BadgedRoute
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
-import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
@@ -246,8 +245,8 @@ internal data class ItinerarySubstitute(val route: InterchangeableRoute, val rou
  * trade the whole itinerary for one route (see [RouteBadgeTap]).
  *
  * These follow the zoom (#2102), receding with the lines they name rather than holding a fixed pixel size
- * — on the same schedule a focused stop's adjacency labels took later (#2195), see
- * [ROUTE_BADGE_SCALE_PROFILE].
+ * — on the map's one label schedule, which a focused stop's adjacency labels also take (#2195); see
+ * [RouteBadge.scale].
  */
 internal fun itineraryRouteBadges(
     legs: List<ItineraryDrawableLeg>,
@@ -278,8 +277,7 @@ internal fun itineraryRouteBadges(
             RouteBadgeRequest(
                 routes = ride.badgedRoutes(palette),
                 paths = ridden.map { RouteBadgePath(it.drawable.points) },
-                tap = RouteBadgeTap.FocusItineraryRide(ridden.mapTo(mutableSetOf()) { it.drawable.index }),
-                scale = ROUTE_BADGE_SCALE_PROFILE
+                tap = RouteBadgeTap.FocusItineraryRide(ridden.mapTo(mutableSetOf()) { it.drawable.index })
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -15,6 +15,7 @@ import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_APPROACH_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
@@ -154,6 +155,11 @@ internal fun FocusedTripGeometry.toTripFocusedRoutePolylines(
  * One badge model per successfully drawn route-direction, preserving the focused-trip order that
  * mirrors the arrivals drawer. The shared layout chooses stable geographic line-center anchors;
  * flavor renderers only draw them.
+ *
+ * Like a directions itinerary's ride labels, these follow the camera rather than holding a fixed pixel
+ * size (#2195): a focused stop's routes fan out from one point, so at an overview zoom their labels are
+ * both oversized against the lines they name and packed tightly enough to hide them — see
+ * [ROUTE_BADGE_SCALE_PROFILE].
  */
 internal fun FocusedTripGeometry.toRouteBadges(
     routes: List<ObaRoute>,
@@ -178,7 +184,8 @@ internal fun FocusedTripGeometry.toRouteBadges(
                 routes = listOf(BadgedRoute(spec.name, color)),
                 paths = spec.shapes.map { shape -> RouteBadgePath(shape.points) },
                 // An adjacency label is the way into its route: it names a route the rider hasn't opened.
-                tap = RouteBadgeTap.ShowRoute(spec.key)
+                tap = RouteBadgeTap.ShowRoute(spec.key),
+                scale = ROUTE_BADGE_SCALE_PROFILE
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -15,7 +15,6 @@ import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_APPROACH_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
-import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
@@ -156,10 +155,9 @@ internal fun FocusedTripGeometry.toTripFocusedRoutePolylines(
  * mirrors the arrivals drawer. The shared layout chooses stable geographic line-center anchors;
  * flavor renderers only draw them.
  *
- * Like a directions itinerary's ride labels, these follow the camera rather than holding a fixed pixel
- * size (#2195): a focused stop's routes fan out from one point, so at an overview zoom their labels are
- * both oversized against the lines they name and packed tightly enough to hide them — see
- * [ROUTE_BADGE_SCALE_PROFILE].
+ * These take the map's label schedule ([RouteBadge.scale]) rather than a fixed pixel size (#2195): a
+ * focused stop's routes fan out from one point, so at an overview zoom their labels are both oversized
+ * against the lines they name and packed tightly enough to hide them.
  */
 internal fun FocusedTripGeometry.toRouteBadges(
     routes: List<ObaRoute>,
@@ -184,8 +182,7 @@ internal fun FocusedTripGeometry.toRouteBadges(
                 routes = listOf(BadgedRoute(spec.name, color)),
                 paths = spec.shapes.map { shape -> RouteBadgePath(shape.points) },
                 // An adjacency label is the way into its route: it names a route the rider hasn't opened.
-                tap = RouteBadgeTap.ShowRoute(spec.key),
-                scale = ROUTE_BADGE_SCALE_PROFILE
+                tap = RouteBadgeTap.ShowRoute(spec.key)
             )
         }
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/layout/RouteBadgeLayout.kt
@@ -20,7 +20,7 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
 import org.onebusaway.android.map.render.BadgedRoute
-import org.onebusaway.android.map.render.FIXED_ROUTE_BADGE_SCALE_PROFILE
+import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeScaleProfile
 import org.onebusaway.android.map.render.RouteBadgeTap
@@ -89,14 +89,14 @@ fun <K> layoutRouteBadges(
 /**
  * One route label to place: the route(s) it names (stacked, in reading order — see [RouteBadge.routes]),
  * what a tap on it does (null for an inert label — see [RouteBadge.tap]), how its size answers the camera
- * (fixed unless the caller says otherwise — see [RouteBadge.scale]), and the shapes it may be anchored on.
- * List order is collision priority, as in [layoutRouteBadges].
+ * (the map's one label schedule unless the caller says otherwise — see [RouteBadge.scale]), and the shapes
+ * it may be anchored on. List order is collision priority, as in [layoutRouteBadges].
  */
 internal data class RouteBadgeRequest(
     val routes: List<BadgedRoute>,
     val paths: List<RouteBadgePath>,
     val tap: RouteBadgeTap? = null,
-    val scale: RouteBadgeScaleProfile = FIXED_ROUTE_BADGE_SCALE_PROFILE
+    val scale: RouteBadgeScaleProfile = ROUTE_BADGE_SCALE_PROFILE
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -129,9 +129,10 @@ private const val ROUTE_BADGE_SCALE_STEPS = 16f
  * [ContinuationBadgeBitmaps.badge] draws, ramped linearly across [rampStartZoom]..[rampEndZoom] and flat
  * on either side of it.
  *
- * A profile rather than a bare function for the reason [RouteLineWidthProfile] is one: the two kinds of
- * label on the map (adjacency, a directions itinerary's rides) answer the camera differently, and that
- * difference should be a value one of them carries rather than a branch in each renderer.
+ * A profile rather than a bare function for the reason [RouteLineWidthProfile] is one: it is carried
+ * unresolved on the label and resolved by each renderer against its live camera, so the day one kind of
+ * label should answer the camera differently from the rest, that is a value it carries rather than a
+ * branch in each renderer. Every label takes the same one today ([ROUTE_BADGE_SCALE_PROFILE]).
  */
 data class RouteBadgeScaleProfile(
     val distantScale: Float,
@@ -167,17 +168,10 @@ data class RouteBadgeScaleProfile(
 }
 
 /**
- * A label that draws at one size whatever the camera does. No label on the map takes it today — a
- * directions itinerary's rides were given a schedule by #2102 and focused-stop adjacency by #2195 — but
- * it stays the default a [RouteBadge] is born with, so a producer opts a label into a schedule rather
- * than inheriting one it never asked for.
- */
-val FIXED_ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(distantScale = 1f, closeScale = 1f)
-
-/**
- * The schedule a route label drawn on a line follows — a directions itinerary's rides (#2102) and a
- * focused stop's adjacency labels (#2195) alike — on the shared detail ramp and pointing the same way as
- * everything else it rides with: half size when zoomed out, full at zoom 16 and above.
+ * What a route label drawn on a line does about the camera, on every view that draws one — a directions
+ * itinerary's rides (#2102) and a focused stop's adjacency labels (#2195): the shared detail ramp,
+ * pointing the same way as everything else it rides with, at half size when zoomed out and full at zoom
+ * 16 and above.
  *
  * A label is a fixed number of screen pixels, so at an overview zoom it is enormous relative to the
  * geometry it annotates — several of them, anchored at line midpoints that are themselves close together
@@ -185,11 +179,12 @@ val FIXED_ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(distantScale = 1f, 
  * lines and stop circles around it ([RouteLineWidthProfile], [focusedRouteStopScale]) keeps the whole view
  * scaling as one thing, and hands the label its full size at the zoom where there's room for it.
  *
- * One schedule for both views rather than one apiece: the two are read against different backdrops
- * (adjacency sits over sibling routes and nearby stops, directions over a bare basemap), but they are the
- * same drawing answering the same problem, and a rider moving between the views should not find the map's
- * labels behaving differently in each. The day one of them should differ, the way to say so is a second
- * profile with its own name — not a branch in a renderer.
+ * This is the **default** a [RouteBadge] is born with rather than a schedule each producer opts into, and
+ * that is the lesson of #2195: #2102 gave the itinerary's labels a schedule while the default stayed a
+ * fixed pill, and adjacency — the older producer, in the more-used view — was simply left behind in it.
+ * A new kind of label should inherit what every other label does; a producer that wants
+ * something else says so with a profile of its own name, which is also how the two views would diverge
+ * (they are read against different backdrops, so they may yet) without a branch in a renderer.
  *
  * Deliberately a starting point to be tuned against the real map, not a settled value.
  */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -167,24 +167,33 @@ data class RouteBadgeScaleProfile(
 }
 
 /**
- * A label that draws at one size whatever the camera does — every route label but a directions
- * itinerary's, which is the only one #2102 gave a schedule to.
+ * A label that draws at one size whatever the camera does. No label on the map takes it today — a
+ * directions itinerary's rides were given a schedule by #2102 and focused-stop adjacency by #2195 — but
+ * it stays the default a [RouteBadge] is born with, so a producer opts a label into a schedule rather
+ * than inheriting one it never asked for.
  */
 val FIXED_ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(distantScale = 1f, closeScale = 1f)
 
 /**
- * A directions itinerary's ride labels (#2102), on the shared detail ramp and pointing the same way as
+ * The schedule a route label drawn on a line follows — a directions itinerary's rides (#2102) and a
+ * focused stop's adjacency labels (#2195) alike — on the shared detail ramp and pointing the same way as
  * everything else it rides with: half size when zoomed out, full at zoom 16 and above.
  *
  * A label is a fixed number of screen pixels, so at an overview zoom it is enormous relative to the
- * itinerary it annotates — several of them, anchored at leg midpoints that are themselves close together
+ * geometry it annotates — several of them, anchored at line midpoints that are themselves close together
  * out there, crowd each other and cover the shape the rider is trying to read. Receding with the route
  * lines and stop circles around it ([RouteLineWidthProfile], [focusedRouteStopScale]) keeps the whole view
  * scaling as one thing, and hands the label its full size at the zoom where there's room for it.
  *
+ * One schedule for both views rather than one apiece: the two are read against different backdrops
+ * (adjacency sits over sibling routes and nearby stops, directions over a bare basemap), but they are the
+ * same drawing answering the same problem, and a rider moving between the views should not find the map's
+ * labels behaving differently in each. The day one of them should differ, the way to say so is a second
+ * profile with its own name — not a branch in a renderer.
+ *
  * Deliberately a starting point to be tuned against the real map, not a settled value.
  */
-val ITINERARY_ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(
+val ROUTE_BADGE_SCALE_PROFILE = RouteBadgeScaleProfile(
     distantScale = ROUTE_DETAIL_DISTANT_SCALE,
     closeScale = 1f
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -375,8 +375,9 @@ data class RouteBadge(
      */
     val tap: RouteBadgeTap? = null,
     /**
-     * How this label's drawn size answers the camera (#2102) — see [RouteBadgeScaleProfile]. Fixed by
-     * default, so a producer opts its labels into a schedule rather than inheriting one.
+     * How this label's drawn size answers the camera (#2102, #2195) — see [RouteBadgeScaleProfile]. It
+     * defaults to what every label on the map does ([ROUTE_BADGE_SCALE_PROFILE]), so a new kind of label
+     * recedes with its line without having to know to ask; a producer that wants otherwise names its own.
      *
      * Carried as an unresolved *profile*, exactly as [RoutePolyline.widthProfile] is, with the renderer
      * resolving it against the live camera. That's the pattern for a **continuous** zoom response;
@@ -387,7 +388,7 @@ data class RouteBadge(
      * which tears down and rebuilds the whole static layer — bikes, generic pins, the continuation
      * overlay, every tap map. Resizing a label is not worth that, so the resolution stays in the renderer.
      */
-    val scale: RouteBadgeScaleProfile = FIXED_ROUTE_BADGE_SCALE_PROFILE
+    val scale: RouteBadgeScaleProfile = ROUTE_BADGE_SCALE_PROFILE
 ) {
     init {
         // Both stated rather than trusted: a label with nothing to read is a marker the rider can't

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -305,10 +305,10 @@ class MapLibreRenderer(
     }
 
     /**
-     * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102). A label on the
-     * fixed profile — every one but a directions itinerary's — resolves to the same scale either side of
-     * the move and is left alone, as is a scheduled one whose camera stayed within a flat end of its ramp
-     * or moved less than one quantization step (see [RouteBadgeScaleProfile.scaleAt]).
+     * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102, #2195). A label
+     * on the fixed profile resolves to the same scale either side of the move and is left alone, as is a
+     * scheduled one whose camera stayed within a flat end of its ramp or moved less than one quantization
+     * step (see [RouteBadgeScaleProfile.scaleAt]).
      */
     private fun updateRouteBadgeScale(zoom: Float) {
         val previous = renderedBadgeZoom
@@ -705,10 +705,11 @@ class MapLibreRenderer(
         private const val TRIP_BAND_WIDTH_DP = 6f
 
         // Sized to hold a whole zoom session's worth of the labels currently on the map, so panning the
-        // ramp end to end never evicts a label that is still drawn: a directions itinerary shows on the
-        // order of ten distinct pills, each of which can be asked for at any of the nine sizes
-        // [RouteBadgeScaleProfile.scaleAt]'s sixteenths quantize its ramp to, in either theme. Matches the
-        // Google flavor's DESCRIPTOR_CACHE_SIZE, which covers the same badges alongside its other icons.
+        // ramp end to end never evicts a label that is still drawn: a directions itinerary, or a focused
+        // stop's adjacent routes, shows on the order of ten distinct pills, each of which can be asked for
+        // at any of the nine sizes [RouteBadgeScaleProfile.scaleAt]'s sixteenths quantize its ramp to, in
+        // either theme. Matches the Google flavor's DESCRIPTOR_CACHE_SIZE, which covers the same badges
+        // alongside its other icons.
         private const val BADGE_ICON_CACHE_SIZE = 256
     }
 }

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -306,9 +306,8 @@ class MapLibreRenderer(
 
     /**
      * Re-stamp the route labels that draw at a different size at the settled [zoom] (#2102, #2195). A label
-     * on the fixed profile resolves to the same scale either side of the move and is left alone, as is a
-     * scheduled one whose camera stayed within a flat end of its ramp or moved less than one quantization
-     * step (see [RouteBadgeScaleProfile.scaleAt]).
+     * whose camera stayed within a flat end of its ramp, or moved less than one quantization step, resolves
+     * to the same scale either side of the move and is left alone (see [RouteBadgeScaleProfile.scaleAt]).
      */
     private fun updateRouteBadgeScale(zoom: Float) {
         val previous = renderedBadgeZoom

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryRouteBadgesTest.kt
@@ -8,7 +8,7 @@ import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.render.BadgedRoute
-import org.onebusaway.android.map.render.ITINERARY_ROUTE_BADGE_SCALE_PROFILE
+import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.util.GeoPoint
@@ -46,8 +46,8 @@ class ItineraryRouteBadgesTest {
         assertEquals(GeoPoint(0.0, 0.5), badge.point)
         // A tap lands back on the ride it names, never on that route's own map.
         assertEquals(RouteBadgeTap.FocusItineraryRide(setOf(1)), badge.tap)
-        // And it follows the zoom (#2102) rather than holding a fixed size, unlike every other label.
-        assertEquals(ITINERARY_ROUTE_BADGE_SCALE_PROFILE, badge.scale)
+        // And it follows the zoom (#2102) rather than holding a fixed size, on the map's one label schedule.
+        assertEquals(ROUTE_BADGE_SCALE_PROFILE, badge.scale)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -7,8 +7,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.DETAIL_RAMP_END_ZOOM
+import org.onebusaway.android.map.render.DETAIL_RAMP_START_ZOOM
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
+import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
@@ -304,6 +307,22 @@ class RouteViewGeometryTest {
         )
 
         assertEquals(listOf("known-route"), badges.map { it.showRouteTap?.routeId })
+    }
+
+    @Test
+    fun `an adjacency label recedes with the map rather than holding a fixed size`() {
+        // A focused stop's routes all leave one point, so their labels are packed tightest exactly where a
+        // fixed-size label is largest against the lines it names — the overview zoom the rider opens the
+        // stop at (#2195). Asserted as the profile the directions map's ride labels carry, since the point
+        // is that the two views answer the camera the same way, not that this one has a schedule at all.
+        val points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0))
+        val geometry = FocusedTripGeometry(listOf(FocusedTripShape("shape", "route", null, points)))
+
+        val badge = geometry.toRouteBadges(listOf(route("route", "A"))).single()
+
+        assertEquals(ROUTE_BADGE_SCALE_PROFILE, badge.scale)
+        assertEquals(0.5f, badge.scale.scaleAt(DETAIL_RAMP_START_ZOOM), 0f)
+        assertEquals(1f, badge.scale.scaleAt(DETAIL_RAMP_END_ZOOM), 0f)
     }
 
     /** The route-direction an adjacency label opens; null if the label leads elsewhere or nowhere. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -7,8 +7,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.ADJACENT_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE
-import org.onebusaway.android.map.render.DETAIL_RAMP_END_ZOOM
-import org.onebusaway.android.map.render.DETAIL_RAMP_START_ZOOM
 import org.onebusaway.android.map.render.FOCUSED_ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_CONTEXT_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
@@ -313,16 +311,14 @@ class RouteViewGeometryTest {
     fun `an adjacency label recedes with the map rather than holding a fixed size`() {
         // A focused stop's routes all leave one point, so their labels are packed tightest exactly where a
         // fixed-size label is largest against the lines it names — the overview zoom the rider opens the
-        // stop at (#2195). Asserted as the profile the directions map's ride labels carry, since the point
-        // is that the two views answer the camera the same way, not that this one has a schedule at all.
+        // stop at (#2195). Asserted here, on the badges this view actually produces, rather than left to
+        // the RouteBadge default that supplies it: what the rider gets is the thing worth pinning.
         val points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0))
         val geometry = FocusedTripGeometry(listOf(FocusedTripShape("shape", "route", null, points)))
 
         val badge = geometry.toRouteBadges(listOf(route("route", "A"))).single()
 
         assertEquals(ROUTE_BADGE_SCALE_PROFILE, badge.scale)
-        assertEquals(0.5f, badge.scale.scaleAt(DETAIL_RAMP_START_ZOOM), 0f)
-        assertEquals(1f, badge.scale.scaleAt(DETAIL_RAMP_END_ZOOM), 0f)
     }
 
     /** The route-direction an adjacency label opens; null if the label leads elsewhere or nowhere. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeScaleProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeScaleProfileTest.kt
@@ -19,16 +19,16 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/** The zoom schedule a route label's drawn size follows (#2102). */
+/** The zoom schedule a route label's drawn size follows (#2102, #2195). */
 class RouteBadgeScaleProfileTest {
 
     @Test
-    fun `an itinerary label grows from half to full between zoom 11 and 16, flat outside`() {
-        assertEquals(0.5f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(8f), 0f)
-        assertEquals(0.5f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(11f), 0f)
-        assertEquals(0.75f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(13.5f), 0f)
-        assertEquals(1f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(16f), 0f)
-        assertEquals(1f, ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(20f), 0f)
+    fun `a line's label grows from half to full between zoom 11 and 16, flat outside`() {
+        assertEquals(0.5f, ROUTE_BADGE_SCALE_PROFILE.scaleAt(8f), 0f)
+        assertEquals(0.5f, ROUTE_BADGE_SCALE_PROFILE.scaleAt(11f), 0f)
+        assertEquals(0.75f, ROUTE_BADGE_SCALE_PROFILE.scaleAt(13.5f), 0f)
+        assertEquals(1f, ROUTE_BADGE_SCALE_PROFILE.scaleAt(16f), 0f)
+        assertEquals(1f, ROUTE_BADGE_SCALE_PROFILE.scaleAt(20f), 0f)
     }
 
     @Test
@@ -42,7 +42,7 @@ class RouteBadgeScaleProfileTest {
         for (zoom in listOf(8f, 11f, 13.5f, 16f, 20f)) {
             assertEquals(
                 ITINERARY_RIDE_WIDTH_PROFILE.multiplierAt(zoom),
-                ITINERARY_ROUTE_BADGE_SCALE_PROFILE.scaleAt(zoom),
+                ROUTE_BADGE_SCALE_PROFILE.scaleAt(zoom),
                 0f
             )
         }
@@ -55,7 +55,7 @@ class RouteBadgeScaleProfileTest {
         // handful of values, not one per camera idle. Sampled far more finely than a user could pinch.
         val scales = generateSequence(DETAIL_RAMP_START_ZOOM) { it + 0.01f }
             .takeWhile { it <= DETAIL_RAMP_END_ZOOM }
-            .map(ITINERARY_ROUTE_BADGE_SCALE_PROFILE::scaleAt)
+            .map(ROUTE_BADGE_SCALE_PROFILE::scaleAt)
             .toSet()
 
         assertTrue("500 sampled zooms should collapse to a few scales, got ${scales.size}", scales.size <= 12)
@@ -66,9 +66,11 @@ class RouteBadgeScaleProfileTest {
     }
 
     @Test
-    fun `every other label holds one size at every zoom`() {
-        // The default a RouteBadge takes, so adjacency labels (#1827) and the continuation badge (#1691) are
-        // untouched by all this — and a renderer's re-stamp on camera settle can skip them entirely.
+    fun `a label that opts out of the schedule holds one size at every zoom`() {
+        // The default a RouteBadge takes when its producer says nothing, which is what lets a renderer's
+        // re-stamp on camera settle skip such a label entirely. Both of the map's labels-on-a-line now opt
+        // in (#2102, #2195), so nothing takes this today — but it is the behaviour the default promises,
+        // and a producer that means it has to keep getting it.
         for (zoom in 1..21) {
             assertEquals(1f, FIXED_ROUTE_BADGE_SCALE_PROFILE.scaleAt(zoom.toFloat()), 0f)
         }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeScaleProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteBadgeScaleProfileTest.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.map.render
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.util.GeoPoint
 
 /** The zoom schedule a route label's drawn size follows (#2102, #2195). */
 class RouteBadgeScaleProfileTest {
@@ -66,13 +67,12 @@ class RouteBadgeScaleProfileTest {
     }
 
     @Test
-    fun `a label that opts out of the schedule holds one size at every zoom`() {
-        // The default a RouteBadge takes when its producer says nothing, which is what lets a renderer's
-        // re-stamp on camera settle skip such a label entirely. Both of the map's labels-on-a-line now opt
-        // in (#2102, #2195), so nothing takes this today — but it is the behaviour the default promises,
-        // and a producer that means it has to keep getting it.
-        for (zoom in 1..21) {
-            assertEquals(1f, FIXED_ROUTE_BADGE_SCALE_PROFILE.scaleAt(zoom.toFloat()), 0f)
-        }
+    fun `it is what a label is born with, so a new one recedes without knowing to ask`() {
+        // #2195 in one assertion: the schedule is the RouteBadge default, not something each producer opts
+        // into. #2102 gave the itinerary's labels a schedule and left the default fixed, which is how
+        // adjacency — the older producer — went on drawing full-size pills at every zoom.
+        val badge = RouteBadge(routes = listOf(BadgedRoute("A", 0xFF123456.toInt())), point = GeoPoint(0.0, 0.0))
+
+        assertEquals(ROUTE_BADGE_SCALE_PROFILE, badge.scale)
     }
 }


### PR DESCRIPTION
Fixes #2195.

A focused stop's adjacency labels held a fixed pixel size at every zoom. At the overview zoom a rider actually opens a stop at, that made them enormous against the thin lines they name — and since a stop's routes all fan out from one point, the labels are packed tightest exactly there, covering the geometry they exist to identify. Everything else in that view already recedes on the shared detail ramp: the adjacency lines (`ADJACENT_ROUTE_LINE_WIDTH_PROFILE`) and the focused-stop circles (`focusedRouteStopScale`). The labels were the one fixed-size element left.

A directions itinerary's ride labels already answer this (#2102) by riding the same ramp — half size when zoomed out, full at zoom 16 and above, quantized to sixteenths so a camera settle inside the ramp hits the badge bitmap cache instead of minting a new pill.

**The fix is the default, not an opt-in.** The first commit simply opted adjacency into the itinerary's profile. That left `FIXED_ROUTE_BADGE_SCALE_PROFILE` with no producer at all — and a default nothing takes is precisely the trap this issue walked into: #2102 gave the itinerary's labels a schedule while the default stayed a fixed pill, so adjacency, the older producer in the more-used view, was quietly left behind in it. The second commit therefore makes the ramp the default of `RouteBadge.scale` / `RouteBadgeRequest.scale`, deletes the fixed profile, and drops the explicit `scale =` at both producers. A new kind of label now recedes with its line without knowing to ask; a producer that wants otherwise names a profile of its own, which is also how the two views would diverge later without a branch in a renderer.

No renderer logic changed — both flavors already resolve each label's profile against the live camera and re-stamp on settle. The renderer edits are the KDoc sentence about a fixed-profile label being left alone (no such label exists now; the real early-out is scale equality across the settle) and one cache constant.

### Performance
Google's `BitmapDescriptorCache` is shared with the vehicle icons that re-stamp at ~20Hz on heading changes, and labels are now the larger half of its working set — a busy stop's dozen adjacency labels, each askable at any of the nine quantized sizes. Raised `DESCRIPTOR_CACHE_SIZE` 256 → 384 so a zoom-out sweep can't evict the vehicle icons. maplibre already gives labels their own cache.

Two knobs deliberately left alone, flagged for a human call:
- `ROUTE_BADGE_SCALE_STEPS` (16) and the 0.5 distant scale are #2102's tuning, whose own KDoc calls them "a starting point to be tuned against the real map." Halving the step count would cut retained label bitmaps ~44%, but that retunes shipped directions behaviour and belongs in its own change.
- The route-continuation badge (#1691) is a third label-on-a-line that sits outside this mechanism entirely (its own model, hardcoded scale 1f), so it still holds a fixed size while its line ramps. It can't co-occur with adjacency labels, so this isn't an inconsistency inside one view — but it is the same complaint, unfixed, in the route-continuation view. Worth its own issue.

### Testing
- `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` with `-PwarningsAsErrors=true`: clean
- `testObaGoogleDebugUnitTest`: passing
- `spotlessCheck`: clean
- Lint left to CI, per CLAUDE.md

**Not verified on a device.** This node has no emulator and the test phone is shared, so the new size hasn't been eyeballed on a real map — worth a look before merge, since the distant scale is inherited tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Route labels and badges now scale smoothly with map zoom across itineraries, directions, and adjacent routes.
  * Consistent scaling behavior is applied to newly displayed route badges.
  * Improved map rendering performance and label retention while zooming.
* **Documentation**
  * Clarified zoom-based route-label scaling and map label caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->