### PR TITLE
Stripe a shared ride in every route's colour (#2100)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -39,8 +39,6 @@ import com.google.android.gms.maps.model.StrokeStyle
 import com.google.android.gms.maps.model.StyleSpan
 import com.google.android.gms.maps.model.TextureStyle
 import java.util.concurrent.TimeUnit
-import kotlin.math.cos
-import kotlin.math.pow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -54,7 +52,6 @@ import org.onebusaway.android.map.render.ContinuationBadge
 import org.onebusaway.android.map.render.ContinuationBadgeBitmaps
 import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.InterlineSeamMark
-import org.onebusaway.android.map.render.METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO
 import org.onebusaway.android.map.render.MapPing
 import org.onebusaway.android.map.render.MapRenderSnapshot
 import org.onebusaway.android.map.render.MapRenderState
@@ -74,6 +71,7 @@ import org.onebusaway.android.map.render.TripMarkerBitmaps
 import org.onebusaway.android.map.render.TripOverlay
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
+import org.onebusaway.android.map.render.metersPerPixel
 import org.onebusaway.android.map.render.rentalZoomBand
 import org.onebusaway.android.map.render.routeLineWidthScale
 import org.onebusaway.android.map.rental.rentalChargeFraction
@@ -574,11 +572,7 @@ class GoogleMapRenderer(
         }
         val progress = MapPing.progress(elapsed)
         val radiusPx = MapPing.MAX_RADIUS_DP * density * MapPing.radiusFraction(progress)
-        val metersPerPx =
-            METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
-                cos(Math.toRadians(center.latitude)) /
-                2.0.pow(map.cameraPosition.zoom.toDouble())
-        val radiusMeters = radiusPx * metersPerPx
+        val radiusMeters = radiusPx * metersPerPixel(center.latitude, map.cameraPosition.zoom.toDouble())
         val color = MapPing.withAlpha(pingColor, MapPing.alpha(progress))
         val existing = pingCircle
         if (existing == null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -135,13 +135,17 @@ class DirectionsMapController(private val host: MapHost) {
         // Every leg's points run in travel order, but no itinerary leg stamps chevrons any more — see
         // [itineraryLegStyle], which also decides the hairline case a ride wears.
         val caps = itineraryLegCaps(legs)
-        legLines = drawableLegs.map { (legIndex, _, points, style) ->
+        legLines = drawableLegs.map { drawable ->
+            val (legIndex, _, points, style) = drawable
             val legCaps = caps[legIndex]
             ItineraryLegLine(
                 legIndex,
                 RoutePolyline(
                     style.color,
                     points,
+                    // The other routes this ride may be taken on, striped through it (#2100) so the line
+                    // says what its badge does; empty for every ride offering no alternative.
+                    stripeColors = drawable.stripeColors(palette),
                     widthProfile = style.widthProfile,
                     dash = style.dash,
                     case = style.case,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -282,6 +282,28 @@ internal fun itineraryRouteBadges(
     )
 }
 
+/**
+ * The colours a ride's line is striped with (#2100): the routes the rider may board in its place, each in
+ * the colour this map gives *that* route's line, and never the planned route's own colour, which the line
+ * is already stroked in ([RoutePolyline.stripeColors] cycles through that first).
+ *
+ * In the label's own order among themselves ([inInterchangeableOrder]), the planned route leading because the
+ * line is stroked in it — so the colours a rider reads along the line are the colours of the badge sitting on
+ * it, arrived at from the route the plan picked. Deduplicated by **colour**, rather than by the name a badge
+ * dedupes on ([itineraryRouteBadges]): a stripe carries no name, so two routes an agency publishes one colour for
+ * — including the two that publish none at all, and share the colourless hue — have one stripe between them
+ * rather than two the rider can't tell apart. That is also why a substitute matching the planned route's
+ * colour drops out entirely: it would stripe the line with the colour it already is.
+ */
+internal fun ItineraryDrawableLeg.stripeColors(palette: RouteLinePalette): List<Int> = interchangeable
+    .inInterchangeableOrder { it.route.displayName }
+    .map { it.lineColor(palette) }
+    .distinct()
+    .filterNot { it == style.color }
+
+/** The colour this map draws [ItinerarySubstitute]'s own line in, were the rider to drill into it (#2063). */
+private fun ItinerarySubstitute.lineColor(palette: RouteLinePalette): Int = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor, palette).color
+
 private data class RideIdentity(val route: String, val interchangeableRouteIds: Set<String>)
 
 private data class Ride(val identity: RideIdentity, val name: String, val drawable: ItineraryDrawableLeg) {
@@ -294,10 +316,7 @@ private data class Ride(val identity: RideIdentity, val name: String, val drawab
     fun badgedRoutes(palette: RouteLinePalette): List<BadgedRoute> = (
         listOf(BadgedRoute(name, drawable.style.color)) +
             drawable.interchangeable.map { substitute ->
-                BadgedRoute(
-                    substitute.route.displayName,
-                    itineraryLegStyle(ItineraryLegKind.TRANSIT, substitute.routeColor, palette).color
-                )
+                BadgedRoute(substitute.route.displayName, substitute.lineColor(palette))
             }
         ).inInterchangeableOrder(BadgedRoute::routeShortName)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -128,7 +128,7 @@ internal fun FocusedTripGeometry.toRoutePolylines(
             RoutePolyline(
                 routeColors[shape.routeDirection] ?: mapRouteLineColorOrNull(shape.routeColor),
                 shape.points,
-                widthProfile,
+                widthProfile = widthProfile,
                 // Adjacent routes in stop focus are plain thin lines — no direction chevrons — so the
                 // mode reads as "these routes pass here", reserving chevrons for a selected route (#1985).
                 directional = false,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -87,11 +87,17 @@ internal fun List<RoutePolyline>.asSelectedRouteApproach(): List<RoutePolyline> 
  * The rider's committed journey retained around a focused transit leg. It keeps each leg's mode/route
  * colour and dash, but drops chevrons and takes a middle weight: stronger than unused route geometry,
  * weaker than the selected ridden segment.
+ *
+ * It also drops a shared ride's stripes (#2100). Striping answers "which of these routes may I board?", a
+ * question about a ride the rider is choosing; a context leg is here to say where the leg being read sits
+ * in the journey, and is drawn at half the width the stripes were cut against — so the same rhythm arrives
+ * as a fleck of noise beside the leg that is actually being read.
  */
 internal fun List<RoutePolyline>.asItineraryContext(): List<RoutePolyline> = map { line ->
     line.copy(
         widthProfile = ITINERARY_CONTEXT_WIDTH_PROFILE,
-        directional = false
+        directional = false,
+        stripeColors = emptyList()
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlin.math.cos
+import kotlin.math.pow
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.Polyline
 import org.onebusaway.android.util.haversineDistance
@@ -55,8 +57,28 @@ internal fun leadingBearing(points: List<GeoPoint>): Float? {
 }
 
 /**
- * Web-Mercator ground resolution at zoom 0 on the equator, in meters per pixel (256px tiles). Scale to
- * a given zoom/latitude with `× cos(lat) / 2^zoom`. The single source for this constant, shared by the
- * route-render pipeline and the map-ping radius math.
+ * Web-Mercator ground resolution at zoom 0 on the equator, in meters per pixel (256px tiles). Scaled to a
+ * given zoom/latitude by [metersPerPixel], which every caller goes through.
  */
-internal const val METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO = 156543.03392804097
+private const val METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO = 156543.03392804097
+
+/** The latitude Web Mercator is cut off at — beyond it the projection runs away to infinity. */
+internal const val MAX_MERCATOR_LATITUDE = 85.05112878
+
+/**
+ * Web-Mercator ground resolution at [latitude] and [zoom], in meters per pixel — how much ground one
+ * screen pixel covers, and so the conversion between a distance meant in *screen* terms and the geometry
+ * that has to realize it.
+ *
+ * The single place this scaling is written: it was copied out three times (route simplification, stripe
+ * length, the ping radius) and the copies had already drifted apart on their guard rails, each clamping a
+ * different subset of the two inputs the formula runs away on. Both clamps live here now — [latitude] to
+ * the projection's own cutoff, [zoom] to a range no camera exceeds — so a caller gets a finite answer
+ * whatever it hands over.
+ */
+internal fun metersPerPixel(latitude: Double, zoom: Double): Double = METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
+    cos(Math.toRadians(latitude.coerceIn(-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE))) /
+    2.0.pow(zoom.coerceIn(0.0, MAX_MERCATOR_ZOOM))
+
+/** Past this the tiles are smaller than a pixel; no map SDK the app drives goes near it. */
+private const val MAX_MERCATOR_ZOOM = 30.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/GeoMath.kt
@@ -73,12 +73,20 @@ internal const val MAX_MERCATOR_LATITUDE = 85.05112878
  * The single place this scaling is written: it was copied out three times (route simplification, stripe
  * length, the ping radius) and the copies had already drifted apart on their guard rails, each clamping a
  * different subset of the two inputs the formula runs away on. Both clamps live here now — [latitude] to
- * the projection's own cutoff, [zoom] to a range no camera exceeds — so a caller gets a finite answer
- * whatever it hands over.
+ * the projection's own cutoff, [zoom] to a range no camera exceeds — so a caller handing over a real
+ * position gets a finite answer however far out of range it is.
+ *
+ * A *non-finite* input is not clamped into range, because there is no range for it to be in: clamping
+ * leaves a `NaN` alone, and every caller here scales geometry by the result, so it would spread silently
+ * through the shapes rather than stopping at the one bad reading. It is a broken camera or a broken
+ * position — a bug upstream, not a position at the edge of the map — so it fails here where it is named.
  */
-internal fun metersPerPixel(latitude: Double, zoom: Double): Double = METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
-    cos(Math.toRadians(latitude.coerceIn(-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE))) /
-    2.0.pow(zoom.coerceIn(0.0, MAX_MERCATOR_ZOOM))
+internal fun metersPerPixel(latitude: Double, zoom: Double): Double {
+    require(latitude.isFinite() && zoom.isFinite()) { "no ground resolution at latitude $latitude, zoom $zoom" }
+    return METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
+        cos(Math.toRadians(latitude.coerceIn(-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE))) /
+        2.0.pow(zoom.coerceIn(0.0, MAX_MERCATOR_ZOOM))
+}
 
 /** Past this the tiles are smaller than a pixel; no map SDK the app drives goes near it. */
 private const val MAX_MERCATOR_ZOOM = 30.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -162,6 +162,15 @@ enum class RouteLineMark {
  * rider. Marked per end rather than per line so a stay-aboard interline can hide its internal seam while
  * keeping bulbs at the beginning and end of the combined ride.
  *
+ * [stripeColors] are the *other* colours this line is shared by — the routes a rider may board in place of
+ * the one it is drawn for (#2100). A line carrying them is striped: cut into equal runs along its length
+ * that cycle through [color] and then each of these in turn, so a ride the rider may take either of two
+ * routes for shows both, exactly as the badge naming it does, instead of quietly showing whichever route
+ * the planner happened to pick. The runs are cut by [StripeRoutePolylinePass] — a stripe has to hold its
+ * length on the *screen*, so how long one is depends on the camera, which is the render pipeline's to know
+ * and not the producer's. Only the line's own [color] reaches the marks and the case: a bulb, a cut and a
+ * case say where the ride begins, ends and sits, none of which the alternatives change.
+ *
  * [transforms] opts this line into renderer-bound geometry processing. Canonical [points] stay intact in
  * [MapRenderState] for framing and other consumers; both native adapters apply the requested transforms
  * only to the list they render. An empty set is a strict pass-through.
@@ -169,6 +178,7 @@ enum class RouteLineMark {
 data class RoutePolyline(
     val color: Int?,
     val points: List<GeoPoint>,
+    val stripeColors: List<Int> = emptyList(),
     val widthProfile: RouteLineWidthProfile? = null,
     val directional: Boolean = false,
     val dash: RouteLineDash = RouteLineDash.NONE,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteLineStripes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteLineStripes.kt
@@ -67,9 +67,15 @@ internal class StripeRoutePolylinePass : RoutePolylineRenderPass {
 private const val STRIPE_LENGTH_IN_WIDTHS = 2.5
 
 /**
- * The most runs one line is cut into. Well over what a viewport holds — a stripe is a few tens of dp, so a
- * screen shows around ten of them — so the cap binds only on a line running far off the edges of the map,
- * where the runs beyond it cost native lines (two apiece, since each is cased) and buy nothing to look at.
+ * The most runs one line is cut into *to hold the rhythm*. Well over what a viewport holds — a stripe is a
+ * few tens of dp, so a screen shows around ten of them — so the cap binds only on a line running far off the
+ * edges of the map, where the runs beyond it cost native lines (two apiece, since each is cased) and buy
+ * nothing to look at.
+ *
+ * It is not a bound on the colours: a ride shared by more routes than this is still cut once per route,
+ * because a stripe past the cap costs a native line nobody can tell from its neighbour while a route past it
+ * is a route the rider is never told they may board. The count that gets through is bounded by the ride —
+ * the same routes the badge on the line names — rather than by how long the line is.
  */
 internal const val MAX_STRIPES = 24
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteLineStripes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteLineStripes.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import kotlin.math.cos
+import kotlin.math.floor
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.Polyline
+
+/**
+ * Striping a line shared by several routes (#2100): a line that carries [RoutePolyline.stripeColors] is cut
+ * into equal runs along its length, cycling through its own colour and then each of the others in turn, so
+ * one drawn corridor says all of the routes a rider may ride it on.
+ *
+ * A directions leg the rider may board any of several routes for was drawn in exactly one of their colours —
+ * whichever route the planner picked — while the badge sitting on it named them all, each in its own colour
+ * (#2083). So the map answered "which of these am I looking at?" with a colour that meant nothing, and a
+ * rider matching the line to the drawer beside it found half the ride's routes unaccounted for.
+ *
+ * **Stripes run along the line, not beside it.** Side by side was the other candidate, and it is what a
+ * printed transit map does — but neither line API this app draws through offsets a stroke (gms polylines
+ * have no such option, and neither does the classic maplibre annotation), so it would mean generating
+ * parallel geometry per stripe, mitre by mitre, and then splitting a corridor only 15dp wide into slivers of
+ * it. Sequential stripes need no new geometry beyond cutting the line the rider is already being shown, and
+ * every stripe keeps the full weight of the ride.
+ *
+ * A run holds its length on the *screen*, tied to the line's own stroke width ([STRIPE_LENGTH_IN_WIDTHS]),
+ * which is why this is a render pass and not something the producer could have done: at overview zoom a
+ * ride drawn in metre-length runs is a blur of alternating flecks, and drilled into one leg it is a single
+ * flat colour from edge to edge. Two bounds keep it readable at the extremes — every colour appears at least
+ * once however short the line, and no line is cut into more than [MAX_STRIPES] runs however long it is (a
+ * cap on native lines as much as on visual noise, since each run is drawn as one).
+ */
+internal class StripeRoutePolylinePass : RoutePolylineRenderPass {
+    override fun apply(
+        polylines: List<RoutePolyline>,
+        context: RoutePolylineRenderContext
+    ): List<RoutePolyline> {
+        if (polylines.none { it.stripeColors.isNotEmpty() }) return polylines
+        // Without a camera there is no screen to hold a stripe's length on, so the lines stay whole and
+        // draw in their planned colour — the pre-#2100 appearance — until the first camera settles.
+        val zoom = context.camera?.zoom ?: return polylines
+        return polylines.flatMap { it.striped(zoom) }
+    }
+}
+
+/**
+ * How long one stripe is, as a multiple of the line's own stroke width. Expressed against the width rather
+ * than in absolute dp so the rhythm belongs to the line: a ride recedes to half its weight at overview zoom
+ * ([RouteLineWidthProfile]), and stripes that didn't recede with it would crowd into a dotted texture there.
+ * Long enough to read as a run of colour rather than as a dash — this line is solid, and a stripe must not
+ * start saying what [RouteLineDash] says.
+ */
+internal const val STRIPE_LENGTH_IN_WIDTHS = 2.5
+
+/**
+ * The most runs one line is cut into. Reached only by a line far longer than the screen it is drawn on,
+ * where the stripes beyond the viewport cost native lines and buy nothing.
+ */
+internal const val MAX_STRIPES = 48
+
+/**
+ * The width assumed for a line carrying no profile of its own — each renderer's own base width, before the
+ * zoom scale it applies to it. Only a producer striping an unprofiled line would reach it, and none does:
+ * the one striped line today is a directions ride, which is [ITINERARY_RIDE_WIDTH_PROFILE].
+ */
+private const val UNPROFILED_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP
+
+/**
+ * This line cut into its stripes for a camera at [zoom], or the line alone when it isn't striped (which is
+ * every line but a shared directions ride) or is too degenerate to cut.
+ *
+ * The end marks go to the ends of the *ride*, not of each run: the first run keeps the line's
+ * [RoutePolyline.startMark] and the last its [RoutePolyline.endMark], and every internal cut is left
+ * unmarked. A bulb at each stripe boundary would read as a dozen alight-and-boards along one ride.
+ */
+private fun RoutePolyline.striped(zoom: Double): List<RoutePolyline> {
+    if (stripeColors.isEmpty()) return listOf(this)
+    val shape = Polyline(points)
+    val length = shape.lengthMeters
+    if (length <= 0.0) return listOf(this)
+
+    val colors = listOf(color) + stripeColors
+    val stripes = (length / stripeLengthMeters(zoom))
+        .roundToInt()
+        .coerceIn(colors.size, maxOf(colors.size, MAX_STRIPES))
+    val stride = length / stripes
+    return (0 until stripes).mapNotNull { index ->
+        val run = shape.subPolyline(index * stride, (index + 1) * stride) ?: return@mapNotNull null
+        copy(
+            color = colors[index % colors.size],
+            points = run,
+            stripeColors = emptyList(),
+            startMark = if (index == 0) startMark else RouteLineMark.NONE,
+            endMark = if (index == stripes - 1) endMark else RouteLineMark.NONE
+        )
+    }
+}
+
+/**
+ * One stripe's length on the ground, for a camera at [zoom]: [STRIPE_LENGTH_IN_WIDTHS] of this line's drawn
+ * width, converted through the Web-Mercator ground resolution at the line's own latitude.
+ *
+ * The line's latitude rather than the camera's, and a whole zoom level rather than the exact one, both so
+ * that the cut is stable while the rider reads the map: it is *geometry*, so anything it varies with
+ * redraws every native line the moment the camera settles there. Panning across a leg — which moves the
+ * camera's latitude but not the leg's — leaves it untouched, and a pinch redraws once per zoom level
+ * crossed rather than continuously. (The badges quantize their scale ramp for the same reason.)
+ */
+private fun RoutePolyline.stripeLengthMeters(zoom: Double): Double {
+    val quantizedZoom = floor(zoom)
+    val widthDp = widthProfile?.thicknessAt(quantizedZoom.toFloat()) ?: UNPROFILED_LINE_WIDTH_DP
+    val metersPerDp = METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
+        cos(Math.toRadians(points.midpointLatitude())) /
+        2.0.pow(quantizedZoom.coerceIn(0.0, 30.0))
+    return widthDp * STRIPE_LENGTH_IN_WIDTHS * metersPerDp
+}
+
+/**
+ * The latitude of the vertex nearest this line's middle. A single leg spans far too little latitude for the
+ * choice among its vertices to move the stripe length; picking one of them, rather than an average that
+ * every added vertex would nudge, is what makes the answer stable across a re-simplification.
+ */
+private fun List<GeoPoint>.midpointLatitude(): Double = this[size / 2].latitude

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteLineStripes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RouteLineStripes.kt
@@ -15,9 +15,7 @@
  */
 package org.onebusaway.android.map.render
 
-import kotlin.math.cos
 import kotlin.math.floor
-import kotlin.math.pow
 import kotlin.math.roundToInt
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.Polyline
@@ -66,20 +64,14 @@ internal class StripeRoutePolylinePass : RoutePolylineRenderPass {
  * Long enough to read as a run of colour rather than as a dash — this line is solid, and a stripe must not
  * start saying what [RouteLineDash] says.
  */
-internal const val STRIPE_LENGTH_IN_WIDTHS = 2.5
+private const val STRIPE_LENGTH_IN_WIDTHS = 2.5
 
 /**
- * The most runs one line is cut into. Reached only by a line far longer than the screen it is drawn on,
- * where the stripes beyond the viewport cost native lines and buy nothing.
+ * The most runs one line is cut into. Well over what a viewport holds — a stripe is a few tens of dp, so a
+ * screen shows around ten of them — so the cap binds only on a line running far off the edges of the map,
+ * where the runs beyond it cost native lines (two apiece, since each is cased) and buy nothing to look at.
  */
-internal const val MAX_STRIPES = 48
-
-/**
- * The width assumed for a line carrying no profile of its own — each renderer's own base width, before the
- * zoom scale it applies to it. Only a producer striping an unprofiled line would reach it, and none does:
- * the one striped line today is a directions ride, which is [ITINERARY_RIDE_WIDTH_PROFILE].
- */
-private const val UNPROFILED_LINE_WIDTH_DP = ROUTE_LINE_WIDTH_DP
+internal const val MAX_STRIPES = 24
 
 /**
  * This line cut into its stripes for a camera at [zoom], or the line alone when it isn't striped (which is
@@ -96,12 +88,17 @@ private fun RoutePolyline.striped(zoom: Double): List<RoutePolyline> {
     if (length <= 0.0) return listOf(this)
 
     val colors = listOf(color) + stripeColors
+    // Never more runs than the cap, and never fewer than one per colour — in that order, so a line with
+    // more routes than the cap still shows every one of them rather than losing the ones past it.
     val stripes = (length / stripeLengthMeters(zoom))
         .roundToInt()
-        .coerceIn(colors.size, maxOf(colors.size, MAX_STRIPES))
+        .coerceAtMost(MAX_STRIPES)
+        .coerceAtLeast(colors.size)
     val stride = length / stripes
-    return (0 until stripes).mapNotNull { index ->
-        val run = shape.subPolyline(index * stride, (index + 1) * stride) ?: return@mapNotNull null
+    return (0 until stripes).map { index ->
+        // A measurable line always cuts, so this is the contract holding rather than a run being dropped:
+        // dropping one would leave a gap mid-ride, where declining to cut at all just draws it as it was.
+        val run = shape.subPolyline(index * stride, (index + 1) * stride) ?: return listOf(this)
         copy(
             color = colors[index % colors.size],
             points = run,
@@ -124,11 +121,10 @@ private fun RoutePolyline.striped(zoom: Double): List<RoutePolyline> {
  */
 private fun RoutePolyline.stripeLengthMeters(zoom: Double): Double {
     val quantizedZoom = floor(zoom)
-    val widthDp = widthProfile?.thicknessAt(quantizedZoom.toFloat()) ?: UNPROFILED_LINE_WIDTH_DP
-    val metersPerDp = METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
-        cos(Math.toRadians(points.midpointLatitude())) /
-        2.0.pow(quantizedZoom.coerceIn(0.0, 30.0))
-    return widthDp * STRIPE_LENGTH_IN_WIDTHS * metersPerDp
+    // The ordinary route width stands in for a line that named no profile, which is the width the renderers
+    // themselves fall back to; no producer stripes such a line today, the one striped line being a ride.
+    val widthDp = (widthProfile ?: ROUTE_LINE_WIDTH_PROFILE).thicknessAt(quantizedZoom.toFloat())
+    return widthDp * STRIPE_LENGTH_IN_WIDTHS * metersPerPixel(points.midpointLatitude(), quantizedZoom)
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
@@ -21,7 +21,6 @@ import kotlin.math.atan
 import kotlin.math.cos
 import kotlin.math.exp
 import kotlin.math.ln
-import kotlin.math.pow
 import kotlin.math.tan
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -36,7 +35,6 @@ import kotlinx.coroutines.withContext
 import org.onebusaway.android.util.EARTH_RADIUS_METERS
 import org.onebusaway.android.util.GeoPoint
 
-private const val MAX_MERCATOR_LATITUDE = 85.05112878
 private const val VIEWPORT_MARGIN_MULTIPLIER = 1.0
 private const val SIMPLIFICATION_ERROR_PIXELS = 0.75
 private const val MIN_SIMPLIFICATION_METERS = 2.0
@@ -111,10 +109,7 @@ internal class ZoomSimplifyRoutePolylinePass : RoutePolylineRenderPass {
     ): List<RoutePolyline> {
         if (polylines.none { RoutePolylineTransform.ZOOM_SIMPLIFY in it.transforms }) return polylines
         val camera = context.camera ?: return polylines
-        val latitude = camera.center.latitude.coerceIn(-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE)
-        val metresPerPixel = METERS_PER_PIXEL_AT_EQUATOR_ZOOM_ZERO *
-            cos(Math.toRadians(latitude)) /
-            2.0.pow(camera.zoom.coerceIn(0.0, 30.0))
+        val metresPerPixel = metersPerPixel(camera.center.latitude, camera.zoom)
         val tolerance = maxOf(MIN_SIMPLIFICATION_METERS, metresPerPixel * SIMPLIFICATION_ERROR_PIXELS)
         var changed = false
         val simplified = polylines.map { polyline ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineRenderPipeline.kt
@@ -57,8 +57,11 @@ internal class RoutePolylineRenderPipeline(
     }
 }
 
+// Striping runs last, on the geometry that will actually be drawn: it cuts a line into runs, so a pass
+// that reshaped one afterwards would be reshaping the stripes instead — and cutting first would leave
+// every later pass with a dozen lines to do the work of one.
 private val DEFAULT_ROUTE_POLYLINE_PIPELINE = RoutePolylineRenderPipeline(
-    listOf(ViewportClipRoutePolylinePass(), ZoomSimplifyRoutePolylinePass())
+    listOf(ViewportClipRoutePolylinePass(), ZoomSimplifyRoutePolylinePass(), StripeRoutePolylinePass())
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/Polyline.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/Polyline.kt
@@ -49,6 +49,12 @@ class Polyline(points: List<GeoPoint>) {
             .toDoubleArray()
 
     /**
+     * The whole line's length in metres — zero for a line of fewer than two distinct points, which is
+     * what a caller measuring one has to handle anyway rather than a length it can divide by.
+     */
+    val lengthMeters: Double get() = cumulativeDistances.last()
+
+    /**
      * Returns the index of the segment start for the given distance, or -1 if the polyline has
      * fewer than 2 points. The distance is clamped to the polyline bounds. Reuse the result across
      * [interpolate] and [bearingAt] to avoid repeated binary searches.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.directions.model.InterchangeableRoute
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
@@ -387,6 +388,74 @@ class ItineraryLegStyleTest {
         // style table deliberately names no `directional` for anything to get wrong.
         assertTrue(tripOf(walk = 0, ride = 1, walk2 = 2).none { it.line.directional })
     }
+
+    @Test
+    fun `a ride is striped with every other route it may be taken on, in the label's order`() {
+        // #2100: the badge on this line names both routes, each in its own colour, while the line itself
+        // was stroked in whichever one the planner picked.
+        val ride = drawableRide(
+            routeColor = 0xFF008000.toInt(),
+            substitutes = listOf(substitute("2 Line", 0xFF0000FF.toInt()), substitute("1 Line", 0xFFFF0000.toInt()))
+        )
+
+        assertEquals(
+            listOf("1 Line", "2 Line").map { name ->
+                itineraryLegStyle(
+                    ItineraryLegKind.TRANSIT,
+                    routeColor = if (name == "1 Line") 0xFFFF0000.toInt() else 0xFF0000FF.toInt(),
+                    palette = DIRECTIONS
+                ).color
+            },
+            ride.stripeColors(DIRECTIONS)
+        )
+    }
+
+    @Test
+    fun `a ride with no alternative is not striped at all`() {
+        assertEquals(emptyList<Int>(), drawableRide(routeColor = 0xFF008000.toInt()).stripeColors(DIRECTIONS))
+    }
+
+    @Test
+    fun `routes drawn in one colour stripe once, and never in the colour the line already is`() {
+        // A stripe carries no name, so two routes an agency publishes the same colour for are one stripe;
+        // and a substitute matching the planned route would stripe the line with the colour it already is.
+        // Both of these read as "the alternative is drawn here", when nothing is.
+        val ride = drawableRide(
+            routeColor = 0xFF008000.toInt(),
+            substitutes = listOf(
+                substitute("A", 0xFF0000FF.toInt()),
+                substitute("B", 0xFF0000FF.toInt()),
+                substitute("C", 0xFF008000.toInt())
+            )
+        )
+
+        assertEquals(
+            listOf(itineraryLegStyle(ItineraryLegKind.TRANSIT, 0xFF0000FF.toInt(), DIRECTIONS).color),
+            ride.stripeColors(DIRECTIONS)
+        )
+    }
+
+    /** A transit leg as the controller hands it over, with the routes offered in its place. */
+    private fun drawableRide(routeColor: Int?, substitutes: List<ItinerarySubstitute> = emptyList()) = ItineraryDrawableLeg(
+        index = 0,
+        leg = TripLeg(mode = TripMode.RAIL, routeId = "route-1", routeShortName = "Line"),
+        points = listOf(GeoPoint(47.6, -122.3), GeoPoint(47.7, -122.4)),
+        style = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor, DIRECTIONS),
+        interchangeable = substitutes
+    )
+
+    private fun substitute(displayName: String, routeColor: Int?) = ItinerarySubstitute(
+        InterchangeableRoute(
+            routeId = "route-for-$displayName",
+            displayName = displayName,
+            // The colour reaches the styling already parsed, so the wire field plays no part here.
+            routeColor = null,
+            agencyId = null,
+            agencyName = null,
+            headsign = null
+        ),
+        routeColor
+    )
 
     private fun legLine(legIndex: Int, kind: ItineraryLegKind): ItineraryLegLine {
         val style = itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -398,15 +398,28 @@ class ItineraryLegStyleTest {
             substitutes = listOf(substitute("2 Line", 0xFF0000FF.toInt()), substitute("1 Line", 0xFFFF0000.toInt()))
         )
 
+        // The 1 Line's colour then the 2 Line's, which is neither the order they were offered in nor the
+        // planner's choice first — it is the order the label stacks them in.
         assertEquals(
-            listOf("1 Line", "2 Line").map { name ->
-                itineraryLegStyle(
-                    ItineraryLegKind.TRANSIT,
-                    routeColor = if (name == "1 Line") 0xFFFF0000.toInt() else 0xFF0000FF.toInt(),
-                    palette = DIRECTIONS
-                ).color
-            },
+            listOf(0xFFFF0000.toInt(), 0xFF0000FF.toInt()).map { rideColor(it) },
             ride.stripeColors(DIRECTIONS)
+        )
+    }
+
+    @Test
+    fun `the colours along a shared ride are the colours of the badge sitting on it`() {
+        // The claim the stripes are for: a rider matching the line to the label above it finds every route
+        // accounted for. Pinned here because the two are built apart — the label from the routes it names,
+        // the stripes from the colours the line takes — and prose is all that has held them together.
+        val ride = drawableRide(
+            routeColor = 0xFF008000.toInt(),
+            substitutes = listOf(substitute("1 Line", 0xFFFF0000.toInt()), substitute("A Line", 0xFF0000FF.toInt()))
+        )
+        val badge = itineraryRouteBadges(listOf(ride), DIRECTIONS).single()
+
+        assertEquals(
+            badge.routes.map { it.color }.toSet(),
+            (listOf(ride.style.color) + ride.stripeColors(DIRECTIONS)).toSet()
         )
     }
 
@@ -429,11 +442,11 @@ class ItineraryLegStyleTest {
             )
         )
 
-        assertEquals(
-            listOf(itineraryLegStyle(ItineraryLegKind.TRANSIT, 0xFF0000FF.toInt(), DIRECTIONS).color),
-            ride.stripeColors(DIRECTIONS)
-        )
+        assertEquals(listOf(rideColor(0xFF0000FF.toInt())), ride.stripeColors(DIRECTIONS))
     }
+
+    /** The colour this map draws a ride whose agency publishes [routeColor] in. */
+    private fun rideColor(routeColor: Int) = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor, DIRECTIONS).color
 
     /** A transit leg as the controller hands it over, with the routes offered in its place. */
     private fun drawableRide(routeColor: Int?, substitutes: List<ItinerarySubstitute> = emptyList()) = ItineraryDrawableLeg(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map.render
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.onebusaway.android.util.GeoPoint
 
@@ -90,6 +91,17 @@ class GeoMathTest {
         )
         assertEquals(metersPerPixel(0.0, 30.0), metersPerPixel(0.0, zoom = 40.0), 1e-9)
         assertEquals(metersPerPixel(0.0, 0.0), metersPerPixel(0.0, zoom = -5.0), 1e-9)
+    }
+
+    @Test
+    fun `a reading that is not a position at all is refused, not clamped into range`() {
+        // Clamping leaves a NaN alone, and the callers scale geometry by what comes back, so a NaN answer
+        // would spread through the shapes instead of stopping at the broken reading that caused it.
+        assertThrows(IllegalArgumentException::class.java) { metersPerPixel(latitude = Double.NaN, zoom = 12.0) }
+        assertThrows(IllegalArgumentException::class.java) { metersPerPixel(latitude = 47.6, zoom = Double.NaN) }
+        assertThrows(IllegalArgumentException::class.java) {
+            metersPerPixel(latitude = Double.POSITIVE_INFINITY, zoom = 12.0)
+        }
     }
 
     private companion object {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/GeoMathTest.kt
@@ -69,6 +69,29 @@ class GeoMathTest {
         assertNull(leadingBearing(List(3) { GeoPoint(47.6, -122.3) }))
     }
 
+    @Test
+    fun `ground resolution halves with each zoom level and narrows towards the poles`() {
+        // The 256px-tile scale everything screen-sized on this map is sized through: one tile spans the
+        // world at zoom 0, so a pixel covers 156543 m at the equator and half that per level down.
+        assertEquals(156543.03, metersPerPixel(latitude = 0.0, zoom = 0.0), 0.01)
+        assertEquals(metersPerPixel(0.0, 10.0) / 2.0, metersPerPixel(0.0, 11.0), 1e-9)
+        // A degree of longitude is shorter at 60°N by exactly a half, and so is the ground under a pixel.
+        assertEquals(metersPerPixel(0.0, 12.0) / 2.0, metersPerPixel(60.0, 12.0), 1e-6)
+    }
+
+    @Test
+    fun `both runaway inputs are clamped, so every caller gets a finite answer`() {
+        // The formula runs away at the projection's cutoff and at absurd zooms, and the callers that used to
+        // write it out each guarded a different one of the two.
+        assertEquals(
+            metersPerPixel(MAX_MERCATOR_LATITUDE, zoom = 12.0),
+            metersPerPixel(latitude = 90.0, zoom = 12.0),
+            1e-9
+        )
+        assertEquals(metersPerPixel(0.0, 30.0), metersPerPixel(0.0, zoom = 40.0), 1e-9)
+        assertEquals(metersPerPixel(0.0, 0.0), metersPerPixel(0.0, zoom = -5.0), 1e-9)
+    }
+
     private companion object {
         // The window's chord is measured over a spherical earth; a degree of slack is far tighter than any
         // difference that would matter to a mark drawn across a line.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineStripesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineStripesTest.kt
@@ -121,6 +121,19 @@ class RouteLineStripesTest {
     }
 
     @Test
+    fun `a ride shared by more routes than the cap shows every one of them, cap and all`() {
+        // The two bounds meet here, and coverage wins: the cap spares native lines nobody can tell apart,
+        // whereas a route dropped past it is a route the rider is never told they may board — the thing
+        // #2100 is about. A leg's routes are all named on the badge sitting on it, so the count that gets
+        // through is bounded by the ride itself rather than by the length of the line.
+        val extras = List(MAX_STRIPES + 4) { 0xFF000000.toInt() or it }
+
+        val striped = stripe(listOf(ride(kilometres = 400.0, stripeColors = extras)), zoom = 18.0)
+
+        assertEquals(listOf(red) + extras, striped.map { it.color })
+    }
+
+    @Test
     fun `until the first camera settles a shared ride draws whole, in its planned colour`() {
         val lines = listOf(ride(kilometres = 4.0, stripeColors = listOf(blue)))
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineStripesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineStripesTest.kt
@@ -1,0 +1,164 @@
+/* Copyright (C) 2026 Open Transit Software Foundation */
+package org.onebusaway.android.map.render
+
+import kotlin.math.cos
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.util.EARTH_RADIUS_METERS
+import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.Polyline
+
+/**
+ * Striping a ride shared by several routes (#2100). The point of these is that the stripes are a *reading*
+ * of one line rather than a second thing drawn on it: the runs cover the ride exactly, in the order the
+ * label names the routes, ending where the ride ends and marked only there.
+ */
+class RouteLineStripesTest {
+
+    private val red = 0xFFB3261E.toInt()
+
+    private val blue = 0xFF0B57D0.toInt()
+
+    private val green = 0xFF146C2E.toInt()
+
+    @Test
+    fun `an ordinary line is not cut, and the list it came in keeps its identity`() {
+        val lines = listOf(ride(kilometres = 4.0))
+
+        assertSame(lines, stripe(lines))
+    }
+
+    @Test
+    fun `a shared ride cycles its own colour and the routes it is shared with, in turn`() {
+        val striped = stripe(listOf(ride(kilometres = 4.0, stripeColors = listOf(blue))))
+
+        // Its own colour leads — the line is stroked in the route the plan picked, and the alternatives
+        // are striped through it.
+        assertEquals(red, striped.first().color)
+        assertEquals(
+            List(striped.size) { if (it % 2 == 0) red else blue },
+            striped.map { it.color }
+        )
+        // Each run is a plain line: the stripes are already cut, so nothing downstream re-cuts them.
+        assertTrue(striped.all { it.stripeColors.isEmpty() })
+    }
+
+    @Test
+    fun `the runs cover the whole ride, end to end, with no gap between them`() {
+        val ride = ride(kilometres = 4.0, stripeColors = listOf(blue, green))
+
+        val striped = stripe(listOf(ride))
+
+        assertEquals(ride.points.first(), striped.first().points.first())
+        assertEquals(ride.points.last(), striped.last().points.last())
+        striped.zipWithNext { earlier, later ->
+            assertEquals(earlier.points.last(), later.points.first())
+        }
+        // ...and the runs are equal in length, so the alternation reads as a rhythm rather than as a
+        // sequence of unrelated segments.
+        val lengths = striped.map { Polyline(it.points).lengthMeters }
+        lengths.forEach { assertEquals(lengths.first(), it, 1.0) }
+    }
+
+    @Test
+    fun `only the ends of the ride are marked, never the cuts inside it`() {
+        val ride = ride(
+            kilometres = 4.0,
+            stripeColors = listOf(blue),
+            startMark = RouteLineMark.INTERLINE_CUT,
+            endMark = RouteLineMark.BULB
+        )
+
+        val striped = stripe(listOf(ride))
+
+        assertEquals(RouteLineMark.INTERLINE_CUT, striped.first().startMark)
+        assertEquals(RouteLineMark.BULB, striped.last().endMark)
+        // A bulb pair means "alight here, board there"; one at every stripe boundary would tell the rider
+        // to get off a dozen times along a single ride.
+        assertTrue(striped.drop(1).all { it.startMark == RouteLineMark.NONE })
+        assertTrue(striped.dropLast(1).all { it.endMark == RouteLineMark.NONE })
+    }
+
+    @Test
+    fun `a stripe holds its length on the screen, so a closer camera cuts more of them`() {
+        val ride = ride(kilometres = 4.0, stripeColors = listOf(blue))
+
+        val overview = stripe(listOf(ride), zoom = 12.0)
+        val close = stripe(listOf(ride), zoom = 15.0)
+
+        assertTrue("$overview stripes vs $close", overview.size < close.size)
+    }
+
+    @Test
+    fun `panning across a ride does not re-cut it`() {
+        // The cut is geometry: anything it varies with redraws every native line the moment the camera
+        // settles there. So it reads the *line's* latitude and a whole zoom level, and a pan — or the
+        // drift within one zoom level that a pinch passes through — leaves it exactly as it was.
+        val ride = ride(kilometres = 4.0, stripeColors = listOf(blue))
+
+        val settled = stripe(listOf(ride), zoom = 13.0, center = GeoPoint(47.6, -122.3))
+
+        assertEquals(settled, stripe(listOf(ride), zoom = 13.0, center = GeoPoint(1.0, 100.0)))
+        assertEquals(settled, stripe(listOf(ride), zoom = 13.9, center = GeoPoint(47.6, -122.3)))
+    }
+
+    @Test
+    fun `every route reaches a ride too short to stripe at its own rhythm`() {
+        // A block-long ride at overview zoom is shorter than one stripe. Drawn in the planned route's
+        // colour alone it would say the rider must board that route, which is the thing #2100 is about.
+        val striped = stripe(listOf(ride(kilometres = 0.02, stripeColors = listOf(blue, green))), zoom = 10.0)
+
+        assertEquals(listOf(red, blue, green), striped.map { it.color })
+    }
+
+    @Test
+    fun `a ride far longer than the screen is capped, not cut into hundreds of lines`() {
+        val striped = stripe(listOf(ride(kilometres = 400.0, stripeColors = listOf(blue))), zoom = 18.0)
+
+        assertEquals(MAX_STRIPES, striped.size)
+    }
+
+    @Test
+    fun `until the first camera settles a shared ride draws whole, in its planned colour`() {
+        val lines = listOf(ride(kilometres = 4.0, stripeColors = listOf(blue)))
+
+        assertSame(lines, StripeRoutePolylinePass().apply(lines, RoutePolylineRenderContext(camera = null)))
+    }
+
+    private fun stripe(
+        lines: List<RoutePolyline>,
+        zoom: Double = 14.0,
+        center: GeoPoint = GeoPoint(47.6, -122.3)
+    ) = StripeRoutePolylinePass().apply(lines, RoutePolylineRenderContext(camera(center, zoom)))
+
+    /** A transit leg running [kilometres] due east from a fixed Seattle-ish anchor. */
+    private fun ride(
+        kilometres: Double,
+        stripeColors: List<Int> = emptyList(),
+        startMark: RouteLineMark = RouteLineMark.NONE,
+        endMark: RouteLineMark = RouteLineMark.NONE
+    ): RoutePolyline {
+        val start = GeoPoint(47.6, -122.3)
+        val east = Math.toDegrees(kilometres * 1000.0 / (EARTH_RADIUS_METERS * cos(Math.toRadians(start.latitude))))
+        return RoutePolyline(
+            color = red,
+            points = listOf(start, GeoPoint(start.latitude, start.longitude + east)),
+            stripeColors = stripeColors,
+            widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
+            case = RouteLineCase.OUTLINE,
+            startMark = startMark,
+            endMark = endMark
+        )
+    }
+
+    private fun camera(center: GeoPoint, zoom: Double) = CameraSnapshot(
+        center = center,
+        zoom = zoom,
+        latSpan = 0.1,
+        lonSpan = 0.1,
+        southWest = GeoPoint(center.latitude - 0.05, center.longitude - 0.05),
+        northEast = GeoPoint(center.latitude + 0.05, center.longitude + 0.05)
+    )
+}


### PR DESCRIPTION
Fixes #2100.

When several interchangeable routes share a transit leg, the badge on that line has named them all — each in its own colour (#2083) — while the line itself was stroked in exactly one of them, whichever route the planner picked. So the map answered "which of these am I looking at?" with a colour that meant nothing, and a rider matching the line to the drawer beside it found half the ride's routes unaccounted for.

A shared ride now carries the other routes' colours and is cut into equal runs cycling through all of them.

### Along the line, not beside it

The issue left the choice open. Side by side is what a printed transit map does, but neither line API this app draws through offsets a stroke (gms polylines have no such option; nor does the classic maplibre annotation), so it would mean generating parallel geometry per stripe, mitre by mitre, and then splitting a corridor only 15dp wide into slivers of it. Sequential stripes need no new geometry beyond cutting the line the rider is already shown, they work identically on both renderers, and every stripe keeps the ride's full weight.

### Where the cut lives

`RoutePolyline.stripeColors` carries the *other* colours; `StripeRoutePolylinePass` (last in the existing render pipeline, after clip and simplify) does the cutting. It's a render pass rather than something `DirectionsMapController` could do, because a stripe has to hold its length on the **screen**: runs of a fixed ground length are a blur of alternating flecks at overview zoom and a single flat colour once the rider drills into a leg. A run is `2.5×` the line's own stroke width, so the rhythm recedes with the ride as the camera pulls back.

Cutting is geometry, so anything it varies with redraws every native line the moment the camera settles there. It therefore reads the **line's** latitude (not the camera's) and a whole zoom level (not the exact one): panning across a leg leaves the cut untouched, and a pinch re-cuts once per zoom level crossed. Two bounds keep it readable at the extremes — every colour appears at least once however short the line, and no line is cut into more than 24 runs however long (a cap on native lines as much as on visual noise). Where the two meet, on a ride shared by more routes than the cap, coverage wins: a stripe past the cap costs a native line nobody can tell from its neighbour, while a route past it is a route the rider is never told they may board.

Only the ends of the *ride* keep their marks — the first run keeps the start mark, the last the end mark. A bulb pair means "alight here, board there", so one at every stripe boundary would read as a dozen alight-and-boards along a single ride.

Stripe colours are deduplicated by **colour** rather than by the name a badge dedupes on, and a substitute matching the planned route's colour drops out: a stripe carries no name, so an invisible stripe is just a cut for nothing.

### Notes

- Until the first camera settles there is no screen to hold a stripe's length on, so a shared ride draws whole in its planned colour — the previous appearance — rather than guessing.
- `Polyline` gained `lengthMeters`; the cut itself reuses its existing `subPolyline`.
- Tests are JVM-only: `RouteLineStripesTest` (coverage, cycling, marks, screen-constant length, pan stability, both bounds) and three cases in `ItineraryLegStyleTest` for which colours a leg stripes with.
- Not visually checked on a device — reaching a plan with interchangeable routes needs a live region, and the test phone is shared. The stripe length is a single constant (`STRIPE_LENGTH_IN_WIDTHS`) if it wants tuning once seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shared transit routes now appear with alternating colors, making interchangeable route options easier to distinguish.
  - Route striping adapts to map zoom and line length while preserving clear endpoint markers.
  - Added support for calculating total route-line distance for improved map rendering.

- **Bug Fixes**
  - Prevented duplicate or matching alternative colors from creating unnecessary stripes.
  - Ensured ordinary routes retain their existing appearance when no alternatives are available.
  - Improved map scaling consistency across latitudes and zoom levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
