### PR TITLE
Settle the stay-aboard continuation walk against its poll (#2206)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RideQueue.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RideQueue.kt
@@ -212,6 +212,16 @@ internal fun rideQueueFrom(groups: List<RideRouteGroup>, ride: RideFocus): RideQ
  * [neighbourRouteOf] resolves the neighbour trip's route (a cached lookup); a trip that resolves to
  * none terminates the walk, as does a schedule with no next trip — OBA's block-end sentinel is blanked
  * to null at the wire boundary (#2003), so it arrives here simply as "no next trip".
+ *
+ * **[seed] is narrowed to the trips [scheduleOf] can actually answer for** (#2206). It plays two roles
+ * — the walk's first frontier, and the visited set that stops a self-linking block looping — and a
+ * member with no schedule is inert as a frontier but was still live as a suppressor: it silently
+ * deleted a continuation the walk had every right to report. That is what let the answer feed back into
+ * the next question, since the caller seeds from a set that carries the *previous* answer forward
+ * (`admitRideTrips` deliberately doesn't intersect continuations with the poll, so a continuation is
+ * drawn the moment its first poll lands). A trip you cannot walk from cannot loop, so it has no
+ * business in the visited set, and dropping it makes the result a function of what the caller can
+ * currently see rather than of what it last concluded.
  */
 internal suspend fun rideContinuations(
     seed: Set<String>,
@@ -222,8 +232,10 @@ internal suspend fun rideContinuations(
     val hops = ride.stayAboardHops
     val rideRouteIds = ride.routeIds
     if (hops <= 0 || seed.isEmpty()) return emptySet()
+    val walkable = seed.filterTo(LinkedHashSet()) { scheduleOf(it) != null }
+    if (walkable.isEmpty()) return emptySet()
     val found = LinkedHashSet<String>()
-    var frontier: Set<String> = seed
+    var frontier: Set<String> = walkable
     repeat(hops) {
         // Collect the hop's candidates with the cheap synchronous guards first, then resolve them
         // together: each neighbour lookup can miss its cache and cost a round trip, and they are
@@ -231,7 +243,7 @@ internal suspend fun rideContinuations(
         val candidates = frontier.mapNotNullTo(LinkedHashSet()) { tripId ->
             scheduleOf(tripId)?.nextTripId
                 // Visited guard: a feed that links a block back on itself must not loop forever.
-                ?.takeIf { it !in seed && it !in found }
+                ?.takeIf { it !in walkable && it !in found }
         }
         val next = coroutineScope {
             candidates.map { async { it to neighbourRouteOf(it) } }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RideQueue.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RideQueue.kt
@@ -233,7 +233,6 @@ internal suspend fun rideContinuations(
     val rideRouteIds = ride.routeIds
     if (hops <= 0 || seed.isEmpty()) return emptySet()
     val walkable = seed.filterTo(LinkedHashSet()) { scheduleOf(it) != null }
-    if (walkable.isEmpty()) return emptySet()
     val found = LinkedHashSet<String>()
     var frontier: Set<String> = walkable
     repeat(hops) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RideSelectionController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RideSelectionController.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.map
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import org.onebusaway.android.extrapolation.data.TripState
 import org.onebusaway.android.extrapolation.data.forEachActiveTrip
 import org.onebusaway.android.models.RouteTrips
@@ -231,25 +232,59 @@ internal class RideSelectionController(
      * selection; the result lands in [continuations] and is picked up by the next pass. That lag is
      * harmless — a continuation only matters once the vehicle reaches the seam, minutes in, by which
      * time many polls have landed.
+     *
+     * **The walk is seeded only from trips this poll reports** (#2206). The seam of the cycle that
+     * wedged the app is that [admitted] carries the *previous* walk's continuations forward
+     * ([admitRideTrips] deliberately doesn't intersect them with the poll, so a continuation is drawn
+     * the moment its first poll lands), so seeding from [admitted] wholesale fed each answer back in as
+     * the next question. A trip the poll is silent about — which a continuation is by definition, until
+     * the vehicle rolls onto it — has no schedule in [schedules] and so can never *extend* the walk; all
+     * it can do is suppress a result through `rideContinuations`' visited guard. That made the answer
+     * alternate (`{t2}`, then `{}` because `t2` now suppressed itself, then `{t2}` again once it fell
+     * out of the poll intersection), and since every alternation is a change, each one republished and
+     * re-entered this pass — an unbounded synchronous cycle on the main thread.
+     *
+     * Intersecting with the poll makes the seed a function of the queue and the poll alone. While one
+     * poll stands the seed can only *grow* (each pass unions the previous admitted set with the queue),
+     * and it is bounded by the trips that poll reports — so the walk reaches its fixed point in at most
+     * that many passes and the republish chain ends. Multi-hop rides are unaffected: `rideContinuations`
+     * walks its own frontier up to [RideFocus.stayAboardHops], so a chain is resolved inside one call
+     * rather than across republishes.
      */
     private fun refreshContinuations(ride: RideFocus, pollTrips: List<RideTrip>) {
-        if (ride.stayAboardHops == 0 || admitted.isEmpty()) {
-            continuations = emptySet()
-            return
-        }
+        if (ride.stayAboardHops == 0) return clearContinuations()
         val schedules = pollTrips.associate { it.tripId to it.schedule }
+        val seed = admitted.filterTo(LinkedHashSet()) { it in schedules }
+        if (seed.isEmpty()) return clearContinuations()
         continuationJob?.cancel()
         continuationJob = scope.launch {
             val resolved = rideContinuations(
-                seed = admitted,
+                seed = seed,
                 ride = ride,
                 scheduleOf = { schedules[it] },
                 neighbourRouteOf = neighbourRouteOf
             )
             if (resolved != continuations) {
+                // Hand the republish back to the event loop before making it. The scope is
+                // `Main.immediate`, and `onSelectionChanged` lands back in `refresh` (the renderer must
+                // see a resolved continuation without waiting a poll, #2149) — so without this the whole
+                // cycle runs as one synchronous stack, and a non-convergent pair of inputs spins the main
+                // thread to an ANR rather than merely flickering (#2206).
+                yield()
                 continuations = resolved
                 onSelectionChanged()
             }
         }
+    }
+
+    /**
+     * Nothing to walk from. The in-flight walk is cancelled as well as the answer cleared: it belongs to
+     * a state this pass has just answered for, and letting it report would reinstate continuations
+     * nothing is riding on.
+     */
+    private fun clearContinuations() {
+        continuationJob?.cancel()
+        continuationJob = null
+        continuations = emptySet()
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RideSelectionController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RideSelectionController.kt
@@ -229,12 +229,12 @@ internal class RideSelectionController(
      * harmless — a continuation only matters once the vehicle reaches the seam, minutes in, by which
      * time many polls have landed.
      *
-     * The walk is seeded from [admitted], which carries the *previous* walk's continuations forward, so
-     * what keeps it from feeding on itself is that `rideContinuations` walks only the trips [schedules]
-     * — this poll — can answer for (#2206). Since [schedules] is the poll's own, the resolved set is a
-     * function of the queue and the poll; while one poll stands the seed can only *grow* (each pass
-     * unions the previous admitted set with the queue) and is bounded by the trips that poll reports, so
-     * the walk reaches its fixed point in at most that many passes and the republish chain below ends.
+     * The walk is seeded from [admitted], which carries its own previous answer forward; what keeps that
+     * from feeding on itself is that `rideContinuations` narrows the seed to what [schedules] can answer
+     * for — see its KDoc for why (#2206). What follows from it *here* is the bound on the republish
+     * chain below: [schedules] is this poll's own, so while one poll stands the seed can only *grow*
+     * (each pass unions the previous admitted set with the queue) and is bounded by the trips that poll
+     * reports — the walk reaches its fixed point in at most that many passes.
      */
     private fun refreshContinuations(ride: RideFocus, pollTrips: List<RideTrip>) {
         if (ride.stayAboardHops == 0 || admitted.isEmpty()) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RideSelectionController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RideSelectionController.kt
@@ -134,11 +134,9 @@ internal class RideSelectionController(
     fun rideChanged() {
         queue = RideQueue.Pending
         admitted = emptySet()
-        continuations = emptySet()
         visibleTrips = emptyList()
         lastInputs = null
-        continuationJob?.cancel()
-        continuationJob = null
+        clearContinuations()
     }
 
     /** Leave route mode: forget the ride entirely and stop drawing a selection. */
@@ -147,13 +145,11 @@ internal class RideSelectionController(
     private fun reset() {
         queue = RideQueue.Pending
         admitted = emptySet()
-        continuations = emptySet()
         seed = emptySet()
         visibility = RideVisibility.All
         visibleTrips = emptyList()
         lastInputs = null
-        continuationJob?.cancel()
-        continuationJob = null
+        clearContinuations()
     }
 
     /** Fresh arrivals for the ride's boarding stop: re-derive the queue against [ride]. */
@@ -233,33 +229,23 @@ internal class RideSelectionController(
      * harmless — a continuation only matters once the vehicle reaches the seam, minutes in, by which
      * time many polls have landed.
      *
-     * **The walk is seeded only from trips this poll reports** (#2206). The seam of the cycle that
-     * wedged the app is that [admitted] carries the *previous* walk's continuations forward
-     * ([admitRideTrips] deliberately doesn't intersect them with the poll, so a continuation is drawn
-     * the moment its first poll lands), so seeding from [admitted] wholesale fed each answer back in as
-     * the next question. A trip the poll is silent about — which a continuation is by definition, until
-     * the vehicle rolls onto it — has no schedule in [schedules] and so can never *extend* the walk; all
-     * it can do is suppress a result through `rideContinuations`' visited guard. That made the answer
-     * alternate (`{t2}`, then `{}` because `t2` now suppressed itself, then `{t2}` again once it fell
-     * out of the poll intersection), and since every alternation is a change, each one republished and
-     * re-entered this pass — an unbounded synchronous cycle on the main thread.
-     *
-     * Intersecting with the poll makes the seed a function of the queue and the poll alone. While one
-     * poll stands the seed can only *grow* (each pass unions the previous admitted set with the queue),
-     * and it is bounded by the trips that poll reports — so the walk reaches its fixed point in at most
-     * that many passes and the republish chain ends. Multi-hop rides are unaffected: `rideContinuations`
-     * walks its own frontier up to [RideFocus.stayAboardHops], so a chain is resolved inside one call
-     * rather than across republishes.
+     * The walk is seeded from [admitted], which carries the *previous* walk's continuations forward, so
+     * what keeps it from feeding on itself is that `rideContinuations` walks only the trips [schedules]
+     * — this poll — can answer for (#2206). Since [schedules] is the poll's own, the resolved set is a
+     * function of the queue and the poll; while one poll stands the seed can only *grow* (each pass
+     * unions the previous admitted set with the queue) and is bounded by the trips that poll reports, so
+     * the walk reaches its fixed point in at most that many passes and the republish chain below ends.
      */
     private fun refreshContinuations(ride: RideFocus, pollTrips: List<RideTrip>) {
-        if (ride.stayAboardHops == 0) return clearContinuations()
+        if (ride.stayAboardHops == 0 || admitted.isEmpty()) {
+            clearContinuations()
+            return
+        }
         val schedules = pollTrips.associate { it.tripId to it.schedule }
-        val seed = admitted.filterTo(LinkedHashSet()) { it in schedules }
-        if (seed.isEmpty()) return clearContinuations()
         continuationJob?.cancel()
         continuationJob = scope.launch {
             val resolved = rideContinuations(
-                seed = seed,
+                seed = admitted,
                 ride = ride,
                 scheduleOf = { schedules[it] },
                 neighbourRouteOf = neighbourRouteOf
@@ -278,8 +264,8 @@ internal class RideSelectionController(
     }
 
     /**
-     * Nothing to walk from. The in-flight walk is cancelled as well as the answer cleared: it belongs to
-     * a state this pass has just answered for, and letting it report would reinstate continuations
+     * Forget the continuations. The in-flight walk is cancelled as well as the answer cleared: it
+     * belongs to a state that no longer holds, and letting it report would reinstate continuations
      * nothing is riding on.
      */
     private fun clearContinuations() {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RideQueueTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RideQueueTest.kt
@@ -229,6 +229,21 @@ class RideQueueTest {
     }
 
     @Test
+    fun aSeedTripTheCallerCannotAnswerForDoesNotSuppressItsOwnContinuation() = runTest {
+        // #2206: `t2` is seeded (the caller carries its last answer forward) but this poll doesn't
+        // report it, so it can't be walked from — and a trip that can't loop has no business in the
+        // visited set. Left there it deleted the continuation `t1` legitimately resolves to, which is
+        // what let each answer decide the next question and spun the walk against one poll forever.
+        val found = continuations(
+            seed = setOf("t1", "t2"),
+            hops = 1,
+            schedules = mapOf("t1" to schedule("board" to 0.0, nextTripId = "t2")),
+            routes = mapOf("t2" to "route_b")
+        )
+        assertEquals(setOf("t2"), found)
+    }
+
+    @Test
     fun aBlockThatLinksBackOnItselfCannotLoopForever() = runTest {
         val found = continuations(
             seed = setOf("t1"),

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RideSelectionControllerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RideSelectionControllerTest.kt
@@ -36,14 +36,21 @@ import org.onebusaway.android.testing.testTripStatus
 import org.onebusaway.android.time.ElapsedTime
 
 /**
+ * How many times one poll may republish before the selection is declared not to settle. Any real pass
+ * republishes at most a handful of times — the walk's seed can only grow while a poll stands — so this
+ * is far above the useful range and exists only so a livelock reports instead of hanging the runner.
+ */
+private const val REPUBLISH_LIMIT = 50
+
+/**
  * Unit tests for [RideSelectionController] — the wiring between the boarding stop's arrivals and the
  * vehicle set, which the pure rules in [RideQueueTest] don't reach: the identity guard that keeps the
  * decision off the 20 Hz sampler, the admitted set carried across polls, the continuation walk it
  * launches, and the resets each focus transition owes.
  *
  * The trip-observation cache enters as the two lambdas the controller calls, so no repository or map
- * host is needed. The continuation coroutine runs on an unconfined test dispatcher, so launching it
- * completes before the test body resumes and every assertion sees a settled state.
+ * host is needed. The continuation coroutine runs on an unconfined test dispatcher and [Harness.refresh]
+ * drains it, so every assertion sees a settled state.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class RideSelectionControllerTest {
@@ -78,12 +85,26 @@ class RideSelectionControllerTest {
         loadTime = ElapsedTime(0L)
     )
 
+    /**
+     * The controller wired the way `RouteMapController` wires it: `onSelectionChanged` is
+     * `publishVehicleSet`, which re-samples and so lands back in [RideSelectionController.refresh]
+     * against the poll already in hand (#2149). A counter-only callback cannot see a selection that
+     * fails to *settle*, which is how #2206 — the continuation walk and the republish feeding each other
+     * forever — shipped: the cycle closed across two files, and neither file's tests re-entered.
+     *
+     * So re-entry is the default here, and [refresh] bounds it: a selection that does not settle against
+     * one poll fails the test that ran it instead of hanging the runner.
+     */
     private class Harness {
         val states = mutableMapOf<String, TripState>()
         val neighbourRoutes = mutableMapOf<String, String>()
         var neighbourLookups = 0
         var republishes = 0
         val scope = TestScope(UnconfinedTestDispatcher())
+
+        /** The pass a republish replays, the way `publishVehicleSet` re-samples the poll it holds. */
+        private var lastPass: (() -> Unit)? = null
+        private var passes = 0
 
         val controller = RideSelectionController(
             lookupTripState = { states[it] },
@@ -92,8 +113,35 @@ class RideSelectionControllerTest {
                 neighbourRoutes[it]
             },
             scope = scope,
-            onSelectionChanged = { republishes++ }
+            onSelectionChanged = {
+                republishes++
+                // Stop *inside* the loop rather than assert here: this runs on the walk's coroutine,
+                // where a thrown AssertionError would be routed to the scope's handler instead of
+                // failing the test. [refresh] asserts on the test thread once the pass has settled.
+                if (++passes < REPUBLISH_LIMIT) lastPass?.invoke()
+            }
         )
+
+        /**
+         * One selection pass, then settle the walk it launched: the walk hands its republish back to the
+         * event loop before reporting, so the scheduler is drained here rather than leaving a test to
+         * assert against a half-resolved state.
+         */
+        fun refresh(
+            ride: RideFocus?,
+            poll: VehiclePoll,
+            extras: Map<String, VehiclePoll> = emptyMap()
+        ) {
+            val pass = { controller.refresh(ride, "route_a", poll, extras) }
+            lastPass = pass
+            passes = 0
+            pass()
+            scope.testScheduler.runCurrent()
+            assertTrue(
+                "the selection republished $passes times against one poll without settling",
+                passes < REPUBLISH_LIMIT
+            )
+        }
 
         fun visibleTripIds() = (controller.visibility as RideVisibility.Only).tripIds
     }
@@ -110,7 +158,7 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
 
-        h.controller.refresh(ride(), "route_a", poll("t1", "t2"), emptyMap())
+        h.refresh(ride(), poll("t1", "t2"))
 
         assertEquals(setOf("t1"), h.visibleTripIds())
     }
@@ -122,7 +170,7 @@ class RideSelectionControllerTest {
         val h = harness("t1" to ridden)
         h.controller.start(focusTripId = null)
 
-        h.controller.refresh(ride = null, "route_a", poll("t1", "t2"), emptyMap())
+        h.refresh(ride = null, poll("t1", "t2"))
 
         assertEquals(RideVisibility.All, h.controller.visibility)
     }
@@ -132,7 +180,7 @@ class RideSelectionControllerTest {
         val h = harness("tapped" to ridden)
         h.controller.start(focusTripId = "tapped")
 
-        h.controller.refresh(ride(), "route_a", poll("tapped", "other"), emptyMap())
+        h.refresh(ride(), poll("tapped", "other"))
 
         assertEquals(setOf("tapped"), h.visibleTripIds())
     }
@@ -143,7 +191,7 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(listOf(RideRouteGroup("route_z", "Elsewhere", listOf("zz"))), ride())
 
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         assertEquals(RideVisibility.All, h.controller.visibility)
     }
@@ -155,16 +203,16 @@ class RideSelectionControllerTest {
         val h = harness("t1" to ridden)
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         // The vehicle passed the boarding stop, so its arrival left the list — but the rider is aboard.
         h.controller.setArrivals(groups(), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1", progress = 500.0), emptyMap())
+        h.refresh(ride(), poll("t1", progress = 500.0))
         assertEquals(setOf("t1"), h.visibleTripIds())
 
         // Past the alighting stop: the ride is provably over.
         h.controller.setArrivals(groups(), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1", progress = 1500.0), emptyMap())
+        h.refresh(ride(), poll("t1", progress = 1500.0))
         assertTrue(h.visibleTripIds().isEmpty())
     }
 
@@ -173,10 +221,10 @@ class RideSelectionControllerTest {
         val h = harness("t1" to ridden)
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         h.controller.setArrivals(groups(), ride())
-        h.controller.refresh(ride(), "route_a", poll(), emptyMap())
+        h.refresh(ride(), poll())
 
         assertTrue(h.visibleTripIds().isEmpty())
     }
@@ -190,11 +238,11 @@ class RideSelectionControllerTest {
         h.controller.setArrivals(groups("t1"), ride(continuation("route_b")))
         val samePoll = poll("t1")
 
-        h.controller.refresh(ride(continuation("route_b")), "route_a", samePoll, emptyMap())
+        h.refresh(ride(continuation("route_b")), samePoll)
         val afterFirst = h.controller.visibleTrips
         val lookupsAfterFirst = h.neighbourLookups
 
-        repeat(20) { h.controller.refresh(ride(continuation("route_b")), "route_a", samePoll, emptyMap()) }
+        repeat(20) { h.refresh(ride(continuation("route_b")), samePoll) }
 
         // Same instance, not merely an equal one: the guard returned before rebuilding anything.
         assertSame(afterFirst, h.controller.visibleTrips)
@@ -212,11 +260,11 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
         val landed = poll("t1", "tapped")
-        h.controller.refresh(ride(), "route_a", landed, emptyMap())
+        h.refresh(ride(), landed)
         assertEquals(setOf("t1"), h.visibleTripIds())
 
         h.controller.seed("tapped")
-        h.controller.refresh(ride(), "route_a", landed, emptyMap())
+        h.refresh(ride(), landed)
 
         assertTrue("tapped" in h.visibleTripIds())
     }
@@ -226,11 +274,11 @@ class RideSelectionControllerTest {
         val h = harness("tapped" to ridden)
         h.controller.start(focusTripId = "tapped")
         val landed = poll("tapped")
-        h.controller.refresh(ride(), "route_a", landed, emptyMap())
+        h.refresh(ride(), landed)
         assertEquals(setOf("tapped"), h.visibleTripIds())
 
         h.controller.clearSeed()
-        h.controller.refresh(ride(), "route_a", landed, emptyMap())
+        h.refresh(ride(), landed)
 
         assertTrue(h.visibleTripIds().isEmpty())
     }
@@ -265,11 +313,11 @@ class RideSelectionControllerTest {
         h.controller.setArrivals(groups("t1"), interlined)
         val landed = poll("t1", "t2")
 
-        h.controller.refresh(interlined, "route_a", landed, emptyMap())
+        h.refresh(interlined, landed)
 
         // The walk ran during that pass and republished; the republish re-enters refresh against the
         // same poll, and must not be turned away.
-        h.controller.refresh(interlined, "route_a", landed, emptyMap())
+        h.refresh(interlined, landed)
         assertTrue(h.visibleTripIds().containsAll(setOf("t1", "t2")))
     }
 
@@ -279,11 +327,11 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
         val landed = poll("t1")
-        h.controller.refresh(ride(), "route_a", landed, emptyMap())
+        h.refresh(ride(), landed)
         assertEquals(setOf("t1"), h.visibleTripIds())
 
         // Same poll and queue, but the rider now alights where this trip has already passed.
-        h.controller.refresh(ride(alightStopId = "board"), "route_a", poll("t1", progress = 500.0), emptyMap())
+        h.refresh(ride(alightStopId = "board"), poll("t1", progress = 500.0))
 
         assertTrue(h.visibleTripIds().isEmpty())
     }
@@ -293,10 +341,10 @@ class RideSelectionControllerTest {
         val h = harness("t1" to ridden)
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
         val afterFirst = h.controller.visibleTrips
 
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         assertEquals(setOf("t1"), h.visibleTripIds())
         assertTrue(afterFirst !== h.controller.visibleTrips)
@@ -312,12 +360,33 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), interlined)
 
-        h.controller.refresh(interlined, "route_a", poll("t1"), emptyMap())
+        h.refresh(interlined, poll("t1"))
 
         assertTrue("t2" in h.visibleTripIds() || h.republishes > 0)
         // The walk republishes so the newly-admitted continuation reaches the renderer.
-        h.controller.refresh(interlined, "route_a", poll("t1", "t2"), emptyMap())
+        h.refresh(interlined, poll("t1", "t2"))
         assertTrue(h.visibleTripIds().containsAll(setOf("t1", "t2")))
+    }
+
+    @Test
+    fun `the walk settles against a poll the continuation has not entered yet`() {
+        // #2206: the walk used to be seeded from `admitted`, which carries its own previous answer, so
+        // for a continuation the poll had yet to report the answer alternated — {t2}, then {} because t2
+        // now suppressed itself through the visited guard, then {t2} again — and every alternation
+        // republished back into the pass that launched it. On device that spun the main thread to an ANR.
+        val h = harness("t1" to schedule("board" to 100.0, nextTripId = "t2"), "t2" to ridden)
+        h.neighbourRoutes["t2"] = "route_b"
+        val interlined = ride(continuation("route_b"))
+        h.controller.start(focusTripId = null)
+        h.controller.setArrivals(groups("t1"), interlined)
+
+        // The continuation is the trip the vehicle rolls onto *next*, so the poll in hand is silent
+        // about it — the ordinary case, not an edge one.
+        h.refresh(interlined, poll("t1"))
+
+        // Settled (Harness.refresh would have failed otherwise), and settled on the right answer: the
+        // continuation stays admitted rather than being walked back off by the next pass.
+        assertEquals(setOf("t1", "t2"), h.visibleTripIds())
     }
 
     @Test
@@ -329,7 +398,7 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
 
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         assertEquals(0, h.neighbourLookups)
         assertEquals(setOf("t1"), h.visibleTripIds())
@@ -342,14 +411,14 @@ class RideSelectionControllerTest {
         val h = harness("t1" to ridden)
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
         assertEquals(setOf("t1"), h.visibleTripIds())
 
         h.controller.rideChanged()
         // The route redraw happens before the next selection pass. Its approach must not read trips
         // derived from the ride that just ended during that window.
         assertTrue(h.controller.visibleTrips.isEmpty())
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         // Back to Pending with no seed: nothing is admitted until the new stop's arrivals land.
         assertTrue(h.visibleTripIds().isEmpty())
@@ -361,7 +430,7 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = "tapped")
         h.controller.clearSeed()
 
-        h.controller.refresh(ride(), "route_a", poll("tapped"), emptyMap())
+        h.refresh(ride(), poll("tapped"))
 
         assertTrue(h.visibleTripIds().isEmpty())
     }
@@ -371,7 +440,7 @@ class RideSelectionControllerTest {
         val h = harness("t1" to ridden)
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
-        h.controller.refresh(ride(), "route_a", poll("t1"), emptyMap())
+        h.refresh(ride(), poll("t1"))
 
         h.controller.stop()
 
@@ -387,7 +456,7 @@ class RideSelectionControllerTest {
         h.controller.start(focusTripId = null)
         h.controller.setArrivals(groups("t1"), ride())
 
-        h.controller.refresh(ride(), "route_a", poll("t1", "t2"), emptyMap())
+        h.refresh(ride(), poll("t1", "t2"))
 
         assertEquals(listOf("t1"), h.controller.visibleTrips.map { it.tripId })
         assertSame(ridden, h.controller.visibleTrips.single().schedule)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RideSelectionControllerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RideSelectionControllerTest.kt
@@ -370,10 +370,10 @@ class RideSelectionControllerTest {
 
     @Test
     fun `the walk settles against a poll the continuation has not entered yet`() {
-        // #2206: the walk used to be seeded from `admitted`, which carries its own previous answer, so
-        // for a continuation the poll had yet to report the answer alternated — {t2}, then {} because t2
-        // now suppressed itself through the visited guard, then {t2} again — and every alternation
-        // republished back into the pass that launched it. On device that spun the main thread to an ANR.
+        // The controller-side half of #2206 (`rideContinuations`' KDoc has the mechanism, and
+        // RideQueueTest pins it): the walk is seeded from `admitted`, which carries its own previous
+        // answer, so an answer that changed every pass republished back into the pass that launched it.
+        // On device that spun the main thread to an ANR.
         val h = harness("t1" to schedule("board" to 100.0, nextTripId = "t2"), "t2" to ridden)
         h.neighbourRoutes["t2"] = "route_b"
         val interlined = ride(continuation("route_b"))


### PR DESCRIPTION
Fixes #2206.

Drilling into a stay-aboard interline ride wedged the app: the continuation walk and the vehicle republish fed each other forever, spinning the main thread at 100% CPU until Android fired an ANR.

## The cycle

`RideSelectionController` is constructed with `onSelectionChanged = ::publishVehicleSet`, and `publishVehicleSet` → `currentVehicleLayer` → `sampleVehicles` opens with `rideSelection.refresh(...)`. So the walk reporting a change re-enters the pass that launched it.

It never damped out because of a conflation inside `rideContinuations`: `seed` plays two roles — the walk's first frontier, and the visited set that stops a self-linking block looping. A seed member with no schedule is inert as a frontier but still *live* as a suppressor. The caller seeds from `admitted`, which carries the previous walk's continuations forward (`admitRideTrips` deliberately doesn't intersect them with the poll, so a continuation is drawn the moment its first poll lands, #2149) — so a continuation the poll hadn't reported yet sat in the seed and silently deleted itself from the answer:

| pass | seed (`admitted`) | returns | changed? |
| --- | --- | --- | --- |
| 1 | `{t1}` | `{t2}` | yes → republish |
| 2 | `{t1, t2}` | `{}` — `t2` now suppresses itself through the visited guard | yes → republish |
| 3 | `{t1}` — `t2` isn't in the poll, so it drops out of `previouslyAdmitted ∩ pollTripIds` | `{t2}` | yes → republish |

`refresh`'s `inputs == lastInputs` guard can only stop a fixed point, and a 2-cycle has none.

## The fix

**`rideContinuations` narrows its seed to the trips `scheduleOf` can answer for.** A trip you cannot walk from cannot loop, so it has no business in the visited set. The resolved set becomes a function of what the caller can currently see rather than of what it last concluded; since the controller's `scheduleOf` is the poll's own, the seed can only *grow* while one poll stands and is bounded by that poll's trips, so the walk reaches its fixed point in at most that many passes and the republish chain ends.

Deliberately at the pure layer rather than at the call site: the invariant is then unbreakable by a future caller, and pinned by a two-line JVM test instead of only through the controller's coroutine harness. Multi-hop rides are unaffected — the walk follows its own frontier up to `RideFocus.stayAboardHops`, so a chain resolves inside one call rather than across republishes.

**`RideSelectionController` hands the republish back to the event loop (`yield()`) before making it.** The re-entrancy itself is load-bearing (#2149: a resolved continuation must reach the renderer without waiting a poll), but on `Main.immediate` with a cache-hitting neighbour lookup the whole cycle ran as one synchronous stack — hence `processUnconfinedEvent` in the ANR trace and 91% *user* CPU on tid 1. Off the stack, the republish is the next main-loop message (sub-millisecond, same frame), and a future non-convergent input pair janks instead of ANRing.

Also cancels the in-flight walk on the "nothing to walk from" path, where it previously only cleared the answer — a walk that outlived the state it was launched for could reinstate continuations nothing is riding on. That teardown is now one `clearContinuations()` that `reset`/`rideChanged` share.

## Tests

The existing controller tests passed `onSelectionChanged = { republishes++ }` — a callback that never re-enters `refresh` — so the loop was invisible to them; it closed across `RideSelectionController` and `RouteMapController`, and neither file's tests re-entered.

The harness now wires the callback the way production does, replaying the pass against the poll in hand, and bounds it: a selection that doesn't settle against one poll fails the test that ran it instead of hanging the runner. Plus two regression tests — `aSeedTripTheCallerCannotAnswerForDoesNotSuppressItsOwnContinuation` (`RideQueueTest`, the rule itself) and `the walk settles against a poll the continuation has not entered yet` (`RideSelectionControllerTest`, the loop it closed).

Verified by reverting the seed narrowing on top of the new tests — all three fail, including the pre-existing stay-aboard test that only became sensitive once the harness re-entered:

```
RideQueueTest > aSeedTripTheCallerCannotAnswerForDoesNotSuppressItsOwnContinuation FAILED
RideSelectionControllerTest > a stay-aboard ride admits the continuation its vehicle rolls onto FAILED
RideSelectionControllerTest > the walk settles against a poll the continuation has not entered yet FAILED
```

`./gradlew spotlessCheck :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ride selection refresh behavior to prevent stale continuation results.
  * Correctly handles continuation trips missing from the latest poll.
  * Prevents refresh loops that could cause the app to hang.
  * Ensures ride selection updates are processed smoothly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->