### PR TITLE
Widen the extrapolator's interval for a vehicle observed off its usual pace

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolator.kt
@@ -41,10 +41,12 @@ import org.onebusaway.android.time.WallTime
  * worst (horizon x deviation) cell's coverage error from 0.278 to 0.089, and the early-vehicle band
  * from 0.602 to 0.799 against a nominal 0.800.
  *
- * On top of that, a vehicle observed holding an unusual pace over a sustained recent window — the
- * death-spiral bus of issue #2202 — gets [PaceModel]'s adjustment: a lump of scheduled time and a
- * dispersion factor, baked into the profile and theta once per snapshot. Without a long enough
- * window the adjustment is identity, so this changes nothing for a freshly opened trip.
+ * On top of that, a vehicle observed holding an unusual pace over a sustained recent window gets
+ * [PaceModel]'s adjustment — a lump of scheduled time and a widened dispersion, baked into the
+ * profile and theta once per snapshot. That widens the interval rather than moving it, which is
+ * all the covariate supports: a vehicle's own pace history does not predict its future rate (see
+ * [PaceModel]). Without a long enough window the adjustment is identity, so this changes nothing
+ * for a freshly opened trip.
  *
  * Known residual, measured and left in deliberately: the left tail is a few points heavier than the
  * model at every horizon — trips that fall badly behind are more common than a single gamma process
@@ -60,8 +62,8 @@ class FirstPassageExtrapolator(state: TripState) : Extrapolator(state) {
      *
      * The profile starts from where the vehicle **actually is**, not its `scheduledDistanceAlongTrip`:
      * the model asks how long the road ahead should take, which is a property of that road, so a late
-     * bus is still governed by the stretch it currently occupies. The pace adjustment's mean effects
-     * are baked into the profile here ([warpedBy]); its dispersion factor rides on theta below.
+     * bus is still governed by the stretch it currently occupies. The pace adjustment's lump is baked
+     * into the profile here ([warpedBy]); its dispersion factor rides on theta below.
      */
     private val fit: Fit? by lazy(LazyThreadSafetyMode.NONE) {
         val anchor = state.anchor ?: return@lazy null

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolator.kt
@@ -41,6 +41,11 @@ import org.onebusaway.android.time.WallTime
  * worst (horizon x deviation) cell's coverage error from 0.278 to 0.089, and the early-vehicle band
  * from 0.602 to 0.799 against a nominal 0.800.
  *
+ * On top of that, a vehicle observed holding an unusual pace over a sustained recent window — the
+ * death-spiral bus of issue #2202 — gets [PaceModel]'s adjustment: a lump of scheduled time and a
+ * dispersion factor, baked into the profile and theta once per snapshot. Without a long enough
+ * window the adjustment is identity, so this changes nothing for a freshly opened trip.
+ *
  * Known residual, measured and left in deliberately: the left tail is a few points heavier than the
  * model at every horizon — trips that fall badly behind are more common than a single gamma process
  * allows. It is not simply stalled buses, whose frequency decays with the horizon as expected, and
@@ -49,20 +54,27 @@ import org.onebusaway.android.time.WallTime
 class FirstPassageExtrapolator(state: TripState) : Extrapolator(state) {
 
     /**
-     * The schedule ahead of the vehicle, and how far off schedule it is — both fixed for the life of
-     * this extrapolator, since [Extrapolator] is built per immutable snapshot.
+     * The schedule ahead of the vehicle, how far off schedule it is, and the pace it was recently
+     * observed holding — all fixed for the life of this extrapolator, since [Extrapolator] is built
+     * per immutable snapshot, so the pace lookback is read from the history once, never per frame.
      *
      * The profile starts from where the vehicle **actually is**, not its `scheduledDistanceAlongTrip`:
      * the model asks how long the road ahead should take, which is a property of that road, so a late
-     * bus is still governed by the stretch it currently occupies.
+     * bus is still governed by the stretch it currently occupies. The pace adjustment's mean effects
+     * are baked into the profile here ([warpedBy]); its dispersion factor rides on theta below.
      */
     private val fit: Fit? by lazy(LazyThreadSafetyMode.NONE) {
         val anchor = state.anchor ?: return@lazy null
         val profile = state.schedule?.passageProfileFrom(anchor.distanceAlongTrip ?: return@lazy null)
-        profile?.let { Fit(it, anchor.scheduleDeviation) }
+        val pace = PaceModel.adjustmentFor(PaceModel.lookbackFor(state))
+        profile?.let { Fit(it.warpedBy(pace), anchor.scheduleDeviation, pace.dispersionMultiplier) }
     }
 
-    private class Fit(val profile: PassageProfile, val deviation: Duration)
+    private class Fit(
+        val profile: PassageProfile,
+        val deviation: Duration,
+        val dispersionMultiplier: Double
+    )
 
     override fun doExtrapolate(
         lastDist: Double,
@@ -79,7 +91,7 @@ class FirstPassageExtrapolator(state: TripState) : Extrapolator(state) {
                 dtSec,
                 current.profile.scheduleSeconds,
                 current.profile.distances,
-                DeviationModel.dispersionFor(current.deviation),
+                DeviationModel.dispersionFor(current.deviation) * current.dispersionMultiplier,
                 DeviationModel.travelMultiplierFor(current.deviation)
             )
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolator.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolator.kt
@@ -65,9 +65,11 @@ class FirstPassageExtrapolator(state: TripState) : Extrapolator(state) {
      */
     private val fit: Fit? by lazy(LazyThreadSafetyMode.NONE) {
         val anchor = state.anchor ?: return@lazy null
-        val profile = state.schedule?.passageProfileFrom(anchor.distanceAlongTrip ?: return@lazy null)
+        val profile =
+            state.schedule?.passageProfileFrom(anchor.distanceAlongTrip ?: return@lazy null)
+                ?: return@lazy null
         val pace = PaceModel.adjustmentFor(PaceModel.lookbackFor(state))
-        profile?.let { Fit(it.warpedBy(pace), anchor.scheduleDeviation, pace.dispersionMultiplier) }
+        Fit(profile.warpedBy(pace), anchor.scheduleDeviation, pace.dispersionMultiplier)
     }
 
     private class Fit(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/PaceModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/PaceModel.kt
@@ -15,7 +15,9 @@
  */
 package org.onebusaway.android.extrapolation
 
+import kotlin.math.abs
 import kotlin.math.exp
+import kotlin.math.ln
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
@@ -31,33 +33,47 @@ import org.onebusaway.android.time.ServerTime
  * schedule speed for a whole route while the extrapolated marker sails ahead and snaps back on
  * every fix.
  *
- * Measured over the same day of King County Metro AVL as the deviation curves, a vehicle's pace
- * over the last ten minutes predicts its next few minutes *beyond* what deviation says, and the
- * signal is not what a "slow bus stays slow" multiplier would suggest. The median mostly recovers;
- * what distinguishes a slow-running vehicle is that it is disproportionately likely to be losing a
- * lump of time **right now** (mid-dwell, held at a timepoint, stuck at a light) and that a sizable
- * minority stay stuck. And the effect is U-shaped: a vehicle running well *ahead* of schedule pace
- * is about to pay its holds and padding back. So the model output is three factors:
+ * **This widens the band; it does not move it.** Measured over the same day of King County Metro
+ * AVL as the deviation curves, a vehicle's own pace history carries essentially no information
+ * about its future *rate*: the rank correlation between pace over the last ten minutes and pace
+ * over the next ten is −0.06, and over the whole trip −0.004 — slightly negative, i.e. mild mean
+ * reversion. Even a bus that has run under 0.6 of schedule pace for half an hour has a median
+ * forward pace of 1.00. So no amount of conditioning on this covariate will stop an extrapolated
+ * marker running ahead of a bunched coach; what it can do is make the interval around that marker
+ * honest, which is what this does.
  *
- *  - [PaceAdjustment.extraSeconds] — a fixed lump added to the scheduled time ahead (+22s for a
- *    sustained-slow vehicle, +19s for a sustained-fast one, 0 on pace);
- *  - [PaceAdjustment.dispersionMultiplier] — the "quarter stay stuck" fat tail, entering as
- *    dispersion (×1.7 for the slow band) rather than as a mean crawl;
- *  - [PaceAdjustment.paceMultiplier] — the ongoing rate, which barely moves (0.92–1.0).
+ * What the pace of a recent window *does* say is that the vehicle is disproportionately likely to
+ * be part-way through losing a chunk of time right now — mid-dwell, held at a timepoint, stuck at
+ * a light — and that its next few minutes are less predictable than usual. Both effects are
+ * U-shaped, since a vehicle running well *ahead* of schedule pace is about to pay its holds and
+ * padding back. So the model output is two factors:
+ *
+ *  - [PaceAdjustment.extraSeconds] — a lump added to the scheduled time ahead (+17s for a
+ *    sustained-slow vehicle, +16s for a sustained-fast one, 0 on pace);
+ *  - [PaceAdjustment.dispersionMultiplier] — widened dispersion, `exp(c·|ln rho|)`, up to ×1.76.
+ *
+ * There is deliberately no rate multiplier. An earlier nine-parameter fit had one, and its fitted
+ * value sat *below* 1 — speeding a slow bus up, partly cancelling its own lump. Dropping it costs
+ * 26% of the held-out calibration gain and nothing at all in worst-cell error, and it makes the
+ * profile warp a pure translation. Neither surviving term works alone: the lump by itself makes
+ * the slow band's distribution shape worse, and dispersion by itself recovers only a seventh of
+ * the gain.
  *
  * **The conditioning variable is deliberately hard to excite.** The pace ratio is shrunk toward 1
- * by a pseudo-count (`rho = (achieved + c) / (elapsed + c)`), and below [MIN_LOOKBACK] of observed
- * window it is exactly 1 — a vehicle without a sustained observation window reproduces the
- * deviation-only model to the bit, so cold start needs no special case. Both guards are structural
- * lessons from the fit: unconstrained, the optimiser turned short lookbacks into a
- * stopped-right-now detector keyed to the dataset's 30-second polling cadence (a different defect,
- * and one that would not survive a different polling schedule).
+ * by a pseudo-count (`rho = (achieved + c) / (elapsed + c)`), clamped to the knot range so a
+ * vehicle that covered no ground at all cannot send dispersion to the moon, and below
+ * [MIN_LOOKBACK_SECONDS] of observed window it is exactly 1 — a vehicle without a sustained
+ * observation window reproduces the deviation-only model to the bit, so cold start needs no
+ * special case. The gate is a structural lesson from the fit: unconstrained, the optimiser turned
+ * short lookbacks into a stopped-right-now detector keyed to the dataset's 30-second polling
+ * cadence (a different defect, and one that would not survive a different polling schedule).
  *
- * Fitted and validated in the companion research repo (extrapolation-science, H39) against the
- * exact deviation curves this multiplies, per (horizon × deviation × pace) cell on held-out trips:
- * the slow band's 80% coverage rises from 0.61–0.69 to 0.72–0.88 across horizons, full-shape
- * calibration improves in every pace band, and the no-lookback population is unchanged by
- * construction.
+ * Fitted and validated in the companion research repo (extrapolation-science, H39 rung G) against
+ * the exact deviation curves this multiplies, scored per (horizon × deviation × pace) cell on
+ * held-out trips: the worst cell's coverage error falls from 0.478 to 0.344, and the slow band's
+ * 80% band — the bunched vehicle a user is most likely to be staring at — goes from covering
+ * 0.61–0.69 of its nominal 0.80 across horizons to 0.71–0.87. The no-lookback population is
+ * unchanged by construction.
  */
 internal object PaceModel {
 
@@ -77,24 +93,21 @@ internal object PaceModel {
     /** Shrunken pace ratio at each knot; 1.0 is on pace, below is slow. */
     private val KNOT_PACE = doubleArrayOf(0.55, 0.80, 1.00, 1.40)
 
-    /** log of the ongoing-rate multiplier at each knot; the rate itself barely moves. */
-    private val LOG_PACE_MULTIPLIER =
-        doubleArrayOf(-0.0395446208412077, -0.08060466991102952, 0.0, -0.06754487223552258)
-
-    /** log of the dispersion multiplier at each knot: the slow band's stuck minority. */
-    private val LOG_DISPERSION_MULTIPLIER =
-        doubleArrayOf(0.5275166183847799, -0.051491911099296225, 0.0, -0.007486369110162433)
-
     /** The lump of time a vehicle off its pace is likely mid-way through losing, in seconds. */
-    private val EXTRA_SECONDS =
-        doubleArrayOf(21.973541744065756, 8.536753997571957, 0.0, 19.32545235621823)
+    private val LUMP_SECONDS =
+        doubleArrayOf(17.120664749783757, 1.3239884700243196, 0.0, 15.882221328828477)
 
-    private val paceMultiplierCurve = MonotoneSpline(KNOT_PACE, LOG_PACE_MULTIPLIER)
-    private val dispersionMultiplierCurve = MonotoneSpline(KNOT_PACE, LOG_DISPERSION_MULTIPLIER)
-    private val extraSecondsCurve = MonotoneSpline(KNOT_PACE, EXTRA_SECONDS)
+    /**
+     * Dispersion widens as `exp(c·|ln rho|)` — symmetric in log pace, so one number covers both
+     * tails, and bounded at ×1.76 by the clamp on `rho`. A spline here was tried and bought
+     * nothing over this single coefficient.
+     */
+    private const val DISPERSION_COEFFICIENT = 0.9460370830512719
+
+    private val lumpCurve = MonotoneSpline(KNOT_PACE, LUMP_SECONDS)
 
     /** No adjustment: the deviation-only model, exactly. */
-    val IDENTITY = PaceAdjustment(1.0, 1.0, 0.0)
+    val IDENTITY = PaceAdjustment(1.0, 0.0)
 
     /**
      * The adjustment for a vehicle whose recent window covered [lookback], or [IDENTITY] when
@@ -102,12 +115,16 @@ internal object PaceModel {
      */
     fun adjustmentFor(lookback: PaceLookback?): PaceAdjustment {
         if (lookback == null || lookback.elapsedSeconds < MIN_LOOKBACK_SECONDS) return IDENTITY
-        val rho = (lookback.achievedSeconds.coerceAtLeast(0.0) + PSEUDO_COUNT_SECONDS) /
-            (lookback.elapsedSeconds + PSEUDO_COUNT_SECONDS)
+        // Clamped before either term is read, so a vehicle that covered no ground at all lands on
+        // the end knot rather than driving |ln rho| — and with it the dispersion — without bound.
+        val rho = (
+            (lookback.achievedSeconds.coerceAtLeast(0.0) + PSEUDO_COUNT_SECONDS) /
+                (lookback.elapsedSeconds + PSEUDO_COUNT_SECONDS)
+            )
+            .coerceIn(KNOT_PACE.first(), KNOT_PACE.last())
         return PaceAdjustment(
-            paceMultiplier = exp(paceMultiplierCurve.valueAt(rho)),
-            dispersionMultiplier = exp(dispersionMultiplierCurve.valueAt(rho)),
-            extraSeconds = extraSecondsCurve.valueAt(rho)
+            dispersionMultiplier = exp(DISPERSION_COEFFICIENT * abs(ln(rho))),
+            extraSeconds = lumpCurve.valueAt(rho)
         )
     }
 
@@ -183,10 +200,8 @@ internal object PaceModel {
 /** A recent observation window: the vehicle covered [achievedSeconds] of schedule in [elapsedSeconds]. */
 internal data class PaceLookback(val achievedSeconds: Double, val elapsedSeconds: Double)
 
-/** The three pace factors [PaceModel] reads off a vehicle's recent window. */
+/** The two pace factors [PaceModel] reads off a vehicle's recent window. */
 internal data class PaceAdjustment(
-    /** Multiplier on the scheduled time ahead — the ongoing rate. */
-    val paceMultiplier: Double,
     /** Multiplier on the gamma-process dispersion theta. */
     val dispersionMultiplier: Double,
     /** Fixed lump added to the scheduled time ahead, in seconds. */
@@ -194,24 +209,21 @@ internal data class PaceAdjustment(
 )
 
 /**
- * Applies the adjustment's mean effects to the profile: every scheduled second ahead is scaled by
- * the rate and shifted by the lump, `tau → paceMultiplier*tau + extraSeconds`. A monotone
- * piecewise-linear warp, so the profile stays a valid profile and the closed-form quantile
- * machinery is untouched; identity returns the same instance so the no-lookback path costs
- * nothing. The dispersion multiplier rides separately, on theta.
+ * Applies the adjustment's mean effect to the profile: every scheduled second ahead is pushed
+ * back by the lump, `tau → tau + extraSeconds`. A pure translation, so the profile stays a valid
+ * profile — spacing and monotonicity are untouched — and the closed-form quantile machinery needs
+ * no changes; identity returns the same instance so the no-lookback path costs nothing. The
+ * dispersion multiplier rides separately, on theta.
  *
- * The first knot is deliberately lifted with the rest: a warped profile starts at `extraSeconds`
- * rather than 0, which is the model saying the vehicle may not have left the anchor yet — the
- * lump puts an atom of probability at the anchor position. [FirstPassageDistribution] handles a
- * non-zero first knot throughout (its cdf short-circuits at the anchor, and quantiles below the
- * atom clamp to it).
+ * The first knot translates with the rest, so a warped profile starts at `extraSeconds` rather
+ * than 0. That is the model saying the vehicle may not have left the anchor yet: the lump puts an
+ * atom of probability at the anchor position. [FirstPassageDistribution] handles a non-zero first
+ * knot throughout (its cdf short-circuits at the anchor, and quantiles below the atom clamp to it).
  */
 internal fun PassageProfile.warpedBy(adjustment: PaceAdjustment): PassageProfile {
     if (adjustment == PaceModel.IDENTITY) return this
     return PassageProfile(
-        DoubleArray(scheduleSeconds.size) {
-            adjustment.paceMultiplier * scheduleSeconds[it] + adjustment.extraSeconds
-        },
+        DoubleArray(scheduleSeconds.size) { scheduleSeconds[it] + adjustment.extraSeconds },
         distances
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/PaceModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/PaceModel.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation
+
+import kotlin.math.exp
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import org.onebusaway.android.extrapolation.data.TripState
+import org.onebusaway.android.extrapolation.math.MonotoneSpline
+import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.models.ObaTripStatus
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * How a vehicle travels, given the pace it was just observed holding — the second conditioning
+ * axis after [DeviationModel], built for the death-spiral bus of issue #2202 that runs far below
+ * schedule speed for a whole route while the extrapolated marker sails ahead and snaps back on
+ * every fix.
+ *
+ * Measured over the same day of King County Metro AVL as the deviation curves, a vehicle's pace
+ * over the last ten minutes predicts its next few minutes *beyond* what deviation says, and the
+ * signal is not what a "slow bus stays slow" multiplier would suggest. The median mostly recovers;
+ * what distinguishes a slow-running vehicle is that it is disproportionately likely to be losing a
+ * lump of time **right now** (mid-dwell, held at a timepoint, stuck at a light) and that a sizable
+ * minority stay stuck. And the effect is U-shaped: a vehicle running well *ahead* of schedule pace
+ * is about to pay its holds and padding back. So the model output is three factors:
+ *
+ *  - [PaceAdjustment.extraSeconds] — a fixed lump added to the scheduled time ahead (+22s for a
+ *    sustained-slow vehicle, +19s for a sustained-fast one, 0 on pace);
+ *  - [PaceAdjustment.dispersionMultiplier] — the "quarter stay stuck" fat tail, entering as
+ *    dispersion (×1.7 for the slow band) rather than as a mean crawl;
+ *  - [PaceAdjustment.paceMultiplier] — the ongoing rate, which barely moves (0.92–1.0).
+ *
+ * **The conditioning variable is deliberately hard to excite.** The pace ratio is shrunk toward 1
+ * by a pseudo-count (`rho = (achieved + c) / (elapsed + c)`), and below [MIN_LOOKBACK] of observed
+ * window it is exactly 1 — a vehicle without a sustained observation window reproduces the
+ * deviation-only model to the bit, so cold start needs no special case. Both guards are structural
+ * lessons from the fit: unconstrained, the optimiser turned short lookbacks into a
+ * stopped-right-now detector keyed to the dataset's 30-second polling cadence (a different defect,
+ * and one that would not survive a different polling schedule).
+ *
+ * Fitted and validated in the companion research repo (extrapolation-science, H39) against the
+ * exact deviation curves this multiplies, per (horizon × deviation × pace) cell on held-out trips:
+ * the slow band's 80% coverage rises from 0.61–0.69 to 0.72–0.88 across horizons, full-shape
+ * calibration improves in every pace band, and the no-lookback population is unchanged by
+ * construction.
+ */
+internal object PaceModel {
+
+    /** Only ground covered within this window of the anchor fix counts as "recent". */
+    private const val MAX_LOOKBACK_SECONDS = 600.0
+
+    /** Below this much observed window the pace ratio is exactly 1 (identity adjustment). */
+    private const val MIN_LOOKBACK_SECONDS = 420.0
+
+    /**
+     * Pseudo-count shrinking the observed ratio toward on-pace, in seconds. Weakly identified
+     * once the [MIN_LOOKBACK_SECONDS] gate exists (the knot values compensate for its choice of
+     * coordinates), so it carries the fitted value rather than a meaningful timescale.
+     */
+    private const val PSEUDO_COUNT_SECONDS = 3.005739011224008
+
+    /** Shrunken pace ratio at each knot; 1.0 is on pace, below is slow. */
+    private val KNOT_PACE = doubleArrayOf(0.55, 0.80, 1.00, 1.40)
+
+    /** log of the ongoing-rate multiplier at each knot; the rate itself barely moves. */
+    private val LOG_PACE_MULTIPLIER =
+        doubleArrayOf(-0.0395446208412077, -0.08060466991102952, 0.0, -0.06754487223552258)
+
+    /** log of the dispersion multiplier at each knot: the slow band's stuck minority. */
+    private val LOG_DISPERSION_MULTIPLIER =
+        doubleArrayOf(0.5275166183847799, -0.051491911099296225, 0.0, -0.007486369110162433)
+
+    /** The lump of time a vehicle off its pace is likely mid-way through losing, in seconds. */
+    private val EXTRA_SECONDS =
+        doubleArrayOf(21.973541744065756, 8.536753997571957, 0.0, 19.32545235621823)
+
+    private val paceMultiplierCurve = MonotoneSpline(KNOT_PACE, LOG_PACE_MULTIPLIER)
+    private val dispersionMultiplierCurve = MonotoneSpline(KNOT_PACE, LOG_DISPERSION_MULTIPLIER)
+    private val extraSecondsCurve = MonotoneSpline(KNOT_PACE, EXTRA_SECONDS)
+
+    /** No adjustment: the deviation-only model, exactly. */
+    val IDENTITY = PaceAdjustment(1.0, 1.0, 0.0)
+
+    /**
+     * The adjustment for a vehicle whose recent window covered [lookback], or [IDENTITY] when
+     * there is no sufficiently long window to read a pace from.
+     */
+    fun adjustmentFor(lookback: PaceLookback?): PaceAdjustment {
+        if (lookback == null || lookback.elapsedSeconds < MIN_LOOKBACK_SECONDS) return IDENTITY
+        val rho = (lookback.achievedSeconds.coerceAtLeast(0.0) + PSEUDO_COUNT_SECONDS) /
+            (lookback.elapsedSeconds + PSEUDO_COUNT_SECONDS)
+        return PaceAdjustment(
+            paceMultiplier = exp(paceMultiplierCurve.valueAt(rho)),
+            dispersionMultiplier = exp(dispersionMultiplierCurve.valueAt(rho)),
+            extraSeconds = extraSecondsCurve.valueAt(rho)
+        )
+    }
+
+    /**
+     * The ground the vehicle covered — in schedule terms — over the window ending at [anchor]'s
+     * GPS fix, read from the oldest fix within [MAX_LOOKBACK_SECONDS] of it, or null when no such
+     * window exists: no GPS fix on the anchor, no earlier GPS-fixed entry in range, or a position
+     * the schedule cannot place. Mirrors the research instrument exactly: fix times are
+     * `lastLocationUpdateTime` (GPS, so poll jitter doesn't leak into the elapsed time) and only
+     * real fixes participate.
+     */
+    fun lookbackFor(
+        history: List<ObaTripStatus>,
+        anchor: ObaTripStatus,
+        schedule: ObaTripSchedule
+    ): PaceLookback? {
+        if (anchor.lastLocationUpdateTime <= 0) return null
+        val anchorDist = anchor.distanceAlongTrip ?: return null
+        val anchorFix = ServerTime(anchor.lastLocationUpdateTime)
+        val windowStart = anchorFix - MAX_LOOKBACK_SECONDS.seconds
+        // Oldest-first, so the first entry inside the window is the longest available lookback.
+        for (entry in history) {
+            if (entry.lastLocationUpdateTime <= 0) continue
+            val entryFix = ServerTime(entry.lastLocationUpdateTime)
+            if (entryFix < windowStart || entryFix >= anchorFix) continue
+            val entryDist = entry.distanceAlongTrip ?: continue
+            val achieved =
+                (schedule.scheduleTimeAt(anchorDist) ?: return null) -
+                    (schedule.scheduleTimeAt(entryDist) ?: return null)
+            return PaceLookback(
+                achievedSeconds = achieved.toDouble(DurationUnit.SECONDS),
+                elapsedSeconds = (anchorFix - entryFix).toDouble(DurationUnit.SECONDS)
+            )
+        }
+        return null
+    }
+
+    /** [lookbackFor] read off a [TripState] snapshot's own history and schedule. */
+    fun lookbackFor(state: TripState): PaceLookback? {
+        val anchor = state.anchor ?: return null
+        val schedule = state.schedule ?: return null
+        return lookbackFor(state.statuses, anchor, schedule)
+    }
+}
+
+/** A recent observation window: the vehicle covered [achievedSeconds] of schedule in [elapsedSeconds]. */
+internal data class PaceLookback(val achievedSeconds: Double, val elapsedSeconds: Double)
+
+/** The three pace factors [PaceModel] reads off a vehicle's recent window. */
+internal data class PaceAdjustment(
+    /** Multiplier on the scheduled time ahead — the ongoing rate. */
+    val paceMultiplier: Double,
+    /** Multiplier on the gamma-process dispersion theta. */
+    val dispersionMultiplier: Double,
+    /** Fixed lump added to the scheduled time ahead, in seconds. */
+    val extraSeconds: Double
+)
+
+/**
+ * Applies the adjustment's mean effects to the profile: every scheduled second ahead is scaled by
+ * the rate and shifted by the lump, `tau → paceMultiplier*tau + extraSeconds`. A monotone
+ * piecewise-linear warp, so the profile stays a valid profile and the closed-form quantile
+ * machinery is untouched; identity returns the same instance so the no-lookback path costs
+ * nothing. The dispersion multiplier rides separately, on theta.
+ */
+internal fun PassageProfile.warpedBy(adjustment: PaceAdjustment): PassageProfile {
+    if (adjustment == PaceModel.IDENTITY) return this
+    return PassageProfile(
+        DoubleArray(scheduleSeconds.size) {
+            adjustment.paceMultiplier * scheduleSeconds[it] + adjustment.extraSeconds
+        },
+        distances
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/PaceModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/PaceModel.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.extrapolation
 
 import kotlin.math.exp
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import org.onebusaway.android.extrapolation.data.TripState
@@ -110,34 +111,61 @@ internal object PaceModel {
         )
     }
 
+    /** The one phase in which a vehicle's movement says anything about its travel state. */
+    private const val PHASE_IN_PROGRESS = "in_progress"
+
+    /**
+     * Distance from either end of the trip within which a stationary vehicle is assumed to be
+     * waiting rather than running. Same margin as the research pipeline's `drop_terminal_idling`.
+     */
+    private const val TERMINAL_MARGIN_METERS = 200.0
+
+    /**
+     * Whether this fix is usable as a pace observation: the vehicle is actually running its trip.
+     * The curves were fitted on fixes filtered exactly this way (`phase == "in_progress"`, terminal
+     * idling dropped); without the same filter here, a bus that sat at its terminal with AVL live
+     * and then departed on time would read as deep-slow for the next ten minutes — a population the
+     * held-out validation never scored. A null phase also fails: better to leave the adjustment at
+     * identity than to condition on windows the fit never saw.
+     */
+    private fun ObaTripStatus.isMidRoute(): Boolean {
+        if (phase != PHASE_IN_PROGRESS) return false
+        val dist = distanceAlongTrip ?: return false
+        if (dist < TERMINAL_MARGIN_METERS && scheduleDeviation <= Duration.ZERO) return false
+        val total = totalDistanceAlongTrip
+        return total == null || total <= 0 || total - dist >= TERMINAL_MARGIN_METERS
+    }
+
     /**
      * The ground the vehicle covered — in schedule terms — over the window ending at [anchor]'s
-     * GPS fix, read from the oldest fix within [MAX_LOOKBACK_SECONDS] of it, or null when no such
-     * window exists: no GPS fix on the anchor, no earlier GPS-fixed entry in range, or a position
-     * the schedule cannot place. Mirrors the research instrument exactly: fix times are
-     * `lastLocationUpdateTime` (GPS, so poll jitter doesn't leak into the elapsed time) and only
-     * real fixes participate.
+     * GPS fix, read from the oldest usable fix within [MAX_LOOKBACK_SECONDS] of it, or null when
+     * no such window exists: no GPS fix on the anchor, the anchor not mid-route, no earlier usable
+     * entry in range, or a position the schedule cannot place. Mirrors the research instrument:
+     * fix times are `lastLocationUpdateTime` (GPS, so poll jitter doesn't leak into the elapsed
+     * time), only real fixes participate, and only [isMidRoute] fixes count — with the one known
+     * divergence that the anchor's distance is the poll-time (server-extrapolated) value the whole
+     * extrapolation anchors on, where the research pipeline kept each fix's first report.
      */
     fun lookbackFor(
         history: List<ObaTripStatus>,
         anchor: ObaTripStatus,
         schedule: ObaTripSchedule
     ): PaceLookback? {
-        if (anchor.lastLocationUpdateTime <= 0) return null
+        if (anchor.lastLocationUpdateTime <= 0 || !anchor.isMidRoute()) return null
         val anchorDist = anchor.distanceAlongTrip ?: return null
+        val anchorSchedule = schedule.scheduleTimeAt(anchorDist) ?: return null
         val anchorFix = ServerTime(anchor.lastLocationUpdateTime)
         val windowStart = anchorFix - MAX_LOOKBACK_SECONDS.seconds
-        // Oldest-first, so the first entry inside the window is the longest available lookback.
+        // Oldest-first, so the first usable entry inside the window is the longest available
+        // lookback; an unusable one falls through to the next rather than giving up.
         for (entry in history) {
-            if (entry.lastLocationUpdateTime <= 0) continue
+            if (entry.lastLocationUpdateTime <= 0 || !entry.isMidRoute()) continue
             val entryFix = ServerTime(entry.lastLocationUpdateTime)
             if (entryFix < windowStart || entryFix >= anchorFix) continue
             val entryDist = entry.distanceAlongTrip ?: continue
-            val achieved =
-                (schedule.scheduleTimeAt(anchorDist) ?: return null) -
-                    (schedule.scheduleTimeAt(entryDist) ?: return null)
+            val entrySchedule = schedule.scheduleTimeAt(entryDist) ?: continue
             return PaceLookback(
-                achievedSeconds = achieved.toDouble(DurationUnit.SECONDS),
+                achievedSeconds = (anchorSchedule - entrySchedule).toDouble(DurationUnit.SECONDS),
                 elapsedSeconds = (anchorFix - entryFix).toDouble(DurationUnit.SECONDS)
             )
         }
@@ -171,6 +199,12 @@ internal data class PaceAdjustment(
  * piecewise-linear warp, so the profile stays a valid profile and the closed-form quantile
  * machinery is untouched; identity returns the same instance so the no-lookback path costs
  * nothing. The dispersion multiplier rides separately, on theta.
+ *
+ * The first knot is deliberately lifted with the rest: a warped profile starts at `extraSeconds`
+ * rather than 0, which is the model saying the vehicle may not have left the anchor yet — the
+ * lump puts an atom of probability at the anchor position. [FirstPassageDistribution] handles a
+ * non-zero first knot throughout (its cdf short-circuits at the anchor, and quantiles below the
+ * atom clamp to it).
  */
 internal fun PassageProfile.warpedBy(adjustment: PaceAdjustment): PassageProfile {
     if (adjustment == PaceModel.IDENTITY) return this

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripScheduleGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripScheduleGeometry.kt
@@ -68,6 +68,31 @@ fun ObaTripSchedule.findSegmentStartIndex(distanceAlongTrip: Double): Int {
 }
 
 /**
+ * The schedule clock read at a single distance along the trip, interpolated across the travel
+ * segment the distance sits in (`departure[i]` → `arrival[i+1]`, so crossing a stop picks up its
+ * whole dwell) — or null when the schedule cannot place it: fewer than two stops, a distance
+ * outside the scheduled range, or a degenerate segment. The scheduled interval between two
+ * distances is then a same-domain [ScheduleTime] subtraction; [PaceModel]'s lookback reads the
+ * ground a vehicle actually covered in schedule terms this way.
+ */
+fun ObaTripSchedule.scheduleTimeAt(distanceAlongTrip: Double): ScheduleTime? {
+    if (stopTimes.size < 2) return null
+    val segIdx =
+        try {
+            findSegmentStartIndex(distanceAlongTrip)
+        } catch (e: IndexOutOfBoundsException) {
+            return null
+        }
+    val segStart = stopTimes[segIdx]
+    val segEnd = stopTimes[segIdx + 1]
+    val segDist = segEnd.distanceAlongTrip - segStart.distanceAlongTrip
+    val segTravel: Duration = segEnd.arrivalTime - segStart.departureTime
+    if (segDist <= 0 || segTravel <= Duration.ZERO) return null
+    val fraction = (distanceAlongTrip - segStart.distanceAlongTrip) / segDist
+    return segStart.departureTime + segTravel * fraction
+}
+
+/**
  * A trip's scheduled clock, read forward from a vehicle's current position: how long the schedule
  * says it should take to *first reach* each point ahead.
  *
@@ -95,24 +120,11 @@ internal constructor(
  * segment under the vehicle, or nothing left ahead of it.
  */
 fun ObaTripSchedule.passageProfileFrom(startDist: Double): PassageProfile? {
-    if (stopTimes.size < 2) return null
-    val segIdx =
-        try {
-            findSegmentStartIndex(startDist)
-        } catch (e: IndexOutOfBoundsException) {
-            return null
-        }
-
-    val segStart = stopTimes[segIdx]
-    val segEnd = stopTimes[segIdx + 1]
-    val segDist = segEnd.distanceAlongTrip - segStart.distanceAlongTrip
-    val segTravel: Duration = segEnd.arrivalTime - segStart.departureTime
-    if (segDist <= 0 || segTravel <= Duration.ZERO) return null
-
-    // The anchor's own place on the schedule clock, interpolated across the segment it sits in —
-    // the same construction replaySchedule uses to put a distance on the schedule timeline.
-    val fraction = (startDist - segStart.distanceAlongTrip) / segDist
-    val origin: ScheduleTime = segStart.departureTime + segTravel * fraction
+    // The anchor's own place on the schedule clock — the same construction replaySchedule uses to
+    // put a distance on the schedule timeline. Also rejects everything a profile can't be built
+    // from: too few stops, a distance out of range, a degenerate segment under the vehicle.
+    val origin: ScheduleTime = scheduleTimeAt(startDist) ?: return null
+    val segIdx = findSegmentStartIndex(startDist)
 
     val seconds = ArrayList<Double>(2 * (stopTimes.size - segIdx))
     val distances = ArrayList<Double>(2 * (stopTimes.size - segIdx))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripScheduleGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripScheduleGeometry.kt
@@ -104,7 +104,8 @@ fun ObaTripSchedule.scheduleTimeAt(distanceAlongTrip: Double): ScheduleTime? {
  * needs the mapping in both directions with its own plateau conventions, so a lookup here would be
  * a second copy of the same interpolation rather than a service to anyone.
  *
- * @property scheduleSeconds cumulative scheduled seconds from the anchor; starts at 0, non-decreasing
+ * @property scheduleSeconds cumulative scheduled seconds from the anchor; non-decreasing. Starts
+ *   at 0 as built here; a pace-warped profile ([warpedBy]) starts at the warp's fixed lump instead
  * @property distances distance along the trip in meters at each knot; starts at the anchor's own
  *   distance, non-decreasing
  */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/FirstPassageDistribution.kt
@@ -45,7 +45,8 @@ private const val MEAN_SAMPLES = 64
  * band here widens with the *square root* of elapsed time.
  *
  * @param elapsedSeconds seconds since the anchoring fix
- * @param scheduleSeconds scheduled seconds from the anchor to each knot; non-decreasing, starts at 0
+ * @param scheduleSeconds scheduled seconds from the anchor to each knot; non-decreasing. Usually
+ *   starts at 0; a pace-warped profile starts above it, an atom of probability at the anchor
  * @param distances distance in meters at each knot; non-decreasing, starts at the anchor's position
  * @param theta gamma-process dispersion in seconds; the travel time to `tau` has variance `tau*theta`
  * @param meanTravelMultiplier how long a vehicle really takes relative to the schedule, in the mean

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolatorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolatorTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation
+
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.adapters.StopTimeData
+import org.onebusaway.android.api.adapters.TripScheduleData
+import org.onebusaway.android.extrapolation.data.TripState
+import org.onebusaway.android.extrapolation.math.prob.FirstPassageDistribution
+import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
+import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.testing.testTripStatus
+import org.onebusaway.android.time.ScheduleTime
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.WallTime
+
+/**
+ * The pace wiring: a vehicle with a sustained slow window extrapolates differently from a cold
+ * start, and a cold start is exactly the deviation-only model. The pace maths itself is pinned in
+ * [PaceModelTest]; this covers the path from a [TripState]'s history to the distribution.
+ */
+class FirstPassageExtrapolatorTest {
+
+    /** Stops every 1000 m, 100 s apart, no dwell: schedule speed exactly 10 m/s. */
+    private val schedule: ObaTripSchedule = TripScheduleData(
+        Array(11) { i ->
+            StopTimeData(
+                stopId = "stop_$i",
+                arrivalTime = ScheduleTime((i * 100).seconds),
+                departureTime = ScheduleTime((i * 100).seconds),
+                distanceAlongTrip = i * 1000.0
+            )
+        }
+    )
+
+    private val t0 = 1_700_000_000_000L
+
+    /** A state whose history is the given (distance, fix-time) observations, oldest first. */
+    private fun state(vararg fixes: Pair<Double, Long>): TripState {
+        var state = TripState.empty("trip").withSchedule(schedule)
+        for ((distance, fixMs) in fixes) {
+            state = state.withStatus(
+                testTripStatus(
+                    distanceAlongTrip = distance,
+                    lastUpdateTime = fixMs,
+                    lastLocationUpdateTime = fixMs
+                ),
+                serverTimeMs = ServerTime(fixMs),
+                localTimeMs = WallTime(fixMs)
+            )
+        }
+        return state
+    }
+
+    private fun distribution(state: TripState, dtSeconds: Long): ProbDistribution {
+        val anchorLocal = state.anchorLocalTimeMs!!
+        val result = state.extrapolate(anchorLocal + dtSeconds.seconds)
+        return (result as ExtrapolationResult.Success).distribution
+    }
+
+    @Test
+    fun `cold start is exactly the deviation-only model`() {
+        val actual = distribution(state(5000.0 to t0), dtSeconds = 60)
+        val profile = schedule.passageProfileFrom(5000.0)!!
+        val expected = FirstPassageDistribution(
+            60.0,
+            profile.scheduleSeconds,
+            profile.distances,
+            DeviationModel.dispersionFor(kotlin.time.Duration.ZERO),
+            DeviationModel.travelMultiplierFor(kotlin.time.Duration.ZERO)
+        )
+        for (x in listOf(5100.0, 5400.0, 5800.0, 6500.0)) {
+            assertEquals("cdf at $x", expected.cdf(x), actual.cdf(x), 1e-12)
+        }
+    }
+
+    @Test
+    fun `a sustained slow window shifts the distribution, a short one does not`() {
+        // 600 m covered in 500 s against a 10 m/s schedule: deep in the slow band.
+        val slow = distribution(state(4400.0 to t0 - 500_000, 5000.0 to t0), dtSeconds = 60)
+        val cold = distribution(state(5000.0 to t0), dtSeconds = 60)
+        // The same slow pace observed over less than the gate: identity, equal to cold.
+        val brief = distribution(state(4520.0 to t0 - 400_000, 5000.0 to t0), dtSeconds = 60)
+
+        var slowDiffers = false
+        for (x in listOf(5100.0, 5400.0, 5800.0)) {
+            assertEquals("gated cdf at $x", cold.cdf(x), brief.cdf(x), 1e-12)
+            // A vehicle likely mid-lump has covered less ground: P(D < x) rises.
+            if (slow.cdf(x) > cold.cdf(x) + 1e-6) slowDiffers = true
+        }
+        assertTrue("slow window should shift probability toward the anchor", slowDiffers)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolatorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/FirstPassageExtrapolatorTest.kt
@@ -59,7 +59,8 @@ class FirstPassageExtrapolatorTest {
                 testTripStatus(
                     distanceAlongTrip = distance,
                     lastUpdateTime = fixMs,
-                    lastLocationUpdateTime = fixMs
+                    lastLocationUpdateTime = fixMs,
+                    phase = "in_progress"
                 ),
                 serverTimeMs = ServerTime(fixMs),
                 localTimeMs = WallTime(fixMs)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/PaceModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/PaceModelTest.kt
@@ -15,7 +15,6 @@
  */
 package org.onebusaway.android.extrapolation
 
-import kotlin.math.ln
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -48,24 +47,23 @@ class PaceModelTest {
     @Test
     fun `on-pace lookback is exactly identity — the rho = 1 knot is pinned`() {
         val adjustment = PaceModel.adjustmentFor(PaceLookback(600.0, 600.0))
-        assertEquals(1.0, adjustment.paceMultiplier, 0.0)
         assertEquals(1.0, adjustment.dispersionMultiplier, 0.0)
         assertEquals(0.0, adjustment.extraSeconds, 0.0)
     }
 
     @Test
-    fun `sustained slow pace costs a lump, wider dispersion, near-unit rate`() {
+    fun `sustained slow pace costs a lump and wider dispersion`() {
         // rho = (120 + c) / (600 + c): deep in the slow band.
         val adjustment = PaceModel.adjustmentFor(PaceLookback(120.0, 600.0))
         assertTrue("extra seconds, was ${adjustment.extraSeconds}", adjustment.extraSeconds > 10.0)
         assertTrue("dispersion, was ${adjustment.dispersionMultiplier}", adjustment.dispersionMultiplier > 1.3)
-        assertEquals(1.0, adjustment.paceMultiplier, 0.15)
     }
 
     @Test
     fun `sustained fast pace also costs a lump — the U shape`() {
         val adjustment = PaceModel.adjustmentFor(PaceLookback(1200.0, 600.0))
         assertTrue("extra seconds, was ${adjustment.extraSeconds}", adjustment.extraSeconds > 10.0)
+        assertTrue("dispersion, was ${adjustment.dispersionMultiplier}", adjustment.dispersionMultiplier > 1.0)
     }
 
     @Test
@@ -76,33 +74,40 @@ class PaceModelTest {
     }
 
     @Test
-    fun `adjustment matches the scipy fit for a deep-slow lookback — clamped at the first knot`() {
-        // rho = (120 + c)/(600 + c) = 0.204, below the 0.55 knot, so the curves read their
-        // first-knot values exactly. References generated with scipy from h39_params_shipped.json.
-        val adjustment = PaceModel.adjustmentFor(PaceLookback(120.0, 600.0))
-        assertEquals(0.9612270622735628, adjustment.paceMultiplier, 1e-12)
-        assertEquals(1.6947184458381417, adjustment.dispersionMultiplier, 1e-12)
-        assertEquals(21.973541744065756, adjustment.extraSeconds, 1e-12)
+    fun `a vehicle that covered no ground at all is bounded, not sent to the moon`() {
+        // rho would be 0.005 unclamped, and exp(0.946*|ln 0.005|) is ~180x. The clamp to the
+        // first knot is what keeps the dispersion finite and equal to the deep-slow case.
+        val stalled = PaceModel.adjustmentFor(PaceLookback(0.0, 600.0))
+        assertEquals(1.7604614678687607, stalled.dispersionMultiplier, 1e-12)
+        assertEquals(PaceModel.adjustmentFor(PaceLookback(120.0, 600.0)), stalled)
     }
 
     @Test
-    fun `spline interior matches scipy PCHIP — generated, not fabricated`() {
-        // rho values chosen between knots; expected values from scipy.interpolate.PchipInterpolator
-        // on the same knots (see extrapolation-science h39_params_shipped.json).
+    fun `adjustment matches the scipy fit for a deep-slow lookback — clamped at the first knot`() {
+        // rho = (120 + c)/(600 + c) = 0.204, below the 0.55 knot, so both terms read their
+        // first-knot values. References generated with scipy from h39_g_shipped_params.json.
+        val adjustment = PaceModel.adjustmentFor(PaceLookback(120.0, 600.0))
+        assertEquals(1.7604614678687607, adjustment.dispersionMultiplier, 1e-12)
+        assertEquals(17.120664749783757, adjustment.extraSeconds, 1e-12)
+    }
+
+    @Test
+    fun `curve interior matches scipy — generated, not fabricated`() {
+        // rho values chosen between knots; expected values from scipy (PchipInterpolator for the
+        // lump, exp(c*|ln rho|) for dispersion) — see extrapolation-science fit_h39_g_shipped.py.
         val cases = mapOf(
-            0.62 to Triple(-0.064795225, 0.280828724, 17.898343016),
-            0.70 to Triple(-0.077656811, 0.062421023, 13.534721639),
-            0.90 to Triple(-0.040302335, -0.025745956, 3.08388969),
-            1.20 to Triple(-0.008443109, -0.000935796, 4.213797938)
+            0.62 to Pair(10.829713413, 1.571828505),
+            0.70 to Pair(5.032578231, 1.401338321),
+            0.90 to Pair(0.371116362, 1.104811746),
+            1.20 to Pair(4.411649809, 1.188251565)
         )
         for ((rho, expected) in cases) {
             // Invert the shrinkage so adjustmentFor sees exactly this rho: with elapsed fixed at
             // 600s, achieved = rho*(600 + c) - c.
             val c = 3.005739011224008
             val adjustment = PaceModel.adjustmentFor(PaceLookback(rho * (600.0 + c) - c, 600.0))
-            assertEquals("log gk at $rho", expected.first, ln(adjustment.paceMultiplier), 1e-8)
-            assertEquals("log gtheta at $rho", expected.second, ln(adjustment.dispersionMultiplier), 1e-8)
-            assertEquals("delta at $rho", expected.third, adjustment.extraSeconds, 1e-8)
+            assertEquals("lump at $rho", expected.first, adjustment.extraSeconds, 1e-8)
+            assertEquals("dispersion at $rho", expected.second, adjustment.dispersionMultiplier, 1e-8)
         }
     }
 
@@ -241,12 +246,17 @@ class PaceModelTest {
     }
 
     @Test
-    fun `warp scales and shifts every schedule knot, distances untouched`() {
+    fun `warp translates every schedule knot, distances and spacing untouched`() {
         val profile = schedule.passageProfileFrom(500.0)!!
-        val warped = profile.warpedBy(PaceAdjustment(paceMultiplier = 0.9, dispersionMultiplier = 2.0, extraSeconds = 30.0))
+        val warped = profile.warpedBy(PaceAdjustment(dispersionMultiplier = 2.0, extraSeconds = 30.0))
         for (i in profile.scheduleSeconds.indices) {
-            assertEquals(0.9 * profile.scheduleSeconds[i] + 30.0, warped.scheduleSeconds[i], 1e-9)
+            assertEquals(profile.scheduleSeconds[i] + 30.0, warped.scheduleSeconds[i], 1e-9)
             assertEquals(profile.distances[i], warped.distances[i], 0.0)
+        }
+        // A translation cannot reorder or compress the profile — the property the closed-form
+        // quantile path depends on.
+        for (i in 1 until warped.scheduleSeconds.size) {
+            assertTrue(warped.scheduleSeconds[i] >= warped.scheduleSeconds[i - 1])
         }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/PaceModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/PaceModelTest.kt
@@ -122,9 +122,10 @@ class PaceModelTest {
         }
     )
 
-    private fun status(distance: Double?, fixMs: Long) = testTripStatus(
+    private fun status(distance: Double?, fixMs: Long, phase: String? = "in_progress") = testTripStatus(
         distanceAlongTrip = distance,
-        lastLocationUpdateTime = fixMs
+        lastLocationUpdateTime = fixMs,
+        phase = phase
     )
 
     @Test
@@ -182,10 +183,51 @@ class PaceModelTest {
     }
 
     @Test
-    fun `null when the lookback position is off the schedule`() {
+    fun `an off-schedule lookback position falls through to the next candidate`() {
         val anchor = status(6000.0, 700_000L)
-        val history = listOf(status(20_000.0, 300_000L), anchor)
-        assertNull(PaceModel.lookbackFor(history, anchor, schedule))
+        val history = listOf(status(20_000.0, 200_000L), status(2000.0, 300_000L), anchor)
+        val lookback = PaceModel.lookbackFor(history, anchor, schedule)!!
+        assertEquals(400.0, lookback.elapsedSeconds, 1e-9)
+    }
+
+    @Test
+    fun `skips fixes from a vehicle not running its trip — the fit never saw them`() {
+        // Parked at the terminal (layover phase), then departs on time: without the phase filter
+        // this window would read as deep-slow for the next ten minutes.
+        val anchor = status(2000.0, 700_000L)
+        val history = listOf(
+            status(0.0, 100_000L, phase = "layover_before"),
+            status(0.0, 500_000L, phase = "layover_before"),
+            status(1000.0, 600_000L),
+            anchor
+        )
+        val lookback = PaceModel.lookbackFor(history, anchor, schedule)!!
+        assertEquals(100.0, lookback.elapsedSeconds, 1e-9)
+    }
+
+    @Test
+    fun `skips in-progress fixes parked within the terminal margin`() {
+        // phase says in_progress but the vehicle sits at the start, not late: terminal idling.
+        val anchor = status(2000.0, 700_000L)
+        val history = listOf(
+            status(100.0, 200_000L),
+            status(1000.0, 600_000L),
+            anchor
+        )
+        val lookback = PaceModel.lookbackFor(history, anchor, schedule)!!
+        assertEquals(100.0, lookback.elapsedSeconds, 1e-9)
+    }
+
+    @Test
+    fun `null when the anchor itself is not running its trip`() {
+        val anchor = status(6000.0, 700_000L, phase = "layover_during")
+        assertNull(PaceModel.lookbackFor(listOf(status(1000.0, 100_000L), anchor), anchor, schedule))
+    }
+
+    @Test
+    fun `null when the phase is unreported — identity beats conditioning on unvetted windows`() {
+        val anchor = status(6000.0, 700_000L, phase = null)
+        assertNull(PaceModel.lookbackFor(listOf(status(1000.0, 100_000L, phase = null), anchor), anchor, schedule))
     }
 
     // ================================================================

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/PaceModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/PaceModelTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.extrapolation
+
+import kotlin.math.ln
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.api.adapters.StopTimeData
+import org.onebusaway.android.api.adapters.TripScheduleData
+import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.testing.testTripStatus
+import org.onebusaway.android.time.ScheduleTime
+
+class PaceModelTest {
+
+    // ================================================================
+    // adjustmentFor: the gate and the shrunken ratio
+    // ================================================================
+
+    @Test
+    fun `no lookback is identity`() {
+        assertSame(PaceModel.IDENTITY, PaceModel.adjustmentFor(null))
+    }
+
+    @Test
+    fun `window shorter than the gate is identity`() {
+        val lookback = PaceLookback(achievedSeconds = 100.0, elapsedSeconds = 419.9)
+        assertSame(PaceModel.IDENTITY, PaceModel.adjustmentFor(lookback))
+    }
+
+    @Test
+    fun `on-pace lookback is exactly identity — the rho = 1 knot is pinned`() {
+        val adjustment = PaceModel.adjustmentFor(PaceLookback(600.0, 600.0))
+        assertEquals(1.0, adjustment.paceMultiplier, 0.0)
+        assertEquals(1.0, adjustment.dispersionMultiplier, 0.0)
+        assertEquals(0.0, adjustment.extraSeconds, 0.0)
+    }
+
+    @Test
+    fun `sustained slow pace costs a lump, wider dispersion, near-unit rate`() {
+        // rho = (120 + c) / (600 + c): deep in the slow band.
+        val adjustment = PaceModel.adjustmentFor(PaceLookback(120.0, 600.0))
+        assertTrue("extra seconds, was ${adjustment.extraSeconds}", adjustment.extraSeconds > 10.0)
+        assertTrue("dispersion, was ${adjustment.dispersionMultiplier}", adjustment.dispersionMultiplier > 1.3)
+        assertEquals(1.0, adjustment.paceMultiplier, 0.15)
+    }
+
+    @Test
+    fun `sustained fast pace also costs a lump — the U shape`() {
+        val adjustment = PaceModel.adjustmentFor(PaceLookback(1200.0, 600.0))
+        assertTrue("extra seconds, was ${adjustment.extraSeconds}", adjustment.extraSeconds > 10.0)
+    }
+
+    @Test
+    fun `negative achieved schedule is floored, not extrapolated`() {
+        val floored = PaceModel.adjustmentFor(PaceLookback(-50.0, 600.0))
+        val zero = PaceModel.adjustmentFor(PaceLookback(0.0, 600.0))
+        assertEquals(zero, floored)
+    }
+
+    @Test
+    fun `adjustment matches the scipy fit for a deep-slow lookback — clamped at the first knot`() {
+        // rho = (120 + c)/(600 + c) = 0.204, below the 0.55 knot, so the curves read their
+        // first-knot values exactly. References generated with scipy from h39_params_shipped.json.
+        val adjustment = PaceModel.adjustmentFor(PaceLookback(120.0, 600.0))
+        assertEquals(0.9612270622735628, adjustment.paceMultiplier, 1e-12)
+        assertEquals(1.6947184458381417, adjustment.dispersionMultiplier, 1e-12)
+        assertEquals(21.973541744065756, adjustment.extraSeconds, 1e-12)
+    }
+
+    @Test
+    fun `spline interior matches scipy PCHIP — generated, not fabricated`() {
+        // rho values chosen between knots; expected values from scipy.interpolate.PchipInterpolator
+        // on the same knots (see extrapolation-science h39_params_shipped.json).
+        val cases = mapOf(
+            0.62 to Triple(-0.064795225, 0.280828724, 17.898343016),
+            0.70 to Triple(-0.077656811, 0.062421023, 13.534721639),
+            0.90 to Triple(-0.040302335, -0.025745956, 3.08388969),
+            1.20 to Triple(-0.008443109, -0.000935796, 4.213797938)
+        )
+        for ((rho, expected) in cases) {
+            // Invert the shrinkage so adjustmentFor sees exactly this rho: with elapsed fixed at
+            // 600s, achieved = rho*(600 + c) - c.
+            val c = 3.005739011224008
+            val adjustment = PaceModel.adjustmentFor(PaceLookback(rho * (600.0 + c) - c, 600.0))
+            assertEquals("log gk at $rho", expected.first, ln(adjustment.paceMultiplier), 1e-8)
+            assertEquals("log gtheta at $rho", expected.second, ln(adjustment.dispersionMultiplier), 1e-8)
+            assertEquals("delta at $rho", expected.third, adjustment.extraSeconds, 1e-8)
+        }
+    }
+
+    // ================================================================
+    // lookbackFor: choosing the window from the history
+    // ================================================================
+
+    /** Stops every 1000 m, 100 s apart, no dwell: schedule speed exactly 10 m/s. */
+    private val schedule: ObaTripSchedule = TripScheduleData(
+        Array(11) { i ->
+            StopTimeData(
+                stopId = "stop_$i",
+                arrivalTime = ScheduleTime((i * 100).seconds),
+                departureTime = ScheduleTime((i * 100).seconds),
+                distanceAlongTrip = i * 1000.0
+            )
+        }
+    )
+
+    private fun status(distance: Double?, fixMs: Long) = testTripStatus(
+        distanceAlongTrip = distance,
+        lastLocationUpdateTime = fixMs
+    )
+
+    @Test
+    fun `reads the oldest fix within the window`() {
+        val anchor = status(6000.0, 700_000L)
+        val history = listOf(
+            status(1000.0, 100_000L), // 600s back: exactly at the window edge, still inside
+            status(2000.0, 200_000L),
+            status(5000.0, 600_000L),
+            anchor
+        )
+        val lookback = PaceModel.lookbackFor(history, anchor, schedule)!!
+        assertEquals(600.0, lookback.elapsedSeconds, 1e-9)
+        // 1000 m -> 6000 m at 10 m/s of schedule = 500 scheduled seconds.
+        assertEquals(500.0, lookback.achievedSeconds, 1e-9)
+    }
+
+    @Test
+    fun `skips entries older than the window`() {
+        val anchor = status(6000.0, 800_000L)
+        val history = listOf(
+            status(500.0, 100_000L), // 700s back: outside
+            status(2000.0, 300_000L), // 500s back: the one
+            anchor
+        )
+        val lookback = PaceModel.lookbackFor(history, anchor, schedule)!!
+        assertEquals(500.0, lookback.elapsedSeconds, 1e-9)
+        assertEquals(400.0, lookback.achievedSeconds, 1e-9)
+    }
+
+    @Test
+    fun `skips entries without a GPS fix or a distance`() {
+        val anchor = status(6000.0, 700_000L)
+        val history = listOf(
+            status(1000.0, 0L), // schedule-projected: no fix
+            status(null, 150_000L), // no distance
+            status(3000.0, 300_000L),
+            anchor
+        )
+        val lookback = PaceModel.lookbackFor(history, anchor, schedule)!!
+        assertEquals(400.0, lookback.elapsedSeconds, 1e-9)
+        assertEquals(300.0, lookback.achievedSeconds, 1e-9)
+    }
+
+    @Test
+    fun `null when the anchor has no GPS fix`() {
+        val anchor = status(6000.0, 0L)
+        assertNull(PaceModel.lookbackFor(listOf(status(1000.0, 100_000L), anchor), anchor, schedule))
+    }
+
+    @Test
+    fun `null when no earlier fix exists`() {
+        val anchor = status(6000.0, 700_000L)
+        assertNull(PaceModel.lookbackFor(listOf(anchor), anchor, schedule))
+    }
+
+    @Test
+    fun `null when the lookback position is off the schedule`() {
+        val anchor = status(6000.0, 700_000L)
+        val history = listOf(status(20_000.0, 300_000L), anchor)
+        assertNull(PaceModel.lookbackFor(history, anchor, schedule))
+    }
+
+    // ================================================================
+    // warpedBy: the profile carrying the mean effects
+    // ================================================================
+
+    @Test
+    fun `identity warp returns the same profile instance`() {
+        val profile = schedule.passageProfileFrom(500.0)!!
+        assertSame(profile, profile.warpedBy(PaceModel.IDENTITY))
+    }
+
+    @Test
+    fun `warp scales and shifts every schedule knot, distances untouched`() {
+        val profile = schedule.passageProfileFrom(500.0)!!
+        val warped = profile.warpedBy(PaceAdjustment(paceMultiplier = 0.9, dispersionMultiplier = 2.0, extraSeconds = 30.0))
+        for (i in profile.scheduleSeconds.indices) {
+            assertEquals(0.9 * profile.scheduleSeconds[i] + 30.0, warped.scheduleSeconds[i], 1e-9)
+            assertEquals(profile.distances[i], warped.distances[i], 0.0)
+        }
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/TripScheduleGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/TripScheduleGeometryTest.kt
@@ -15,11 +15,14 @@
  */
 package org.onebusaway.android.extrapolation
 
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.onebusaway.android.api.adapters.StopTimeData
 import org.onebusaway.android.api.adapters.TripScheduleData
 import org.onebusaway.android.models.ObaTripSchedule
+import org.onebusaway.android.time.ScheduleTime
 
 class TripScheduleGeometryTest {
 
@@ -70,6 +73,51 @@ class TripScheduleGeometryTest {
         val schedule = createSchedule(doubleArrayOf(0.0))
         schedule.findSegmentStartIndex(0.0)
     }
+
+    // ================================================================
+    // scheduleTimeAt
+    // ================================================================
+
+    @Test
+    fun `scheduleTimeAt interpolates within a travel segment`() {
+        // 0 m at 0s .. 1000 m arriving 100s: halfway is 50s.
+        assertEquals(50.0, timedSchedule.scheduleTimeAt(500.0)!!.sinceServiceDayStart.toDouble(DurationUnit.SECONDS), 1e-9)
+    }
+
+    @Test
+    fun `scheduleTimeAt reads a stop's departure at exactly its distance`() {
+        // The segment starting at the middle stop begins at its departure (130s), after the dwell.
+        assertEquals(130.0, timedSchedule.scheduleTimeAt(1000.0)!!.sinceServiceDayStart.toDouble(DurationUnit.SECONDS), 1e-9)
+    }
+
+    @Test
+    fun `scheduleTimeAt spans a dwell — the interval across a stop includes it`() {
+        val before = timedSchedule.scheduleTimeAt(750.0)!! // 75s
+        val after = timedSchedule.scheduleTimeAt(1500.0)!! // 130 + (330-130)/2000*500 = 180s
+        assertEquals(105.0, (after - before).toDouble(DurationUnit.SECONDS), 1e-9)
+    }
+
+    @Test
+    fun `scheduleTimeAt returns null outside the scheduled range`() {
+        assertEquals(null, timedSchedule.scheduleTimeAt(3500.0))
+        assertEquals(null, timedSchedule.scheduleTimeAt(-1.0))
+    }
+
+    /** 0/1000/3000 m; middle stop dwells 100s→130s; last arrival 330s. */
+    private val timedSchedule: ObaTripSchedule = TripScheduleData(
+        arrayOf(
+            timedStop("a", 0.0, 0, 0),
+            timedStop("b", 1000.0, 100, 130),
+            timedStop("c", 3000.0, 330, 330)
+        )
+    )
+
+    private fun timedStop(id: String, dist: Double, arriveS: Long, departS: Long) = StopTimeData(
+        stopId = id,
+        arrivalTime = ScheduleTime(arriveS.seconds),
+        departureTime = ScheduleTime(departS.seconds),
+        distanceAlongTrip = dist
+    )
 
     private fun createSchedule(distances: DoubleArray): ObaTripSchedule {
         val stopTimes: Array<ObaTripSchedule.StopTime> = Array(distances.size) { i ->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
@@ -32,6 +32,7 @@ fun testTripStatus(
     distanceAlongTrip: Double? = null,
     totalDistanceAlongTrip: Double? = null,
     lastUpdateTime: Long = 0L,
+    lastLocationUpdateTime: Long = 0L,
     vehicleId: String? = null,
     activeTripId: String? = null,
     predicted: Boolean = false,
@@ -41,6 +42,7 @@ fun testTripStatus(
     distanceAlongTrip = distanceAlongTrip,
     totalDistanceAlongTrip = totalDistanceAlongTrip,
     lastUpdateTime = lastUpdateTime,
+    lastLocationUpdateTime = lastLocationUpdateTime,
     vehicleId = vehicleId,
     activeTripId = activeTripId,
     predicted = predicted,
@@ -52,6 +54,7 @@ private class TestTripStatus(
     distanceAlongTrip: Double?,
     totalDistanceAlongTrip: Double?,
     lastUpdateTime: Long,
+    lastLocationUpdateTime: Long,
     vehicleId: String?,
     activeTripId: String?,
     predicted: Boolean,
@@ -78,7 +81,7 @@ private class TestTripStatus(
     override val lastUpdateTime: Long = lastUpdateTime
     override val lastKnownLocation: Location?
         get() = if (hasLastKnownLocation) FAKE_LOCATION else null
-    override val lastLocationUpdateTime: Long = 0L
+    override val lastLocationUpdateTime: Long = lastLocationUpdateTime
     override val lastKnownDistanceAlongTrip: Double? = null
     override val lastKnownOrientation: Double? = null
     override val blockTripSequence: Int = 0

--- a/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/testing/TestTripStatus.kt
@@ -37,7 +37,8 @@ fun testTripStatus(
     activeTripId: String? = null,
     predicted: Boolean = false,
     hasLastKnownLocation: Boolean = false,
-    hasPosition: Boolean = false
+    hasPosition: Boolean = false,
+    phase: String? = null
 ): ObaTripStatus = TestTripStatus(
     distanceAlongTrip = distanceAlongTrip,
     totalDistanceAlongTrip = totalDistanceAlongTrip,
@@ -47,7 +48,8 @@ fun testTripStatus(
     activeTripId = activeTripId,
     predicted = predicted,
     hasLastKnownLocation = hasLastKnownLocation,
-    hasPosition = hasPosition
+    hasPosition = hasPosition,
+    phase = phase
 )
 
 private class TestTripStatus(
@@ -59,7 +61,8 @@ private class TestTripStatus(
     activeTripId: String?,
     predicted: Boolean,
     private val hasLastKnownLocation: Boolean,
-    private val hasPosition: Boolean
+    private val hasPosition: Boolean,
+    phase: String?
 ) : ObaTripStatus {
     override val serviceDate: Long = 0L
     override val isPredicted: Boolean = predicted
@@ -76,7 +79,7 @@ private class TestTripStatus(
     override val orientation: Double? = null
     override val nextStop: String? = null
     override val nextStopTimeOffset: Long? = null
-    override val phase: String? = null
+    override val phase: String? = phase
     override val status: Status? = null
     override val lastUpdateTime: Long = lastUpdateTime
     override val lastKnownLocation: Location?


### PR DESCRIPTION
Addresses part of #2202. **Read the caveat before the numbers: this is a calibration fix, not a fix for the marker overshoot the issue describes.** The original version of this PR claimed otherwise; the measurements below retract that.

## What this does

A vehicle observed holding an unusual pace over a sustained recent window gets two adjustments to its position distribution: a **lump** of scheduled time added to the road ahead (+17s slow band, +16s fast band, 0 on pace) and a **widened dispersion** (`exp(c·|ln ρ|)`, bounded at ×1.76). The lump is baked into the passage profile once per snapshot as a pure translation, so the closed-form quantile path from #2190 is untouched and nothing new happens per frame.

`PaceModel` reads the window off the `TripState` history the app already keeps: ground covered in schedule terms over up to 600s ending at the anchor's GPS fix, via the new `ObaTripSchedule.scheduleTimeAt`.

## What it does *not* do

The issue describes an extrapolated marker running ahead of a bunched coach and snapping back. **This does not fix that, and no fit of this covariate will.** Measured over 400k held-out pairs at 5–15 minute horizons:

| covariate | Spearman vs forward pace |
|---|---|
| pace over the last 600 s | **−0.064** |
| pace over the whole trip | **−0.004** |

R² ≈ 0.01 either way, sign negative — mild mean reversion, not persistence. Even a bus that has run under 0.6 of schedule pace for thirty minutes has a median forward pace of **1.00**. Drawn against a real route-8 doom loop (on time → 18 minutes down, 5.0 km of an 11.4 km trip in 38 minutes), this model moves the projected median from +1564 m to +1526 m while the 80% band goes from 1145 m to 1557 m, and the coach falls inside at four of five anchors instead of three. That is the whole effect: **the interval becomes honest; the marker does not move.**

Aiming the marker needs the gap to the bus ahead — leading headway predicts forward pace monotonically (1.008 tailgating → 0.913 abandoned) and survives conditioning on deviation. Separate covariate, separate change.

## Why four parameters

A nested ladder, same split and objective, held out on 3.47M pairs:

| rung | params | cell score | worst cell |
|---|---|---|---|
| H37 (deviation only) | 0 | 0.004868 | 0.478 |
| θ, one scalar | 1 | 0.004611 | 0.310 |
| lump, one scalar | 1 | 0.004182 | 0.366 |
| **lump spline + θ scalar (this PR)** | **4** | **0.003608** | **0.344** |
| earlier nine-parameter version | 9 | 0.003164 | 0.344 |

Four parameters take 74% of the nine-parameter gain with an **identical worst cell**, and match it on slow-band coverage at every horizon. The dropped rate-multiplier spline had a fitted value *below 1* — speeding a slow bus up, partly cancelling its own lump — and removing it makes the profile warp a pure translation. Neither surviving term works alone: the lump alone makes the slow band's shape *worse*, θ alone recovers a seventh of the gain. What the extra five parameters still bought was distribution shape in the tails, not coverage.

## Held-out calibration (full test split, per horizon × deviation × pace cell)

| | H37 (today) | this PR |
|---|---|---|
| worst-cell coverage error | 0.478 | **0.344** |
| slow-band 80% coverage | 0.61–0.69 | **0.71–0.87** |
| no-lookback population | — | unchanged by construction |

## Guardrails (structural, learned from degenerate fits)

- **420 s minimum window**: below it the adjustment is identity — cold start reproduces the deviation-only model *to the bit*, asserted in the eval rather than assumed. Unconstrained, the optimiser turned short lookbacks into a stopped-right-now detector keyed to the dataset's 30 s polling cadence.
- **ρ clamped to the knot range**: unclamped, a bus that covered no ground at all has ρ = 0.005 and would multiply θ by 180.
- **Lookback mirrors the fit's own fix filters** (`phase == in_progress`, 200 m terminal margins). Without them a bus idling at its terminal then departing on time reads as deep-slow for ten minutes — a population the validation never scored.

Fit artifacts and measurements live in the companion repo (extrapolation-science): `fit_h39_g_shipped.py`, `fit_h39_ladder.py`, `measure_pace_effect.py`, `measure_chronic_pace.py`, `measure_headway_regime.py`, `plot_doom_loop.py`.

Unit tests: scipy-generated references pin the Kotlin curve; lookback selection, gating, the ρ clamp, the translation warp, and the cold-start-identity path are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved arrival-time predictions using recent vehicle pace and travel history.
  * Sustained slow or fast travel now adjusts predicted arrival distributions.
  * Added more accurate schedule-time interpolation, including dwell periods between stops.
  * Standard predictions remain unchanged when insufficient or unavailable history exists.

* **Bug Fixes**
  * Improved handling of unsupported, out-of-range, or incomplete schedule data.

* **Tests**
  * Added coverage for pace adjustments, schedule interpolation, profile behavior, and historical tracking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->