### PR TITLE
Show every bay's departures at transit-centre zoom (#2107)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt
@@ -309,6 +309,53 @@ data class ArrivalsForStop(
 )
 
 /**
+ * The arrivals-and-departures-for-location entry: every [arrivalsAndDepartures] at every stop inside
+ * the queried bounding box, in one response. Each arrival names its own `stopId`, so the bays to show
+ * are the distinct stop ids *on the arrivals themselves*, resolved against [References.stop] — **not**
+ * [stopIds] (which repeats ids: one per matched arrival group, so a box of 8 stops answered with 16
+ * entries) and not `references.stops` (a pool that also carries nearby + trip stops — 126 of them for
+ * those same 8 bays).
+ *
+ * [limitExceeded] reports that more matched than were returned. Note the server truncates the
+ * *arrivals* list, not the stop list, so a truncated response drops whole bays rather than trimming
+ * each one — which is why the caller leaves `maxCount` at the server default (see
+ * [org.onebusaway.android.api.data.NearbyArrivalsDataSource]).
+ */
+@Serializable
+data class ArrivalsForLocation(
+    val arrivalsAndDepartures: List<ArrivalDeparture> = emptyList(),
+    val nearbyStopIds: List<NearbyStop> = emptyList(),
+    val situationIds: List<String> = emptyList(),
+    val stopIds: List<String> = emptyList(),
+    val limitExceeded: Boolean = false
+)
+
+/** A stop near the query point ("across the street"), with its distance from that point in metres. */
+@Serializable
+data class NearbyStop(
+    val stopId: String = "",
+    val distanceFromQuery: Double = 0.0
+)
+
+/**
+ * The `data` shape of arrivals-and-departures-for-location. Unlike every other single-entry endpoint
+ * this one cannot use [EntryWithReferences], because the server answers a box containing **no stops**
+ * with a different shape: `ArrivalsAndDeparturesForLocationAction.emptyResponse()` returns the raw
+ * `StopsWithArrivalsAndDeparturesBean` (a flat `{arrivalsAndDepartures, nearbyStops, situations,
+ * stops, timeZone, limitExceeded}`), while the populated path wraps it through
+ * `factory.getResponse(...)` into the usual `{entry, references}`. So `entry` is genuinely absent on
+ * that path — verified identical on all four regions that serve this endpoint — and a non-nullable
+ * field here would make panning onto water throw instead of showing an empty list.
+ *
+ * A null [entry] therefore means "no stops in the box", not a malformed response.
+ */
+@Serializable
+data class ArrivalsForLocationData(
+    val entry: ArrivalsForLocation? = null,
+    val references: References = References()
+)
+
+/**
  * One predicted/scheduled arrival-departure at a stop. Wire names `tripHeadsign`/`routeShortName`
  * match the API; times are epoch millis; occupancy/status are wire strings mapped to the display
  * enums by the projection. Only the fields the arrivals projection reads are modeled.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt
@@ -133,6 +133,32 @@ interface ObaWebService {
     ): ObaEnvelope<EntryWithReferences<ArrivalsForStop>>
 
     /**
+     * arrivals-and-departures-for-location — real-time arrivals at **every** stop in the [latSpan] /
+     * [lonSpan] box around [lat]/[lon], in one request, with the stops/routes/trips/situations in the
+     * references. The transit-centre drawer (#2107) reads a whole viewport with this instead of one
+     * request per bay.
+     *
+     * Not on developer.onebusaway.org (docs PR OneBusAway/onebusaway-docs#166 is open to add it), but
+     * implemented in onebusaway-application-modules since 2022 as
+     * `ArrivalsAndDeparturesForLocationAction` and documented in that repo's own
+     * `src/site/markdown/api/where/methods/arrivals-and-departures-for-location.md`. **Older and
+     * forked deployments answer HTTP 404** — see [org.onebusaway.android.api.data.NearbyArrivalsDataSource]
+     * for how that is read as "this region doesn't serve it".
+     *
+     * No `maxCount`: the server truncates the *arrivals* list rather than the stop list, so capping it
+     * drops whole bays out of the response instead of trimming each one. The window ([minutesAfter])
+     * is the response-size lever instead.
+     */
+    @GET("api/where/arrivals-and-departures-for-location.json")
+    suspend fun arrivalsAndDeparturesForLocation(
+        @Query("lat") lat: Double,
+        @Query("lon") lon: Double,
+        @Query("latSpan") latSpan: Double,
+        @Query("lonSpan") lonSpan: Double,
+        @Query("minutesAfter") minutesAfter: Int? = null
+    ): ObaEnvelope<ArrivalsForLocationData>
+
+    /**
      * current-time — the OBA server's current time, used to sync the client clock to the server.
      * {http://developer.onebusaway.org/.../api/where/methods/current-time.html}
      */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsDataSource.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import android.util.Log
+import java.net.HttpURLConnection
+import javax.inject.Inject
+import org.onebusaway.android.api.adapters.DtoRoute
+import org.onebusaway.android.api.adapters.DtoStop
+import org.onebusaway.android.api.adapters.asArrivalData
+import org.onebusaway.android.api.contract.ArrivalsForLocationData
+import org.onebusaway.android.api.net.ObaApiProvider
+import org.onebusaway.android.api.requireData
+import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.models.ObaRoute
+import org.onebusaway.android.models.ObaSituation
+import org.onebusaway.android.models.ObaStop
+import org.onebusaway.android.time.ServerTime
+import retrofit2.HttpException
+
+/**
+ * A resolved snapshot of every stop's arrivals inside one viewport, from a single
+ * arrivals-and-departures-for-location response (#2107). The stop-scoped sibling is [StopArrivals];
+ * this exposes the same `models` interfaces so the UI never sees a wire DTO, and keeps the envelope
+ * private the same way.
+ */
+class NearbyArrivals internal constructor(
+    private val data: ArrivalsForLocationData,
+    /**
+     * The server clock this response was rendered at — the baseline every ETA below is measured
+     * against, so device clock skew cancels (#1612). Minted here at the wire boundary rather than
+     * carried as a bare `Long` for each consumer to wrap (#1620).
+     */
+    val serverNow: ServerTime,
+    /** The effective minutes-after window this response was fetched with. */
+    val minutesAfter: Int
+) {
+    private val refs get() = data.references
+
+    /**
+     * True when more matched the box than the server returned. Worth surfacing rather than ignoring:
+     * the server truncates the *arrivals* list ordered by distance from the query centre, so a
+     * truncated response drops the farthest bays outright instead of trimming each one — a rider
+     * could find their bay simply absent with nothing on screen saying so.
+     */
+    val limitExceeded: Boolean get() = data.entry?.limitExceeded ?: false
+
+    /**
+     * Every arrival at every stop in the box, adapted to [ArrivalData], with unrecoverable corrupt
+     * timestamps dropped and duplicate trip instances collapsed — the same treatment
+     * [StopArrivals.arrivals] gives one stop's list (#1710 / #2012). `directionId` is resolved off
+     * the trip references, since the arrival elements don't carry it (as on the per-stop path).
+     *
+     * A null `entry` is the server's own empty-box answer, not a broken response (see
+     * `ArrivalsForLocationData`), so it resolves to no arrivals rather than an error.
+     */
+    val arrivals: List<ArrivalData>
+        get() = data.entry?.arrivalsAndDepartures.orEmpty()
+            .mapNotNull { it.asArrivalData(refs.trip(it.tripId)?.directionId?.toIntOrNull()) }
+            .collapseDuplicateTripInstances { tripId -> refs.trip(tripId)?.blockId }
+
+    /** Resolves a bay from the references pool by id, or null when absent. */
+    fun stop(id: String): ObaStop? = refs.stop(id)?.let(::DtoStop)
+
+    /** Resolves a route from the references pool by id, or null when absent. */
+    fun route(id: String): ObaRoute? = refs.route(id)?.let(::DtoRoute)
+
+    /** Resolves a route's agency name from the references pool, or null. */
+    fun agencyName(id: String): String? = refs.agency(id)?.name
+
+    /**
+     * Every service alert this response references: the box-level ones plus every alert an arrival
+     * names, de-duplicated by id with order preserved — matching [StopArrivals.situations].
+     */
+    fun situations(): List<ObaSituation> {
+        val entry = data.entry ?: return emptyList()
+        val arrivalSituationIds = entry.arrivalsAndDepartures.flatMap { it.situationIds }
+        return (entry.situationIds + arrivalSituationIds)
+            .distinct()
+            .mapNotNull { refs.situation(it) }
+            .map(::DtoSituation)
+    }
+}
+
+/** One viewport's arrivals fetch, or the verdict that this region cannot serve them. */
+sealed interface NearbyArrivalsResult {
+
+    /** The response, resolved. Its `arrivals` may be empty — a box with no stops in it. */
+    data class Loaded(val arrivals: NearbyArrivals) : NearbyArrivalsResult
+
+    /**
+     * This region's server does not implement arrivals-and-departures-for-location: it answered HTTP
+     * 404. A durable fact about the deployment, not an error to retry — see [isEndpointAbsent].
+     */
+    data object Unsupported : NearbyArrivalsResult
+
+    /** A transient failure (transport, timeout, a non-OK OBA envelope code). Retry on the next poll. */
+    data class Failed(val cause: Throwable) : NearbyArrivalsResult
+}
+
+/** Fetches every stop's arrivals inside a viewport in one request (#2107). */
+interface NearbyArrivalsDataSource {
+
+    /**
+     * One viewport's arrivals at [minutesAfter]. Never throws, and deliberately not a `Result`: the
+     * three outcomes the caller has to tell apart are a response, an unsupported region, and a
+     * transient failure, and folding the middle one into `failure` is exactly the conflation that
+     * would switch the feature off on a timeout.
+     */
+    suspend fun arrivals(viewport: CameraSnapshot, minutesAfter: Int): NearbyArrivalsResult
+}
+
+class DefaultNearbyArrivalsDataSource @Inject constructor(
+    private val api: ObaApiProvider
+) : NearbyArrivalsDataSource {
+
+    override suspend fun arrivals(
+        viewport: CameraSnapshot,
+        minutesAfter: Int
+    ): NearbyArrivalsResult {
+        val result = api.call {
+            val envelope = it.arrivalsAndDeparturesForLocation(
+                lat = viewport.center.latitude,
+                lon = viewport.center.longitude,
+                latSpan = viewport.latSpan,
+                lonSpan = viewport.lonSpan,
+                minutesAfter = minutesAfter
+            )
+            NearbyArrivals(
+                envelope.requireData(),
+                ServerTime(serverNowOrDeviceClock(envelope.currentTime)),
+                minutesAfter
+            )
+        }
+        return result.fold(
+            onSuccess = { NearbyArrivalsResult.Loaded(it) },
+            onFailure = { cause ->
+                if (isEndpointAbsent(cause)) {
+                    Log.i(TAG, "Region does not serve arrivals-and-departures-for-location")
+                    NearbyArrivalsResult.Unsupported
+                } else {
+                    Log.e(TAG, "nearby arrivals failed", cause)
+                    NearbyArrivalsResult.Failed(cause)
+                }
+            }
+        )
+    }
+
+    private companion object {
+        const val TAG = "NearbyArrivalsDataSource"
+    }
+}
+
+/**
+ * Whether a failure says this server has no such endpoint. **HTTP 404 and nothing else.**
+ *
+ * Not an inference about the response — an explicit statement from the transport that the resource
+ * does not exist, read off the status line before any decoding. It has to be read from the code
+ * rather than the body because a deployment lacking the endpoint answers with whatever its container
+ * serves: the San Diego region returns a raw Tomcat HTML error page, which no JSON decode could
+ * classify. And there is no legitimate 404 on this path for a server that *does* implement the
+ * action — the path is fixed and the query carries only a viewport, so an empty box is answered with
+ * an empty response, never a 404.
+ *
+ * Deliberately narrow, keyed on the *HTTP* status alone. An OBA envelope code of 404 arrives as
+ * [org.onebusaway.android.api.ObaApiException] and stays transient, as do timeouts, TLS failures,
+ * 5xx, and parse errors — all things that happen to regions which do serve this endpoint. Nothing
+ * but an explicit HTTP 404 switches the feature off.
+ *
+ * Failure mode: a server that implements the action but sits behind a proxy 404-ing it for an
+ * unrelated reason loses the drawer until the process restarts. Tolerable because the verdict is
+ * held in memory only and re-probed on the next launch (see `NearbyArrivalsSupport`).
+ */
+internal fun isEndpointAbsent(error: Throwable): Boolean = error is HttpException && error.code() == HttpURLConnection.HTTP_NOT_FOUND

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsSupport.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsSupport.kt
@@ -19,38 +19,49 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Which regions have been found not to serve arrivals-and-departures-for-location (#2107).
+ * Which OBA deployments have been found not to serve arrivals-and-departures-for-location (#2107).
  *
- * The endpoint reached onebusaway-application-modules in 2022, so whether a region answers it is a
+ * The endpoint reached onebusaway-application-modules in 2022, so whether a server answers it is a
  * property of how old that deployment is — a fact no directory field records. `RegionDto` carries
  * `supportsObaDiscoveryApis` / `supportsObaRealtimeApis` but nothing for this, and adding one would
  * mean the regions directory, the bundled `regions_v3.json`, and `tools/check-regions-drift.py`'s
  * `CHECKED_FIELDS` all had to agree before a single rider benefited. So it is discovered instead:
  * ask once, and believe an explicit HTTP 404 ([isEndpointAbsent]).
  *
- * **Held in memory only, deliberately.** Persisting the verdict would pin a region off across
- * launches, so a deployment that upgraded would need either a TTL — a magic number, and one nobody
- * can derive — or a manual invalidation with nothing to invalidate against. Re-probing each process
- * costs one request per unsupported region per launch, which is nothing next to being wrong until a
+ * **Held in memory only, deliberately.** Persisting the verdict would pin a deployment off across
+ * launches, so a server that upgraded would need either a TTL — a magic number, and one nobody can
+ * derive — or a manual invalidation with nothing to invalidate against. Re-probing each process costs
+ * one request per unsupported deployment per launch, which is nothing next to being wrong until a
  * reinstall.
  *
- * Keyed by region id, since the verdict is about one deployment; a region switch needs no reset,
- * because an unknown id is simply un-probed. Reads and writes come from the arrivals query on its
- * own coroutines, hence the synchronized access rather than a plain field.
+ * **Keyed by the OBA base URL, not by `Region.id`.** The verdict is a statement about the *server*
+ * that answered, and the region is only how the app happens to reach one: a directory refresh can
+ * repoint an existing region's `obaBaseUrl` at a different deployment under the same id, and a
+ * deep-link-added custom region is a host the directory never named. Keying on our primary key would
+ * carry a 404 from one server across to another and leave the drawer switched off where it would in
+ * fact work. An unknown endpoint is simply un-probed, so a region switch needs no reset.
+ *
+ * The one thing this key does not distinguish is a user-entered custom API URL
+ * (`preference_key_oba_api_url`, applied by `ObaEndpointResolver` ahead of the region): overriding it
+ * without changing regions reuses the region's verdict. That preference is a developer-facing escape
+ * hatch, and the cost is one stale in-memory verdict until the next launch.
+ *
+ * Reads and writes come from the arrivals query on its own coroutines, hence the synchronized access
+ * rather than a plain field.
  */
 @Singleton
 class NearbyArrivalsSupport @Inject constructor() {
 
-    private val unsupported = mutableSetOf<Long>()
+    private val unsupported = mutableSetOf<String>()
 
-    /** Whether [regionId] is already known not to serve the endpoint. Unknown ids read as supported
-     *  (un-probed), which is what makes the first query the probe. */
+    /** Whether [obaBaseUrl] is already known not to serve the endpoint. Unknown (and null) endpoints
+     *  read as supported (un-probed), which is what makes the first query the probe. */
     @Synchronized
-    fun isKnownUnsupported(regionId: Long?): Boolean = regionId != null && regionId in unsupported
+    fun isKnownUnsupported(obaBaseUrl: String?): Boolean = obaBaseUrl != null && obaBaseUrl in unsupported
 
-    /** Record that [regionId]'s server answered 404 for the endpoint. */
+    /** Record that the deployment at [obaBaseUrl] answered 404 for the endpoint. */
     @Synchronized
-    fun recordAbsent(regionId: Long?) {
-        regionId?.let(unsupported::add)
+    fun recordAbsent(obaBaseUrl: String?) {
+        obaBaseUrl?.let(unsupported::add)
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsSupport.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsSupport.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api.data
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Which regions have been found not to serve arrivals-and-departures-for-location (#2107).
+ *
+ * The endpoint reached onebusaway-application-modules in 2022, so whether a region answers it is a
+ * property of how old that deployment is — a fact no directory field records. `RegionDto` carries
+ * `supportsObaDiscoveryApis` / `supportsObaRealtimeApis` but nothing for this, and adding one would
+ * mean the regions directory, the bundled `regions_v3.json`, and `tools/check-regions-drift.py`'s
+ * `CHECKED_FIELDS` all had to agree before a single rider benefited. So it is discovered instead:
+ * ask once, and believe an explicit HTTP 404 ([isEndpointAbsent]).
+ *
+ * **Held in memory only, deliberately.** Persisting the verdict would pin a region off across
+ * launches, so a deployment that upgraded would need either a TTL — a magic number, and one nobody
+ * can derive — or a manual invalidation with nothing to invalidate against. Re-probing each process
+ * costs one request per unsupported region per launch, which is nothing next to being wrong until a
+ * reinstall.
+ *
+ * Keyed by region id, since the verdict is about one deployment; a region switch needs no reset,
+ * because an unknown id is simply un-probed. Reads and writes come from the arrivals query on its
+ * own coroutines, hence the synchronized access rather than a plain field.
+ */
+@Singleton
+class NearbyArrivalsSupport @Inject constructor() {
+
+    private val unsupported = mutableSetOf<Long>()
+
+    /** Whether [regionId] is already known not to serve the endpoint. Unknown ids read as supported
+     *  (un-probed), which is what makes the first query the probe. */
+    @Synchronized
+    fun isKnownUnsupported(regionId: Long?): Boolean = regionId != null && regionId in unsupported
+
+    /** Record that [regionId]'s server answered 404 for the endpoint. */
+    @Synchronized
+    fun recordAbsent(regionId: Long?) {
+        regionId?.let(unsupported::add)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/di/RepositoryModule.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.api.data.AgenciesDataSource
 import org.onebusaway.android.api.data.DefaultAgenciesDataSource
 import org.onebusaway.android.api.data.DefaultLocationSearchDataSource
 import org.onebusaway.android.api.data.DefaultMapDataSource
+import org.onebusaway.android.api.data.DefaultNearbyArrivalsDataSource
 import org.onebusaway.android.api.data.DefaultProblemReportDataSource
 import org.onebusaway.android.api.data.DefaultRouteDataSource
 import org.onebusaway.android.api.data.DefaultStopArrivalsDataSource
@@ -33,6 +34,7 @@ import org.onebusaway.android.api.data.DefaultTripDetailsDataSource
 import org.onebusaway.android.api.data.DefaultTripVehiclesDataSource
 import org.onebusaway.android.api.data.LocationSearchDataSource
 import org.onebusaway.android.api.data.MapDataSource
+import org.onebusaway.android.api.data.NearbyArrivalsDataSource
 import org.onebusaway.android.api.data.ProblemReportDataSource
 import org.onebusaway.android.api.data.RouteDataSource
 import org.onebusaway.android.api.data.StopArrivalsDataSource
@@ -166,6 +168,11 @@ abstract class RepositoryModule {
     abstract fun bindStopArrivalsDataSource(
         impl: DefaultStopArrivalsDataSource
     ): StopArrivalsDataSource
+
+    @Binds
+    abstract fun bindNearbyArrivalsDataSource(
+        impl: DefaultNearbyArrivalsDataSource
+    ): NearbyArrivalsDataSource
 
     @Binds
     abstract fun bindTripDetailsDataSource(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapDecisions.kt
@@ -18,6 +18,11 @@ package org.onebusaway.android.map
 import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.haversineMeters
@@ -27,6 +32,23 @@ import org.onebusaway.android.util.PreferenceUtils
 
 /** Debounce before reacting to a camera move, matching the old MapWatcher poll cadence (stops + bikes). */
 internal const val STOP_LOAD_DEBOUNCE_MS = 250L
+
+/**
+ * The settled-viewport stream every viewport-scoped loader shares: debounce [STOP_LOAD_DEBOUNCE_MS],
+ * then drop any emission that lands while a gesture is still in flight — the gesture's terminating
+ * camera-idle re-arms the debounce and fires one emission at the true drag-end. Combined, these keep a
+ * whole pan to a single load instead of one per intermediate settle, which is what killed the mid-pan
+ * jank.
+ *
+ * One definition, so the stop loader, the rental loader, and the transit-centre arrivals query (#2107)
+ * cannot drift apart on what "settled" means — the expression was previously duplicated verbatim in
+ * the first two.
+ */
+@OptIn(FlowPreview::class)
+internal fun MapHost.settledCamera(): Flow<CameraSnapshot> = camera
+    .filterNotNull()
+    .debounce(STOP_LOAD_DEBOUNCE_MS)
+    .filter { !cameraInteracting.value }
 
 /** The map's initial camera (point + zoom) before the loaders / region centering take over. */
 data class MapCameraSeed(val point: GeoPoint, val zoom: Float)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RentalLayerController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RentalLayerController.kt
@@ -17,17 +17,13 @@ package org.onebusaway.android.map
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
@@ -61,7 +57,7 @@ import org.onebusaway.android.util.toLocation
  * so turning both on costs exactly one request; the split happens in [rentalLayersOf] after the
  * response lands.
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class RentalLayerController(
     private val host: MapHost,
     private val rentalPlacesRepository: RentalPlacesRepository,
@@ -149,8 +145,7 @@ class RentalLayerController(
             combine(
                 // Settle on drag-end, matching the stop loader: hold the load until the gesture
                 // settles so a pan fires one load at drag-end, not one per intermediate camera-idle.
-                host.camera.filterNotNull().debounce(STOP_LOAD_DEBOUNCE_MS)
-                    .filter { !host.cameraInteracting.value },
+                host.settledCamera(),
                 visibleLayers,
                 // The rental server itself is an input, not a fact read once inside the collector: a
                 // region switch changes which endpoint answers, and neither the camera nor the toggles

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -20,12 +20,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -68,7 +65,7 @@ import org.onebusaway.android.util.toGeoPoint
  * route-header camera bias on programmatic focus is supplied by [routeActive] (the home map passes a
  * route-mode predicate; standalone stop maps leave it false).
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class StopsMapController(
     private val host: MapHost,
     private val mapDataSource: MapDataSource,
@@ -184,15 +181,7 @@ class StopsMapController(
         var lastHadResponse = false
         var lastLimitExceeded = false
 
-        host.camera
-            .filterNotNull()
-            .debounce(STOP_LOAD_DEBOUNCE_MS)
-            // Settle on drag-end: if the debounce elapses while a gesture is still in flight (the user is
-            // mid-pan, or a fling that emitted an intermediate idle is still going), drop this viewport —
-            // the gesture's terminating camera-idle re-arms the debounce and fires one load at the true
-            // drag-end. Combined with the debounce this keeps a whole pan to a single load + redraw
-            // instead of one per intermediate settle, killing the mid-pan jank.
-            .filter { !host.cameraInteracting.value }
+        host.settledCamera()
             .filterNot { next -> stopRequestFulfilled(lastLoad, lastHadResponse, lastLimitExceeded, next) }
             .flatMapLatest { snapshot ->
                 // flatMapLatest cancels an in-flight load when a newer viewport arrives, matching the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -65,6 +65,20 @@ const val STOP_ROUTE_LABEL_Z_INDEX = 1f
 enum class StopBand { DOT, FULL, ROUTES }
 
 /**
+ * Whether this band is close enough in for the transit-centre arrivals drawer (#2107) — the zoom at
+ * which route *labels* appear is the zoom at which their *departures* are worth listing.
+ *
+ * One definition, read by both the query that asks and the sheet decision that shows the answer: if
+ * they disagreed, the drawer could gate on a band the query does not serve (an empty drawer) or the
+ * query could poll a band nothing displays (wasted requests every minute).
+ *
+ * An ordering rather than equality, so a band added above [StopBand.ROUTES] keeps the drawer instead
+ * of silently switching it off at the zoom that wants it most — the rule `stopRouteLabel` follows for
+ * the same reason.
+ */
+val StopBand.showsNearbyArrivals: Boolean get() = this >= StopBand.ROUTES
+
+/**
  * The [StopBand] a stop falls in at [zoom]: a dot below [STOP_DOT_ZOOM_THRESHOLD], its full icon from
  * there, and from [STOP_ROUTES_ZOOM_THRESHOLD] that icon plus its route label.
  */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -120,6 +120,37 @@ fun <T : RouteDirectionItem> groupByRouteDirection(
 }
 
 /**
+ * Groups [items] into (route, direction, **stop**) rows for the transit-centre drawer (#2107), which
+ * merges many bays into one list — the sibling of [groupByRouteDirection], which groups one stop's
+ * arrivals and so needs no stop in its key.
+ *
+ * **The stop is part of the identity on purpose.** A route+direction boarding from two bays inside one
+ * transit centre is two rows, not one: a merged row would either have to name both bays (the
+ * stop-by-stop scan this drawer exists to remove) or pick one, which is a claim that can be false on
+ * the ground — and sending a rider to the wrong bay is the exact failure the feature is meant to
+ * prevent. Two bays for one route is real at precisely the places this targets: rail platforms,
+ * bay-numbered centres, and construction reroutes that add a temporary boarding point.
+ *
+ * Ordering is [groupByRouteDirection]'s (agency, line, headsign) key — the same stable,
+ * non-ETA-driven order, so a row doesn't move as its countdown ticks — with [stopSortKeyOf] as a
+ * final tiebreak so the two-bay case is deterministic rather than left to incoming order.
+ */
+fun <T : RouteDirectionItem> groupByRouteDirectionAndStop(
+    items: List<T>,
+    agencyNameOf: (T) -> String?,
+    stopIdOf: (T) -> String,
+    stopSortKeyOf: (T) -> String?
+): List<List<T>> {
+    val groups = LinkedHashMap<String, MutableList<T>>()
+    for (item in items) {
+        groups.getOrPut("${stopIdOf(item)}\u0000${item.groupKey()}") { mutableListOf() }.add(item)
+    }
+    val order = routeSortComparator(agencyNameOf)
+        .thenBy(BLANK_LAST_COMPARATOR) { group: List<T> -> stopSortKeyOf(group.first()) }
+    return groups.values.sortedWith(order)
+}
+
+/**
  * Builds the (agency, line, headsign)-ordered route rows for the arrivals list (#1822; see
  * [groupByRouteDirection]). [agencyNameOf] resolves an arrival's agency display name — not carried on
  * [ArrivalInfo] itself, only resolvable from the loaded snapshot's route/agency refs (see

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -306,7 +307,11 @@ fun RouteArrivalRow(
     // glyph from it, and the corner eye appears. Resolved by the list, like [isFavorite]: set
     // membership is the list's business, and this row is also drawn by hosts (directions, the
     // trip-results stop strips) that know nothing about tracking.
-    tracked: Boolean = false
+    tracked: Boolean = false,
+    // The bay this row departs from, drawn under the headsign — for the transit-centre drawer (#2107),
+    // whose list spans every stop in view and where "which bay" is half the answer. Null on every
+    // stop-scoped surface, where the stop is already the screen's subject and naming it again is noise.
+    stopLabel: String? = null
 ) {
     val representative = group.representative
     val routeActions = actionsFor(representative)
@@ -391,6 +396,18 @@ fun RouteArrivalRow(
                 Column(Modifier.weight(1f)) {
                     if (direction.isNotBlank()) {
                         DirectionHeadsign(direction)
+                        Spacer(Modifier.height(2.dp))
+                    }
+                    if (stopLabel != null) {
+                        Text(
+                            text = stopLabel,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    if (direction.isNotBlank() || stopLabel != null) {
                         Spacer(Modifier.height(6.dp))
                     }
                     EtaStrip(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -65,14 +65,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlin.math.roundToInt
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.map.RideRouteGroup
 import org.onebusaway.android.map.RouteHeader
-import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
@@ -250,11 +247,10 @@ fun HomeScreen(
                 // — and fed the settled viewport + zoom band by MapFeature, which holds the map VM.
                 val nearbyArrivalsViewModel = hiltViewModel<NearbyArrivalsViewModel>()
                 val nearbyArrivalsState by nearbyArrivalsViewModel.state.collectAsStateWithLifecycle()
-                // The map's zoom band, read off the render snapshot rather than recomputed — the stop
-                // loader already derives and dedups it there.
-                val stopBand by remember(mapViewModel) {
-                    mapViewModel.renderState.snapshot.map { it.stopBand }.distinctUntilChanged()
-                }.collectAsStateWithLifecycle(StopBand.FULL)
+                // The map's zoom band, read back off the nearby query rather than derived a second time
+                // here: MapFeature holds the map VM and is the single producer, pushing the band into
+                // the query — so the sheet decision and the query it gates can't drift.
+                val stopBand by nearbyArrivalsViewModel.stopBand.collectAsStateWithLifecycle()
                 val favoriteRouteIds by focusBannerViewModel.favoriteRouteIds.collectAsStateWithLifecycle()
                 val favoriteStopIds by focusBannerViewModel.favoriteStopIds.collectAsStateWithLifecycle()
                 val stopFavoritesReady by focusBannerViewModel.stopFavoritesReady.collectAsStateWithLifecycle()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -65,11 +65,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.map.RideRouteGroup
 import org.onebusaway.android.map.RouteHeader
+import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
@@ -108,6 +111,12 @@ import org.onebusaway.android.ui.home.map.FocusBannerState
 import org.onebusaway.android.ui.home.map.FocusBannerViewModel
 import org.onebusaway.android.ui.home.map.MapChrome
 import org.onebusaway.android.ui.home.map.MapFeature
+import org.onebusaway.android.ui.home.nearby.NearbyArrivalsSheetHost
+import org.onebusaway.android.ui.home.nearby.NearbyArrivalsViewModel
+import org.onebusaway.android.ui.home.nearby.limitExceeded
+import org.onebusaway.android.ui.home.nearby.rememberNearbyActionsFor
+import org.onebusaway.android.ui.home.nearby.rememberNearbyRouteRows
+import org.onebusaway.android.ui.home.nearby.rememberNearbyRowCallbacks
 import org.onebusaway.android.ui.home.weather.WeatherFeature
 import org.onebusaway.android.ui.home.weather.WeatherViewModel
 import org.onebusaway.android.ui.home.widealert.WideAlertDialog
@@ -237,6 +246,15 @@ fun HomeScreen(
                 val canUndoMapAction by homeViewModel.canUndoMapAction.collectAsStateWithLifecycle()
                 val mapRouteColors by mapViewModel.focusedRouteColors.collectAsStateWithLifecycle()
                 val focusBannerViewModel = hiltViewModel<FocusBannerViewModel>()
+                // The transit-centre drawer's query (#2107). Created here — the sheet is this screen's
+                // — and fed the settled viewport + zoom band by MapFeature, which holds the map VM.
+                val nearbyArrivalsViewModel = hiltViewModel<NearbyArrivalsViewModel>()
+                val nearbyArrivalsState by nearbyArrivalsViewModel.state.collectAsStateWithLifecycle()
+                // The map's zoom band, read off the render snapshot rather than recomputed — the stop
+                // loader already derives and dedups it there.
+                val stopBand by remember(mapViewModel) {
+                    mapViewModel.renderState.snapshot.map { it.stopBand }.distinctUntilChanged()
+                }.collectAsStateWithLifecycle(StopBand.FULL)
                 val favoriteRouteIds by focusBannerViewModel.favoriteRouteIds.collectAsStateWithLifecycle()
                 val favoriteStopIds by focusBannerViewModel.favoriteStopIds.collectAsStateWithLifecycle()
                 val stopFavoritesReady by focusBannerViewModel.stopFavoritesReady.collectAsStateWithLifecycle()
@@ -345,13 +363,27 @@ fun HomeScreen(
                 // above it and the nav-bar inset below (matching what the collapsed sheet actually shows).
                 val contentPeekDp = with(density) { contentPx.toDp() } + DRAG_HANDLE_HEIGHT + peekBottomPadding
 
-                // Visibility is business state: the sheet is shown (its peek slid up) iff a stop is focused.
-                // Because there's no `Hidden` drag anchor, "shown" is a plain flag that drives the animated peek
-                // height rather than a sheet drag state. The key is the focused stop id while shown (else null),
-                // so the effect reacts to focus/tab changes but NOT to a user drag (same stop -> same key).
+                // The transit-centre drawer's rows, built from the query's last response (#2107). Needed
+                // before the sheet decision below, which gates on there being rows to show.
+                val nearbyRows = rememberNearbyRouteRows(nearbyArrivalsState)
+                val nearbyActionsFor = rememberNearbyActionsFor(nearbyArrivalsState)
+                val nearbyLimitExceeded = nearbyArrivalsState.limitExceeded
+                val nearbyRowCallbacks = rememberNearbyRowCallbacks(
+                    homeViewModel = homeViewModel,
+                    rows = nearbyRows,
+                    undoViewport = { mapViewModel.viewport },
+                    onShowTrip = onShowTrip
+                )
+
+                // Visibility is business state: the sheet is shown (its peek slid up) iff it has something
+                // to show — a focused stop, or (since #2107) the routes leaving every bay in view at
+                // transit-centre zoom. Because there's no `Hidden` drag anchor, "shown" is a plain flag that
+                // drives the animated peek height rather than a sheet drag state. The key is the *identity*
+                // of what's shown, so the effect reacts to focus/mode changes but NOT to a user drag, and
+                // not to a pan that re-queries the same nearby list.
                 var sheetShown by remember { mutableStateOf(false) }
-                val showSheet = shouldShowSheet(currentFocus)
-                val sheetKey = if (showSheet) stopFocus?.stop?.id else null
+                val sheetContent = homeSheetContent(currentFocus, stopBand, nearbyRows.isNotEmpty())
+                val sheetKey = sheetContent.sheetKey
                 LaunchedEffect(sheetKey) {
                     if (sheetKey == null) {
                         // Hide: an expanded sheet is first collapsed to peek (so it then slides straight down as
@@ -362,10 +394,25 @@ fun HomeScreen(
                         }
                         sheetShown = false
                     } else {
-                        // Show immediately on focus — a fixed-fraction peek can't strand the drag, so there's no
-                        // need to wait for arrivals; the peek shows a loading spinner until they land.
+                        // Show immediately — a fixed-fraction peek can't strand the drag, so there's no need to
+                        // wait for arrivals; the peek shows a loading spinner until they land. Collapse to peek
+                        // on the way in, so switching *between* modes (a stop tapped out of the nearby list, or
+                        // back again) doesn't silently hand a full-height sheet to entirely different content.
+                        runCatching {
+                            if (sheetShown && sheetState.currentValue == SheetValue.Expanded) {
+                                sheetState.partialExpand()
+                            }
+                        }
                         sheetShown = true
                     }
+                }
+
+                // Tell the query whether the drawer is the sheet's subject: focusing a stop hands the sheet
+                // to that stop's own arrivals session, so this stops polling a list nobody can see.
+                // Keyed on the focus, not on sheetContent: the drawer's own rows feed sheetContent, so
+                // keying on that would make this effect depend on its own output.
+                LaunchedEffect(currentFocus, nearbyArrivalsViewModel) {
+                    nearbyArrivalsViewModel.setActive(currentFocus is CurrentFocus.None)
                 }
 
                 // One keyed arrivals session feeds the focus banner, alert modal, and drawer body. Keeping it
@@ -544,9 +591,16 @@ fun HomeScreen(
 
                 // Semantic map actions have HOME-local undo history. An expanded arrivals sheet still
                 // collapses first; every other back gesture restores the preceding focus and viewport.
-                BackHandler(enabled = canUndoMapAction) {
-                    val sheetAction = if (currentFocus is CurrentFocus.Stop && sheetShown) {
-                        sheetBackAction(sheetState.currentValue.toArrivalsSheetState())
+                //
+                // The expansion term is what makes this work for the nearby drawer (#2107), which shows
+                // with *no* focus and so usually has no undo history behind it: without it, back from a
+                // full-height nearby list would leave the app instead of collapsing it. At peek that
+                // drawer consumes nothing — it's ambient, with nothing behind it to go back to — so back
+                // falls through to the system (see [sheetBackAction]).
+                val sheetExpanded = sheetShown && sheetState.currentValue == SheetValue.Expanded
+                BackHandler(enabled = canUndoMapAction || sheetExpanded) {
+                    val sheetAction = if (sheetShown) {
+                        sheetBackAction(sheetState.currentValue.toArrivalsSheetState(), sheetContent)
                     } else {
                         SheetBackAction.NONE
                     }
@@ -594,13 +648,27 @@ fun HomeScreen(
                                 )
                             },
                             sheetContent = {
-                                ArrivalsSheetHost(
-                                    session = arrivalsSession,
-                                    state = arrivalsState,
-                                    selectedRoute = stopFocus?.selectedRoute,
-                                    mapRouteColors = mapRouteColors,
-                                    onContentHeight = { px -> contentPx = px }
-                                )
+                                // The nearby list only while it *is* the sheet's subject; otherwise the
+                                // per-stop panel, which stays composed through the hide animation (it
+                                // returns early on a null session) so the sheet doesn't blank mid-slide.
+                                if (sheetContent == HomeSheetContent.NearbyRoutes) {
+                                    NearbyArrivalsSheetHost(
+                                        rows = nearbyRows,
+                                        actionsFor = nearbyActionsFor,
+                                        favoriteRouteIds = favoriteRouteIds,
+                                        callbacks = nearbyRowCallbacks,
+                                        limitExceeded = nearbyLimitExceeded,
+                                        onContentHeight = { px -> contentPx = px }
+                                    )
+                                } else {
+                                    ArrivalsSheetHost(
+                                        session = arrivalsSession,
+                                        state = arrivalsState,
+                                        selectedRoute = stopFocus?.selectedRoute,
+                                        mapRouteColors = mapRouteColors,
+                                        onContentHeight = { px -> contentPx = px }
+                                    )
+                                }
                             }
                         ) {
                             // Trip-plan directions focus: the compact form replaces the top-chrome search field and
@@ -762,6 +830,7 @@ fun HomeScreen(
                                 MapFeature(
                                     mapViewModel = mapViewModel,
                                     homeViewModel = homeViewModel,
+                                    nearbyArrivalsViewModel = nearbyArrivalsViewModel,
                                     fabBottomInset = fabInsetTarget,
                                     onMapLongPress = { longPressPoint = it },
                                     onResumePinnedTrip = onResumePinnedTrip,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.home
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.onebusaway.android.map.render.StopBand
 
 /**
  * Pure decision logic for the arrivals bottom sheet, lifted out of [HomeScreen]'s `LaunchedEffect`
@@ -32,10 +33,63 @@ import androidx.compose.ui.unit.dp
  *  the toggle/back decisions below operate on. */
 enum class ArrivalsSheetState { Hidden, Collapsed, Expanded }
 
-/** The sheet is shown (peeking or full) iff a stop is focused. (HOME is always the map now — the
- *  list screens are their own destinations — so a focused stop is the only condition.) [HomeScreen]
- *  translates this into an animated peek height (the sheet has no `Hidden` drag anchor). */
-internal fun shouldShowSheet(focus: CurrentFocus): Boolean = focus is CurrentFocus.Stop
+/**
+ * What the bottom sheet is showing. Three states, not two, since #2107: at transit-centre zoom the
+ * sheet also engages with **no** stop focused, listing every route leaving every bay in view.
+ *
+ * Derived, never stored — deliberately not a [CurrentFocus] variant. `CurrentFocus` is the map's
+ * mutually-exclusive *subject*: it is persisted across process death and it drives the undo stack. The
+ * nearby list has no subject — it is precisely what shows when there is none — so a variant for it
+ * would push a state onto the back stack that Back has no meaning for, and force every `when (focus)`
+ * in the view model to grow a branch the map never renders.
+ */
+sealed interface HomeSheetContent {
+
+    /** Nothing shown; the peek is retracted. */
+    data object None : HomeSheetContent
+
+    /** One focused stop's arrivals — the original drawer. */
+    data class Stop(val stopId: String) : HomeSheetContent
+
+    /** Every route leaving every bay in view, at transit-centre zoom (#2107). */
+    data object NearbyRoutes : HomeSheetContent
+}
+
+/**
+ * The sheet's content for the current [focus], zoom [band], and whether the nearby query has rows to
+ * show ([nearbyRowsReady]).
+ *
+ * A focused stop always wins: it is a deliberate choice about one bay, and the map is already showing
+ * it selected. Otherwise the transit-centre band engages the nearby list — read as an ordering rather
+ * than equality, so a band added above `ROUTES` keeps the drawer instead of silently switching it off
+ * at the zoom that wants it most (the rule `stopRouteLabel` follows for the same reason).
+ *
+ * Gating on rows rather than on the query's state is what keeps the drawer honest: it never opens
+ * empty while loading, never opens over a viewport with no departures, and never opens at all on a
+ * region whose server can't answer the query.
+ */
+internal fun homeSheetContent(
+    focus: CurrentFocus,
+    band: StopBand,
+    nearbyRowsReady: Boolean
+): HomeSheetContent = when {
+    focus is CurrentFocus.Stop -> HomeSheetContent.Stop(focus.stop.id)
+    focus is CurrentFocus.None && band >= StopBand.ROUTES && nearbyRowsReady ->
+        HomeSheetContent.NearbyRoutes
+    else -> HomeSheetContent.None
+}
+
+/**
+ * The reveal effect's key: the identity of what is shown, or null when nothing is. Stable across a pan
+ * or zoom *within* the nearby mode, so re-querying a new viewport updates the list in place instead of
+ * re-running the reveal or fighting a drag the rider is in the middle of.
+ */
+internal val HomeSheetContent.sheetKey: String?
+    get() = when (this) {
+        HomeSheetContent.None -> null
+        is HomeSheetContent.Stop -> "stop:$stopId"
+        HomeSheetContent.NearbyRoutes -> "nearby"
+    }
 
 /**
  * Bottom edge used to keep map content below the active top chrome: the stop/route focus banner, or —
@@ -78,8 +132,24 @@ internal fun toggleSheetTarget(current: ArrivalsSheetState): ArrivalsSheetState 
 /** Whether the sheet consumes back by collapsing before focus navigation proceeds. */
 enum class SheetBackAction { COLLAPSE, NAVIGATE_BACK, NONE }
 
-internal fun sheetBackAction(current: ArrivalsSheetState): SheetBackAction = when (current) {
+/**
+ * Back's effect given the sheet's resting position and what it is showing.
+ *
+ * An expanded sheet always collapses to peek first, whatever it holds. From peek it depends: a focused
+ * stop is a focus to step out of, but the **nearby list is not** — it is ambient, the thing that shows
+ * when nothing is focused, and there is nothing behind it to go back to. Swallowing Back there would
+ * strand the rider on a screen they can't leave, so it passes to the system.
+ */
+internal fun sheetBackAction(
+    current: ArrivalsSheetState,
+    content: HomeSheetContent = HomeSheetContent.None
+): SheetBackAction = when (current) {
     ArrivalsSheetState.Expanded -> SheetBackAction.COLLAPSE // full -> peek
-    ArrivalsSheetState.Collapsed -> SheetBackAction.NAVIGATE_BACK
+    ArrivalsSheetState.Collapsed ->
+        if (content == HomeSheetContent.NearbyRoutes) {
+            SheetBackAction.NONE
+        } else {
+            SheetBackAction.NAVIGATE_BACK
+        }
     ArrivalsSheetState.Hidden -> SheetBackAction.NONE // let the system handle back
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.home
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.map.render.showsNearbyArrivals
 
 /**
  * Pure decision logic for the arrivals bottom sheet, lifted out of [HomeScreen]'s `LaunchedEffect`
@@ -60,9 +61,9 @@ sealed interface HomeSheetContent {
  * show ([nearbyRowsReady]).
  *
  * A focused stop always wins: it is a deliberate choice about one bay, and the map is already showing
- * it selected. Otherwise the transit-centre band engages the nearby list — read as an ordering rather
- * than equality, so a band added above `ROUTES` keeps the drawer instead of silently switching it off
- * at the zoom that wants it most (the rule `stopRouteLabel` follows for the same reason).
+ * it selected. Otherwise the transit-centre band engages the nearby list, through the same
+ * [showsNearbyArrivals] predicate `NearbyArrivalsViewModel` gates its query on — one definition, so
+ * the sheet cannot decide to show a band the query never asked for.
  *
  * Gating on rows rather than on the query's state is what keeps the drawer honest: it never opens
  * empty while loading, never opens over a viewport with no departures, and never opens at all on a
@@ -74,7 +75,7 @@ internal fun homeSheetContent(
     nearbyRowsReady: Boolean
 ): HomeSheetContent = when {
     focus is CurrentFocus.Stop -> HomeSheetContent.Stop(focus.stop.id)
-    focus is CurrentFocus.None && band >= StopBand.ROUTES && nearbyRowsReady ->
+    focus is CurrentFocus.None && band.showsNearbyArrivals && nearbyRowsReady ->
         HomeSheetContent.NearbyRoutes
     else -> HomeSheetContent.None
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -528,6 +528,47 @@ class HomeViewModel @Inject constructor(
         )
     }
 
+    /**
+     * A row of the transit-centre drawer was tapped (#2107): show that route on the map, scoped to the
+     * bay the row departs from.
+     *
+     * Reaching the same place a rider gets by tapping the bay and then its row — `CurrentFocus.Stop`
+     * with that route selected — but in **one** [pushFocus], so one Back returns straight to the nearby
+     * list rather than parking them on a per-stop panel they never asked for. It can't go through
+     * [selectArrivalRoute], which requires a stop focus to already exist; here there is none, which is
+     * exactly the condition that put the nearby list on screen.
+     */
+    fun showNearbyRouteOnMap(
+        bay: FocusedStop,
+        routeId: String,
+        shortName: String,
+        directionId: Int?,
+        headsign: String?,
+        undoViewport: MapViewport? = null
+    ) {
+        presentedRoutes = emptySet()
+        pushFocus(
+            CurrentFocus.Stop(
+                stop = bay,
+                selectedRoute = StopRouteSelection(
+                    originHeadsign = headsign,
+                    legs = listOf(RouteLeg(routeId, shortName, directionId))
+                )
+            ),
+            undoViewport
+        )
+        emitMapDirective(
+            MapDirective.ShowRoute(
+                ShowRouteRequest(
+                    routeId = routeId,
+                    directionStopId = bay.id,
+                    initialDirectionId = directionId
+                ),
+                stopScoped = true
+            )
+        )
+    }
+
     private fun selectStopRoute(
         stopFocus: CurrentFocus.Stop,
         request: ShowRouteRequest,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -547,6 +547,12 @@ class HomeViewModel @Inject constructor(
         undoViewport: MapViewport? = null
     ) {
         presentedRoutes = emptySet()
+        // Drop any restore/deep-link latch first, the way [clearMapFocus] and [enterDirections] do. A
+        // restore that set one and then had its stop unfocused before the arrivals landed leaves it
+        // armed with no focus — which is exactly the state that puts this list on screen — and this
+        // bay's own load would consume it and recenter on a focus the rider never asked to return to.
+        // The map is told what to show here explicitly, so nothing needs the latch.
+        pendingFocus = null
         pushFocus(
             CurrentFocus.Stop(
                 stop = bay,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -81,6 +81,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.util.Locale
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import org.onebusaway.android.BuildConfig
 import org.onebusaway.android.R
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -100,6 +101,7 @@ import org.onebusaway.android.map.render.stopZoomBand
 import org.onebusaway.android.map.rental.RentalKind
 import org.onebusaway.android.map.rental.RentalLayer
 import org.onebusaway.android.map.rental.RentalPlace
+import org.onebusaway.android.map.settledCamera
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.ui.home.CurrentFocus
 import org.onebusaway.android.ui.home.FocusedStop
@@ -110,6 +112,7 @@ import org.onebusaway.android.ui.home.chrome.mapTopChromeInsetPx
 import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.home.focusedBikeStationId
 import org.onebusaway.android.ui.home.focusedStop
+import org.onebusaway.android.ui.home.nearby.NearbyArrivalsViewModel
 import org.onebusaway.android.ui.tutorial.MapStopSpotlight
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.ObaRequestErrors
@@ -135,6 +138,10 @@ private const val SHOW_DEBUG_ZOOM_INDICATOR = false
 fun MapFeature(
     mapViewModel: MapViewModel,
     homeViewModel: HomeViewModel,
+    // The transit-centre drawer's query (#2107). Created by the host (the sheet is its), fed from here,
+    // which is where the map view model lives — the same bridge role this module already plays for
+    // padding, insets, and directives.
+    nearbyArrivalsViewModel: NearbyArrivalsViewModel,
     // The sheet-driven FAB lift, computed by HomeScreen from its live SheetState (the map composes only
     // when HOME is the destination, so this lives with the sheet rather than round-tripping the VM).
     fabBottomInset: Dp,
@@ -303,6 +310,20 @@ fun MapFeature(
     }
     LaunchedEffect(mapViewModel, homeViewModel) {
         homeViewModel.directionsBottomInset.collect { mapViewModel.host.setDirectionsBottomInset(it) }
+    }
+    // Feed the transit-centre drawer's query (#2107) the settled viewport, on the same "settled" the
+    // stop and rental loaders use — so it re-queries once at drag-end rather than per intermediate idle.
+    // Collected straight into the VM, never into Compose state, so a pan doesn't recompose the map.
+    LaunchedEffect(mapViewModel, nearbyArrivalsViewModel) {
+        mapViewModel.host.settledCamera()
+            .distinctUntilChanged()
+            .collect { nearbyArrivalsViewModel.onViewportSettled(it) }
+    }
+    LaunchedEffect(mapViewModel, nearbyArrivalsViewModel) {
+        mapViewModel.renderState.snapshot
+            .map { it.stopBand }
+            .distinctUntilChanged()
+            .collect { nearbyArrivalsViewModel.onStopBand(it) }
     }
     // Publish the floating top chrome's footprint (status-bar inset + FAB-row clearance) as the map's
     // baseline top inset, so the Google compass and centered content clear the FABs instead of drawing at

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsSheetHost.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.nearby
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.arrivals.ArrivalActions
+import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
+import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
+import org.onebusaway.android.ui.arrivals.convertArrivals
+import org.onebusaway.android.ui.compose.navigationBarBottomPadding
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * The transit-centre drawer's body (#2107): every route leaving every bay in the current viewport,
+ * one row per (route, direction, bay), in the shared (agency, line, headsign) order.
+ *
+ * Route-first rather than grouped by stop, because the rider this is for is standing in the centre
+ * looking for *their route* — grouping by stop would just reproduce the bay-by-bay scan they are
+ * already doing by hand.
+ */
+@Composable
+internal fun NearbyArrivalsSheetHost(
+    rows: List<NearbyRouteRow>,
+    actionsFor: (ArrivalInfo) -> ArrivalActions?,
+    favoriteRouteIds: Set<String>,
+    callbacks: ArrivalRowCallbacks,
+    limitExceeded: Boolean,
+    onContentHeight: (heightPx: Int) -> Unit,
+    listState: LazyListState = rememberLazyListState()
+) {
+    Surface(color = MaterialTheme.colorScheme.surface) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(bottom = navigationBarBottomPadding())
+        ) {
+            items(rows, key = { it.key }) { row ->
+                RouteArrivalRow(
+                    group = row.group,
+                    actionsFor = actionsFor,
+                    isFavorite = row.group.routeId in favoriteRouteIds,
+                    callbacks = callbacks,
+                    stopLabel = row.bay.label()
+                )
+            }
+            // The server truncates its arrivals list by distance from the viewport centre, so a
+            // truncated response drops the farthest bays outright. Say so rather than letting a rider
+            // conclude their route doesn't stop here.
+            if (limitExceeded) {
+                item(key = LIMIT_NOTICE_KEY) {
+                    Text(
+                        text = stringResource(R.string.nearby_arrivals_limit_exceeded),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                }
+            }
+        }
+    }
+
+    // The laid-out height, so the host can fit the peek to a short list. Real layout, not an estimate:
+    // Material3 measures sheet content at full container height regardless of the peek, so if the last
+    // item is present its bottom is the true content height; if it isn't, the list is taller than the
+    // screen and an exact number isn't needed. Same measurement ArrivalsPanel makes.
+    val contentHeightPx by remember(listState, rows) {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            val last = info.visibleItemsInfo.lastOrNull()
+            if (rows.isNotEmpty() && last != null && last.index == info.totalItemsCount - 1) {
+                last.offset + last.size
+            } else {
+                null
+            }
+        }
+    }
+    contentHeightPx?.let { px -> LaunchedEffect(px) { onContentHeight(px) } }
+}
+
+/**
+ * How a bay reads on a row: its code when the feed publishes one (that is what's painted on the pole),
+ * then its name, then the compass direction it serves. At a real transit centre the direction is what
+ * separates the two sides of an intersection — "Pine St & 4th Ave" exists twice.
+ */
+internal fun NearbyBay.label(): String {
+    val head = code?.takeIf(String::isNotBlank)?.let { "$it · $name" } ?: name
+    return direction?.takeIf(String::isNotBlank)?.let { "$head ($it)" } ?: head
+}
+
+/**
+ * Builds the drawer's rows from the query's state. Lives in composition because turning wire arrivals
+ * into [ArrivalInfo]s needs a `Context` — which is exactly why [NearbyArrivalsViewModel] stops at the
+ * resolved response and stays a plain JVM unit test.
+ */
+@Composable
+internal fun rememberNearbyRouteRows(state: NearbyArrivalsUiState): List<NearbyRouteRow> {
+    val context = LocalContext.current
+    val loaded = state as? NearbyArrivalsUiState.Loaded ?: return emptyList()
+    return remember(loaded, context) {
+        val snapshot = loaded.arrivals
+        val arrivals = convertArrivals(
+            context,
+            snapshot.arrivals,
+            snapshot.serverNow,
+            includeArrivalDepartureInStatusLabel = false
+        )
+        nearbyRouteRows(
+            arrivals = arrivals,
+            bayOf = { stopId ->
+                snapshot.stop(stopId)?.let { stop ->
+                    NearbyBay(
+                        id = stop.id,
+                        name = stop.name.orEmpty(),
+                        code = stop.stopCode,
+                        direction = stop.direction,
+                        point = GeoPoint(stop.location.latitude, stop.location.longitude)
+                    )
+                }
+            },
+            agencyNameOf = { snapshot.route(it.routeId)?.agencyId?.let(snapshot::agencyName) }
+        )
+    }
+}
+
+/**
+ * Resolves each row's route-level actions from the response's own references — the colour and names the
+ * badge draws, the agency the ordering sorts on, and the schedule URL whose absence hides that menu
+ * item. `alertSituationId` is left null: the alert glyph opens a dialog owned by the focused stop's
+ * banner, which this many-bay list has no equivalent of (see [rememberNearbyRowCallbacks]).
+ */
+@Composable
+internal fun rememberNearbyActionsFor(
+    state: NearbyArrivalsUiState
+): (ArrivalInfo) -> ArrivalActions? {
+    val loaded = state as? NearbyArrivalsUiState.Loaded
+    return remember(loaded) {
+        fun(arrival: ArrivalInfo): ArrivalActions? {
+            val snapshot = loaded?.arrivals ?: return null
+            val route = snapshot.route(arrival.routeId)
+            return ArrivalActions(
+                tripId = arrival.tripId,
+                routeId = arrival.routeId,
+                routeShortName = route?.shortName,
+                routeLongName = route?.longName,
+                routeColor = route?.color,
+                scheduleUrl = route?.url,
+                agencyName = route?.agencyId?.let(snapshot::agencyName),
+                blockId = null
+            )
+        }
+    }
+}
+
+/** Whether the last response was truncated, so the drawer can say some bays are missing. */
+internal val NearbyArrivalsUiState.limitExceeded: Boolean
+    get() = (this as? NearbyArrivalsUiState.Loaded)?.arrivals?.limitExceeded ?: false
+
+private const val LIMIT_NOTICE_KEY = "nearby-limit-notice"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModel.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.nearby
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import org.onebusaway.android.api.data.NearbyArrivals
+import org.onebusaway.android.api.data.NearbyArrivalsDataSource
+import org.onebusaway.android.api.data.NearbyArrivalsResult
+import org.onebusaway.android.api.data.NearbyArrivalsSupport
+import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.region.RegionRepository
+
+/**
+ * The refresh cadence, matching every other live-ETA surface in the app
+ * ([org.onebusaway.android.ui.arrivals.ArrivalsPolling], the starred-stops list, trip details).
+ * Because the whole viewport is one request, this costs the same as a single focused stop does.
+ */
+internal const val NEARBY_REFRESH_PERIOD_MS = 60_000L
+
+/**
+ * The arrivals window this asks for. Deliberately the starred-stop list's 35 minutes rather than the
+ * focused-stop default of 65: the window is the only lever on this response's size — the server's
+ * `maxCount` truncates the *arrivals* list ordered by distance, so capping it drops the farthest bays
+ * outright instead of trimming each one — and at a dense downtown transit centre 35 minutes is ~29 KB
+ * gzipped against ~40 KB at 65, for departures further out than anyone standing at the stop is
+ * waiting for. A product judgement, not a derived number (#2107).
+ */
+internal const val NEARBY_MINUTES_AFTER = 35
+
+/** What the transit-centre drawer has to show for the current viewport. */
+sealed interface NearbyArrivalsUiState {
+
+    /** Not asking: outside the transit-centre zoom band, or the drawer isn't the sheet's subject. */
+    data object Idle : NearbyArrivalsUiState
+
+    /** A first query for this viewport is in flight and nothing has been shown yet. */
+    data object Loading : NearbyArrivalsUiState
+
+    /**
+     * A resolved response. [arrivals] may hold none at all (a box with no stops, or none due inside
+     * the window), which is why the sheet gates on rows rather than on this state.
+     */
+    data class Loaded(val arrivals: NearbyArrivals) : NearbyArrivalsUiState
+
+    /** This region's server does not serve the endpoint; the drawer never engages here. */
+    data object Unsupported : NearbyArrivalsUiState
+}
+
+/**
+ * Reads every stop's arrivals in the current viewport, for the transit-centre drawer (#2107).
+ *
+ * Self-wiring feature module obtained through `hiltViewModel()` on the HOME nav entry, mirroring
+ * [org.onebusaway.android.ui.home.map.MapChromeViewModel]. It is fed the settled viewport and the zoom
+ * band by the host (which holds the map view model) and asks nothing of the map itself.
+ *
+ * Deliberately Android-free — no `Context`, no `ArrivalInfo` — so it is a plain JVM unit test, the same
+ * discipline that keeps `HomeViewModel`'s tests off the device. Turning the response into display rows
+ * needs a `Context` and happens in composition.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class NearbyArrivalsViewModel @Inject constructor(
+    private val dataSource: NearbyArrivalsDataSource,
+    private val regionRepo: RegionRepository,
+    private val support: NearbyArrivalsSupport
+) : ViewModel() {
+
+    private val viewport = MutableStateFlow<CameraSnapshot?>(null)
+    private val band = MutableStateFlow(StopBand.FULL)
+
+    // Whether the drawer is this sheet's subject. Focusing a stop hands the sheet to that stop's own
+    // arrivals session, so this query stops rather than polling a list nobody can see.
+    private val active = MutableStateFlow(false)
+
+    // The last response, held across a viewport change so a pan updates the list in place instead of
+    // emptying it (see [poll]). Written and read only from the single collector `state` builds below,
+    // which flatMapLatest serializes, so a plain field needs no synchronization.
+    private var lastLoaded: NearbyArrivalsUiState.Loaded? = null
+
+    /**
+     * The viewport's arrivals, re-queried on every settled camera inside the band and polled at
+     * [NEARBY_REFRESH_PERIOD_MS] while collected.
+     *
+     * `WhileSubscribed` is what stops the poll when the screen goes away: the host collects with
+     * `collectAsStateWithLifecycle`, so a backgrounded app unsubscribes and the loop is cancelled —
+     * the same effect `ArrivalsPolling` gets from `repeatOnLifecycle`, without a composable.
+     */
+    val state: StateFlow<NearbyArrivalsUiState> =
+        combine(viewport, band, active) { viewport, band, active ->
+            // Only the transit-centre band asks. Read as an ordering, not equality, so a band added
+            // above ROUTES keeps the drawer rather than silently switching it off (the same rule
+            // stopRouteLabel follows).
+            if (active && band >= StopBand.ROUTES) viewport else null
+        }
+            .distinctUntilChanged()
+            .flatMapLatest { viewport ->
+                // flatMapLatest cancels an in-flight query when a newer viewport arrives, matching the
+                // stop loader's discipline; the data source is suspend + runCatchingCancellable, so the
+                // cancellation propagates rather than being swallowed (#1908).
+                if (viewport == null) {
+                    // The gate closed (zoomed out, or another surface took the sheet). Drop the held
+                    // rows so re-entering the band somewhere else doesn't flash the last centre's bays.
+                    lastLoaded = null
+                    flowOf(NearbyArrivalsUiState.Idle)
+                } else {
+                    poll(viewport)
+                }
+            }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(SUBSCRIPTION_GRACE_MS),
+                NearbyArrivalsUiState.Idle
+            )
+
+    /** The settled viewport (see `MapHost.settledCamera`). */
+    fun onViewportSettled(snapshot: CameraSnapshot) {
+        viewport.value = snapshot
+    }
+
+    /** The map's current stop zoom band, read off the render snapshot rather than recomputed. */
+    fun onStopBand(value: StopBand) {
+        band.value = value
+    }
+
+    /** Whether the drawer is the sheet's current subject. */
+    fun setActive(value: Boolean) {
+        active.value = value
+    }
+
+    private fun poll(viewport: CameraSnapshot) = flow {
+        // Keep showing what's already on screen while the new viewport loads. Re-emitting Loading here
+        // would empty the drawer's rows, and the sheet gates its visibility on having rows — so every
+        // pan would retract the drawer and slide it back up a request later. The held rows are at most
+        // one viewport stale, and a pan inside a transit centre mostly re-reads the same bays.
+        emit(lastLoaded ?: NearbyArrivalsUiState.Loading)
+        while (coroutineContext.isActive) {
+            val regionId = regionRepo.region.value?.id
+            if (support.isKnownUnsupported(regionId)) {
+                emit(NearbyArrivalsUiState.Unsupported)
+                return@flow
+            }
+            when (val result = dataSource.arrivals(viewport, NEARBY_MINUTES_AFTER)) {
+                is NearbyArrivalsResult.Loaded -> {
+                    NearbyArrivalsUiState.Loaded(result.arrivals).also {
+                        lastLoaded = it
+                        emit(it)
+                    }
+                }
+                NearbyArrivalsResult.Unsupported -> {
+                    support.recordAbsent(regionId)
+                    emit(NearbyArrivalsUiState.Unsupported)
+                    return@flow
+                }
+                // Transient: hold the last good rows and say nothing. The rider is looking at ETAs that
+                // are at most a minute stale, which beats blanking the drawer — and a timeout must never
+                // read as "this region can't do this".
+                is NearbyArrivalsResult.Failed -> lastLoaded?.let { emit(it) }
+            }
+            delay(NEARBY_REFRESH_PERIOD_MS)
+        }
+    }
+
+    private companion object {
+        // Ride out a configuration change without cancelling the poll and re-querying on the way back.
+        const val SUBSCRIPTION_GRACE_MS = 5_000L
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import org.onebusaway.android.api.data.NearbyArrivals
@@ -38,6 +39,7 @@ import org.onebusaway.android.api.data.NearbyArrivalsResult
 import org.onebusaway.android.api.data.NearbyArrivalsSupport
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.map.render.showsNearbyArrivals
 import org.onebusaway.android.region.RegionRepository
 
 /**
@@ -102,10 +104,19 @@ class NearbyArrivalsViewModel @Inject constructor(
     // arrivals session, so this query stops rather than polling a list nobody can see.
     private val active = MutableStateFlow(false)
 
+    /** The map's current stop zoom band, republished for the sheet decision — see [onStopBand]. */
+    val stopBand: StateFlow<StopBand> = band
+
+    // What to ask, or null when nothing should be asked at all. A data class so `distinctUntilChanged`
+    // compares every input: an unchanged viewport on a *different* endpoint is a different query.
+    private data class NearbyQuery(val viewport: CameraSnapshot, val obaBaseUrl: String?)
+
     // The last response, held across a viewport change so a pan updates the list in place instead of
-    // emptying it (see [poll]). Written and read only from the single collector `state` builds below,
-    // which flatMapLatest serializes, so a plain field needs no synchronization.
+    // emptying it (see [poll]) — tagged with the endpoint that produced it, so a region switch can't
+    // hold one city's bays over another's. Written and read only from the single collector `state`
+    // builds below, which flatMapLatest serializes, so a plain field needs no synchronization.
     private var lastLoaded: NearbyArrivalsUiState.Loaded? = null
+    private var lastLoadedEndpoint: String? = null
 
     /**
      * The viewport's arrivals, re-queried on every settled camera inside the band and polled at
@@ -116,24 +127,35 @@ class NearbyArrivalsViewModel @Inject constructor(
      * the same effect `ArrivalsPolling` gets from `repeatOnLifecycle`, without a composable.
      */
     val state: StateFlow<NearbyArrivalsUiState> =
-        combine(viewport, band, active) { viewport, band, active ->
-            // Only the transit-centre band asks. Read as an ordering, not equality, so a band added
-            // above ROUTES keeps the drawer rather than silently switching it off (the same rule
-            // stopRouteLabel follows).
-            if (active && band >= StopBand.ROUTES) viewport else null
+        combine(
+            viewport,
+            band,
+            active,
+            // The server that answers is an input, not a fact read once inside the poll loop: switching
+            // regions changes which deployment is asked — and whether it serves this endpoint at all —
+            // without the camera or the sheet moving, and the standing query would otherwise keep
+            // polling the old host. Distinct on the endpoint alone so an unrelated region field can't
+            // re-fire it (the discipline `RentalLayerController` follows for its own source).
+            regionRepo.region.map { it?.obaBaseUrl }.distinctUntilChanged()
+        ) { viewport, band, active, obaBaseUrl ->
+            if (active && band.showsNearbyArrivals && viewport != null) {
+                NearbyQuery(viewport, obaBaseUrl)
+            } else {
+                null
+            }
         }
             .distinctUntilChanged()
-            .flatMapLatest { viewport ->
+            .flatMapLatest { query ->
                 // flatMapLatest cancels an in-flight query when a newer viewport arrives, matching the
                 // stop loader's discipline; the data source is suspend + runCatchingCancellable, so the
                 // cancellation propagates rather than being swallowed (#1908).
-                if (viewport == null) {
+                if (query == null) {
                     // The gate closed (zoomed out, or another surface took the sheet). Drop the held
                     // rows so re-entering the band somewhere else doesn't flash the last centre's bays.
-                    lastLoaded = null
+                    clearHeldRows()
                     flowOf(NearbyArrivalsUiState.Idle)
                 } else {
-                    poll(viewport)
+                    poll(query)
                 }
             }
             .stateIn(
@@ -157,27 +179,35 @@ class NearbyArrivalsViewModel @Inject constructor(
         active.value = value
     }
 
-    private fun poll(viewport: CameraSnapshot) = flow {
+    private fun clearHeldRows() {
+        lastLoaded = null
+        lastLoadedEndpoint = null
+    }
+
+    private fun poll(query: NearbyQuery) = flow {
+        // Rows fetched from a different deployment describe a different place entirely, so a region
+        // switch starts from Loading rather than holding them the way a pan does.
+        if (query.obaBaseUrl != lastLoadedEndpoint) clearHeldRows()
         // Keep showing what's already on screen while the new viewport loads. Re-emitting Loading here
         // would empty the drawer's rows, and the sheet gates its visibility on having rows — so every
         // pan would retract the drawer and slide it back up a request later. The held rows are at most
         // one viewport stale, and a pan inside a transit centre mostly re-reads the same bays.
         emit(lastLoaded ?: NearbyArrivalsUiState.Loading)
         while (coroutineContext.isActive) {
-            val regionId = regionRepo.region.value?.id
-            if (support.isKnownUnsupported(regionId)) {
+            if (support.isKnownUnsupported(query.obaBaseUrl)) {
                 emit(NearbyArrivalsUiState.Unsupported)
                 return@flow
             }
-            when (val result = dataSource.arrivals(viewport, NEARBY_MINUTES_AFTER)) {
+            when (val result = dataSource.arrivals(query.viewport, NEARBY_MINUTES_AFTER)) {
                 is NearbyArrivalsResult.Loaded -> {
                     NearbyArrivalsUiState.Loaded(result.arrivals).also {
                         lastLoaded = it
+                        lastLoadedEndpoint = query.obaBaseUrl
                         emit(it)
                     }
                 }
                 NearbyArrivalsResult.Unsupported -> {
-                    support.recordAbsent(regionId)
+                    support.recordAbsent(query.obaBaseUrl)
                     emit(NearbyArrivalsUiState.Unsupported)
                     return@flow
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRouteRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRouteRows.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.nearby
+
+import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.arrivals.RouteRowGroup
+import org.onebusaway.android.ui.arrivals.groupByRouteDirectionAndStop
+import org.onebusaway.android.ui.arrivals.routeRowKey
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * The bay a [NearbyRouteRow] departs from. Resolved from the response's stop references, and carried
+ * on the row rather than looked up at draw time so a row can always name where to stand.
+ *
+ * [code] is what is painted on the pole and [direction] the compass bearing the stop serves; at a real
+ * transit centre those two, not a "Bay C", are what tell one side of an intersection from the other
+ * ("Pine St & 4th Ave" southbound vs northbound). [point] is what a row tap recentres on.
+ */
+data class NearbyBay(
+    val id: String,
+    val name: String,
+    val code: String?,
+    val direction: String?,
+    val point: GeoPoint
+) {
+    /**
+     * The deterministic tiebreak between two bays serving the same route and direction. The stop code
+     * when the feed publishes one — it is both the rider-facing identifier and the one that sorts
+     * meaningfully between adjacent bays — else the name.
+     */
+    val sortKey: String get() = code?.takeIf(String::isNotBlank) ?: name
+}
+
+/**
+ * One row of the transit-centre drawer (#2107): every upcoming trip for a single (route, direction) at
+ * a single bay, ETA-sorted, plus the bay it leaves from.
+ *
+ * The stop-scoped drawer's row is the [group] alone, because there the stop is the screen's subject.
+ * Here the list spans a whole viewport, so the bay is half the answer — which is why it is part of the
+ * row's identity as well as its display (see [groupByRouteDirectionAndStop]).
+ */
+data class NearbyRouteRow(val group: RouteRowGroup, val bay: NearbyBay) {
+
+    /** A stable LazyColumn key: the stop-scoped sibling of [RouteRowGroup.key]. */
+    val key: String get() = "${bay.id}\u0000${routeRowKey(group.routeId, group.directionId, group.headsign)}"
+}
+
+/**
+ * Builds the drawer's rows from one viewport's [arrivals].
+ *
+ * [bayOf] resolves an arrival's stop from the response references; an arrival whose bay the references
+ * don't carry is **dropped rather than shown bay-less** — a row in this list that can't say where to
+ * stand answers nothing, and the per-stop drawer is the surface for "arrivals at a stop you already
+ * chose". [agencyNameOf] feeds the shared (agency, line, headsign) ordering.
+ *
+ * Pure: [ArrivalInfo]s are built by the caller (they need a `Context`), so the grouping stays
+ * JVM-testable — the same split [groupByRouteDirection] uses.
+ */
+fun nearbyRouteRows(
+    arrivals: List<ArrivalInfo>,
+    bayOf: (stopId: String) -> NearbyBay?,
+    agencyNameOf: (ArrivalInfo) -> String?
+): List<NearbyRouteRow> {
+    val bays = HashMap<String, NearbyBay?>()
+    fun bay(stopId: String) = bays.getOrPut(stopId) { bayOf(stopId) }
+    return groupByRouteDirectionAndStop(
+        items = arrivals.filter { bay(it.stopId) != null },
+        agencyNameOf = agencyNameOf,
+        stopIdOf = { it.stopId },
+        stopSortKeyOf = { bay(it.stopId)?.sortKey }
+    ).mapNotNull { trips ->
+        val resolved = bay(trips.first().stopId) ?: return@mapNotNull null
+        NearbyRouteRow(RouteRowGroup(trips), resolved)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRowCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRowCallbacks.kt
@@ -52,6 +52,11 @@ internal fun rememberNearbyRowCallbacks(
     val context = LocalContext.current
     val currentRows = rememberUpdatedState(rows)
     val currentOnShowTrip = rememberUpdatedState(onShowTrip)
+    // Read through the latest lambda, like the two above: this object outlives recomposition (it is
+    // keyed only on the view model), so capturing the one passed at first composition would pin a
+    // caller whose lambda closes over a viewport *value* to the viewport it had then — and Back would
+    // restore a camera position the rider had long since panned away from.
+    val currentUndoViewport = rememberUpdatedState(undoViewport)
     return remember(homeViewModel, context) {
         fun bayOf(arrival: ArrivalInfo): NearbyBay? = currentRows.value
             .firstOrNull { it.bay.id == arrival.stopId }
@@ -68,7 +73,7 @@ internal fun rememberNearbyRowCallbacks(
                 shortName = arrival.shortName.orEmpty().ifBlank { arrival.routeId },
                 directionId = arrival.directionId,
                 headsign = arrival.headsign,
-                undoViewport = undoViewport()
+                undoViewport = currentUndoViewport.value()
             )
         }
 
@@ -86,7 +91,7 @@ internal fun rememberNearbyRowCallbacks(
             onShowRouteOnMap = { arrival ->
                 homeViewModel.focusStandaloneRoute(
                     ShowRouteRequest(routeId = arrival.routeId),
-                    undoViewport = undoViewport()
+                    undoViewport = currentUndoViewport.value()
                 )
             },
             onShowTripStatus = { arrival ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRowCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRowCallbacks.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.nearby
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.map.render.MapViewport
+import org.onebusaway.android.ui.arrivals.ArrivalActions
+import org.onebusaway.android.ui.arrivals.ArrivalInfo
+import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
+import org.onebusaway.android.ui.home.FocusedStop
+import org.onebusaway.android.ui.home.HomeViewModel
+import org.onebusaway.android.util.ExternalIntents
+
+/**
+ * The nearby drawer's row actions.
+ *
+ * The two taps a rider actually makes here — the row body and an ETA pill — do what this drawer is
+ * for: show that route on the map, scoped to the bay the row named, in one focus push so Back returns
+ * straight to the list.
+ *
+ * **The long-press menu's per-stop actions (star, reminder, tracking, report a problem) and the alert
+ * glyph are not wired to their own dialogs in this first version**: each needs the stop-scoped
+ * `ArrivalsViewModel` and alert store that the per-stop drawer hoists per focused stop, which this
+ * list — spanning many bays at once — deliberately does not create. Rather than no-op them, they focus
+ * the row's bay, which lands the rider on that stop's own panel where every one of those actions is
+ * fully wired. Worth a follow-up: see the PR description.
+ */
+@Composable
+internal fun rememberNearbyRowCallbacks(
+    homeViewModel: HomeViewModel,
+    rows: List<NearbyRouteRow>,
+    undoViewport: () -> MapViewport?,
+    onShowTrip: (tripId: String, stopId: String) -> Unit
+): ArrivalRowCallbacks {
+    val context = LocalContext.current
+    val currentRows = rememberUpdatedState(rows)
+    val currentOnShowTrip = rememberUpdatedState(onShowTrip)
+    return remember(homeViewModel, context) {
+        fun bayOf(arrival: ArrivalInfo): NearbyBay? = currentRows.value
+            .firstOrNull { it.bay.id == arrival.stopId }
+            ?.bay
+
+        fun focusedStop(bay: NearbyBay) = FocusedStop(bay.id, bay.name, bay.code, bay.point)
+
+        // Show the arrival's route on the map, scoped to the bay its row named.
+        fun revealAtBay(arrival: ArrivalInfo) {
+            val bay = bayOf(arrival) ?: return
+            homeViewModel.showNearbyRouteOnMap(
+                bay = focusedStop(bay),
+                routeId = arrival.routeId,
+                shortName = arrival.shortName.orEmpty().ifBlank { arrival.routeId },
+                directionId = arrival.directionId,
+                headsign = arrival.headsign,
+                undoViewport = undoViewport()
+            )
+        }
+
+        // Focus the bay alone, for the actions that live on the per-stop panel (see the KDoc above).
+        fun openBay(arrival: ArrivalInfo) {
+            val bay = bayOf(arrival) ?: return
+            homeViewModel.revealStop(focusedStop(bay), animate = true)
+        }
+
+        ArrivalRowCallbacks(
+            onShowVehiclesOnMap = ::revealAtBay,
+            onEtaClick = ::revealAtBay,
+            // The badge long-press reveals the whole route, unscoped — the same meaning it has in the
+            // per-stop drawer, where it deliberately drops the stop/direction scoping.
+            onShowRouteOnMap = { arrival ->
+                homeViewModel.focusStandaloneRoute(
+                    ShowRouteRequest(routeId = arrival.routeId),
+                    undoViewport = undoViewport()
+                )
+            },
+            onShowTripStatus = { arrival ->
+                currentOnShowTrip.value(arrival.tripId, arrival.stopId)
+            },
+            onShowRouteSchedule = { scheduleUrl -> ExternalIntents.goToUrl(context, scheduleUrl) },
+            onRouteFavorite = { actions -> openBayForRoute(currentRows.value, actions, homeViewModel) },
+            onSetReminder = ::openBay,
+            onToggleTracking = ::openBay,
+            onReportArrivalProblem = { actions ->
+                openBayForRoute(currentRows.value, actions, homeViewModel)
+            },
+            onShowAlert = { /* Alerts are shown by the focused stop's banner; see the KDoc above. */ }
+        )
+    }
+}
+
+/** [ArrivalActions] carries no stop, so the bay is found through the row that produced it. */
+private fun openBayForRoute(
+    rows: List<NearbyRouteRow>,
+    actions: ArrivalActions,
+    homeViewModel: HomeViewModel
+) {
+    val bay = rows.firstOrNull { row -> row.group.trips.any { it.tripId == actions.tripId } }?.bay
+        ?: return
+    homeViewModel.revealStop(FocusedStop(bay.id, bay.name, bay.code, bay.point), animate = true)
+}

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -703,6 +703,9 @@
     <string name="preferences_experimental_regions_summary">Enables regions that may be unstable
     </string>
     <string name="map_zoom_in_for_more_stops">Zoom in to see all stops</string>
+    <!-- Shown at the end of the nearby-arrivals drawer when the server truncated its response, so
+         some stops in view are missing from the list entirely (#2107). -->
+    <string name="nearby_arrivals_limit_exceeded">Some stops in view aren\'t listed. Zoom in to see them.</string>
     <string name="preferences_map_stop_cache_size_title">Map stop cache size</string>
     <string name="preferences_map_stop_cache_size_summary">Max bus stops kept on the map while panning (currently %1$d)</string>
     <!-- Not a plural candidate: "%1$d and %2$d" are the bounds of a range, not a count that inflects. -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/api/NearbyArrivalsDecodeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/api/NearbyArrivalsDecodeTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.api
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.contract.ArrivalsForLocationData
+import org.onebusaway.android.api.contract.ObaEnvelope
+
+/**
+ * Guards the arrivals-and-departures-for-location wire shape (#2107) — and above all the fact that
+ * this endpoint answers with **two different shapes**.
+ *
+ * Both bodies below are trimmed from real captures (Puget Sound / Tampa) against the production Json
+ * config. The empty one is the case that would otherwise crash: the server's `emptyResponse()` path
+ * returns the raw `StopsWithArrivalsAndDeparturesBean` with no `entry` and no `references`, while the
+ * populated path wraps it through `factory.getResponse(...)`. A non-nullable `entry` would make
+ * panning the map onto water throw instead of showing an empty list.
+ */
+class NearbyArrivalsDecodeTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    private val populated = """
+        {
+          "version": 2, "code": 200, "currentTime": 1786132299765, "text": "OK",
+          "data": {
+            "entry": {
+              "stopIds": ["1_431", "1_431", "1_578"],
+              "situationIds": ["1_sit"],
+              "limitExceeded": false,
+              "nearbyStopIds": [
+                { "stopId": "1_700", "distanceFromQuery": 26.843080565472977 }
+              ],
+              "arrivalsAndDepartures": [
+                {
+                  "routeId": "1_100479", "tripId": "1_t1", "stopId": "1_431",
+                  "tripHeadsign": "Capitol Hill", "routeShortName": "10", "routeLongName": "",
+                  "stopSequence": 3, "serviceDate": 1786089600000, "vehicleId": "1_6980",
+                  "predicted": true,
+                  "scheduledArrivalTime": 1786132501000, "predictedArrivalTime": 1786132162000,
+                  "scheduledDepartureTime": 1786132501000, "predictedDepartureTime": 1786132162000,
+                  "numberOfStopsAway": 2, "occupancyStatus": "EMPTY",
+                  "situationIds": ["1_sit2"]
+                },
+                {
+                  "routeId": "1_100512", "tripId": "1_t2", "stopId": "1_578",
+                  "tripHeadsign": "Northgate", "routeShortName": "40", "routeLongName": "",
+                  "stopSequence": 7, "serviceDate": 1786089600000,
+                  "predicted": false,
+                  "scheduledArrivalTime": 1786132900000, "predictedArrivalTime": 0,
+                  "scheduledDepartureTime": 1786132900000, "predictedDepartureTime": 0,
+                  "situationIds": []
+                }
+              ]
+            },
+            "references": {
+              "agencies": [ { "id": "1", "name": "Metro Transit" } ],
+              "stops": [
+                { "id": "1_431", "name": "Pine St & 4th Ave", "code": "431", "direction": "W",
+                  "lat": 47.6109, "lon": -122.3376, "locationType": 0, "routeIds": ["1_100479"] },
+                { "id": "1_578", "name": "3rd Ave & Pine St", "code": "578", "direction": "SE",
+                  "lat": 47.6112, "lon": -122.3382, "locationType": 0, "routeIds": ["1_100512"] }
+              ],
+              "routes": [
+                { "id": "1_100479", "shortName": "10", "agencyId": "1", "type": 3 },
+                { "id": "1_100512", "shortName": "40", "agencyId": "1", "type": 3 }
+              ],
+              "trips": [
+                { "id": "1_t1", "routeId": "1_100479", "directionId": "0", "blockId": "1_b1" },
+                { "id": "1_t2", "routeId": "1_100512", "directionId": "1", "blockId": "1_b2" }
+              ],
+              "situations": []
+            }
+          }
+        }
+    """.trimIndent()
+
+    /**
+     * The server's answer for a box with no stops in it — captured verbatim (modulo currentTime) and
+     * identical on all four regions that serve this endpoint.
+     */
+    private val empty = """
+        {
+          "code": 200, "currentTime": 1786132839215, "text": "OK", "version": 2,
+          "data": {
+            "arrivalsAndDepartures": [], "limitExceeded": false, "nearbyStops": [],
+            "situations": [], "stops": [], "timeZone": ""
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `decodes a populated response`() {
+        val envelope = json.decodeFromString<ObaEnvelope<ArrivalsForLocationData>>(populated)
+        assertEquals(200, envelope.code)
+        assertEquals(1786132299765L, envelope.currentTime)
+
+        val entry = requireNotNull(envelope.data?.entry)
+        assertEquals(2, entry.arrivalsAndDepartures.size)
+        assertFalse(entry.limitExceeded)
+        assertEquals(listOf("1_sit"), entry.situationIds)
+
+        val first = entry.arrivalsAndDepartures.first()
+        assertEquals("1_431", first.stopId)
+        assertEquals("10", first.routeShortName)
+        assertEquals("Capitol Hill", first.tripHeadsign)
+        assertEquals(1786132162000L, first.predictedArrivalTime)
+    }
+
+    /** Each arrival names its own bay — the field the per-stop entry doesn't need and this one lives on. */
+    @Test
+    fun `every arrival carries a stop id resolvable in the references`() {
+        val data = json.decodeFromString<ObaEnvelope<ArrivalsForLocationData>>(populated).data!!
+        val stopIds = data.entry!!.arrivalsAndDepartures.map { it.stopId }
+        assertEquals(listOf("1_431", "1_578"), stopIds)
+        assertEquals("Pine St & 4th Ave", data.references.stop("1_431")?.name)
+        assertEquals("SE", data.references.stop("1_578")?.direction)
+    }
+
+    /**
+     * directionId lives on the trip references, not the arrival — the same resolution the per-stop
+     * path does, and the thing the route-first grouping keys on.
+     */
+    @Test
+    fun `direction id resolves through the trip references`() {
+        val data = json.decodeFromString<ObaEnvelope<ArrivalsForLocationData>>(populated).data!!
+        val arrivals = data.entry!!.arrivalsAndDepartures
+        assertEquals(0, data.references.trip(arrivals[0].tripId)?.directionId?.toIntOrNull())
+        assertEquals(1, data.references.trip(arrivals[1].tripId)?.directionId?.toIntOrNull())
+    }
+
+    /** stopIds repeats ids, which is why the bays come off the arrivals rather than this list. */
+    @Test
+    fun `stop ids list is not a distinct set`() {
+        val entry = json.decodeFromString<ObaEnvelope<ArrivalsForLocationData>>(populated)
+            .data!!.entry!!
+        assertEquals(3, entry.stopIds.size)
+        assertEquals(2, entry.stopIds.toSet().size)
+    }
+
+    /**
+     * The whole reason `entry` is nullable: this body carries no `entry` key at all. It must decode to
+     * an empty result, not throw.
+     */
+    @Test
+    fun `decodes the empty-box response shape`() {
+        val envelope = json.decodeFromString<ObaEnvelope<ArrivalsForLocationData>>(empty)
+        assertEquals(200, envelope.code)
+        assertNotNull(envelope.data)
+        assertNull(envelope.data?.entry)
+        assertTrue(envelope.data!!.references.stops.isEmpty())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -92,6 +92,7 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
 /** Minimal [Region] fixture — only the id matters to the selection logic (compared by id). */
 internal fun region(
     id: Long,
+    obaBaseUrl: String? = null,
     supportsOtpBikeshare: Boolean = false,
     twitterUrl: String? = null,
     otpContactEmail: String? = null,
@@ -102,7 +103,7 @@ internal fun region(
     id = id,
     name = "Region $id",
     active = true,
-    obaBaseUrl = null,
+    obaBaseUrl = obaBaseUrl,
     siriBaseUrl = null,
     bounds = emptyArray(),
     open311Servers = emptyArray(),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/NearbyRouteGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/NearbyRouteGroupingTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * JVM unit tests for [groupByRouteDirectionAndStop] — the transit-centre drawer's grouping (#2107),
+ * which spans many bays and so keys the stop into a row's identity. Uses the same lightweight
+ * [RouteDirectionItem] fake as [RouteRowGroupingTest], since building an [ArrivalInfo] needs a
+ * `Context`.
+ */
+class NearbyRouteGroupingTest {
+
+    private data class FakeItem(
+        override val routeId: String,
+        override val headsign: String?,
+        override val eta: Long,
+        val stopId: String,
+        val stopSortKey: String? = stopId,
+        override val directionId: Int? = null,
+        override val lineName: String = routeId,
+        val agencyName: String? = null
+    ) : RouteDirectionItem
+
+    private fun group(items: List<FakeItem>) = groupByRouteDirectionAndStop(
+        items = items,
+        agencyNameOf = { it.agencyName },
+        stopIdOf = { it.stopId },
+        stopSortKeyOf = { it.stopSortKey }
+    )
+
+    /**
+     * The point of the whole function: one route+direction leaving two bays is two rows, so neither
+     * row can send a rider to the wrong side of the street.
+     */
+    @Test
+    fun `one route and direction at two bays produces two rows`() {
+        val rows = group(
+            listOf(
+                FakeItem("r1", "Downtown", eta = 3, stopId = "bayA"),
+                FakeItem("r1", "Downtown", eta = 9, stopId = "bayB"),
+                FakeItem("r1", "Downtown", eta = 12, stopId = "bayA")
+            )
+        )
+        assertEquals(2, rows.size)
+        assertEquals(listOf("bayA", "bayA"), rows[0].map { it.stopId })
+        assertEquals(listOf("bayB"), rows[1].map { it.stopId })
+    }
+
+    /** Same bay, one route, two directions — still split, exactly as the per-stop grouping does. */
+    @Test
+    fun `one route with two directions at one bay produces two rows`() {
+        val rows = group(
+            listOf(
+                FakeItem("r1", "Downtown", eta = 3, stopId = "bayA", directionId = 0),
+                FakeItem("r1", "Uptown", eta = 5, stopId = "bayA", directionId = 1)
+            )
+        )
+        assertEquals(2, rows.size)
+    }
+
+    /** Different routes at the same bay stay separate rows, ordered by the shared line comparator. */
+    @Test
+    fun `rows order by line name with natural sort, not lexical`() {
+        val rows = group(
+            listOf(
+                FakeItem("r40", "A", eta = 1, stopId = "bay", lineName = "40"),
+                FakeItem("r8", "A", eta = 2, stopId = "bay", lineName = "8"),
+                FakeItem("r550", "A", eta = 3, stopId = "bay", lineName = "550")
+            )
+        )
+        assertEquals(listOf("8", "40", "550"), rows.map { it.first().lineName })
+    }
+
+    @Test
+    fun `agency orders ahead of line name`() {
+        val rows = group(
+            listOf(
+                FakeItem("r1", "A", eta = 1, stopId = "bay", lineName = "1", agencyName = "Zed Transit"),
+                FakeItem("r9", "A", eta = 2, stopId = "bay", lineName = "9", agencyName = "Ace Transit")
+            )
+        )
+        assertEquals(listOf("Ace Transit", "Zed Transit"), rows.map { it.first().agencyName })
+    }
+
+    /** The bay is the last tiebreak, so the two-bay case is deterministic rather than input-ordered. */
+    @Test
+    fun `two bays for one route order by their stop sort key`() {
+        val rows = group(
+            listOf(
+                FakeItem("r1", "Downtown", eta = 3, stopId = "z", stopSortKey = "Bay 9"),
+                FakeItem("r1", "Downtown", eta = 4, stopId = "a", stopSortKey = "Bay 2")
+            )
+        )
+        assertEquals(listOf("Bay 2", "Bay 9"), rows.map { it.first().stopSortKey })
+    }
+
+    /** A bay with no sort key sorts last rather than dominating the top. */
+    @Test
+    fun `a bay with no sort key sorts last`() {
+        val rows = group(
+            listOf(
+                FakeItem("r1", "Downtown", eta = 3, stopId = "z", stopSortKey = null),
+                FakeItem("r1", "Downtown", eta = 4, stopId = "a", stopSortKey = "Bay 2")
+            )
+        )
+        assertEquals(listOf("Bay 2", null), rows.map { it.first().stopSortKey })
+    }
+
+    /**
+     * Ordering is by the stable (agency, line, headsign, bay) key and never by ETA, so a row does not
+     * jump around the list as its countdown ticks or a poll lands.
+     */
+    @Test
+    fun `row order does not depend on eta`() {
+        val soonestFirst = group(
+            listOf(
+                FakeItem("r8", "A", eta = 1, stopId = "bay", lineName = "8"),
+                FakeItem("r40", "A", eta = 2, stopId = "bay", lineName = "40")
+            )
+        )
+        val soonestLast = group(
+            listOf(
+                FakeItem("r40", "A", eta = 1, stopId = "bay", lineName = "40"),
+                FakeItem("r8", "A", eta = 99, stopId = "bay", lineName = "8")
+            )
+        )
+        assertEquals(listOf("8", "40"), soonestFirst.map { it.first().lineName })
+        assertEquals(listOf("8", "40"), soonestLast.map { it.first().lineName })
+    }
+
+    /**
+     * The stop id is joined into the key with the same NUL the route key uses, so a bay whose id
+     * happens to contain that separator still reads as its own bay rather than merging with another.
+     */
+    @Test
+    fun `a stop id containing the key separator stays its own row`() {
+        val rows = group(
+            listOf(
+                FakeItem("r1", null, eta = 1, stopId = "a"),
+                FakeItem("r1", null, eta = 2, stopId = "a\u0000r1"),
+                FakeItem("r1", null, eta = 3, stopId = "a")
+            )
+        )
+        assertEquals(2, rows.size)
+        assertEquals(2, rows.first { it.first().stopId == "a" }.size)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.map.render.showsNearbyArrivals
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -99,10 +100,22 @@ class HomeSheetLogicTest {
      */
     @Test
     fun `the nearby key is stable while the stop key is per stop`() {
-        assertEquals(HomeSheetContent.NearbyRoutes.sheetKey, HomeSheetContent.NearbyRoutes.sheetKey)
+        assertEquals("nearby", HomeSheetContent.NearbyRoutes.sheetKey)
         assertEquals("stop:1", HomeSheetContent.Stop("1").sheetKey)
         assertEquals("stop:2", HomeSheetContent.Stop("2").sheetKey)
         assertNull(HomeSheetContent.None.sheetKey)
+    }
+
+    /**
+     * The sheet decision and `NearbyArrivalsViewModel`'s query gate must read the same predicate, or
+     * the drawer can engage on a band the query never asked for — so pin the predicate itself, not
+     * each caller's copy of `>= ROUTES`.
+     */
+    @Test
+    fun `only the transit-centre band shows nearby arrivals`() {
+        assertFalse(StopBand.DOT.showsNearbyArrivals)
+        assertFalse(StopBand.FULL.showsNearbyArrivals)
+        assertTrue(StopBand.ROUTES.showsNearbyArrivals)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -18,8 +18,10 @@ package org.onebusaway.android.ui.home
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -32,14 +34,75 @@ class HomeSheetLogicTest {
 
     private val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
 
-    // --- shouldShowSheet ---
+    // --- homeSheetContent ---
+
+    /** The nearby drawer's preconditions, so each test below varies one thing away from them. */
+    private fun content(
+        focus: CurrentFocus = CurrentFocus.None,
+        band: StopBand = StopBand.ROUTES,
+        nearbyRowsReady: Boolean = true
+    ) = homeSheetContent(focus, band, nearbyRowsReady)
 
     @Test
-    fun `sheet shows only with a focused stop`() {
-        assertTrue(shouldShowSheet(CurrentFocus.Stop(stop)))
-        assertFalse(shouldShowSheet(CurrentFocus.Route(RouteTarget("route"))))
-        assertFalse(shouldShowSheet(CurrentFocus.BikeStation("bike")))
-        assertFalse(shouldShowSheet(CurrentFocus.None))
+    fun `a focused stop shows its own panel at any zoom`() {
+        assertEquals(HomeSheetContent.Stop("1"), content(CurrentFocus.Stop(stop), StopBand.ROUTES))
+        assertEquals(HomeSheetContent.Stop("1"), content(CurrentFocus.Stop(stop), StopBand.DOT))
+    }
+
+    /** A focused stop is a deliberate choice about one bay; it outranks the ambient nearby list. */
+    @Test
+    fun `a focused stop wins over the nearby list`() {
+        assertEquals(
+            HomeSheetContent.Stop("1"),
+            content(focus = CurrentFocus.Stop(stop), nearbyRowsReady = true)
+        )
+    }
+
+    @Test
+    fun `nearby routes show unfocused at transit-centre zoom with rows`() {
+        assertEquals(HomeSheetContent.NearbyRoutes, content())
+    }
+
+    /** Widening bands: a band added above ROUTES must keep the drawer, not switch it off. */
+    @Test
+    fun `nearby routes read the band as an ordering`() {
+        assertEquals(
+            HomeSheetContent.NearbyRoutes,
+            content(band = StopBand.entries.last())
+        )
+    }
+
+    @Test
+    fun `nothing shows below the transit-centre band`() {
+        assertEquals(HomeSheetContent.None, content(band = StopBand.FULL))
+        assertEquals(HomeSheetContent.None, content(band = StopBand.DOT))
+    }
+
+    /** Never open an empty drawer: no rows means no sheet, whatever the zoom. */
+    @Test
+    fun `nothing shows without nearby rows`() {
+        assertEquals(HomeSheetContent.None, content(nearbyRowsReady = false))
+    }
+
+    @Test
+    fun `route, bike, and directions focus show no sheet`() {
+        assertEquals(HomeSheetContent.None, content(focus = CurrentFocus.Route(RouteTarget("route"))))
+        assertEquals(HomeSheetContent.None, content(focus = CurrentFocus.BikeStation("bike")))
+        assertEquals(HomeSheetContent.None, content(focus = CurrentFocus.Directions()))
+    }
+
+    // --- sheetKey ---
+
+    /**
+     * The reveal effect keys off this, so it must NOT change as the rider pans within the nearby mode
+     * — otherwise every settled camera would re-run the reveal and fight a drag in progress.
+     */
+    @Test
+    fun `the nearby key is stable while the stop key is per stop`() {
+        assertEquals(HomeSheetContent.NearbyRoutes.sheetKey, HomeSheetContent.NearbyRoutes.sheetKey)
+        assertEquals("stop:1", HomeSheetContent.Stop("1").sheetKey)
+        assertEquals("stop:2", HomeSheetContent.Stop("2").sheetKey)
+        assertNull(HomeSheetContent.None.sheetKey)
     }
 
     @Test
@@ -126,5 +189,30 @@ class HomeSheetLogicTest {
         assertEquals(SheetBackAction.COLLAPSE, sheetBackAction(ArrivalsSheetState.Expanded))
         assertEquals(SheetBackAction.NAVIGATE_BACK, sheetBackAction(ArrivalsSheetState.Collapsed))
         assertEquals(SheetBackAction.NONE, sheetBackAction(ArrivalsSheetState.Hidden))
+    }
+
+    /** An expanded sheet collapses to peek whatever it holds — including the nearby list. */
+    @Test
+    fun `back collapses an expanded nearby list`() {
+        assertEquals(
+            SheetBackAction.COLLAPSE,
+            sheetBackAction(ArrivalsSheetState.Expanded, HomeSheetContent.NearbyRoutes)
+        )
+    }
+
+    /**
+     * The nearby drawer is ambient, not a focus: at peek there is nothing behind it to go back to, so
+     * back must reach the system rather than being swallowed into a focus pop.
+     */
+    @Test
+    fun `back at peek passes through for the nearby list but pops a focused stop`() {
+        assertEquals(
+            SheetBackAction.NONE,
+            sheetBackAction(ArrivalsSheetState.Collapsed, HomeSheetContent.NearbyRoutes)
+        )
+        assertEquals(
+            SheetBackAction.NAVIGATE_BACK,
+            sheetBackAction(ArrivalsSheetState.Collapsed, HomeSheetContent.Stop("1"))
+        )
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModelTest.kt
@@ -95,10 +95,16 @@ class NearbyArrivalsViewModelTest {
         }
     }
 
+    /** The OBA deployment every test below is pointed at — the key the support verdict is held under. */
+    private val endpoint = "https://api.pugetsound.onebusaway.org/"
+
+    private fun regions(obaBaseUrl: String? = endpoint) = FakeRegionRepository(region(id = 1, obaBaseUrl = obaBaseUrl))
+
     private fun viewModel(
         dataSource: NearbyArrivalsDataSource,
-        support: NearbyArrivalsSupport = NearbyArrivalsSupport()
-    ) = NearbyArrivalsViewModel(dataSource, FakeRegionRepository(region(id = 1)), support)
+        support: NearbyArrivalsSupport = NearbyArrivalsSupport(),
+        regionRepo: FakeRegionRepository = regions()
+    ) = NearbyArrivalsViewModel(dataSource, regionRepo, support)
 
     private fun http(code: Int) = HttpException(
         Response.error<Unit>(code, "".toResponseBody("text/html".toMediaType()))
@@ -269,7 +275,7 @@ class NearbyArrivalsViewModelTest {
         advanceTimeBy(1)
 
         assertEquals(NearbyArrivalsUiState.Unsupported, vm.state.value)
-        assertTrue(support.isKnownUnsupported(1L))
+        assertTrue(support.isKnownUnsupported(endpoint))
 
         advanceTimeBy(NEARBY_REFRESH_PERIOD_MS * 3)
         assertEquals(1, source.requests.size)
@@ -279,7 +285,7 @@ class NearbyArrivalsViewModelTest {
     /** Once recorded, a later viewport in the same region doesn't re-probe within the process. */
     @Test
     fun `a region already known unsupported is not queried again`() = runTest(scheduler) {
-        val support = NearbyArrivalsSupport().apply { recordAbsent(1L) }
+        val support = NearbyArrivalsSupport().apply { recordAbsent(endpoint) }
         val source = FakeDataSource()
         val vm = viewModel(source, support)
         val collector = launchCollect(vm)
@@ -309,7 +315,7 @@ class NearbyArrivalsViewModelTest {
         advanceTimeBy(NEARBY_REFRESH_PERIOD_MS + 1)
 
         assertEquals(2, source.requests.size)
-        assertFalse(support.isKnownUnsupported(1L))
+        assertFalse(support.isKnownUnsupported(endpoint))
         collector.cancel()
     }
 
@@ -329,13 +335,76 @@ class NearbyArrivalsViewModelTest {
         assertFalse(isEndpointAbsent(SocketTimeoutException("slow")))
     }
 
-    /** The verdict is per deployment, so one region's 404 must not silence another. */
+    /**
+     * The verdict is about the *server*, so it is keyed by the OBA base URL rather than by
+     * `Region.id`: a directory refresh can repoint an existing region at another deployment, and a
+     * deep-link-added region is a host the directory never named — either would inherit the other's
+     * 404 under an id key and lose the drawer where it in fact works.
+     */
     @Test
-    fun `the unsupported verdict is scoped to its region`() {
+    fun `the unsupported verdict is scoped to the deployment that answered`() {
         val support = NearbyArrivalsSupport()
-        support.recordAbsent(1L)
-        assertTrue(support.isKnownUnsupported(1L))
-        assertFalse(support.isKnownUnsupported(2L))
+        support.recordAbsent(endpoint)
+        assertTrue(support.isKnownUnsupported(endpoint))
+        assertFalse(support.isKnownUnsupported("https://api.tampa.onebusaway.org/"))
         assertFalse(support.isKnownUnsupported(null))
+    }
+
+    // --- switching regions ------------------------------------------------------------------------
+
+    /**
+     * The server is a query input, not a fact read once: switching regions must re-ask, even though
+     * neither the camera nor the sheet moved. Keyed on the endpoint alone, so an unrelated region
+     * field can't re-fire it.
+     */
+    @Test
+    fun `switching regions re-queries the new deployment`() = runTest(scheduler) {
+        val source = FakeDataSource(NearbyArrivalsResult.Loaded(nearbyArrivals()))
+        val regionRepo = regions()
+        val vm = viewModel(source, regionRepo = regionRepo)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        assertEquals(1, source.requests.size)
+
+        // A field that isn't the endpoint: same deployment, so nothing to re-ask.
+        regionRepo.emit(region(id = 1, obaBaseUrl = endpoint, twitterUrl = "https://example.test"))
+        advanceTimeBy(1)
+        assertEquals(1, source.requests.size)
+
+        regionRepo.emit(region(id = 2, obaBaseUrl = "https://api.tampa.onebusaway.org/"))
+        advanceTimeBy(1)
+        assertEquals(2, source.requests.size)
+        collector.cancel()
+    }
+
+    /**
+     * Rows are held across a *pan* so the drawer updates in place — but rows from another deployment
+     * describe another city, so a region switch starts from Loading rather than showing the previous
+     * region's bays over the new one.
+     */
+    @Test
+    fun `a region switch drops the held rows instead of holding them through the load`() = runTest(scheduler) {
+        val source = FakeDataSource(NearbyArrivalsResult.Loaded(nearbyArrivals()))
+        val regionRepo = regions()
+        val vm = viewModel(source, regionRepo = regionRepo)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        assertTrue(vm.state.value is NearbyArrivalsUiState.Loaded)
+
+        // Never answers, so whatever the switch emitted first is what stays observable.
+        source.result = NearbyArrivalsResult.Failed(SocketTimeoutException("slow"))
+        regionRepo.emit(region(id = 2, obaBaseUrl = "https://api.tampa.onebusaway.org/"))
+        advanceTimeBy(1)
+
+        assertEquals(NearbyArrivalsUiState.Loading, vm.state.value)
+        collector.cancel()
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsViewModelTest.kt
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.nearby
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.api.ObaApiException
+import org.onebusaway.android.api.contract.ArrivalsForLocation
+import org.onebusaway.android.api.contract.ArrivalsForLocationData
+import org.onebusaway.android.api.data.NearbyArrivals
+import org.onebusaway.android.api.data.NearbyArrivalsDataSource
+import org.onebusaway.android.api.data.NearbyArrivalsResult
+import org.onebusaway.android.api.data.NearbyArrivalsSupport
+import org.onebusaway.android.api.data.isEndpointAbsent
+import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.region.FakeRegionRepository
+import org.onebusaway.android.region.region
+import org.onebusaway.android.testing.MainDispatcherRule
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.util.GeoPoint
+import retrofit2.HttpException
+import retrofit2.Response
+
+/**
+ * JVM unit tests for the transit-centre drawer's query (#2107): when it asks, when it stops, and how
+ * it tells "this region can't serve this" apart from "the network hiccuped" — the distinction that
+ * decides whether the feature is switched off for a region or simply retried.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NearbyArrivalsViewModelTest {
+
+    // One scheduler shared by the rule's Main dispatcher and every runTest below, so advanceTimeBy
+    // drives the view model's own poll delay (which runs on viewModelScope -> Main) and not just the
+    // test body's. Unconfined so the derived `state` recomputes eagerly and can be read synchronously.
+    private val scheduler = TestCoroutineScheduler()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(UnconfinedTestDispatcher(scheduler))
+
+    /**
+     * `state` is a `stateIn(WhileSubscribed)`, so it only asks while something is collecting — which is
+     * the mechanism that stops the poll when the screen goes away. Tests therefore need a live
+     * collector; `backgroundScope` cancels it when the test ends.
+     */
+    private fun TestScope.launchCollect(vm: NearbyArrivalsViewModel): Job = backgroundScope.launch { vm.state.collect { } }
+
+    private val viewport = CameraSnapshot(
+        center = GeoPoint(47.6109, -122.3376),
+        zoom = 17.8,
+        latSpan = 0.002,
+        lonSpan = 0.003,
+        southWest = GeoPoint(47.60, -122.34),
+        northEast = GeoPoint(47.62, -122.33)
+    )
+
+    private class FakeDataSource(
+        var result: NearbyArrivalsResult = NearbyArrivalsResult.Failed(IOException("unset"))
+    ) : NearbyArrivalsDataSource {
+        val requests = mutableListOf<CameraSnapshot>()
+        override suspend fun arrivals(
+            viewport: CameraSnapshot,
+            minutesAfter: Int
+        ): NearbyArrivalsResult {
+            requests += viewport
+            return result
+        }
+    }
+
+    private fun viewModel(
+        dataSource: NearbyArrivalsDataSource,
+        support: NearbyArrivalsSupport = NearbyArrivalsSupport()
+    ) = NearbyArrivalsViewModel(dataSource, FakeRegionRepository(region(id = 1)), support)
+
+    private fun http(code: Int) = HttpException(
+        Response.error<Unit>(code, "".toResponseBody("text/html".toMediaType()))
+    )
+
+    /** A resolved response. Contents don't matter here — these tests are about *when* it asks. */
+    private fun nearbyArrivals() = NearbyArrivals(
+        ArrivalsForLocationData(entry = ArrivalsForLocation()),
+        ServerTime(1_786_132_299_765L),
+        NEARBY_MINUTES_AFTER
+    )
+
+    // --- when it asks -----------------------------------------------------------------------------
+
+    /** Below the transit-centre band the drawer isn't shown, so nothing is fetched for it. */
+    @Test
+    fun `no request below the transit-centre band`() = runTest(scheduler) {
+        val source = FakeDataSource()
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.FULL)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+
+        assertTrue(source.requests.isEmpty())
+        assertEquals(NearbyArrivalsUiState.Idle, vm.state.value)
+        collector.cancel()
+    }
+
+    /** A focused stop hands the sheet to that stop's own session; this query must stop polling. */
+    @Test
+    fun `no request while another surface owns the sheet`() = runTest(scheduler) {
+        val source = FakeDataSource()
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(false)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+
+        assertTrue(source.requests.isEmpty())
+        collector.cancel()
+    }
+
+    @Test
+    fun `a settled viewport in the band is queried once`() = runTest(scheduler) {
+        val source = FakeDataSource()
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+
+        assertEquals(1, source.requests.size)
+        collector.cancel()
+    }
+
+    /** A pan re-queries; re-reporting the *same* viewport does not. */
+    @Test
+    fun `a new viewport re-queries and an identical one does not`() = runTest(scheduler) {
+        val source = FakeDataSource()
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        assertEquals(1, source.requests.size)
+
+        vm.onViewportSettled(viewport.copy(center = GeoPoint(47.7, -122.3)))
+        advanceTimeBy(1)
+        assertEquals(2, source.requests.size)
+        collector.cancel()
+    }
+
+    /** The cadence the rest of the app's live-ETA surfaces use. */
+    @Test
+    fun `the query repeats on the refresh period`() = runTest(scheduler) {
+        val source = FakeDataSource()
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        assertEquals(1, source.requests.size)
+
+        advanceTimeBy(NEARBY_REFRESH_PERIOD_MS + 1)
+        assertEquals(2, source.requests.size)
+        collector.cancel()
+    }
+
+    /**
+     * A pan must not empty the drawer. The sheet gates its visibility on having rows, so re-emitting
+     * Loading for the new viewport would retract the drawer and slide it back up a request later —
+     * once per pan. The previous response is held until the new one lands.
+     */
+    @Test
+    fun `a pan keeps the previous rows instead of reverting to loading`() = runTest(scheduler) {
+        val source = FakeDataSource()
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+
+        val loaded = NearbyArrivalsResult.Loaded(nearbyArrivals())
+        source.result = loaded
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        assertTrue(vm.state.value is NearbyArrivalsUiState.Loaded)
+
+        // A new viewport, whose response hasn't arrived yet: the state must still be Loaded.
+        source.result = NearbyArrivalsResult.Failed(SocketTimeoutException("in flight"))
+        vm.onViewportSettled(viewport.copy(center = GeoPoint(47.62, -122.33)))
+        advanceTimeBy(1)
+        assertTrue(vm.state.value is NearbyArrivalsUiState.Loaded)
+        collector.cancel()
+    }
+
+    /** Leaving the band drops the held rows, so re-entering elsewhere can't flash the old centre. */
+    @Test
+    fun `leaving the band clears the held rows`() = runTest(scheduler) {
+        val source = FakeDataSource(NearbyArrivalsResult.Loaded(nearbyArrivals()))
+        val vm = viewModel(source)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        assertTrue(vm.state.value is NearbyArrivalsUiState.Loaded)
+
+        vm.onStopBand(StopBand.FULL)
+        advanceTimeBy(1)
+        assertEquals(NearbyArrivalsUiState.Idle, vm.state.value)
+
+        // Back into the band with a response not yet in: Loading, not the previous centre's rows.
+        source.result = NearbyArrivalsResult.Failed(SocketTimeoutException("in flight"))
+        vm.onStopBand(StopBand.ROUTES)
+        advanceTimeBy(1)
+        assertEquals(NearbyArrivalsUiState.Loading, vm.state.value)
+        collector.cancel()
+    }
+
+    // --- unsupported vs transient -----------------------------------------------------------------
+
+    /** A 404 is durable: the state says so and the poll stops rather than hammering the server. */
+    @Test
+    fun `a 404 marks the region unsupported and stops querying`() = runTest(scheduler) {
+        val support = NearbyArrivalsSupport()
+        val source = FakeDataSource(NearbyArrivalsResult.Unsupported)
+        val vm = viewModel(source, support)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+
+        assertEquals(NearbyArrivalsUiState.Unsupported, vm.state.value)
+        assertTrue(support.isKnownUnsupported(1L))
+
+        advanceTimeBy(NEARBY_REFRESH_PERIOD_MS * 3)
+        assertEquals(1, source.requests.size)
+        collector.cancel()
+    }
+
+    /** Once recorded, a later viewport in the same region doesn't re-probe within the process. */
+    @Test
+    fun `a region already known unsupported is not queried again`() = runTest(scheduler) {
+        val support = NearbyArrivalsSupport().apply { recordAbsent(1L) }
+        val source = FakeDataSource()
+        val vm = viewModel(source, support)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+
+        assertTrue(source.requests.isEmpty())
+        assertEquals(NearbyArrivalsUiState.Unsupported, vm.state.value)
+        collector.cancel()
+    }
+
+    /** A transient failure must never be mistaken for "unsupported": it retries on the next poll. */
+    @Test
+    fun `a transient failure keeps polling and does not disable the region`() = runTest(scheduler) {
+        val support = NearbyArrivalsSupport()
+        val source = FakeDataSource(NearbyArrivalsResult.Failed(SocketTimeoutException("slow")))
+        val vm = viewModel(source, support)
+        val collector = launchCollect(vm)
+
+        vm.setActive(true)
+        vm.onStopBand(StopBand.ROUTES)
+        vm.onViewportSettled(viewport)
+        advanceTimeBy(1)
+        advanceTimeBy(NEARBY_REFRESH_PERIOD_MS + 1)
+
+        assertEquals(2, source.requests.size)
+        assertFalse(support.isKnownUnsupported(1L))
+        collector.cancel()
+    }
+
+    // --- isEndpointAbsent -------------------------------------------------------------------------
+
+    @Test
+    fun `only an http 404 reads as an absent endpoint`() {
+        assertTrue(isEndpointAbsent(http(404)))
+
+        assertFalse(isEndpointAbsent(http(500)))
+        assertFalse(isEndpointAbsent(http(401)))
+        assertFalse(isEndpointAbsent(http(403)))
+        // An OBA envelope code of 404 arrives inside a well-formed 200; it is not the transport
+        // saying the action is unmapped, so it stays transient.
+        assertFalse(isEndpointAbsent(ObaApiException(404)))
+        assertFalse(isEndpointAbsent(IOException("offline")))
+        assertFalse(isEndpointAbsent(SocketTimeoutException("slow")))
+    }
+
+    /** The verdict is per deployment, so one region's 404 must not silence another. */
+    @Test
+    fun `the unsupported verdict is scoped to its region`() {
+        val support = NearbyArrivalsSupport()
+        support.recordAbsent(1L)
+        assertTrue(support.isKnownUnsupported(1L))
+        assertFalse(support.isKnownUnsupported(2L))
+        assertFalse(support.isKnownUnsupported(null))
+    }
+}


### PR DESCRIPTION
Closes the second half of #2107. Item (1) (#2136) put route *names* on each stop
marker from zoom 17.5. What a label can't say is *when*. At that same zoom, with
nothing focused, the arrivals drawer now engages at its peek listing every route
leaving every bay in view — so a rider standing in a transit centre reads the
whole place at once instead of opening bay after bay.

Route-first, not stop-grouped: one row per (route, direction, bay), each naming
where to stand. Grouping by stop would only reproduce the bay-by-bay scan the
feature exists to remove. A route+direction boarding from two bays is two rows —
merging them would either name both (the same scan) or pick one, which is a claim
that can be false on the ground.

## One request per viewport, not one per stop

`arrivals-and-departures-for-location` takes the viewport parameters the map
already computes for `stops-for-location` and answers with every arrival at every
stop in the box, each carrying its own `stopId`.

**It is missing from developer.onebusaway.org** — [docs PR onebusaway-docs#166](https://github.com/OneBusAway/onebusaway-docs/pull/166)
is open to add it — but it has been in onebusaway-application-modules since 2022
as [`ArrivalsAndDeparturesForLocationAction`](https://github.com/OneBusAway/onebusaway-application-modules/blob/main/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/ArrivalsAndDeparturesForLocationAction.java),
with docs in that repo's own `src/site/markdown/`. Worth stating plainly so a
future reader doesn't conclude it was invented.

Measured at 3rd Ave & Pine, Seattle, in a zoom-17.5-sized box: **8 bays, 40 rows,
~29 KB gzipped**. One single-stop request at the same window is 6.8 KB — so this
is about half the bytes of an eight-way fan-out and an eighth of the requests,
i.e. the same cost as the one focused stop the drawer already polls at 60s.

Two behaviours found by probing the live servers that the code has to know:

- **The empty box answers a different shape.** With stops it is
  `{entry, references}`; with none it is the raw bean with no `entry` at all
  (`emptyResponse()` skips `factory.getResponse`). Identical on all four regions
  that serve it. `entry` is nullable for exactly this reason — otherwise panning
  onto water throws instead of showing an empty list. Both shapes are pinned by
  `NearbyArrivalsDecodeTest`.
- **`maxCount` truncates arrivals, not stops.** At `maxCount=10` the response
  covered *one* bay, not ten: the nearest bay's departures eat the budget and the
  rest vanish. Using it as a cost lever would silently drop bays the rider is
  looking straight at. It is left at the server default; `minutesAfter` is the
  size lever, and `limitExceeded` is surfaced in the drawer.

## Support is discovered, not configured

| | |
|---|---|
| Puget Sound, Tampa Bay, WMATA, Davis (Unitrans) | 200 |
| MTA New York (own fork), San Diego (old build), Adelaide Metro | 404 |

That is every region in the live directory, probed with the app's own key. No
directory field records this, so the first query is the probe and an explicit
**HTTP 404** is believed — read off the status line, since San Diego replies with
a raw Tomcat HTML page no JSON decode could classify. Nothing else counts: a
timeout, a 5xx, or a non-OK OBA envelope code stays transient, because those
happen to regions that *do* serve it.

The verdict is in-memory per region id, deliberately not persisted: a deployment
that upgrades is then picked up on the next launch rather than pinned off until a
reinstall, at a cost of one wasted request per launch per unsupported region.

## The rest

- `HomeSheetLogic` grows a three-way `HomeSheetContent` in place of
  `shouldShowSheet`. **No new `CurrentFocus` variant** — that type is the map's
  *subject*, persisted and undoable, and this list is precisely what shows when
  there isn't one. It gates on having rows, so the drawer never opens empty,
  never opens mid-load, and never opens at all where the server can't answer.
- Back collapses an expanded list to peek; at peek it passes to the system,
  since the list is ambient with nothing behind it to return to.
- A pan updates the list in place. The previous response is held while the new
  viewport loads — re-emitting `Loading` would empty the rows, and since the
  sheet gates on rows that would retract and re-reveal the drawer once per pan.
- `settledCamera()` is extracted from the byte-identical debounce +
  `cameraInteracting` gate that `StopsMapController` and `BikeLayerController`
  each carried, so all three loaders share one definition of "settled".
- ETAs are measured against the response's own `currentTime`, minted to
  `ServerTime` at the wire boundary (#1612 / #1620).

Row tap shows that route on the map scoped to the row's bay, in **one** focus
push so one Back returns straight to the list.

## Needs a human decision before merge

1. **`minutesAfter = 35` is a new product threshold** (the starred-stops list's
   value, against the focused-stop default of 65) — ~29 KB vs ~40 KB gzipped, for
   departures further out than anyone standing at the stop is waiting for.
   CLAUDE.md wants thresholds called out for sign-off; this is that.
2. **The long-press menu is partially wired.** Star, reminder, tracking and
   report-a-problem each need the stop-scoped `ArrivalsViewModel` that this
   many-bay list deliberately does not create. Rather than no-op them they focus
   the row's bay, landing the rider on the panel where they are wired. Coherent,
   but not what a rider expects from a menu item — a follow-up issue is the
   honest fix, and service alerts on rows are deferred with it.
3. **40 rows at 3rd & Pine is a long list** and the peek cap
   (`PEEK_HEIGHT_FRACTION = 0.30f`) is untuned for it — a device-tuning job, the
   way #2136 tuned the zoom threshold itself.

Also worth noting: three of seven regions, including MTA New York, get nothing.
That was a deliberate call over carrying a second fan-out data path.

## Testing

- **1,895 unit tests, 0 failures**, both flavors (`obaGoogle` + `obaMaplibre`)
- `compileObaGoogleDebugKotlin` + `compileObaMaplibreDebugKotlin` with
  `-PwarningsAsErrors=true` — clean
- `spotlessCheck` — clean
- 24 new tests: both wire shapes; grouping/ordering including the two-bay case
  and that row order never depends on ETA; the three-way sheet mode and back
  behaviour; and the query's band gating, requery-on-pan, poll cadence,
  hold-rows-through-a-pan, and the 404-vs-transient split.

**Not yet exercised on device.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added nearby arrivals for transit-centre views, including real-time route and bay information.
  - Nearby arrivals appear on the map and in an expandable sheet when zoomed appropriately.
  - Added actions for viewing routes, stops, schedules, trips, favorites, reminders, and service details.
  - Added automatic refresh and graceful handling for unsupported or unavailable nearby-arrivals data.
- **Improvements**
  - Improved map loading after camera movement settles.
  - Route rows now remain distinct by stop and display bay or stop labels.
  - Added messaging when nearby results are truncated and users should zoom in.
- **Tests**
  - Added coverage for response decoding, grouping, sheet behavior, polling, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->