### PR TITLE
Remove the route focus sub-header from the stop focus banner

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -50,28 +50,23 @@ class FocusBannerTest {
 
     private fun setStopBanner(
         hasAlerts: Boolean = true,
-        onClearSubordinateRoute: () -> Unit = {}
+        favoriteEnabled: Boolean = true,
+        direction: String? = "N",
+        stopCode: String? = "12345"
     ) {
         composeRule.setContent {
             FocusBanner(
                 state = FocusBannerState.Stop(
                     title = "Pine St & 3rd Ave",
-                    direction = "N",
-                    stopCode = "12345",
+                    direction = direction,
+                    stopCode = stopCode,
                     isFavorite = false,
-                    favoriteEnabled = true,
-                    hasAlerts = hasAlerts,
-                    subordinateRoutes = listOf(
-                        FocusBannerState.SubordinateRoute("65"),
-                        FocusBannerState.SubordinateRoute("75"),
-                        FocusBannerState.SubordinateRoute("40")
-                    ),
-                    subordinateHeadsign = "Downtown"
+                    favoriteEnabled = favoriteEnabled,
+                    hasAlerts = hasAlerts
                 ),
                 onClose = {},
                 onToggleFavorite = {},
                 onShowAlerts = {},
-                onClearSubordinateRoute = onClearSubordinateRoute,
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
@@ -126,7 +121,6 @@ class FocusBannerTest {
                 onClose = {},
                 onToggleFavorite = {},
                 onShowAlerts = {},
-                onClearSubordinateRoute = {},
                 onRecenterStop = {},
                 onSelectDirection = onSelectDirection,
                 onFrameRoute = onFrameRoute,
@@ -234,55 +228,22 @@ class FocusBannerTest {
     }
 
     @Test
-    fun stopBannerShowsIdentityAndFullSubordinateRouteChain() {
+    fun stopBannerShowsStopIdentity() {
         setStopBanner()
         composeRule.onNodeWithText("Pine St & 3rd Ave").assertIsDisplayed()
         val expectedSubtitle = "${context.getString(R.string.stop_details_code, "12345")} · " +
             context.getString(R.string.direction_n)
         composeRule.onNodeWithText(expectedSubtitle).assertIsDisplayed()
-        listOf("65", "75", "40", "Downtown").forEach {
-            composeRule.onNodeWithText(it).assertIsDisplayed()
-        }
-    }
-
-    @Test
-    fun subordinateRouteDismissIsACompactExactSizeTarget() {
-        var cleared = false
-        setStopBanner(onClearSubordinateRoute = { cleared = true })
-
-        val dismiss = composeRule.onNodeWithContentDescription(
-            context.getString(R.string.stop_info_unselect_route)
-        ).assertIsDisplayed().assertHasClickAction()
-        val bounds = dismiss.getUnclippedBoundsInRoot()
-        assertTrue((bounds.right - bounds.left).value in 21.5f..22.5f)
-        assertTrue((bounds.bottom - bounds.top).value in 21.5f..22.5f)
-        dismiss.performClick()
-        assertTrue(cleared)
     }
 
     @Test
     fun loadingStopBannerReservesTheFavoriteStar() {
-        composeRule.setContent {
-            FocusBanner(
-                state = FocusBannerState.Stop(
-                    title = "Pine St & 3rd Ave",
-                    direction = null,
-                    stopCode = null,
-                    isFavorite = false,
-                    favoriteEnabled = false,
-                    hasAlerts = false
-                ),
-                onClose = {},
-                onToggleFavorite = {},
-                onShowAlerts = {},
-                onClearSubordinateRoute = {},
-                onRecenterStop = {},
-                onSelectDirection = {},
-                onFrameRoute = {},
-                onShowSchedule = {},
-                onHeight = {}
-            )
-        }
+        setStopBanner(
+            hasAlerts = false,
+            favoriteEnabled = false,
+            direction = null,
+            stopCode = null
+        )
 
         val star = composeRule.onNodeWithContentDescription(
             context.getString(R.string.bus_options_menu_add_star)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RouteRowGroup.kt
@@ -171,9 +171,13 @@ internal fun promoteSelectedRouteGroup(
 }
 
 /**
- * Resolve a map selection against the rows the arrivals response actually contains. Direction labels
- * can differ between the route response and arrivals feed; in that case a sole row for the route is
- * unambiguous. Multiple rows still require an exact direction match rather than guessing.
+ * Resolve a map selection against the rows the arrivals response actually contains — the single
+ * identity→row resolution every stop-focus surface shares, so a map route-label tap and an
+ * arrivals-row tap that name the same (route, direction) can never disagree on the row they select.
+ *
+ * Direction labels can differ between the route response and arrivals feed; in that case a sole row
+ * for the route is unambiguous. Multiple rows still require an exact direction match rather than
+ * guessing.
  */
 internal fun resolveSelectedRouteGroupKey(
     groups: List<RouteRowGroup>,
@@ -183,20 +187,4 @@ internal fun resolveSelectedRouteGroupKey(
     groups.firstOrNull { it.key == requestedKey }?.let { return it.key }
     if (routeId == null) return null
     return groups.filter { it.routeId == routeId }.singleOrNull()?.key
-}
-
-/**
- * The selected row's *group* (not just its key) — the single identity→row resolution every stop-focus
- * surface shares. The drawer promotes this row and the focus banner reads its shown headsign from the
- * same resolver, so a map route-label tap and an arrivals-row tap that name the same (route, direction)
- * can never disagree on the headsign shown: it's projected from the resolved row, never carried on the
- * selection. Null when the selection resolves to no row (see [resolveSelectedRouteGroupKey]).
- */
-internal fun resolveSelectedRouteGroup(
-    groups: List<RouteRowGroup>,
-    requestedKey: String?,
-    routeId: String?
-): RouteRowGroup? {
-    val key = resolveSelectedRouteGroupKey(groups, requestedKey, routeId) ?: return null
-    return groups.firstOrNull { it.key == key }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/RouteBadgeChip.kt
@@ -147,8 +147,8 @@ private val CHEVRON_LEAN_ALLOWANCE = ROUTE_BADGE_HEIGHT * JOIN_LEAN_RATIO / 2
 /**
  * A small route roundel — the route's short name on a chip tinted from its GTFS color (via
  * [rememberRouteBadgeColors]), or a neutral chip when the route has no color. The compact form used
- * where several routes sit in a row (the stop-focus header's subordinate routes, the trip-plan option
- * cards), as opposed to the large square [LineBadge]. [scale] enlarges the whole chip (text + padding)
+ * where several routes sit in a row (the trip-plan option cards, an arrival row's ETA strip), as
+ * opposed to the large square [LineBadge]. [scale] enlarges the whole chip (text + padding)
  * proportionally — e.g. the directions board badge uses 1.5×.
  *
  * The chip is never narrower than it is tall ([ROUTE_BADGE_HEIGHT] at the default font scale), so a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
@@ -119,10 +119,10 @@ data class RouteLeg(
 /** A route selected inside stop focus, anchored to its original arrivals row across continuations. */
 data class StopRouteSelection(
     // Row *identity*, never display: with [originLeg]'s route + directionId it forms the row key
-    // ([selectedArrivalRowKey]) fed to `resolveSelectedRouteGroup`, disambiguating the legacy case where
-    // a response omits directionId and only the headsign string tells two directions apart. The headsign
-    // the banner *shows* is read back from the resolved arrivals row, not from here — so don't render
-    // this and don't duplicate the rest of the row onto the selection.
+    // ([selectedArrivalRowKey]) fed to `resolveSelectedRouteGroupKey`, disambiguating the legacy case
+    // where a response omits directionId and only the headsign string tells two directions apart. What
+    // the user sees is the resolved arrivals row itself, drawn as the drawer's focus outline — so don't
+    // render this and don't duplicate the rest of the row onto the selection.
     val originHeadsign: String?,
     val legs: List<RouteLeg>
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -74,7 +74,6 @@ import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
-import org.onebusaway.android.ui.arrivals.resolveSelectedRouteGroup
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
@@ -85,7 +84,6 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.home.arrivals.ArrivalsSheetHost
 import org.onebusaway.android.ui.home.arrivals.ServiceAlertsDialog
 import org.onebusaway.android.ui.home.arrivals.rememberArrivalsSession
-import org.onebusaway.android.ui.home.arrivals.selectedArrivalRowKey
 import org.onebusaway.android.ui.home.chrome.MAP_TOP_CHROME_CLEARANCE
 import org.onebusaway.android.ui.home.chrome.MapTopChrome
 import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
@@ -456,25 +454,7 @@ fun HomeScreen(
                         // without the arrivals source the glyph would be missing on most entry points.
                         wheelchairBoarding = arrivalsContent?.header?.wheelchairBoarding
                             ?.takeIf { it != WheelchairBoarding.UNKNOWN }
-                            ?: currentFocus.stop.wheelchairBoarding,
-                        subordinateRoutes = currentFocus.selectedRoute?.legs?.map { leg ->
-                            FocusBannerState.SubordinateRoute(
-                                shortName = leg.shortName,
-                                color = arrivalsContent?.actions?.values
-                                    ?.firstOrNull { it.routeId == leg.routeId }
-                                    ?.routeColor
-                            )
-                        }.orEmpty(),
-                        subordinateHeadsign = currentFocus.selectedRoute?.let { selection ->
-                            // Resolve the shown headsign from the loaded arrivals via the same row resolver the
-                            // drawer highlight uses, so every entry point (arrivals row, map route-label tap)
-                            // projects it identically instead of each carrying its own copy.
-                            resolveSelectedRouteGroup(
-                                arrivalsContent?.routeGroups.orEmpty(),
-                                selection.selectedArrivalRowKey(),
-                                selection.originLeg.routeId
-                            )?.headsign
-                        }
+                            ?: currentFocus.stop.wheelchairBoarding
                     )
                     is CurrentFocus.Route -> routeHeader?.let { header ->
                         FocusBannerState.Route(
@@ -726,7 +706,6 @@ fun HomeScreen(
                                                 }
                                             },
                                             onShowAlerts = { serviceAlertsVisible = true },
-                                            onClearSubordinateRoute = homeViewModel::clearStopRouteSelection,
                                             onRecenterStop = {
                                                 homeViewModel.recenterOnFocusedStop(mapViewModel.viewport)
                                             },
@@ -1029,7 +1008,6 @@ private fun BoxScope.HomeMapOverlays(
     onCloseFocus: () -> Unit,
     onToggleFavorite: () -> Unit,
     onShowAlerts: () -> Unit,
-    onClearSubordinateRoute: () -> Unit,
     onRecenterStop: () -> Unit,
     onSelectRouteDirection: (Int?) -> Unit,
     onFrameRoute: () -> Unit,
@@ -1076,7 +1054,6 @@ private fun BoxScope.HomeMapOverlays(
             onClose = onCloseFocus,
             onToggleFavorite = onToggleFavorite,
             onShowAlerts = onShowAlerts,
-            onClearSubordinateRoute = onClearSubordinateRoute,
             onRecenterStop = onRecenterStop,
             onSelectDirection = onSelectRouteDirection,
             onFrameRoute = onFrameRoute,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -503,13 +503,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /** Clear only the route selected inside the current stop. */
-    fun clearStopRouteSelection() {
-        val stopFocus = _currentFocus.value as? CurrentFocus.Stop ?: return
-        if (stopFocus.selectedRoute == null) return
-        unfocusMapOneLevel()
-    }
-
     /**
      * A focused-stop route badge behaves like its arrivals-drawer row: carry the focused stop as the
      * direction anchor so route mode preserves adjacency focus underneath it. The badge additionally

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -38,7 +39,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -82,7 +82,6 @@ import org.onebusaway.android.ui.compose.components.DirectionHeadsign
 import org.onebusaway.android.ui.compose.components.LineBadge
 import org.onebusaway.android.ui.compose.components.MaterialSymbols
 import org.onebusaway.android.ui.compose.components.MenuRow
-import org.onebusaway.android.ui.compose.components.RouteBadgeChip
 import org.onebusaway.android.ui.compose.components.rememberRouteBadgeColors
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.icons.AppIcons
@@ -113,11 +112,6 @@ sealed interface FocusBannerState {
 
     @get:StringRes val focusDescriptionRes: Int
 
-    data class SubordinateRoute(
-        val shortName: String,
-        val color: Int? = null
-    )
-
     data class Stop(
         val title: String,
         val direction: String?,
@@ -125,9 +119,7 @@ sealed interface FocusBannerState {
         override val isFavorite: Boolean,
         override val favoriteEnabled: Boolean,
         val hasAlerts: Boolean,
-        val wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN,
-        val subordinateRoutes: List<SubordinateRoute> = emptyList(),
-        val subordinateHeadsign: String? = null
+        val wheelchairBoarding: WheelchairBoarding = WheelchairBoarding.UNKNOWN
     ) : FocusBannerState {
         override val focusIconRes = R.drawable.stop_flag
         override val focusDescriptionRes = R.string.stop_shortcut
@@ -145,8 +137,7 @@ sealed interface FocusBannerState {
 
 /**
  * Floating information and actions for the current stop or standalone route focus. It reports its
- * measured height so map framing stays clear of the complete banner, including a subordinate route
- * status line beneath a focused stop.
+ * measured height so map framing stays clear of the banner.
  */
 @Composable
 fun FocusBanner(
@@ -154,7 +145,6 @@ fun FocusBanner(
     onClose: () -> Unit,
     onToggleFavorite: () -> Unit,
     onShowAlerts: () -> Unit,
-    onClearSubordinateRoute: () -> Unit,
     onRecenterStop: () -> Unit,
     onSelectDirection: (Int?) -> Unit,
     onFrameRoute: () -> Unit,
@@ -186,7 +176,6 @@ fun FocusBanner(
                     is FocusBannerState.Stop -> StopFocusBanner(
                         state = state,
                         onShowAlerts = onShowAlerts,
-                        onClearSubordinateRoute = onClearSubordinateRoute,
                         onRecenter = onRecenterStop,
                         onClose = onClose
                     )
@@ -235,97 +224,55 @@ private fun FocusIdentityRail(
 private fun StopFocusBanner(
     state: FocusBannerState.Stop,
     onShowAlerts: () -> Unit,
-    onClearSubordinateRoute: () -> Unit,
     onRecenter: () -> Unit,
     onClose: () -> Unit
 ) {
-    Column(Modifier.fillMaxWidth().fillMaxHeight()) {
-        Row(
-            Modifier
-                .fillMaxWidth()
-                .then(
-                    if (state.subordinateRoutes.isEmpty()) {
-                        Modifier.weight(1f)
-                    } else {
-                        Modifier
-                    }
-                )
-                .padding(start = 8.dp, top = 4.dp, end = 4.dp, bottom = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            val subtitle = stopSubtitleText(state.stopCode, state.direction)
-            Column(
-                modifier = Modifier.weight(1f).clickable(
-                    onClickLabel = stringResource(R.string.stop_info_recenter),
-                    role = Role.Button,
-                    onClick = onRecenter
-                )
-            ) {
-                ShrinkToFitStopTitle(state.title)
-                val wheelchairGlyph = wheelchairGlyph(state.wheelchairBoarding)
-                if (subtitle != null || wheelchairGlyph != null) {
-                    Row(
-                        modifier = Modifier.padding(top = 4.dp),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (subtitle != null) {
-                            Text(
-                                text = subtitle,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f, fill = false)
-                            )
-                        }
-                        if (wheelchairGlyph != null) {
-                            WheelchairBoardingIndicator(wheelchairGlyph)
-                        }
-                    }
-                }
-            }
-            if (state.hasAlerts) {
-                BannerAlertAction(onClick = onShowAlerts)
-            }
-            HeaderIconButton(
-                painter = painterResource(R.drawable.ic_navigation_close),
-                contentDescription = stringResource(android.R.string.cancel),
-                onClick = onClose
+    Row(
+        Modifier
+            .fillMaxSize()
+            .padding(start = 8.dp, top = 4.dp, end = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val subtitle = stopSubtitleText(state.stopCode, state.direction)
+        Column(
+            modifier = Modifier.weight(1f).clickable(
+                onClickLabel = stringResource(R.string.stop_info_recenter),
+                role = Role.Button,
+                onClick = onRecenter
             )
-        }
-        if (state.subordinateRoutes.isNotEmpty()) {
-            HorizontalDivider()
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 8.dp, top = 7.dp, end = 8.dp, bottom = 7.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                state.subordinateRoutes.forEachIndexed { index, route ->
-                    if (index > 0) {
+        ) {
+            ShrinkToFitStopTitle(state.title)
+            val wheelchairGlyph = wheelchairGlyph(state.wheelchairBoarding)
+            if (subtitle != null || wheelchairGlyph != null) {
+                Row(
+                    modifier = Modifier.padding(top = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (subtitle != null) {
                         Text(
-                            text = "›",
+                            text = subtitle,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 3.dp)
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false)
                         )
                     }
-                    CompactRouteBadge(route)
+                    if (wheelchairGlyph != null) {
+                        WheelchairBoardingIndicator(wheelchairGlyph)
+                    }
                 }
-                state.subordinateHeadsign?.takeIf { it.isNotBlank() }?.let { headsign ->
-                    Text(
-                        text = headsign,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(start = 6.dp).weight(1f)
-                    )
-                } ?: Spacer(Modifier.weight(1f))
-                CompactRouteDismissAction(onClick = onClearSubordinateRoute)
             }
         }
+        if (state.hasAlerts) {
+            BannerAlertAction(onClick = onShowAlerts)
+        }
+        HeaderIconButton(
+            painter = painterResource(R.drawable.ic_navigation_close),
+            contentDescription = stringResource(android.R.string.cancel),
+            onClick = onClose
+        )
     }
 }
 
@@ -387,25 +334,6 @@ private fun stopSubtitleText(stopCode: String?, direction: String?): String? {
         ?.let { stringResource(R.string.stop_details_code, it) }
     val directionText = DisplayFormat.stopDirectionText(LocalContext.current, direction)
     return listOfNotNull(codeText, directionText).takeIf { it.isNotEmpty() }?.joinToString(" · ")
-}
-
-/** A deliberately tiny route chip: only enough padding to distinguish the route from its headsign. */
-@Composable
-private fun CompactRouteBadge(route: FocusBannerState.SubordinateRoute) {
-    RouteBadgeChip(shortName = route.shortName, routeColor = route.color)
-}
-
-/** The nested-route dismiss affordance keeps its visible 22dp size as its exact clickable bounds. */
-@Composable
-private fun CompactRouteDismissAction(onClick: () -> Unit) {
-    Icon(
-        painter = painterResource(R.drawable.ic_navigation_close),
-        contentDescription = stringResource(R.string.stop_info_unselect_route),
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .size(22.dp)
-            .clickable(onClick = onClick)
-    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -694,17 +622,11 @@ private fun FocusBannerPreview() {
                     isFavorite = true,
                     favoriteEnabled = true,
                     hasAlerts = true,
-                    wheelchairBoarding = WheelchairBoarding.ACCESSIBLE,
-                    subordinateRoutes = listOf(
-                        FocusBannerState.SubordinateRoute("65", 0xFF26823B.toInt()),
-                        FocusBannerState.SubordinateRoute("75", 0xFF125BA8.toInt())
-                    ),
-                    subordinateHeadsign = "Downtown Seattle"
+                    wheelchairBoarding = WheelchairBoarding.ACCESSIBLE
                 ),
                 onClose = {},
                 onToggleFavorite = {},
                 onShowAlerts = {},
-                onClearSubordinateRoute = {},
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
@@ -731,7 +653,6 @@ private fun FocusBannerPreview() {
                 onClose = {},
                 onToggleFavorite = {},
                 onShowAlerts = {},
-                onClearSubordinateRoute = {},
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},
@@ -758,7 +679,6 @@ private fun FocusBannerPreview() {
                 onClose = {},
                 onToggleFavorite = {},
                 onShowAlerts = {},
-                onClearSubordinateRoute = {},
                 onRecenterStop = {},
                 onSelectDirection = {},
                 onFrameRoute = {},

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -230,7 +230,6 @@
     </plurals>
     <string name="stop_info_eta_now">NOW</string>
     <string name="stop_info_option_showonmap">Show on map</string>
-    <string name="stop_info_unselect_route">Unselect route</string>
     <string name="menu_option_sort_by">Sort by</string>
     <string name="stop_info_option_refresh">Refresh</string>
     <string name="stop_info_option_show_details">Show stop details</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RouteRowGroupingTest.kt
@@ -342,29 +342,6 @@ class RouteRowGroupingTest {
     }
 
     @Test
-    fun selectedRouteGroup_suppliesRowHeadsign_forMapBadgeDirectionKey() {
-        // A map route-label tap names (route, direction) with no headsign string; the resolved group
-        // supplies the headsign the focus banner shows — the same row the drawer promotes.
-        val groups = listOf(
-            RouteRowGroup(listOf(previewArrival("11", "Madison Park", 2, routeId = "11", directionId = 0))),
-            RouteRowGroup(listOf(previewArrival("11", "Downtown", 5, routeId = "11", directionId = 1)))
-        )
-
-        val group = resolveSelectedRouteGroup(groups, routeRowKey("11", 1, null), "11")
-        assertEquals("Downtown", group?.headsign)
-    }
-
-    @Test
-    fun selectedRouteGroup_null_whenNoRowResolves() {
-        val groups = listOf(
-            RouteRowGroup(listOf(previewArrival("11", "Madison Park", 2, routeId = "11"))),
-            RouteRowGroup(listOf(previewArrival("11", "Downtown", 5, routeId = "11")))
-        )
-
-        assertEquals(null, resolveSelectedRouteGroup(groups, routeRowKey("11", "Different label"), "11"))
-    }
-
-    @Test
     fun grouping_usesNumericDirectionRatherThanDisplayHeadsign() {
         val arrivals = listOf(
             previewArrival("11", "Same label", 2, routeId = "11", directionId = 0),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -1028,24 +1028,6 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `clearing a subordinate route retains stop focus`() = runTest {
-        val vm = viewModel()
-        val map = MapDirectiveRecorder(vm)
-        val mapJob = launch { map.collect() }
-        advanceUntilIdle()
-        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
-        vm.onStopFocused(stop)
-        vm.requestShowFocusedStopRouteOnMap("65", null, "65")
-
-        vm.clearStopRouteSelection()
-        advanceUntilIdle()
-
-        assertEquals(CurrentFocus.Stop(stop), vm.currentFocus.value)
-        assertEquals(1, map.sent.count { it is MapDirective.ClearSelectedRoute })
-        mapJob.cancel()
-    }
-
-    @Test
     fun `focus undo returns from stop route to stop to none`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)
@@ -1205,6 +1187,7 @@ class HomeViewModelTest {
         vm.unfocusMapOneLevel()
         advanceUntilIdle()
         assertEquals(CurrentFocus.Stop(stop), vm.currentFocus.value)
+        assertEquals(1, map.sent.count { it is MapDirective.ClearSelectedRoute })
         map.sent.clear()
 
         assertTrue(vm.navigateBackFocus())


### PR DESCRIPTION
Fixes #2203.

The row of route chips + headsign beneath a focused stop restated what the arrivals drawer already shows with its focus outline on the selected route row, so the banner now carries stop identity only.

### What goes

- `FocusBannerState.SubordinateRoute`, and the `Stop` state's `subordinateRoutes` / `subordinateHeadsign` fields.
- The sub-header itself: the `›`-joined chip chain, the headsign, and the dismiss "X" with its `stop_info_unselect_route` string (no translations existed for it).
- `HomeViewModel.clearStopRouteSelection()` — the dismiss X was its only caller, and it just delegated to `unfocusMapOneLevel()`, which a background map tap and back navigation already use to pop the route selection off a stop focus. Its unit test was folded into `back restores a route removed by a map tap`, which already covers that transition with a directive recorder.
- The group-returning `resolveSelectedRouteGroup` — the banner's headsign projection was its only production caller. The drawer resolves its own selection through `resolveSelectedRouteGroupKey`, so the wrapper goes and the shared-resolution rationale moves onto the key resolver that still has callers. Its two tests were dropped; both cases are covered at key level by `selectedRow_matchesNumericDirection_whenHeadsignsDiffer` and `selectedRow_doesNotGuess_whenRouteHasMultipleDirectionRows`.

### What stays

`CurrentFocus.Stop.selectedRoute` / `StopRouteSelection` are untouched — only their banner projection is gone. The selection still promotes and outlines its arrivals row, still partial-expands the sheet, still persists across process death, and still follows block continuations. `StopFocusBanner` is a single `Row` again now that the stop row no longer has to give up its `weight(1f)` to a second row.

### Testing

- `compileObaGoogleDebugKotlin` + `compileObaGoogleDebugAndroidTestKotlin` with `-PwarningsAsErrors=true`, the full `testObaGoogleDebugUnitTest` suite, and `spotlessCheck` all pass locally. Lint left to CI per `CLAUDE.md`.
- Installed `obaGoogleDebug` on a physical device and confirmed by hand: focusing a stop and then a route row from its arrivals drawer leaves the header as one stop row, with the drawer's promoted/outlined row carrying the route; a background map tap still drops back to the plain stop focus.
- `FocusBannerTest` was updated (`stopBannerShowsIdentityAndFullSubordinateRouteChain` → `stopBannerShowsStopIdentity`; the sub-header dismiss-target test deleted) but the instrumented suite itself was not run locally — leaving that to CI's API 33 emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified the stop focus banner to display stop information, alerts, and a close action.
  * Removed subordinate-route status details and the option to dismiss or clear a selected subordinate route.
  * Updated route selection behavior so the focused arrivals row provides the displayed route emphasis.
  * Improved banner layout so its content fills the available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->