### PR TITLE
Add a stop->route->trip focus level (#2205)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaPillFocusOutlineTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaPillFocusOutlineTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelected
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
+import org.onebusaway.android.ui.arrivals.components.previewArrival
+import org.onebusaway.android.ui.arrivals.components.previewRowCallbacks
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+
+/**
+ * The stop→route→trip focus (#2205) as the drawer shows it: the focused trip's ETA pill is outlined,
+ * and only that one. Asserted through the pill's `selected` semantics — the handle the outline is
+ * published under — rather than by sampling pixels, so the test states the meaning, not the colour.
+ *
+ * The two pills are told apart by the "NOW" label rather than by their countdowns: the ETA and clock
+ * lines are digits, which a device in the wrong timezone can make ambiguous, while the label is read
+ * from resources and appears on exactly one of the two.
+ */
+class EtaPillFocusOutlineTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val nowLabel: String
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+            .getString(R.string.stop_info_eta_now)
+
+    @Test
+    fun onlyTheFocusedTripsPillIsOutlined() {
+        setRow(selectedTripId = TRIP_NOW)
+
+        assertSelectedPillCount(1)
+        // ...and it is the focused trip's pill, not merely some pill.
+        assertSelectedNowPillCount(1)
+    }
+
+    @Test
+    fun theOutlineFollowsWhichTripIsFocused() {
+        setRow(selectedTripId = TRIP_LATER)
+
+        assertSelectedPillCount(1)
+        assertSelectedNowPillCount(0)
+    }
+
+    @Test
+    fun noPillIsOutlinedWhenTheFocusStopsAtTheRoute() {
+        setRow(selectedTripId = null)
+
+        assertSelectedPillCount(0)
+    }
+
+    private fun assertSelectedPillCount(expected: Int) {
+        composeRule.onAllNodes(isSelected(), useUnmergedTree = true).assertCountEquals(expected)
+    }
+
+    /** How many outlined pills are the "NOW" one — i.e. whether the outline landed on [TRIP_NOW]. */
+    private fun assertSelectedNowPillCount(expected: Int) {
+        composeRule.onAllNodes(
+            isSelected() and hasAnyDescendant(hasText(nowLabel)),
+            useUnmergedTree = true
+        ).assertCountEquals(expected)
+    }
+
+    /** A selected two-trip route row, drilled into [selectedTripId] (null = the plain route focus). */
+    private fun setRow(selectedTripId: String?) {
+        val trips = listOf(
+            previewArrival("40", "Northgate", etaMinutes = 0, tripId = TRIP_NOW),
+            previewArrival("40", "Northgate", etaMinutes = 9, tripId = TRIP_LATER)
+        )
+        composeRule.setContent {
+            RouteArrivalRow(
+                group = RouteRowGroup(trips),
+                actionsFor = { null },
+                isFavorite = false,
+                callbacks = previewRowCallbacks(),
+                // The row is the map's selected route, which is what supplies the outline colour the
+                // pill borrows.
+                mapRouteColor = 0xFF0A5B3E.toInt(),
+                selected = true,
+                selectedTripId = selectedTripId
+            )
+        }
+    }
+
+    private companion object {
+        const val TRIP_NOW = "trip_now"
+        const val TRIP_LATER = "trip_later"
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -404,9 +404,15 @@ class MapViewModel @Inject constructor(
     /** A stop marker was tapped: render-focus it without disturbing the current viewport. */
     fun onStopTapped(stop: ObaStop) = stopsController.onStopTapped(stop)
 
-    /** Selects the tapped vehicle, so the renderer shows its most-recent-data marker. */
-    fun onVehicleTapped(status: ObaTripStatus) {
-        renderState.setSelectedVehicle(status.activeTripId)
+    /**
+     * Select the vehicle running [tripId] (null clears), driving its most-recent-data marker, exact
+     * shape/stops, extrapolation confidence band and block continuation. The map's only vehicle-selection
+     * entry point: over a stop's focused route, Home drives it from its stop→route→trip focus level
+     * (#2205) so the selection is undone by the same background tap that peels that level; elsewhere a
+     * vehicle tap sets it directly.
+     */
+    fun selectVehicleTrip(tripId: String?) {
+        renderState.setSelectedVehicle(tripId)
     }
 
     /** Animate/move the camera to a point with no route-header bias (a general recenter for any screen). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -366,6 +366,9 @@ internal fun ArrivalsList(
     selectedRouteId: String? = null,
     /** Route names in the selected vehicle block, beginning with the route on this row. */
     selectedRouteNames: List<String> = emptyList(),
+    /** The trip drilled into within the selected row (the stop→route→trip focus, #2205); null when the
+     *  selection stops at the route. */
+    selectedTripId: String? = null,
     listState: LazyListState = rememberLazyListState(),
     /** Hosts that show the stop's direction elsewhere (e.g. in their own header) set this false to
      *  avoid duplicating it as a list item. */
@@ -428,15 +431,18 @@ internal fun ArrivalsList(
             item(key = "empty") { EmptyArrivals(content.minutesAfter) }
         } else {
             itemsIndexed(routeGroups, key = { _, group -> group.key }) { index, group ->
+                // Every aspect of the map's selection applies to exactly one row, so the row-key test
+                // is made once here rather than repeated per aspect.
+                val isSelectedRow = group.key == effectiveSelectedRowKey
                 RouteArrivalRow(
                     group = group,
                     actionsFor = { content.actions[it.tripId] },
                     isFavorite = group.routeId in content.favoriteRouteIds,
                     callbacks = rowCallbacks,
                     mapRouteColor = mapRouteColors[RouteDirectionKey(group.routeId, group.directionId)],
-                    selected = group.key == effectiveSelectedRowKey,
-                    selectedRouteNames =
-                    if (group.key == effectiveSelectedRowKey) selectedRouteNames else emptyList(),
+                    selected = isSelectedRow,
+                    selectedRouteNames = if (isSelectedRow) selectedRouteNames else emptyList(),
+                    selectedTripId = selectedTripId.takeIf { isSelectedRow },
                     // The onboarding ETA spotlight anchors on the first route row's pill only.
                     etaAnchor = if (index == 0) etaAnchor else Modifier,
                     tracked = group.representative.trackedRouteKey() in content.trackedRows,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -301,6 +301,10 @@ fun RouteArrivalRow(
     mapRouteColor: Int? = null,
     selected: Boolean = false,
     selectedRouteNames: List<String> = emptyList(),
+    // The trip of this row the map is drilled into (the stop→route→trip focus, #2205), or null. Only
+    // meaningful on the selected row, and gated on [selected] below so a stale id can't outline a pill
+    // in a row that isn't the focused one.
+    selectedTripId: String? = null,
     etaAnchor: Modifier = Modifier,
     // Whether a live countdown is running for this row (#2166) — the row's menu picks its verb and
     // glyph from it, and the corner eye appears. Resolved by the list, like [isFavorite]: set
@@ -325,6 +329,9 @@ fun RouteArrivalRow(
     val selectionBorder = selectionColor
         ?.takeIf { selected }
         ?.let { BorderStroke(2.dp, Color(it)) }
+    // The focused trip's pill wears the card's own selection border — the same stroke object — so the
+    // two outlines read as one focus rather than two unrelated highlights (#2205).
+    val pillFocus = selectionBorder?.let { border -> selectedTripId?.let { EtaPillFocus(it, border) } }
     ArrivalCard(modifier, border = selectionBorder) {
         Box(Modifier.fillMaxWidth()) {
             Row(
@@ -397,7 +404,8 @@ fun RouteArrivalRow(
                         trips = group.trips,
                         actionsFor = actionsFor,
                         callbacks = callbacks,
-                        firstPillModifier = etaAnchor
+                        firstPillModifier = etaAnchor,
+                        focus = pillFocus
                     )
                 }
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -60,6 +60,7 @@ fun ArrivalsPanel(
     selectedRowKey: String? = null,
     selectedRouteId: String? = null,
     selectedRouteNames: List<String> = emptyList(),
+    selectedTripId: String? = null,
     // Reports the list's total content height in px so the host can fit the peek to short stops; not
     // reported until the whole list is laid out.
     onContentHeight: (heightPx: Int) -> Unit,
@@ -110,6 +111,7 @@ fun ArrivalsPanel(
                     selectedRowKey = selectedRowKey,
                     selectedRouteId = selectedRouteId,
                     selectedRouteNames = selectedRouteNames,
+                    selectedTripId = selectedTripId,
                     modifier = Modifier.weight(1f),
                     listState = listState,
                     // The focus banner already shows the direction as a "(N)" tag.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.arrivals.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.animateScrollBy
@@ -62,6 +63,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.SpanStyle
@@ -149,6 +151,8 @@ internal fun EtaStrip(
     firstPillModifier: Modifier = Modifier,
     routeBadgeFor: (ArrivalInfo) -> RouteBadge? = { null },
     marker: EtaStripMarker? = null,
+    /** The trip this strip's row is drilled into, if any — see [EtaPillFocus]. */
+    focus: EtaPillFocus? = null,
     // Hoisted for previews/tests ONLY (both real call sites use the default) so a caller can start
     // the strip mid-scroll.
     state: LazyListState = rememberLazyListState()
@@ -260,6 +264,7 @@ internal fun EtaStrip(
                             actions = actionsFor(trip),
                             callbacks = callbacks,
                             routeBadge = routeBadgeFor(trip),
+                            outline = focus?.takeIf { it.tripId == trip.tripId }?.outline,
                             modifier = pillModifier.passedByMarker(marker, isPassed = index < (markerIndex ?: 0))
                         )
                     }
@@ -281,6 +286,23 @@ internal fun EtaStrip(
         )
     }
 }
+
+/**
+ * The trip a row is drilled into (the stop→route→trip focus, #2205) and the stroke to outline its pill
+ * with. One value rather than two loose parameters, so a pill can never be told which trip is focused
+ * without also being told what to draw for it. [outline] is literally the row card's own selection
+ * border — the same object, built once by [RouteArrivalRow] — so the pill reads as belonging to the
+ * outlined row and the two can't drift in width or colour.
+ */
+internal data class EtaPillFocus(val tripId: String, val outline: BorderStroke)
+
+/**
+ * Announces the focused pill as selected, so the outline reaches accessibility services (and UI tests)
+ * as more than a colour. Applied only to that pill — marking every other one "not selected" would have
+ * TalkBack narrate a selection state on strips that have none. Hoisted because it captures nothing and
+ * a pill recomposes every second off the strip's live clock.
+ */
+private val FOCUSED_PILL_SEMANTICS = Modifier.semantics { selected = true }
 
 /** The gap between adjacent ETA pills, for the LazyRow's [Arrangement.spacedBy]. */
 private val PILL_SPACING = 6.dp
@@ -423,7 +445,8 @@ private fun EtaPillWithMenu(
     actions: ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
     modifier: Modifier = Modifier,
-    routeBadge: RouteBadge? = null
+    routeBadge: RouteBadge? = null,
+    outline: BorderStroke? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
     // fillMaxHeight here and on the pill so the colored Surface stretches to the strip's tallest pill
@@ -441,6 +464,7 @@ private fun EtaPillWithMenu(
             canceled = trip.status == Status.CANCELED,
             clock = clock,
             routeBadge = routeBadge,
+            outline = outline,
             onClick = { callbacks.onEtaClick(trip) },
             onLongClick = { expanded = true }
         )
@@ -513,6 +537,9 @@ internal fun EtaPill(
     onMap: Boolean = false,
     canceled: Boolean = false,
     clock: ArrivalClock? = null,
+    // The row is drilled into this pill's trip (#2205): its card's selection border, drawn on the pill
+    // too. Null is the ordinary unfocused pill.
+    outline: BorderStroke? = null,
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null
 ) {
@@ -546,7 +573,12 @@ internal fun EtaPill(
     // See tightLineStyle's doc: keyed to each Text's own (dominant) size, so the padding/gap values
     // below are the actual on-screen spacing rather than a guess fighting Android's hidden font padding.
     val baseTextStyle = LocalTextStyle.current
-    Surface(modifier = modifier.then(interaction), shape = shape, color = color) {
+    Surface(
+        modifier = modifier.then(if (outline == null) Modifier else FOCUSED_PILL_SEMANTICS).then(interaction),
+        shape = shape,
+        color = color,
+        border = outline
+    ) {
         // A Box so the live indicator can overlay the pill (below) instead of reserving layout width:
         // live and scheduled pills stay identical widths, and the glyph is free to overlap the ETA
         // text at the top-trailing corner rather than widening the pill.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -264,6 +264,14 @@ internal fun EtaStrip(
                             actions = actionsFor(trip),
                             callbacks = callbacks,
                             routeBadge = routeBadgeFor(trip),
+                            // Matched on trip id alone, deliberately narrower than this LazyRow's
+                            // (route, trip, serviceDate, stopSequence) key: the focus names a *vehicle*,
+                            // not one arrival instance. A loop route's two visits share a trip id
+                            // because they are the same bus coming round again — one vehicle, one
+                            // confidence band on the map — so outlining both pills is what the focus
+                            // actually means. There is also no instance to match on when the level was
+                            // entered by tapping that vehicle: ObaTripStatus carries an activeTripId
+                            // and no stop sequence, so a 4-part identity could only be guessed.
                             outline = focus?.takeIf { it.tripId == trip.tripId }?.outline,
                             modifier = pillModifier.passedByMarker(marker, isPassed = index < (markerIndex ?: 0))
                         )
@@ -293,6 +301,9 @@ internal fun EtaStrip(
  * without also being told what to draw for it. [outline] is literally the row card's own selection
  * border — the same object, built once by [RouteArrivalRow] — so the pill reads as belonging to the
  * outlined row and the two can't drift in width or colour.
+ *
+ * [tripId] is a vehicle, not one arrival instance — see the match site in [EtaStrip] for why that is
+ * narrower than the strip's own item key, and why it has to be.
  */
 internal data class EtaPillFocus(val tripId: String, val outline: BorderStroke)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
@@ -81,13 +81,43 @@ sealed interface DirectionsSubFocus {
 internal val CurrentFocus.keepsDrawnItinerary: Boolean
     get() = this is CurrentFocus.Directions && subFocus !is DirectionsSubFocus.Route
 
+/**
+ * This focus with its innermost attention layer removed, or null when there is nothing left to peel.
+ * The one definition of the focus ladder: a stop's route selection sits under its drilled-into trip
+ * (#2205), a directions overview under its focused leg, and every top-level focus under the root.
+ *
+ * Both consumers read it from here rather than each spelling the levels out: a background tap peels one
+ * rung ([org.onebusaway.android.ui.home.HomeViewModel.unfocusMapOneLevel]), and a focus restored after
+ * process death — where only the deepest rung is persisted — rebuilds its undo history by walking the
+ * whole ladder. A new level therefore has to be added in one place for both to agree.
+ */
+internal fun CurrentFocus.peeledOneLevel(): CurrentFocus? = when (this) {
+    CurrentFocus.None -> null
+    is CurrentFocus.Stop -> when {
+        selectedRoute == null -> CurrentFocus.None
+        // The trip drilled into is the innermost rung, so it goes first — the route stays drawn and
+        // only its confidence band and pill outline are given up.
+        selectedRoute.selectedTripId != null ->
+            CurrentFocus.Stop(stop, selectedRoute.copy(selectedTripId = null))
+        else -> CurrentFocus.Stop(stop)
+    }
+    // A focused leg — its route, or an on-street leg framed on its own — becomes the plain itinerary
+    // overview; a plain overview exits.
+    is CurrentFocus.Directions -> if (subFocus == null) CurrentFocus.None else CurrentFocus.Directions()
+    is CurrentFocus.Route, is CurrentFocus.BikeStation -> CurrentFocus.None
+}
+
 val CurrentFocus.focusedStop: FocusedStop?
     get() = (this as? CurrentFocus.Stop)?.stop
 
 val CurrentFocus.focusedBikeStationId: String?
     get() = (this as? CurrentFocus.BikeStation)?.id
 
-/** Durable route identity. Vehicle-trip focus remains a transient [ShowRouteRequest] field. */
+/**
+ * Durable route identity. It names no trip: within stop focus the drilled-into trip is a level of its own
+ * ([StopRouteSelection.selectedTripId], #2205), and the [ShowRouteRequest.focusTripId] this mints is the
+ * one-shot "fit that vehicle" camera instruction a drill-in gesture passes, not retained state.
+ */
 data class RouteTarget(
     val routeId: String,
     val directionStopId: String? = null,
@@ -124,7 +154,18 @@ data class StopRouteSelection(
     // the user sees is the resolved arrivals row itself, drawn as the drawer's focus outline — so don't
     // render this and don't duplicate the rest of the row onto the selection.
     val originHeadsign: String?,
-    val legs: List<RouteLeg>
+    val legs: List<RouteLeg>,
+    /**
+     * The one trip drilled into from this route — the stop→route→trip level (#2205), entered by tapping
+     * that trip's ETA pill or its vehicle on the map. Both gestures mean the same thing, so both land
+     * here. Null is the plain stop→route focus.
+     *
+     * A level of its own rather than a render-only vehicle selection, so a background tap peels it before
+     * the route (see [peeledOneLevel]) — which is what makes the map's
+     * [org.onebusaway.android.map.render.MapRenderState.selectedVehicleTripId] a projection of this focus
+     * rather than a second, independently-mutated truth.
+     */
+    val selectedTripId: String? = null
 ) {
     init {
         require(legs.isNotEmpty()) { "StopRouteSelection requires at least one route leg" }
@@ -134,5 +175,7 @@ data class StopRouteSelection(
     val currentLeg: RouteLeg get() = legs.last()
     fun target(stopId: String) = RouteTarget(currentLeg.routeId, stopId, currentLeg.directionId)
 
-    fun continueTo(leg: RouteLeg): StopRouteSelection = copy(legs = legs + leg)
+    /** Follow the block onto [leg]. The trip level doesn't survive: the continuation is a *different*
+     *  trip of that block, and this tap doesn't name its id. */
+    fun continueTo(leg: RouteLeg): StopRouteSelection = copy(legs = legs + leg, selectedTripId = null)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -37,6 +37,7 @@ internal object CurrentFocusPersistence {
     private const val KEY_ROUTE_LEG_IDS = "home.currentFocus.route.legIds"
     private const val KEY_ROUTE_LEG_NAMES = "home.currentFocus.route.legNames"
     private const val KEY_ROUTE_LEG_DIRECTIONS = "home.currentFocus.route.legDirections"
+    private const val KEY_ROUTE_SELECTED_TRIP = "home.currentFocus.route.selectedTripId"
 
     private const val FOCUS_NONE = "none"
     private const val FOCUS_STOP = "stop"
@@ -90,6 +91,7 @@ internal object CurrentFocusPersistence {
         state[KEY_ROUTE_LEG_DIRECTIONS] = selected?.legs
             ?.map { it.directionId ?: NO_DIRECTION }
             ?.toIntArray()
+        state[KEY_ROUTE_SELECTED_TRIP] = selected?.selectedTripId
     }
 
     private fun readLegacyFocus(state: SavedStateHandle, stop: FocusedStop?): CurrentFocus {
@@ -135,7 +137,8 @@ internal object CurrentFocusPersistence {
         if (legs.isEmpty()) return null
         return StopRouteSelection(
             originHeadsign = state[KEY_ROUTE_ORIGIN_HEADSIGN],
-            legs = legs
+            legs = legs,
+            selectedTripId = state[KEY_ROUTE_SELECTED_TRIP]
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -105,19 +105,16 @@ class HomeViewModel @Inject constructor(
         val viewport: MapViewport? = null
     )
 
-    private val mapUndoHistory = ArrayDeque<MapUndoEntry>().apply {
-        when (val restored = _currentFocus.value) {
-            CurrentFocus.None -> Unit
-            is CurrentFocus.Stop -> {
-                addLast(MapUndoEntry(CurrentFocus.None))
-                if (restored.selectedRoute != null) {
-                    addLast(MapUndoEntry(CurrentFocus.Stop(restored.stop)))
-                }
-            }
-            is CurrentFocus.Route, is CurrentFocus.BikeStation, is CurrentFocus.Directions ->
-                addLast(MapUndoEntry(CurrentFocus.None))
-        }
-    }
+    private val mapUndoHistory = ArrayDeque(
+        // Walk the restored focus down to the root ([peeledOneLevel] — the same ladder a background tap
+        // descends), drop the focus itself, and push the ancestors outermost-first. Viewports aren't
+        // persisted, so the reconstructed entries carry none.
+        generateSequence(_currentFocus.value) { it.peeledOneLevel() }
+            .drop(1)
+            .map { MapUndoEntry(it) }
+            .toList()
+            .asReversed()
+    )
     private val _canUndoMapAction = MutableStateFlow(mapUndoHistory.isNotEmpty())
     val canUndoMapAction: StateFlow<Boolean> = _canUndoMapAction.asStateFlow()
 
@@ -420,15 +417,30 @@ class HomeViewModel @Inject constructor(
                 trips = focusedTrips
             )
         )
-        focus.selectedRoute?.let {
-            emitMapDirective(
-                MapDirective.ShowRoute(
-                    it.target(focus.stop.id).toRequest(),
-                    stopScoped = true,
-                    frameRoute = frameSelectedRoute
-                )
-            )
-        }
+        focus.selectedRoute?.let { showStopRoute(focus.stop.id, it, frameRoute = frameSelectedRoute) }
+    }
+
+    /**
+     * Show a stop-scoped route on the map together with its trip level (#2205): every entry into — or
+     * replay of — a stop's route selection goes through here, so the route directive can never be sent
+     * without the [MapDirective.SelectVehicle] that makes the map's vehicle selection (what draws the
+     * extrapolation band) a projection of the focus. The selection is emitted after the route directive
+     * so it survives the teardown a route change performs, and unconditionally (null included) so no
+     * path can leave a previous trip selected on the map.
+     *
+     * [request] defaults to the selection's own, which carries no `focusTripId` even when a trip *is*
+     * focused: that field is a one-shot camera instruction (fit the vehicle with the stop, and ping it),
+     * and the replaying callers run on every arrivals poll. Only the gesture that entered the trip level
+     * passes a request asking for that fit — the same reason a poll must not reframe the route (#1895).
+     */
+    private fun showStopRoute(
+        stopId: String,
+        selection: StopRouteSelection,
+        request: ShowRouteRequest = selection.target(stopId).toRequest(),
+        frameRoute: Boolean = true
+    ) {
+        emitMapDirective(MapDirective.ShowRoute(request, stopScoped = true, frameRoute = frameRoute))
+        emitMapDirective(MapDirective.SelectVehicle(selection.selectedTripId))
     }
 
     /** Animate the map's camera back onto the focused stop, if one is focused (else a no-op). */
@@ -490,9 +502,7 @@ class HomeViewModel @Inject constructor(
                 val selected = focus.selectedRoute ?: return
                 val next = selected.continueTo(RouteLeg(routeId, shortName, directionId))
                 pushFocus(focus.copy(selectedRoute = next), undoViewport)
-                emitMapDirective(
-                    MapDirective.ShowRoute(next.target(focus.stop.id).toRequest(), stopScoped = true)
-                )
+                showStopRoute(focus.stop.id, next)
             }
             is CurrentFocus.Route -> {
                 val target = RouteTarget(routeId, directionId = directionId)
@@ -535,49 +545,60 @@ class HomeViewModel @Inject constructor(
         originHeadsign: String?,
         undoViewport: MapViewport?
     ) {
-        val next = stopFocus.copy(
-            selectedRoute = StopRouteSelection(
-                originHeadsign = originHeadsign,
-                legs = listOf(firstLeg)
-            )
+        val selection = StopRouteSelection(
+            originHeadsign = originHeadsign,
+            legs = listOf(firstLeg),
+            // An ETA-pill tap names the trip it belongs to, and that *is* the trip level (#2205): the
+            // pill lands one level deeper than the row body, which names no trip and stops at the route.
+            selectedTripId = request.focusTripId
         )
-        pushFocus(next, undoViewport)
-        emitMapDirective(
-            MapDirective.ShowRoute(
-                request.copy(directionStopId = stopFocus.stop.id),
-                stopScoped = true
-            )
+        pushFocus(stopFocus.copy(selectedRoute = selection), undoViewport)
+        // The caller's own request, not the selection's: this is the drill-in gesture, so it keeps the
+        // focusTripId that fits the camera to the vehicle.
+        showStopRoute(
+            stopFocus.stop.id,
+            selection,
+            request = request.copy(directionStopId = stopFocus.stop.id)
         )
     }
 
     /**
-     * A background-map tap drops one attention layer: route-over-stop becomes the plain stop; a focused
-     * itinerary leg becomes the plain itinerary overview; any plain stop, standalone route, or bike focus
-     * returns to the unfocused root.
+     * A vehicle tapped on the map enters the stop→route→trip level (#2205) — the same state its ETA pill
+     * reaches — so the band it raises can be unwound by a background tap instead of lingering as a
+     * render-only selection. Returns false when there is no stop→route focus to deepen (standalone route
+     * focus, directions), leaving the tap to the map's own vehicle selection — so the same two gestures
+     * unwind differently by how the route was reached: over a focused stop a background tap gives up
+     * just the band, while in standalone route focus it still gives up the whole route.
+     *
+     * [tripId] is the tapped vehicle's active trip, which the wire leaves nullable: a vehicle running no
+     * identifiable trip has nothing to drill into, so it lands back at the plain route level rather than
+     * letting the focus and the map's selection drift apart.
+     */
+    fun selectFocusedRouteTrip(tripId: String?): Boolean {
+        val focus = _currentFocus.value as? CurrentFocus.Stop ?: return false
+        val selected = focus.selectedRoute ?: return false
+        pushFocus(focus.copy(selectedRoute = selected.copy(selectedTripId = tripId)))
+        emitMapDirective(MapDirective.SelectVehicle(tripId))
+        return true
+    }
+
+    /**
+     * A background-map tap drops one attention layer: trip-over-route-over-stop becomes the plain
+     * route-over-stop; route-over-stop becomes the plain stop; a focused itinerary leg becomes the plain
+     * itinerary overview; any plain stop, standalone route, or bike focus returns to the unfocused root.
      */
     fun unfocusMapOneLevel() {
         val focus = _currentFocus.value
-        val target = when (focus) {
-            is CurrentFocus.Stop -> if (focus.selectedRoute == null) {
-                CurrentFocus.None
-            } else {
-                CurrentFocus.Stop(focus.stop)
-            }
-            // A focused leg — its route, or an on-street leg framed on its own — becomes the plain
-            // itinerary overview; a plain overview exits.
-            is CurrentFocus.Directions -> if (focus.subFocus == null) {
-                CurrentFocus.None
-            } else {
-                CurrentFocus.Directions()
-            }
-            is CurrentFocus.Route, is CurrentFocus.BikeStation -> CurrentFocus.None
-            CurrentFocus.None -> return
-        }
+        val target = focus.peeledOneLevel() ?: return
         // A stray background tap is the cheapest gesture on the map; where it would take a planned trip
         // off it, it asks first (#2140) — judged on the transition the `when` above just decided.
         if (stageDirectionsExitConfirmation(focus, target)) return
         pushFocus(target)
         when {
+            // Peeled the trip only: the route is still focused, so drop the vehicle selection (and with
+            // it the band) rather than tearing route mode down.
+            target is CurrentFocus.Stop && target.selectedRoute != null ->
+                emitMapDirective(MapDirective.SelectVehicle(null))
             target is CurrentFocus.Stop -> emitMapDirective(MapDirective.ClearSelectedRoute)
             // Popped a leg sub-focus back to the whole trip.
             target is CurrentFocus.Directions -> emitMapDirective(itineraryOverviewDirective(focus))
@@ -1082,17 +1103,14 @@ class HomeViewModel @Inject constructor(
             from.stop.id == target.stop.id
         if (returnsToSameStop) {
             val selected = target.selectedRoute
-            emitMapDirective(
-                if (selected == null) {
-                    MapDirective.ClearSelectedRoute
-                } else {
-                    MapDirective.ShowRoute(
-                        selected.target(target.stop.id).toRequest(),
-                        stopScoped = true,
-                        frameRoute = frameFocus
-                    )
-                }
-            )
+            when {
+                selected == null -> emitMapDirective(MapDirective.ClearSelectedRoute)
+                // Only the trip level moved (#2205): the same route is already drawn, so just move the
+                // vehicle selection rather than reloading and reframing the route beneath it.
+                from.selectedRoute?.legs == selected.legs ->
+                    emitMapDirective(MapDirective.SelectVehicle(selected.selectedTripId))
+                else -> showStopRoute(target.stop.id, selected, frameRoute = frameFocus)
+            }
         } else {
             when (target) {
                 is CurrentFocus.Stop -> {
@@ -1245,6 +1263,13 @@ sealed interface MapDirective {
 
     /** Leave route mode while retaining the focused stop's adjacency session. */
     data object ClearSelectedRoute : MapDirective
+
+    /**
+     * Select the vehicle running [tripId] — what draws its extrapolation confidence band — or clear the
+     * selection with null. The stop→route→trip focus level (#2205) is the authority here, so this rides
+     * alongside every stop-scoped [ShowRoute] rather than the map setting it alone from a vehicle tap.
+     */
+    data class SelectVehicle(val tripId: String?) : MapDirective
 
     /** Clear the map's render focus (back-press from a peeking arrivals sheet). */
     object ClearFocus : MapDirective

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -168,6 +168,7 @@ internal fun ArrivalsSheetHost(
             selectedRowKey = selectedRoute?.selectedArrivalRowKey(),
             selectedRouteId = selectedRoute?.originLeg?.routeId,
             selectedRouteNames = selectedRoute?.legs?.map { it.shortName }.orEmpty(),
+            selectedTripId = selectedRoute?.selectedTripId,
             onContentHeight = onContentHeight,
             etaAnchor = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_ETA)
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -233,7 +233,15 @@ fun MapFeature(
             }
 
             override fun onVehicleClick(status: ObaTripStatus) {
-                mapViewModel.onVehicleTapped(status)
+                // Over a stop's focused route the tapped vehicle is a focus level of its own (#2205), so
+                // HOME owns the transition and the selection arrives as its directive; a background tap
+                // then unwinds it. Anywhere else (standalone route focus, directions) the tap stays what
+                // it has always been: a bare render selection with nothing to unwind. Same ask-HOME-then-
+                // render shape as the stop and bike taps above.
+                val tripId = status.activeTripId
+                if (!homeViewModel.selectFocusedRouteTrip(tripId)) {
+                    mapViewModel.selectVehicleTrip(tripId)
+                }
             }
 
             override fun onRouteContinuationClick(
@@ -329,6 +337,7 @@ fun MapFeature(
                     mapViewModel.setRideArrivals(directive.stopId, directive.groups)
                 MapDirective.ClearStopRoutes -> mapViewModel.clearStopRoutes()
                 MapDirective.ClearSelectedRoute -> mapViewModel.clearSelectedRoute()
+                is MapDirective.SelectVehicle -> mapViewModel.selectVehicleTrip(directive.tripId)
                 MapDirective.ClearFocus -> mapViewModel.clearAllFocus()
                 is MapDirective.FocusStop ->
                     mapViewModel.focusStop(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -77,12 +77,16 @@ private class MapDirectiveRecorder(private val vm: HomeViewModel) {
     val clearFocusCount get() = sent.count { it is MapDirective.ClearFocus }
     val focusStops get() = sent.filterIsInstance<MapDirective.FocusStop>()
     val viewportRestores get() = sent.filterIsInstance<MapDirective.RestoreViewport>()
+    val vehicleSelections get() = sent.filterIsInstance<MapDirective.SelectVehicle>().map { it.tripId }
     val lastBottomPadding get() = vm.mapBottomPadding.value
 
     suspend fun collect() {
         vm.mapDirectives.collect { sent.add(it) }
     }
 }
+
+/** The route selection under the current stop focus, or null when nothing is focused that deeply. */
+private fun HomeViewModel.stopRouteSelection(): StopRouteSelection? = (currentFocus.value as? CurrentFocus.Stop)?.selectedRoute
 
 /**
  * Unit tests for [HomeViewModel]: focus coordination, the arrivals-sheet → map effects, and region resolution.
@@ -1211,6 +1215,147 @@ class HomeViewModelTest {
 
         assertEquals(CurrentFocus.None, vm.currentFocus.value)
         assertTrue(vm.canUndoMapAction.value)
+    }
+
+    @Test
+    fun `an eta pill tap enters the trip level and a map tap peels it back to the route`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
+        vm.onStopFocused(stop)
+        // The ETA pill's request — the row body's differs only in carrying no focusTripId.
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65", "stop", focusTripId = "trip", initialDirectionId = 0),
+            shortName = "65",
+            headsign = "Downtown"
+        )
+        advanceUntilIdle()
+        assertEquals("trip", vm.stopRouteSelection()?.selectedTripId)
+        assertEquals(listOf("trip"), map.vehicleSelections)
+        map.sent.clear()
+
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        // The route survives — only its trip level went, so route mode is not torn down.
+        assertEquals("65", vm.stopRouteSelection()?.currentLeg?.routeId)
+        assertEquals(null, vm.stopRouteSelection()?.selectedTripId)
+        assertEquals(listOf(null), map.vehicleSelections)
+        assertEquals(0, map.sent.count { it is MapDirective.ClearSelectedRoute })
+        map.sent.clear()
+
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Stop(stop), vm.currentFocus.value)
+        assertEquals(1, map.sent.count { it is MapDirective.ClearSelectedRoute })
+        mapJob.cancel()
+    }
+
+    @Test
+    fun `a row-body tap stops at the route level`() = runTest {
+        val vm = viewModel()
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65", "stop", initialDirectionId = 0),
+            shortName = "65",
+            headsign = "Downtown"
+        )
+
+        assertEquals(null, vm.stopRouteSelection()?.selectedTripId)
+    }
+
+    @Test
+    fun `a tapped vehicle enters the trip level only under a focused route`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
+        vm.onStopFocused(stop)
+        // Plain stop focus: there is no route to deepen, so the map keeps its own selection.
+        assertEquals(false, vm.selectFocusedRouteTrip("trip"))
+
+        vm.requestShowFocusedStopRouteOnMap("65", directionId = 0)
+        advanceUntilIdle()
+        map.sent.clear()
+
+        assertEquals(true, vm.selectFocusedRouteTrip("trip"))
+        advanceUntilIdle()
+        assertEquals("trip", vm.stopRouteSelection()?.selectedTripId)
+        assertEquals(listOf("trip"), map.vehicleSelections)
+
+        // Back reverses the drill-in without reloading the route it is drawn over.
+        map.sent.clear()
+        assertTrue(vm.navigateBackFocus())
+        advanceUntilIdle()
+        assertEquals(null, vm.stopRouteSelection()?.selectedTripId)
+        assertEquals(listOf(null), map.vehicleSelections)
+        assertEquals(emptyList<String>(), map.routesShown)
+        mapJob.cancel()
+    }
+
+    @Test
+    fun `a block continuation drops the trip level it was followed from`() = runTest {
+        val vm = viewModel()
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65", "stop", focusTripId = "trip", initialDirectionId = 0),
+            shortName = "65",
+            headsign = "Downtown"
+        )
+
+        vm.advanceRouteContinuation("75", "75", directionId = 1)
+
+        assertEquals("75", vm.stopRouteSelection()?.currentLeg?.routeId)
+        assertEquals(null, vm.stopRouteSelection()?.selectedTripId)
+    }
+
+    @Test
+    fun `a restored trip level reconstructs its route, stop and root parents`() = runTest {
+        val state = SavedStateHandle()
+        val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
+        viewModel(savedState = state).apply {
+            onStopFocused(stop)
+            requestShowFocusedStopRouteOnMap("65", directionId = 0)
+            selectFocusedRouteTrip("trip")
+        }
+        val restored = viewModel(savedState = state)
+        assertEquals("trip", restored.stopRouteSelection()?.selectedTripId)
+
+        assertTrue(restored.navigateBackFocus())
+        assertEquals(null, restored.stopRouteSelection()?.selectedTripId)
+        assertEquals("65", restored.stopRouteSelection()?.currentLeg?.routeId)
+        assertTrue(restored.navigateBackFocus())
+        assertEquals(CurrentFocus.Stop(stop), restored.currentFocus.value)
+        assertTrue(restored.navigateBackFocus())
+        assertEquals(CurrentFocus.None, restored.currentFocus.value)
+    }
+
+    @Test
+    fun `an arrivals poll replays the focused trip without refitting its vehicle`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        vm.onStopFocused(FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)))
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65", "1", focusTripId = "trip", initialDirectionId = 0),
+            shortName = "65",
+            headsign = "Downtown"
+        )
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
+        advanceUntilIdle()
+
+        // The band keeps following the focused trip, but the poll must not re-fit the camera onto its
+        // vehicle — focusTripId is the drill-in gesture's one-shot instruction, not replayable state.
+        assertEquals(listOf("trip"), map.vehicleSelections)
+        assertEquals(null, map.routeRequests.single().focusTripId)
+        assertEquals(false, map.routeCommands.single().frameRoute)
+        mapJob.cancel()
     }
 
     @Test


### PR DESCRIPTION
Closes #2205.

Adds a third focus level beneath a stop's selected route. Tapping an **ETA pill** or a **vehicle on the map** enters it; both gestures mean the same thing, so both land in the same state:

- the map draws that trip's extrapolation confidence band, and
- the drawer outlines its ETA pill in the selected row's own selection border.

The level lives on the action stack, so a background map tap unwinds to the plain stop→route focus (the route stays drawn) and Back reverses the drill-in.

## Why the two entry points diverged before

An ETA-pill tap changed `CurrentFocus` but dropped the trip on the floor — `ShowRouteRequest.focusTripId` survived only as a one-shot camera instruction. A vehicle tap did the opposite: it set the map's `selectedVehicleTripId` without touching focus at all, so the band it raised had nothing to unwind it and only a route teardown ever cleared it. This unifies them onto one level.

## Shape

**`StopRouteSelection.selectedTripId`, not a nested sealed type.** `DirectionsSubFocus` is sealed because it has two kinds with disjoint payloads; the trip level has one kind and one `String`. Hanging it off the route selection is also what makes `continueTo()` dropping it a local invariant (a continuation is a *different* trip of the block, whose id that tap doesn't name) rather than a rule coordinated between two objects.

**It is persisted**, unlike `DirectionsSubFocus` — one string that re-resolves against the next arrivals poll, versus a whole `ShowRouteRequest` and a `FocusedLeg`.

**`MapRenderState.selectedVehicleTripId` becomes a projection of the focus.** The new `MapDirective.SelectVehicle` rides alongside every stop-scoped `ShowRoute` through a single `showStopRoute()` helper, so a route directive can't be sent without its selection.

**The replayed request deliberately carries no `focusTripId`.** That field fits the camera to the vehicle and pings it, and `onArrivalsLoaded` replays on every poll — replaying it would yank the camera every minute (the #1895 rule). Only the drill-in gesture passes a request asking for that fit. There's a unit test pinning this.

## Scope note

Vehicle taps outside stop-scoped route focus (standalone route focus, directions) keep today's render-only behaviour, since #2205 scopes the new state to stop→route→trip. The consequence is that the same two gestures unwind differently depending on how the route was reached — over a focused stop a background tap gives up just the band, in standalone route focus it still gives up the whole route. That asymmetry is documented at `selectFocusedRouteTrip` rather than left for a reader to trip over.

## Incidental cleanup

The focus ladder is now defined once. "One level up" had been written out twice — in `unfocusMapOneLevel` and in the undo-history reconstruction — so adding a level meant editing both or having Back and the background tap silently diverge after process death. Both now read `CurrentFocus.peeledOneLevel()`, which also subsumes the hand-written `Route`/`BikeStation`/`Directions` rungs. Net line reduction.

Also: `MapViewModel.onVehicleTapped` had become a one-caller pass-through and was folded into `selectVehicleTrip`, leaving one vehicle-selection entry point on the map.

## Testing

- 6 new `HomeViewModelTest` cases: pill-tap entry and the two-step peel, row-body tap stopping at the route, vehicle-tap entry gated on stop→route focus, continuation dropping the trip level, restore reconstructing all three parents, and the poll-doesn't-refit pin. Full unit suite green.
- New `EtaPillFocusOutlineTest` asserts the outline through the pill's `selected` semantics rather than by sampling pixels.
- `compileObaGoogleDebugKotlin` and `compileObaMaplibreDebugKotlin` clean under `-PwarningsAsErrors=true`; `spotlessCheck` passes.

⚠️ **The instrumented suite could not validate the new Compose test locally.** On the dev phone (Pixel 7 Pro / Android 17, well past the API 33 target) 86 of 232 instrumented tests fail with `IllegalStateException: No compose hierarchies found in the app` — essentially every Compose render test in the repo, including ones this branch doesn't touch (`TripPlanFormRenderTest`, `FocusBannerTest`, `DonationDismissDialogUiTest`) plus non-Compose `LastKnownLocationTest`/`NotificationChannelsTest`. That's an environment problem, not this change, but it does mean `EtaPillFocusOutlineTest` is **unverified**: two of its cases hit that error and the third passed only vacuously (`assertCountEquals(0)` doesn't require a compose root). CI's API 33 emulator is the first real run of it — please check that leg before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trip-level selection for arrivals, linking a focused ETA pill with its corresponding vehicle on the map.
  * Added clear visual focus outlines to selected ETA pills.
  * Improved navigation between stop, route, trip, and vehicle selections, including undo and restoration behavior.
  * Preserved selected trip information when restoring app state.

* **Tests**
  * Added coverage for ETA-pill focus, map selection, navigation, restoration, and arrivals updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->