### PR TITLE
Contrast the trip band against the line as drawn, and fill its markers with it (#1990)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -271,6 +271,45 @@ class VehicleIconAllocationTest {
     }
 
     /**
+     * The selected vehicle's disc takes its band's colour over its route's (#1990) — and does so through
+     * the icon key, so a selection genuinely re-stamps the marker instead of leaving it on the cached
+     * route-coloured bitmap.
+     */
+    @Test
+    fun aSelectedVehiclesBandColourTakesOverItsDisc() {
+        val (response, vehicle) = fixture()
+        val unselected = pinned(vehicle).copy(routeColor = 0xFF1050C0.toInt())
+        val selected = unselected.copy(bandColor = 0xFFC05010.toInt())
+
+        assertNotEquals(
+            "the band colour must be part of the icon key",
+            VehicleBitmaps.iconKey(context, unselected, response),
+            VehicleBitmaps.iconKey(context, selected, response)
+        )
+        assertEquals(
+            "the selected vehicle's disc must be drawn in the band's colour",
+            0xFFC05010.toInt(),
+            VehicleBitmaps.discColor(context, selected)
+        )
+    }
+
+    /**
+     * Liveness still outranks the band colour: a scheduled vehicle stays gray. It has no real-time fix to
+     * extrapolate, so it has no band either — a selection must not paint one on by recolouring its disc.
+     */
+    @Test
+    fun aScheduledVehicleKeepsItsGrayDiscWhenSelected() {
+        val (response, vehicle) = fixture()
+        val scheduled = pinned(vehicle, isRealtime = false).copy(routeColor = 0xFF1050C0.toInt())
+
+        assertEquals(
+            "a band colour must not reach a scheduled vehicle's disc",
+            VehicleBitmaps.iconKey(context, scheduled, response),
+            VehicleBitmaps.iconKey(context, scheduled.copy(bandColor = 0xFFC05010.toInt()), response)
+        )
+    }
+
+    /**
      * The cache's eviction + [BitmapDescriptorCache.clear] contract, which the production [CACHE_SIZE] is
      * deliberately large enough to never hit. Drive past `maxSize` distinct keys and confirm an evicted key
      * re-invokes its supplier, and that a `get` after `clear()` is a miss.

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/TripMarkerBitmapsTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/TripMarkerBitmapsTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.R
+
+/**
+ * The trip markers take the uncertainty band's colour as their disc fill (#1990), and everything drawn
+ * on that disc — the ring and the glyph — flips to whichever of black/white reads on it.
+ *
+ * Instrumented rather than a JVM test because this is `Canvas` work: the unit-test `android.graphics`
+ * stubs draw nothing, so the only way to see the disc is to read the pixels back. The polarity is
+ * checked on both a light and a dark fill, since a marker that hardcoded either ink would pass on one
+ * of them — which is exactly what the pre-#1990 fixed gray-on-white pair did.
+ */
+@RunWith(AndroidJUnit4::class)
+class TripMarkerBitmapsTest {
+
+    private val context: Context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val density: Float get() = context.resources.displayMetrics.density
+
+    @Test
+    fun aLightFillInksTheRingAndGlyphBlack() = assertDiscInk(0xFFFFE08A.toInt(), Color.BLACK)
+
+    @Test
+    fun aDarkFillInksTheRingAndGlyphWhite() = assertDiscInk(0xFF1050C0.toInt(), Color.WHITE)
+
+    @Test
+    fun aTranslucentFillIsDrawnOpaque() {
+        // The disc must not blend with the map beneath it — overlapping, per-frame-moving markers would
+        // shimmer. The caller's alpha is therefore dropped rather than honoured.
+        val bitmap = TripMarkerBitmaps.circle(context, R.drawable.ic_fast_estimate, 0x401050C0)
+        assertEquals(0xFF1050C0.toInt(), bitmap.fillSample())
+    }
+
+    @Test
+    fun eachFillGetsItsOwnDisc() {
+        // Two colours must not collide in the (drawable, fill) cache, and the second must not be served
+        // the first's bitmap — the fill is what tells a rider which band a marker belongs to.
+        val warm = TripMarkerBitmaps.circle(context, R.drawable.ic_signal_indicator, 0xFFFFE08A.toInt())
+        val cool = TripMarkerBitmaps.circle(context, R.drawable.ic_signal_indicator, 0xFF1050C0.toInt())
+        assertNotEquals(warm.fillSample(), cool.fillSample())
+    }
+
+    @Test
+    fun theSameFillIsServedFromTheCache() {
+        val first = TripMarkerBitmaps.circle(context, R.drawable.ic_fast_estimate, 0xFF1050C0.toInt())
+        val second = TripMarkerBitmaps.circle(context, R.drawable.ic_fast_estimate, 0xFF1050C0.toInt())
+        assertTrue("the same (drawable, fill) must reuse one bitmap", first === second)
+    }
+
+    /** Both glyphs, so neither drawable's own authored colour survives into the disc. */
+    private fun assertDiscInk(fill: Int, expectedInk: Int) {
+        for (glyph in listOf(R.drawable.ic_fast_estimate, R.drawable.ic_signal_indicator)) {
+            val bitmap = TripMarkerBitmaps.circle(context, glyph, fill)
+
+            assertEquals("disc fill", fill, bitmap.fillSample())
+            // The ring is stroked centered on `radius - strokeWidth/2`, so its own half-width row down
+            // the vertical centerline is solidly inside it.
+            assertEquals("ring ink", expectedInk, bitmap.getPixel(bitmap.width / 2, (strokeWidthPx / 2f).toInt()))
+            // Glyph ink, counted strictly inside the fill disc so no ring pixel can stand in for it: the
+            // glyph is tinted, not left at whatever colour its vector authored.
+            assertTrue("glyph ink", bitmap.countInkInsideDisc(expectedInk) > 0)
+        }
+    }
+
+    private val strokeWidthPx: Float get() = TripMarkerBitmaps.STROKE_WIDTH_DP * density
+
+    private val paddingPx: Float get() = TripMarkerBitmaps.ICON_PADDING_DP * density
+
+    /**
+     * A pixel that is inside the fill but outside the glyph's bounds: on the vertical centerline, between
+     * the ring's inner edge (`strokeWidth` from the top) and the glyph box's top edge (`padding`).
+     */
+    private fun Bitmap.fillSample(): Int = getPixel(width / 2, ((strokeWidthPx + paddingPx) / 2f).toInt())
+
+    /** Exact-[ink] pixels at least 2px inside the fill disc — everything there is glyph, never ring. */
+    private fun Bitmap.countInkInsideDisc(ink: Int): Int {
+        val center = width / 2f
+        val innerRadius = center - strokeWidthPx - 2f
+        var count = 0
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val dx = x + 0.5f - center
+                val dy = y + 0.5f - center
+                if (dx * dx + dy * dy <= innerRadius * innerRadius && getPixel(x, y) == ink) count++
+            }
+        }
+        return count
+    }
+}

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -64,6 +64,7 @@ import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineReconciler
+import org.onebusaway.android.map.render.STOP_ROUTE_LABEL_Z_INDEX
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.TripMarkerBitmaps
 import org.onebusaway.android.map.render.TripOverlay
@@ -694,7 +695,7 @@ class GoogleMapRenderer(
                     .position(target.toLatLng())
                     .icon(dataAgeIcon(fillColor))
                     .anchor(0.5f, 0.5f)
-                    .zIndex(0.5f)
+                    .zIndex(DATA_AGE_Z_INDEX)
                     .title(MOST_RECENT_DATA_TITLE)
                     .snippet(formatDataAge(context.resources, ageSeconds))
             )
@@ -921,10 +922,32 @@ class GoogleMapRenderer(
         private const val DEFAULT_ROUTE_WIDTH_PX = 10f
         private const val TRIP_BAND_WIDTH_PX = 44f
 
-        // z-index used to show vehicle markers on top of stop markers (default marker z-index is 0).
-        private const val VEHICLE_Z_INDEX = 1f
+        /**
+         * The vehicle and the two markers of its estimate sit above the **whole** stop group, and this is
+         * a tappability decision before it is a drawing one: gms delivers a tap to the topmost marker
+         * under the finger and [routeMarkerTap] then asks what that marker is, so a stop drawn over one of
+         * these doesn't merely cover it — it answers for it, and the tap focuses the stop instead.
+         *
+         * The stop group's ceiling is [STOP_ROUTE_LABEL_Z_INDEX], not [stopZIndex]: a stop's route label
+         * (#2107) is a wide pill floating above its point, registered as a tap target for that stop, and
+         * it is the highest thing the group draws. Both of these are therefore expressed relative to it
+         * rather than as literals, so a change to the stop scale can't silently sink them back under it —
+         * which is what each had done:
+         *
+         *  - the vehicle sat exactly *on* [STOP_ROUTE_LABEL_Z_INDEX], and gms leaves ties undefined, so a
+         *    label overlapping a vehicle took its taps unpredictably;
+         *  - the most-recent-data dot sat at 0.5, under every route stop (0.75) and tied with favourites,
+         *    so a stop anywhere near the last fix swallowed the dot outright.
+         *
+         * The vehicle outranks the dot where the two coincide (a just-fixed vehicle sits on its own last
+         * fix): the vehicle's tap selects the trip and opens its details, the dot's only shows a bubble.
+         */
+        private const val DATA_AGE_Z_INDEX = STOP_ROUTE_LABEL_Z_INDEX + 0.1f
+        private const val VEHICLE_Z_INDEX = STOP_ROUTE_LABEL_Z_INDEX + 0.2f
 
         // The uncertainty band draws above the static route line; the fast-estimate marker above the band.
+        // The fast estimate was already clear of the stop group and stays where it is — it is the one of
+        // the three that never needed lifting.
         private const val TRIP_BAND_Z_INDEX = 2f
         private const val FAST_ESTIMATE_Z_INDEX = 4f
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -181,8 +181,8 @@ class GoogleMapRenderer(
 
     // The selected vehicle's fast-estimate marker: it owns its native marker + ease state, a fixed
     // info-window title, and a z-index above the band, and glides to a fresh fix. Icon resolves lazily
-    // on first show.
-    private val fastEstimate = TripEstimateMarker({ fastEstimateIcon() }, "Fast estimate", FAST_ESTIMATE_Z_INDEX)
+    // on first show, in the band's own colour (#1990), and is re-stamped when that colour changes.
+    private val fastEstimate = TripEstimateMarker(::fastEstimateIcon, "Fast estimate", FAST_ESTIMATE_Z_INDEX)
 
     // Smooths the most-recent-data dot to a fresh fix (it's static between fixes). Tracks the dot's current
     // selection + fix so we only move / refresh on an actual change or while settling — never while its
@@ -191,6 +191,10 @@ class GoogleMapRenderer(
     private var dotSelectedId: String? = null
     private var dotFixTimeMs: Long = 0L
     private var dotAgeSeconds: Long = -1L
+
+    // The fill the dot's icon is currently stamped with (the band's colour, #1990), so it's re-stamped
+    // only when that colour actually changes. 0 whenever there is no dot — not a colour any fill can be.
+    private var dotFillColor: Int = 0
 
     // The selected vehicle's most-recent-data dot: a static marker at its last actual AVL fix (where the
     // live estimate was last corrected from), shown while a vehicle is selected, with a "Most recent
@@ -549,7 +553,10 @@ class GoogleMapRenderer(
      * fresh fix (a decaying correction on the dead-reckon glide); the band is re-added.
      */
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
-        moveVehicles(vehicles, nowMs)
+        // The dot is the band's origin marker, so it is filled with the band's colour (#1990) — carried on
+        // the overlay even when that frame has no band to draw. Only a selection with no overlay at all
+        // (nothing selected, so no dot either) reaches the default.
+        moveVehicles(vehicles, overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR, nowMs)
         updateTripOverlay(overlay, nowMs)
     }
 
@@ -630,14 +637,14 @@ class GoogleMapRenderer(
     // A gliding vehicle used to need its direction arrow re-stamped whenever its heading octant flipped;
     // since #2194 removed that arrow, nothing about the icon varies between polls (see
     // [VehicleBitmaps.iconKey]), so the whole per-frame icon path is gone.
-    private fun moveVehicles(vehicles: MapVehicles?, nowMs: Long) {
+    private fun moveVehicles(vehicles: MapVehicles?, dotFill: Int, nowMs: Long) {
         for (vehicle in vehicles?.markers.orEmpty()) {
             val marker = vehicleMarkersByTripId[vehicle.activeTripId] ?: continue
             marker.position = vehicleSmoother
                 .displayPosition(vehicle.activeTripId, vehicle.point, vehicle.fixTimeMs, nowMs)
                 .toLatLng()
         }
-        updateMostRecentDataDot(nowMs)
+        updateMostRecentDataDot(dotFill, nowMs)
     }
 
     /**
@@ -652,8 +659,14 @@ class GoogleMapRenderer(
      * the flicker. So we move it only on an actual change or while a fix correction is still settling,
      * and refresh the age only while closed (it's current when reopened, frozen while open — like every
      * other info window here).
+     *
+     * [fillColor] is the uncertainty band's colour: the dot marks the band's origin, so it is filled with
+     * it (#1990). It is re-stamped whenever it changes — unconditionally, unlike the per-second age,
+     * because it changes only when the selected trip's line recolours (its route loading, a stop-focus
+     * session opening), and a dot left in the old colour would be a data marker that disagrees with its
+     * own band.
      */
-    private fun updateMostRecentDataDot(nowMs: Long) {
+    private fun updateMostRecentDataDot(fillColor: Int, nowMs: Long) {
         val selectedId = renderState.selectedVehicleTripId.value
         // Read the dot's inputs from the reconciled (per-poll) set, not the per-frame motion samples:
         // the fix point + age are discrete, changing only when a new poll lands, and the set is where the
@@ -670,6 +683,7 @@ class GoogleMapRenderer(
             dotSmoother.retainOnly(emptySet())
             dotSelectedId = null
             dotAgeSeconds = -1L
+            dotFillColor = 0
             return
         }
         val ageSeconds = TimeUnit.MILLISECONDS.toSeconds(nowMs - selected.fixTimeMs)
@@ -678,7 +692,7 @@ class GoogleMapRenderer(
             val marker = map.addMarkerOrFail(
                 MarkerOptions()
                     .position(target.toLatLng())
-                    .icon(dataAgeIcon())
+                    .icon(dataAgeIcon(fillColor))
                     .anchor(0.5f, 0.5f)
                     .zIndex(0.5f)
                     .title(MOST_RECENT_DATA_TITLE)
@@ -686,6 +700,7 @@ class GoogleMapRenderer(
             )
             mostRecentDataMarker = marker
             dotAgeSeconds = ageSeconds
+            dotFillColor = fillColor
             // The dot is created only after a no-selection gap cleared the smoother, so just prime it
             // (records the shown position; no correction).
             dotSmoother.prime(selectedId, target, selected.fixTimeMs)
@@ -703,6 +718,10 @@ class GoogleMapRenderer(
             if (ageSeconds != dotAgeSeconds && !existing.isInfoWindowShown) {
                 existing.snippet = formatDataAge(context.resources, ageSeconds)
                 dotAgeSeconds = ageSeconds
+            }
+            if (fillColor != dotFillColor) {
+                existing.setIcon(dataAgeIcon(fillColor))
+                dotFillColor = fillColor
             }
         }
         dotSelectedId = selectedId
@@ -785,30 +804,41 @@ class GoogleMapRenderer(
         while (bandPolylines.size > band.size) {
             bandPolylines.removeAt(bandPolylines.size - 1).remove()
         }
-        // The fast-estimate marker owns its smoothing + fixed title; hand it the fresh fix + tick clock.
-        fastEstimate.update(overlay?.fastEstimatePoint, overlay?.fixTimeMs ?: 0L, nowMs)
+        // The fast-estimate marker owns its smoothing + fixed title; hand it the fresh fix + tick clock,
+        // and the band's colour to fill its disc with. A frame with no overlay leaves the marker gone.
+        fastEstimate.update(
+            overlay?.fastEstimatePoint,
+            overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR,
+            overlay?.fixTimeMs ?: 0L,
+            nowMs
+        )
     }
 
     /**
      * The selected vehicle's fast-estimate marker: owns its native [Marker] and its own
      * [CorrectionSmoother], with a fixed info-window [title] set at creation. [update] creates it on the
      * first non-null point, removes it on null, and smooths it across a fresh fix. The icon resolves lazily
-     * on first show via [iconProvider] (so it isn't built until a vehicle is selected). Driven every tick
-     * (the overlay sampler runs each frame), so the decay just progresses.
+     * on first show via [iconProvider] (so it isn't built until a vehicle is selected), filled with the
+     * band's colour and re-stamped when that colour changes (#1990). Driven every tick (the overlay
+     * sampler runs each frame), so the decay just progresses.
      */
     private inner class TripEstimateMarker(
-        private val iconProvider: () -> BitmapDescriptor,
+        private val iconProvider: (Int) -> BitmapDescriptor,
         private val title: String,
         private val zIndex: Float
     ) {
         private var marker: Marker? = null
         private val smoother = CorrectionSmoother()
 
-        fun update(point: GeoPoint?, fixTimeMs: Long, nowMs: Long) {
+        // The fill the current icon was stamped with; 0 whenever there is no marker.
+        private var iconFillColor: Int = 0
+
+        fun update(point: GeoPoint?, fillColor: Int, fixTimeMs: Long, nowMs: Long) {
             val existing = marker
             if (point == null) {
                 existing?.remove()
                 marker = null
+                iconFillColor = 0
                 smoother.retainOnly(emptySet()) // drop any in-flight correction + forget
                 return
             }
@@ -816,31 +846,37 @@ class GoogleMapRenderer(
                 marker = map.addMarkerOrFail(
                     MarkerOptions()
                         .position(point.toLatLng())
-                        .icon(iconProvider())
+                        .icon(iconProvider(fillColor))
                         .title(title)
                         .anchor(0.5f, 0.5f)
                         .zIndex(zIndex)
                 )
+                iconFillColor = fillColor
                 smoother.prime(ESTIMATE_EASE_KEY, point, fixTimeMs)
                 return
+            }
+            if (fillColor != iconFillColor) {
+                existing.setIcon(iconProvider(fillColor))
+                iconFillColor = fillColor
             }
             existing.position =
                 smoother.displayPosition(ESTIMATE_EASE_KEY, point, fixTimeMs, nowMs).toLatLng()
         }
 
         /** Remove the marker and drop any in-flight correction — the null-point branch of [update]. */
-        fun dispose() = update(null, 0L, 0L)
+        fun dispose() = update(null, TripMarkerBitmaps.DEFAULT_FILL_COLOR, 0L, 0L)
     }
 
     // The overlay/dot icons, cached through [descriptorCache] by a stable per-icon key so each resolves
     // lazily on first show and reuses one descriptor thereafter (released, with the rest, in [dispose]).
-    private fun fastEstimateIcon(): BitmapDescriptor = tripCircleIcon(R.drawable.ic_fast_estimate)
+    // Both are filled with the band's colour, and both glyphs are tinted to read on it by the shared
+    // bitmap factory — so the band, its origin and its leading end are visibly one object (#1990).
+    private fun fastEstimateIcon(fillColor: Int): BitmapDescriptor = tripCircleIcon(R.drawable.ic_fast_estimate, fillColor)
 
-    // The signal glyph is light, so tint it gray to read on the white disc (used by the most-recent-data dot).
-    private fun dataAgeIcon(): BitmapDescriptor = tripCircleIcon(R.drawable.ic_signal_indicator, TripMarkerBitmaps.STROKE_COLOR)
+    private fun dataAgeIcon(fillColor: Int): BitmapDescriptor = tripCircleIcon(R.drawable.ic_signal_indicator, fillColor)
 
-    private fun tripCircleIcon(drawableRes: Int, tintColor: Int = 0): BitmapDescriptor = descriptorCache.get("circle:$drawableRes:$tintColor") {
-        TripMarkerBitmaps.circle(context, drawableRes, tintColor)
+    private fun tripCircleIcon(drawableRes: Int, fillColor: Int): BitmapDescriptor = descriptorCache.get("circle:$drawableRes:$fillColor") {
+        TripMarkerBitmaps.circle(context, drawableRes, fillColor)
     }
 
     fun stopForMarker(marker: Marker): StopMarker? = stopMarkerLayer.stopForMarker(marker) ?: routeStopLayer.stopForMarker(marker)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -273,6 +273,13 @@ class MapViewModel @Inject constructor(
     val focusedRouteColors: StateFlow<Map<RouteDirectionKey, Int>> get() = routeController.focusedRouteColors
 
     /**
+     * The selected trip's uncertainty-band tint, or null when no vehicle is selected — see
+     * [RouteMapController.selectedTripBandColor]. The arrivals list outlines the focused trip's ETA pill
+     * in it, so the pill and the band on the map read as one object (#1990).
+     */
+    val selectedTripBandColor: StateFlow<Int?> get() = routeController.selectedTripBandColor
+
+    /**
      * Suspend map content padding while the rider aims the centre crosshair at a From/To point. The
      * captured point is the camera target, which padding would move off the crosshair — see
      * [org.onebusaway.android.map.render.MapRenderState.setCenterPickActive].

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -442,6 +442,10 @@ class RouteMapController(
             renderState.selectedVehicleTripId.collectLatest { tripId ->
                 showSelectionOverlay(tripId)
                 showSelectionPresentation(tripId)
+                // Re-stamp the vehicle discs: the newly selected one takes the band's colour and the
+                // previously selected one gives it back (#1990). After the presentation, because that is
+                // what settles [selectedTripLineColor] — the tint's basis — for this selection.
+                publishVehicleSet()
                 showContinuation(tripId)
             }
         }
@@ -604,8 +608,12 @@ class RouteMapController(
         // other (#2149).
         val colors = RouteColorInputs(poll, extraPolls, stopFocus.routeColors.value, palette)
         refreshRouteColorMemo(colors)
+        // Resolved once per sample, not per vehicle: at most one vehicle is selected, and the tint is an
+        // HSV round trip we'd otherwise repeat for every marker on the 20 Hz sampler.
+        val selectedId = renderState.selectedVehicleTripId.value
+        val bandColor = selectedId?.let { contrastingColor(selectedTripLineColor) }
         return MapVehicles(
-            markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source, colors) },
+            markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source, colors, selectedId, bandColor) },
             response = poll.response
         )
     }
@@ -924,6 +932,7 @@ class RouteMapController(
             selected = selectedTripRenderInput(routeColor),
             projectedFocusStops = focus::projectedStops
         )
+        val recoloured = selectedTripLineColor != (plan.selectedTripColor ?: routeColor)
         selectedTripLineColor = plan.selectedTripColor ?: routeColor
         renderState.setRoutePolylines(
             // Over a highlighted leg segment: the route's approach to the boarding point first, the rider's
@@ -940,6 +949,12 @@ class RouteMapController(
         )
         renderState.setRouteBadges(plan.badges)
         stopsController.setRoutePresentation(plan.stopPresentation)
+        // The band's tint is derived from the colour just settled above, and the selected vehicle's disc
+        // is drawn in it (#1990) — so a publish that recolours the trip's line has to re-stamp that disc
+        // too, or the vehicle keeps a tint of the line it *used* to be drawn over. Gated on an actual
+        // change (and on there being a selection to re-stamp), which is also what keeps this from
+        // bouncing: the republish reaches [publishVehicleSet], never back here.
+        if (recoloured && renderState.selectedVehicleTripId.value != null) publishVehicleSet()
     }
 
     /**
@@ -1283,8 +1298,17 @@ class RouteMapController(
      *
      * [response] is the poll this vehicle came out of — one of [colors]' own polls, since that pairing is
      * what [sampleVehicles] builds the vehicle list from.
+     *
+     * [bandColor] is the uncertainty band's tint, and reaches only the vehicle running [selectedTripId] —
+     * the one vehicle that has a band — so its disc joins the band's colour rather than its route's
+     * (#1990). Both are resolved once by [sampleVehicles] rather than per vehicle here.
      */
-    private fun ExtrapolatedVehicle.toMarker(response: RouteTrips, colors: RouteColorInputs): VehicleMarker = VehicleMarker(
+    private fun ExtrapolatedVehicle.toMarker(
+        response: RouteTrips,
+        colors: RouteColorInputs,
+        selectedTripId: String?,
+        bandColor: Int?
+    ): VehicleMarker = VehicleMarker(
         // Vehicles are only built for trips with a resolvable active id, so this is non-null here.
         activeTripId = status.activeTripId.orEmpty(),
         point = point,
@@ -1293,7 +1317,8 @@ class RouteMapController(
         fixTimeMs = fixTimeMs,
         bearing = bearing,
         dataFixPoint = dataFixPoint,
-        routeColor = displayedRouteColor(colors, response, status.activeTripId)
+        routeColor = displayedRouteColor(colors, response, status.activeTripId),
+        bandColor = bandColor?.takeIf { status.activeTripId == selectedTripId }
     )
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -43,6 +43,7 @@ import org.onebusaway.android.map.render.RouteContinuation
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineWidthProfile
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.map.render.TripOverlay
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.ObaRoute
@@ -353,6 +354,14 @@ class RouteMapController(
     // by collectLatest either way. Cancelled with the route session in [stop].
     private var selectionJob: Job? = null
 
+    // The colour the last publish drew the selected trip's line in — the uncertainty band's contrast
+    // basis, so the band contrasts the line that is on screen rather than the route's wire colour
+    // (#1990). Recorded from the plan ([RouteMapPresentation.selectedTripColor]) rather than re-derived,
+    // and falling back to the shown route's colour on a publish that drew no selected-trip line, since
+    // the band then lies over the base route instead. Read per frame by [showSelectionOverlay]'s sampler,
+    // so a republish that recolours the line recolours the band with it.
+    private var selectedTripLineColor: Int = DEFAULT_ROUTE_LINE_COLOR
+
     // A pending arrivals ETA-pill focus: the trip id whose live vehicle should be fit together with the
     // originating stop once it appears. Held until the first vehicle set arrives, then resolved once by
     // [tryFocusVehicle]: if a marker for the trip is on the map the camera fits the vehicle↔stop box;
@@ -647,7 +656,8 @@ class RouteMapController(
     /**
      * Install (or clear) the selected vehicle's trip overlay. When a vehicle is selected ([tripId]
      * non-null), drive a per-frame sampler that extrapolates its trip and draws the uncertainty band +
-     * fast-estimate marker, tinted to contrast the route line. The live vehicle disc is already the
+     * fast-estimate marker, tinted to contrast the trip line as drawn ([selectedTripLineColor], #1990) —
+     * a tint the band's own bounding markers are then filled with. The live vehicle disc is already the
      * best (median) estimate and route mode already shows the most-recent-data dot on selection, so the
      * overlay's own vehicle-point and data-age markers are suppressed — a focused vehicle gains only the
      * band + fast marker (#1752). Null (a deselect) clears the sampler.
@@ -657,10 +667,18 @@ class RouteMapController(
             renderState.setTripOverlaySampler(null)
             return
         }
-        val bandColor = contrastingColor(currentRouteColor())
         renderState.setTripOverlaySampler { nowMs ->
-            extrapolationFromState(tripObservationRepository.lookupTripState(tripId), WallTime(nowMs), includeMarkers = false)
-                ?.toTripOverlay(bandColor)
+            // Derived per frame off [selectedTripLineColor], not captured once here: the line the band
+            // lies over recolours under the selection (the route's own load landing, a stop-focus
+            // session opening or closing reassigning its adjacency hue), and a colour snapshotted at
+            // selection would stay contrasting the line that was drawn then (#1990).
+            val bandColor = contrastingColor(selectedTripLineColor)
+            val extrapolation =
+                extrapolationFromState(tripObservationRepository.lookupTripState(tripId), WallTime(nowMs), includeMarkers = false)
+            // A frame with no extrapolation at all (no shape, or no fix yet) still publishes the colour:
+            // the most-recent-data dot is drawn from the selection rather than from the band, and takes
+            // the band's colour whether or not there is a band to draw beside it.
+            extrapolation?.toTripOverlay(bandColor) ?: TripOverlay(markerColorArgb = bandColor)
         }
     }
 
@@ -861,8 +879,11 @@ class RouteMapController(
         renderState.setVehicleSet(null)
         renderState.setVehiclesSampler(null)
         renderState.setSelectedVehicle(null)
-        // The selection collector is cancelled above, so clear its overlays explicitly.
+        // The selection collector is cancelled above, so clear its overlays explicitly. The band's
+        // contrast basis goes back to the default with them — the publish above set it from the route
+        // this session is leaving, and the next session's first publish is what should decide it.
         renderState.setTripOverlaySampler(null)
+        selectedTripLineColor = DEFAULT_ROUTE_LINE_COLOR
         renderState.setRouteContinuation(null)
         _loadedRoute.value = null
     }
@@ -903,6 +924,7 @@ class RouteMapController(
             selected = selectedTripRenderInput(routeColor),
             projectedFocusStops = focus::projectedStops
         )
+        selectedTripLineColor = plan.selectedTripColor ?: routeColor
         renderState.setRoutePolylines(
             // Over a highlighted leg segment: the route's approach to the boarding point first, the rider's
             // remaining itinerary at a middle weight, then the ridden span(s) cased on top (#2048, #2082).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -362,6 +362,20 @@ class RouteMapController(
     // so a republish that recolours the line recolours the band with it.
     private var selectedTripLineColor: Int = DEFAULT_ROUTE_LINE_COLOR
 
+    private val _selectedTripBandColor = MutableStateFlow<Int?>(null)
+
+    /**
+     * The selected trip's uncertainty-band tint — the contrast of the line as drawn ([contrastingColor])
+     * — or null when no vehicle is selected.
+     *
+     * Published because the band's colour is no longer only the map's: the arrivals row outlines the
+     * focused trip's ETA pill in it (#1990), so the pill and the band it names are one object. Exposed as
+     * the resolved tint rather than as the line colour it derives from, so there is exactly one place
+     * that decides what contrasts what — a second caller applying [contrastingColor] itself would be free
+     * to apply it to a different basis, which is the bug this issue started as.
+     */
+    val selectedTripBandColor: StateFlow<Int?> = _selectedTripBandColor.asStateFlow()
+
     // A pending arrivals ETA-pill focus: the trip id whose live vehicle should be fit together with the
     // originating stop once it appears. Held until the first vehicle set arrives, then resolved once by
     // [tryFocusVehicle]: if a marker for the trip is on the map the camera fits the vehicle↔stop box;
@@ -892,6 +906,7 @@ class RouteMapController(
         // this session is leaving, and the next session's first publish is what should decide it.
         renderState.setTripOverlaySampler(null)
         selectedTripLineColor = DEFAULT_ROUTE_LINE_COLOR
+        _selectedTripBandColor.value = null
         renderState.setRouteContinuation(null)
         _loadedRoute.value = null
     }
@@ -934,6 +949,10 @@ class RouteMapController(
         )
         val recoloured = selectedTripLineColor != (plan.selectedTripColor ?: routeColor)
         selectedTripLineColor = plan.selectedTripColor ?: routeColor
+        // Republished here rather than from the selection collector alone, because both of its inputs land
+        // here: this publish is what settles the line's colour, and it is also what every selection change
+        // runs through ([showSelectionPresentation]). A deselect passes through it too and clears this.
+        _selectedTripBandColor.value = renderState.selectedVehicleTripId.value?.let { contrastingColor(selectedTripLineColor) }
         renderState.setRoutePolylines(
             // Over a highlighted leg segment: the route's approach to the boarding point first, the rider's
             // remaining itinerary at a middle weight, then the ridden span(s) cased on top (#2048, #2082).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
@@ -34,7 +34,15 @@ internal data class RouteMapPresentation(
     val framingPolylines: List<RoutePolyline>,
     val routeModeScalesStopsWithZoom: Boolean,
     val badges: List<RouteBadge>,
-    val stopPresentation: RouteStopPresentation?
+    val stopPresentation: RouteStopPresentation?,
+    /**
+     * The colour this plan drew the selected trip's own line in, or null when no selected trip line was
+     * drawn. Reported rather than left implicit because the uncertainty band is tinted to contrast the
+     * line it lies over, and the line's colour is decided here — a selection inside stop focus takes an
+     * adjacency hue, not the shown route's ([selectedTripStyle]), so the controller re-deriving it would
+     * be a second copy of that rule, free to disagree (#1990).
+     */
+    val selectedTripColor: Int? = null
 )
 
 /** A selected vehicle's exact trip, as read fresh after its shape/schedule resolve. */
@@ -124,7 +132,8 @@ internal fun assembleRouteMapPresentation(
                 framingPolylines = listOf(selectedTrip),
                 routeModeScalesStopsWithZoom = isActive,
                 badges = badges,
-                stopPresentation = selected.stopPresentation()
+                stopPresentation = selected.stopPresentation(),
+                selectedTripColor = style.color
             )
         }
         // A resolved-but-undrawable (< 2-point) trip falls through to the base/focus branches.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripOverlayTint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripOverlayTint.kt
@@ -27,10 +27,13 @@ import org.onebusaway.android.map.render.TripOverlay
 // map's selected-vehicle overlay ([RouteMapController]).
 
 /**
- * Produces a color that contrasts with [color] (the route line's color), so the uncertainty band reads
- * against the shape it's drawn over. Rotating the hue 180° works for a saturated line, but a
- * near-grayscale line (gray/black/white) has no meaningful hue to rotate — there we flip the value
- * (dark→white, light→black) instead so the band still stands out.
+ * Produces a color that contrasts with [color] — the color the line is **drawn** in, not the agency's
+ * raw GTFS color (#1990): the band is drawn over that line, and the map puts every route color through
+ * its own line policy ([mapRouteLineColor]) or a stop-focus adjacency hue before drawing it, so
+ * contrasting the wire color contrasts something that isn't on screen. Rotating
+ * the hue 180° works for a saturated line, but a near-grayscale line (gray/black/white) has no
+ * meaningful hue to rotate — there we flip the value (dark→white, light→black) instead so the band
+ * still stands out.
  */
 internal fun contrastingColor(color: Int): Int {
     val hsv = FloatArray(3)
@@ -47,6 +50,9 @@ internal fun contrastingColor(color: Int): Int {
  * Composites the display [bandColorArgb] onto this color-free [TripExtrapolation] to produce the render
  * [TripOverlay]: each band slice's model weight becomes the hue's alpha. Only the band + fast-estimate
  * marker are carried — the route map draws the live vehicle disc and the most-recent-data dot itself (#1752).
+ *
+ * The undimmed color rides along as [TripOverlay.markerColorArgb], because the markers that bound the
+ * band are filled with it (#1990) and a marker takes the band's *color*, not one slice's weight.
  */
 internal fun TripExtrapolation.toTripOverlay(bandColorArgb: Int): TripOverlay {
     val baseRgb = bandColorArgb and 0x00FFFFFF
@@ -56,6 +62,7 @@ internal fun TripExtrapolation.toTripOverlay(bandColorArgb: Int): TripOverlay {
             val alpha = (slice.weight.coerceIn(0f, 1f) * 255f).roundToInt()
             BandSegment(slice.points, (alpha shl 24) or baseRgb)
         },
-        fixTimeMs = fixTimeMs
+        fixTimeMs = fixTimeMs,
+        markerColorArgb = bandColorArgb or 0xFF000000.toInt()
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -228,7 +228,14 @@ data class VehicleMarker(
     // color (#2043). Resolved by the controller from the same map the polylines use, so the two
     // cannot disagree. Null when the route carries no color and none was assigned; the renderer applies
     // [DEFAULT_ROUTE_LINE_COLOR], exactly as [RoutePolyline.resolvedColor] does.
-    val routeColor: Int? = null
+    val routeColor: Int? = null,
+    // The uncertainty band's colour, on the **selected** vehicle only; null on every other one. Its disc
+    // is drawn in this instead of [routeColor], so the live estimate reads as part of the same data
+    // object as the band it sits in and the two markers that bound that band (#1990). Kept separate from
+    // [routeColor] rather than overwriting it: that field states which line this vehicle travels with,
+    // and it is still true of the selected vehicle — this only says what its disc is *drawn* in while it
+    // is the one carrying a band.
+    val bandColor: Int? = null
 )
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -40,8 +40,11 @@ const val STOP_ROUTES_ZOOM_THRESHOLD = 17.5f
 const val STOP_FOCUS_ROUTE_MIN_SCALE = 0.3f
 
 /**
- * Marker-group ordering. Native map SDKs always place markers above route polylines, but adjacent
- * route stops must still win every marker overlap; favorites remain above ordinary nearby stops.
+ * Marker-group ordering **within the stop group**. Native map SDKs always place markers above route
+ * polylines, but adjacent route stops must still win every overlap with another *stop*; favorites remain
+ * above ordinary nearby stops. Vehicles and the selected trip's estimate markers deliberately outrank the
+ * whole group — see the Google renderer's `VEHICLE_Z_INDEX`, which derives from
+ * [STOP_ROUTE_LABEL_Z_INDEX] for exactly that reason.
  */
 fun stopZIndex(routeStop: Boolean, favorite: Boolean): Float = when {
     routeStop -> 0.75f
@@ -53,6 +56,11 @@ fun stopZIndex(routeStop: Boolean, favorite: Boolean): Float = when {
  * A stop's route label (#2107) draws above every stop marker — including the enlarged focused one, whose
  * icon would otherwise cover the label of the stop behind it. Below the route labels a selected line
  * carries (`ROUTE_BADGE_Z_INDEX`), which name the map's current subject rather than what's merely nearby.
+ *
+ * Being the highest thing the stop group draws, this is also the group's **ceiling** for anything that has
+ * to stay tappable over a stop: the label is a wide pill floating above its point and is itself a tap
+ * target for that stop, so clearing [stopZIndex] alone doesn't clear the group. The renderers place the
+ * vehicle + trip-estimate markers relative to this constant rather than to a literal.
  */
 const val STOP_ROUTE_LABEL_Z_INDEX = 1f
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripMarkerBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripMarkerBitmaps.kt
@@ -20,6 +20,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import androidx.annotation.VisibleForTesting
+import androidx.collection.LruCache
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 
@@ -53,13 +54,30 @@ object TripMarkerBitmaps {
     @VisibleForTesting
     internal const val STROKE_WIDTH_DP = 2f
 
-    private val cache = HashMap<Long, Bitmap>()
+    /**
+     * Bounded in **bytes**, not entries, for the reason [VehicleBitmaps]' cache is: a disc is ~28 KiB at
+     * xxhdpi and ~50 KiB at xxxhdpi, so an entry count would mean wildly different memory on different
+     * devices for the same nominal size.
+     *
+     * An LRU rather than the plain map this was, because taking the caller's fill turned a fixed key
+     * space into an open one: it used to be two drawables x two tints — four bitmaps, for the life of the
+     * process — and is now two drawables x however many band colours a session ever shows, which is a
+     * fresh hue per route and per stop-focus adjacency slot. This is an `object`, so unbounded it would
+     * outlive every renderer that filled it. 512 KiB holds ~18 discs at xxhdpi, against a working set of
+     * exactly two (one selection's dot + fast estimate); the slack is what keeps flipping between
+     * recently-visited selections off the render path. Overflow only costs a re-render.
+     */
+    private val cache = object : LruCache<Long, Bitmap>(MAX_CACHE_BYTES) {
+        override fun sizeOf(key: Long, value: Bitmap): Int = value.allocationByteCount
+    }
+
+    private const val MAX_CACHE_BYTES = 512 * 1024
 
     /** A circular marker for [drawableRes] centered on a disc filled [fillColor] (forced opaque). */
     fun circle(context: Context, drawableRes: Int, fillColor: Int = DEFAULT_FILL_COLOR): Bitmap {
         val opaqueFill = fillColor or OPAQUE_ALPHA
         val key = (drawableRes.toLong() shl 32) or (opaqueFill.toLong() and 0xFFFFFFFFL)
-        return cache.getOrPut(key) { draw(context, drawableRes, opaqueFill) }
+        return cache.get(key) ?: draw(context, drawableRes, opaqueFill).also { cache.put(key, it) }
     }
 
     private fun draw(context: Context, drawableRes: Int, fillColor: Int): Bitmap {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripMarkerBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripMarkerBitmaps.kt
@@ -19,46 +19,56 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 
 /**
- * Circular trip-marker bitmaps: a dark-stroked, opaque-white-filled disc with a drawable centered
- * inside (ported from the feature's Google-only MapIconUtils.createCircleIcon, lifted to `src/main` so
- * both flavors share it — the Google adapter wraps the Bitmap in a `BitmapDescriptor`, maplibre in an
- * `Icon`). Used for the trip map's extrapolated-vehicle / fast-estimate / last-fix markers. The fill is
- * fully opaque: these markers overlap and move every frame, so a translucent fill makes the blended
- * overlap shimmer. Cached per (drawable, tint).
+ * Circular trip-marker bitmaps: a ringed, opaque-filled disc with a drawable centered inside (ported
+ * from the feature's Google-only MapIconUtils.createCircleIcon, lifted to `src/main` so both flavors
+ * share it — the Google adapter wraps the Bitmap in a `BitmapDescriptor`, maplibre in an `Icon`). Used
+ * for the trip map's extrapolated-vehicle / fast-estimate / last-fix markers. The fill is fully opaque:
+ * these markers overlap and move every frame, so a translucent fill makes the blended overlap shimmer.
+ * Cached per (drawable, fill).
+ *
+ * The **fill is the caller's** — the selected trip's markers take the uncertainty band's own colour, so
+ * a rider reads the band, the fix it starts at and the fast estimate it ends at as one data object
+ * rather than three unrelated map decorations (#1990). Everything drawn *on* the disc (the ring and the
+ * glyph) is then whichever of black/white reads against that fill ([MarkerRendering.legibleOn]), the
+ * same call every other route-coloured map element makes — so no fill can render a marker's own ring or
+ * glyph invisible, as a fixed gray pair chosen for a white disc could.
  */
 object TripMarkerBitmaps {
 
-    /** The stroke + tint color (gray); callers tint a light glyph (e.g. the signal indicator) with it. */
-    const val STROKE_COLOR = 0xFF616161.toInt()
+    /** The default disc fill, for a marker with no data colour of its own to take. */
+    const val DEFAULT_FILL_COLOR = 0xFFFFFFFF.toInt()
+
+    private const val OPAQUE_ALPHA = 0xFF000000.toInt()
 
     private const val ICON_SIZE_DP = 28
-    private const val ICON_PADDING_DP = 4
-    private const val STROKE_WIDTH_DP = 2f
 
-    // Fully opaque: overlapping, per-frame-moving estimate markers blend visibly with a translucent fill.
-    private const val FILL_COLOR = 0xFFFFFFFF.toInt()
+    @VisibleForTesting
+    internal const val ICON_PADDING_DP = 4
+
+    @VisibleForTesting
+    internal const val STROKE_WIDTH_DP = 2f
 
     private val cache = HashMap<Long, Bitmap>()
 
-    /**
-     * A circular marker for [drawableRes] centered on the disc. [tintColor] tints the glyph when
-     * non-zero (use it for light/white glyphs like the signal indicator); 0 keeps its intrinsic color.
-     */
-    fun circle(context: Context, drawableRes: Int, tintColor: Int = 0): Bitmap {
-        val key = (drawableRes.toLong() shl 32) or (tintColor.toLong() and 0xFFFFFFFFL)
-        return cache.getOrPut(key) { draw(context, drawableRes, tintColor) }
+    /** A circular marker for [drawableRes] centered on a disc filled [fillColor] (forced opaque). */
+    fun circle(context: Context, drawableRes: Int, fillColor: Int = DEFAULT_FILL_COLOR): Bitmap {
+        val opaqueFill = fillColor or OPAQUE_ALPHA
+        val key = (drawableRes.toLong() shl 32) or (opaqueFill.toLong() and 0xFFFFFFFFL)
+        return cache.getOrPut(key) { draw(context, drawableRes, opaqueFill) }
     }
 
-    private fun draw(context: Context, drawableRes: Int, tintColor: Int): Bitmap {
+    private fun draw(context: Context, drawableRes: Int, fillColor: Int): Bitmap {
         val density = context.resources.displayMetrics.density
         val sizePx = (ICON_SIZE_DP * density).toInt()
         val padding = (ICON_PADDING_DP * density).toInt()
         val strokeWidth = STROKE_WIDTH_DP * density
         val center = sizePx / 2f
+        val onFill = MarkerRendering.legibleOn(fillColor)
 
         val bitmap = createBitmap(sizePx, sizePx)
         val canvas = Canvas(bitmap)
@@ -68,7 +78,7 @@ object TripMarkerBitmaps {
             center,
             center - strokeWidth / 2f,
             Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = STROKE_COLOR
+                color = onFill
                 style = Paint.Style.STROKE
                 this.strokeWidth = strokeWidth
             }
@@ -78,13 +88,15 @@ object TripMarkerBitmaps {
             center,
             center - strokeWidth,
             Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = FILL_COLOR
+                color = fillColor
                 style = Paint.Style.FILL
             }
         )
 
-        ContextCompat.getDrawable(context, drawableRes)?.apply {
-            if (tintColor != 0) setTint(tintColor)
+        // mutate(), because the glyph is now tinted per fill colour: without it the tint would be written
+        // into the shared ConstantState and recolour every other use of the same drawable.
+        ContextCompat.getDrawable(context, drawableRes)?.mutate()?.apply {
+            setTint(onFill)
             setBounds(padding, padding, sizePx - padding, sizePx - padding)
             draw(canvas)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
@@ -47,9 +47,14 @@ data class DataAgeMarker(val point: GeoPoint, val ageMillis: Long)
  * @property band the graded uncertainty band over the route shape (empty when no estimate)
  * @property fixTimeMs the latest AVL fix's timestamp — constant between fixes, so a change signals
  *   fresh data; the renderer animates the marker to its new position when it changes
+ * @property markerColorArgb the band's own colour, opaque — the fill for the markers that bound the
+ *   band (the fast estimate at its leading end, the most-recent-data dot at its origin), so the three
+ *   read as one data object rather than as unrelated decorations (#1990). Carried even on a frame with
+ *   no estimate at all, because the data dot is drawn from the selection, not from the band
  */
 data class TripOverlay(
     val fastEstimatePoint: GeoPoint? = null,
     val band: List<BandSegment> = emptyList(),
-    val fixTimeMs: Long = 0L
+    val fixTimeMs: Long = 0L,
+    val markerColorArgb: Int = TripMarkerBitmaps.DEFAULT_FILL_COLOR
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -267,10 +267,17 @@ object VehicleBitmaps {
      * line with, which is *not* always its GTFS color; see there — under the same
      * [DEFAULT_ROUTE_LINE_COLOR] fallback [RoutePolyline.resolvedColor] applies, so a vehicle and its
      * line always match.
+     *
+     * The one exception is the **selected** vehicle, which takes [VehicleMarker.bandColor] instead: it is
+     * the median estimate at the middle of its own uncertainty band, and drawing it in the band's colour
+     * (as the two markers bounding that band are) says so (#1990). Identity is not lost with it — the
+     * selected vehicle is the one the rider just picked out, and the band beneath it is drawn along its
+     * line. Liveness still wins over both: a scheduled vehicle stays gray, which is also why a selection
+     * can only reach this branch while it is live, exactly as the band itself can.
      */
     @VisibleForTesting
     internal fun discColor(context: Context, vehicle: VehicleMarker): Int = if (vehicle.isRealtime) {
-        vehicle.routeColor ?: DEFAULT_ROUTE_LINE_COLOR
+        vehicle.bandColor ?: vehicle.routeColor ?: DEFAULT_ROUTE_LINE_COLOR
     } else {
         ContextCompat.getColor(context, ScheduleDeviation.Status.SCHEDULED.displayColorRes)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsScreen.kt
@@ -360,6 +360,8 @@ internal fun ArrivalsList(
     modifier: Modifier = Modifier,
     /** Stop-focus map colors keyed by route-direction. Empty outside the home drawer. */
     mapRouteColors: Map<RouteDirectionKey, Int> = emptyMap(),
+    // The selected trip's band tint (#1990), or null when no vehicle is selected.
+    selectedTripBandColor: Int? = null,
     /** Exact route-direction row selected over the home map's stop focus; null outside that state. */
     selectedRowKey: String? = null,
     /** Origin route used to resolve an unambiguous row when map and arrivals headsign labels differ. */
@@ -440,6 +442,7 @@ internal fun ArrivalsList(
                     isFavorite = group.routeId in content.favoriteRouteIds,
                     callbacks = rowCallbacks,
                     mapRouteColor = mapRouteColors[RouteDirectionKey(group.routeId, group.directionId)],
+                    selectedTripBandColor = selectedTripBandColor,
                     selected = isSelectedRow,
                     selectedRouteNames = if (isSelectedRow) selectedRouteNames else emptyList(),
                     selectedTripId = selectedTripId.takeIf { isSelectedRow },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -274,6 +274,29 @@ internal fun ArrivalRowContent(
 }
 
 /**
+ * The colour of the focused trip's ETA-pill rim, or null when no pill should be outlined.
+ *
+ * The pill's rim and the row card's own selection stroke mark **different selections**, and since #1990
+ * they say so in different colours. The card's says *this route* is the one the map is showing, and keeps
+ * the colour that route's line is drawn in ([cardSelectionColor]). The pill's says *this trip* is the one
+ * drilled into — and the map draws that trip's whole estimate (the uncertainty band, the fix it starts
+ * from, the fast estimate it ends at, and the vehicle in the middle) in one contrasting colour. Wearing
+ * that colour is what makes the pill a member of that set rather than a second, differently-scoped copy
+ * of the route highlight, which is what it was when #2205 first gave it the card's stroke to borrow.
+ *
+ * [bandColor] is null whenever the map has no band to name — nothing selected yet, or a trip with no
+ * real-time fix to extrapolate — and the pill falls back to borrowing the card's stroke as it used to.
+ *
+ * [selected] gates both, because [bandColor] arrives as one map-wide value rather than per row: without
+ * the gate a stale trip id would outline a pill in a row that isn't the focused one.
+ */
+internal fun focusedPillRimColor(
+    selected: Boolean,
+    bandColor: Int?,
+    cardSelectionColor: Int?
+): Int? = if (selected) bandColor ?: cardSelectionColor else null
+
+/**
  * One arrivals row for a single (route, direction): the route badge on the left, and on the right
  * the direction name over a horizontally-scrollable strip of per-trip ETA pills (soonest first).
  * The unified row (issue #1707) — replaces the old per-trip Style A row and Style B card.
@@ -306,6 +329,9 @@ fun RouteArrivalRow(
     // meaningful on the selected row, and gated on [selected] below so a stale id can't outline a pill
     // in a row that isn't the focused one.
     selectedTripId: String? = null,
+    // The uncertainty band's tint for [selectedTripId] on the map, or null when no vehicle is selected.
+    // The focused pill's rim wears it (#1990) — see [pillFocus] below.
+    selectedTripBandColor: Int? = null,
     etaAnchor: Modifier = Modifier,
     // Whether a live countdown is running for this row (#2166) — the row's menu picks its verb and
     // glyph from it, and the corner eye appears. Resolved by the list, like [isFavorite]: set
@@ -334,9 +360,9 @@ fun RouteArrivalRow(
     val selectionBorder = selectionColor
         ?.takeIf { selected }
         ?.let { BorderStroke(2.dp, Color(it)) }
-    // The focused trip's pill wears the card's own selection border — the same stroke object — so the
-    // two outlines read as one focus rather than two unrelated highlights (#2205).
-    val pillFocus = selectionBorder?.let { border -> selectedTripId?.let { EtaPillFocus(it, border) } }
+    val pillBorder = focusedPillRimColor(selected, selectedTripBandColor, selectionColor)
+        ?.let { BorderStroke(2.dp, Color(it)) }
+    val pillFocus = pillBorder?.let { border -> selectedTripId?.let { EtaPillFocus(it, border) } }
     ArrivalCard(modifier, border = selectionBorder) {
         Box(Modifier.fillMaxWidth()) {
             Row(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -54,6 +54,8 @@ fun ArrivalsPanel(
     listState: LazyListState,
     handler: ArrivalActionHandler,
     mapRouteColors: Map<RouteDirectionKey, Int> = emptyMap(),
+    // The selected trip's band tint (#1990), or null when no vehicle is selected.
+    selectedTripBandColor: Int? = null,
     selectedRowKey: String? = null,
     selectedRouteId: String? = null,
     selectedRouteNames: List<String> = emptyList(),
@@ -89,6 +91,7 @@ fun ArrivalsPanel(
                     // only recompose that one item, not this whole panel.
                     loadingMore = viewModel.loadingMore,
                     mapRouteColors = mapRouteColors,
+                    selectedTripBandColor = selectedTripBandColor,
                     selectedRowKey = selectedRowKey,
                     selectedRouteId = selectedRouteId,
                     selectedRouteNames = selectedRouteNames,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -244,6 +244,7 @@ fun HomeScreen(
                 val stopFocus = currentFocus as? CurrentFocus.Stop
                 val canUndoMapAction by homeViewModel.canUndoMapAction.collectAsStateWithLifecycle()
                 val mapRouteColors by mapViewModel.focusedRouteColors.collectAsStateWithLifecycle()
+                val selectedTripBandColor by mapViewModel.selectedTripBandColor.collectAsStateWithLifecycle()
                 val focusBannerViewModel = hiltViewModel<FocusBannerViewModel>()
                 // The transit-centre drawer's query (#2107). Created here — the sheet is this screen's
                 // — and fed the settled viewport + zoom band by MapFeature, which holds the map VM.
@@ -684,6 +685,7 @@ fun HomeScreen(
                                             state = arrivalsState,
                                             selectedRoute = stopFocus?.selectedRoute,
                                             mapRouteColors = mapRouteColors,
+                                            selectedTripBandColor = selectedTripBandColor,
                                             onContentHeight = { px -> contentPx = px }
                                         )
                                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/arrivals/ArrivalsSheetHost.kt
@@ -154,6 +154,8 @@ internal fun ArrivalsSheetHost(
     state: ArrivalsUiState,
     selectedRoute: StopRouteSelection?,
     mapRouteColors: Map<RouteDirectionKey, Int>,
+    // The selected trip's band tint (#1990), or null when no vehicle is selected.
+    selectedTripBandColor: Int?,
     onContentHeight: (heightPx: Int) -> Unit
 ) {
     session ?: return
@@ -165,6 +167,7 @@ internal fun ArrivalsSheetHost(
             listState = session.listState,
             handler = session.handler,
             mapRouteColors = mapRouteColors,
+            selectedTripBandColor = selectedTripBandColor,
             selectedRowKey = selectedRoute?.selectedArrivalRowKey(),
             selectedRouteId = selectedRoute?.originLeg?.routeId,
             selectedRouteNames = selectedRoute?.legs?.map { it.shortName }.orEmpty(),

--- a/onebusaway-android/src/main/res/drawable/ic_fast_estimate.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_fast_estimate.xml
@@ -3,7 +3,9 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <!-- Lightning bolt (placeholder for fast estimate icon) -->
+    <!-- Lightning bolt (placeholder for fast estimate icon). The authored fill never reaches the map:
+         TripMarkerBitmaps tints the glyph to read on the marker's disc, which is the uncertainty band's
+         colour (#1990). -->
     <path
         android:fillColor="#FF616161"
         android:pathData="M11,21h-1l1,-7H7.5c-0.58,0 -0.57,-0.32 -0.38,-0.66 0.19,-0.34 0.05,-0.08 0.07,-0.12C8.48,10.94 10.42,7.54 13,3h1l-1,7h3.5c0.49,0 0.56,0.33 0.47,0.51L11,21z"/>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -221,10 +221,16 @@ class MapLibreRenderer(
 
     private val iconFactory = IconFactory.getInstance(context)
 
-    // Trip-marker icons by (drawable, fill). Cached because every `iconFactory.fromBitmap` mints a fresh
-    // native sprite id, and these are asked for on the per-frame path; the set is tiny (two glyphs x the
-    // handful of band colours a session sees).
-    private val tripCircleIcons = HashMap<Pair<Int, Int>, Icon>()
+    // Trip-marker icons by (drawable, fill). Cached because every `iconFactory.fromBitmap` carries a full
+    // ARGB copy of its bitmap and mints a fresh native sprite id, and these sit on the per-frame path.
+    //
+    // An LRU rather than a plain map, for the same reason [routeBadgeIcons] is one: the fill dimension of
+    // the key is the band's colour, which turns over with every route and every stop-focus adjacency slot
+    // the session shows, so unbounded this retains a bitmap and a sprite per colour it ever drew. Only one
+    // selection exists at a time, so the live working set is two entries — the slack is what keeps
+    // flipping between recently-visited selections off the render path. Evicting is safe for the reason it
+    // is there: a marker holds its own reference to the Icon it was given. Freed in [dispose].
+    private val tripCircleIcons = LruCache<Pair<Int, Int>, Icon>(TRIP_ICON_CACHE_SIZE)
 
     // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION],
     // recentered each frame on trip [pingTripId]'s vehicle marker so it follows the icon as it settles (the
@@ -424,7 +430,7 @@ class MapLibreRenderer(
         vehicleMarkersByTripId.clear()
         tripMarkersByRole.clear()
         tripMarkerFills.clear()
-        tripCircleIcons.clear()
+        tripCircleIcons.evictAll()
         bandPolylines.clear()
         vehicleByMarker.clear()
         rentalByMarker.clear()
@@ -731,8 +737,11 @@ class MapLibreRenderer(
 
     private fun dataAgeIcon(fillColor: Int): Icon = tripCircleIcon(R.drawable.ic_signal_indicator, fillColor)
 
-    private fun tripCircleIcon(drawableRes: Int, fillColor: Int): Icon = tripCircleIcons.getOrPut(drawableRes to fillColor) {
-        iconFactory.fromBitmap(TripMarkerBitmaps.circle(context, drawableRes, fillColor))
+    private fun tripCircleIcon(drawableRes: Int, fillColor: Int): Icon {
+        val key = drawableRes to fillColor
+        return tripCircleIcons.get(key)
+            ?: iconFactory.fromBitmap(TripMarkerBitmaps.circle(context, drawableRes, fillColor))
+                .also { tripCircleIcons.put(key, it) }
     }
     fun stopForMarker(marker: Marker): StopMarker? = stopMarkerLayer.stopForMarker(marker)
 
@@ -794,6 +803,11 @@ class MapLibreRenderer(
         // either theme. Matches the Google flavor's DESCRIPTOR_CACHE_SIZE, which covers the same badges
         // alongside its other icons.
         private const val BADGE_ICON_CACHE_SIZE = 256
+
+        // Two glyphs (the fast estimate, the most-recent-data dot) across the last several band colours.
+        // Far smaller than the badge cache because only one vehicle is selected at a time, so exactly two
+        // of these are ever on the map at once; this is reuse across selections, not a working set.
+        private const val TRIP_ICON_CACHE_SIZE = 16
     }
 }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -192,6 +192,10 @@ class MapLibreRenderer(
     // each vehicle-set reconcile, so a scale change can re-stamp the retained markers' icons.
     private val vehicleMarkersByTripId = HashMap<String, Marker>()
     private val tripMarkersByRole = HashMap<String, Marker>()
+
+    // The fill each trip marker's icon is currently stamped with, so a role is re-stamped only when its
+    // band colour changes (#1990); dropped with the marker.
+    private val tripMarkerFills = HashMap<String, Int>()
     private val bandPolylines = mutableListOf<Polyline>()
     private var lastVehicleResponse: RouteTrips? = null
 
@@ -211,7 +215,16 @@ class MapLibreRenderer(
     private var dotFixTimeMs: Long = 0L
     private var dotAgeSeconds: Long = -1L
 
+    // The fill the dot's icon is currently stamped with (the band's colour, #1990), so it's re-stamped
+    // only when that colour actually changes. 0 whenever there is no dot — not a colour any fill can be.
+    private var dotFillColor: Int = 0
+
     private val iconFactory = IconFactory.getInstance(context)
+
+    // Trip-marker icons by (drawable, fill). Cached because every `iconFactory.fromBitmap` mints a fresh
+    // native sprite id, and these are asked for on the per-frame path; the set is tiny (two glyphs x the
+    // handful of band colours a session sees).
+    private val tripCircleIcons = HashMap<Pair<Int, Int>, Icon>()
 
     // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION],
     // recentered each frame on trip [pingTripId]'s vehicle marker so it follows the icon as it settles (the
@@ -386,7 +399,10 @@ class MapLibreRenderer(
      * across a fresh fix via [nowMs]); the band is re-added.
      */
     fun renderDynamic(overlay: TripOverlay?, vehicles: MapVehicles?, nowMs: Long) {
-        moveVehicles(vehicles, nowMs)
+        // The dot is the band's origin marker, so it is filled with the band's colour (#1990) — carried on
+        // the overlay even when that frame has no band to draw. Only a selection with no overlay at all
+        // (nothing selected, so no dot either) reaches the default.
+        moveVehicles(vehicles, overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR, nowMs)
         updateTripOverlay(overlay, nowMs)
     }
 
@@ -407,6 +423,8 @@ class MapLibreRenderer(
         staticAnnotations.clear()
         vehicleMarkersByTripId.clear()
         tripMarkersByRole.clear()
+        tripMarkerFills.clear()
+        tripCircleIcons.clear()
         bandPolylines.clear()
         vehicleByMarker.clear()
         rentalByMarker.clear()
@@ -491,14 +509,14 @@ class MapLibreRenderer(
     // A gliding vehicle used to need its direction arrow re-stamped whenever its heading octant flipped;
     // since #2194 removed that arrow, nothing about the icon varies between polls (see
     // [VehicleBitmaps.iconKey]), so the whole per-frame icon path is gone.
-    private fun moveVehicles(vehicles: MapVehicles?, nowMs: Long) {
+    private fun moveVehicles(vehicles: MapVehicles?, dotFill: Int, nowMs: Long) {
         for (vehicle in vehicles?.markers.orEmpty()) {
             val marker = vehicleMarkersByTripId[vehicle.activeTripId] ?: continue
             marker.moveTo(
                 vehicleSmoother.displayPosition(vehicle.activeTripId, vehicle.point, vehicle.fixTimeMs, nowMs).toLatLng()
             )
         }
-        updateMostRecentDataDot(nowMs)
+        updateMostRecentDataDot(dotFill, nowMs)
     }
 
     /**
@@ -511,8 +529,12 @@ class MapLibreRenderer(
      * As on Google, the marker is touched only on an actual change or while a fix correction is still
      * settling — never an unconditional per-tick set, which would redraw an open bubble; the age is
      * refreshed only while the bubble is closed.
+     *
+     * [fillColor] is the uncertainty band's colour: the dot marks the band's origin, so it is filled with
+     * it (#1990), and re-stamped whenever that colour changes — which is only when the selected trip's
+     * line recolours, not per tick.
      */
-    private fun updateMostRecentDataDot(nowMs: Long) {
+    private fun updateMostRecentDataDot(fillColor: Int, nowMs: Long) {
         val selectedId = renderState.selectedVehicleTripId.value
         // Read the dot's inputs from the reconciled (per-poll) set, not the per-frame motion samples:
         // the fix point + age are discrete, changing only when a new poll lands, and the set is where the
@@ -529,6 +551,7 @@ class MapLibreRenderer(
             dotSmoother.retainOnly(emptySet())
             dotSelectedId = null
             dotAgeSeconds = -1L
+            dotFillColor = 0
             return
         }
         val ageSeconds = TimeUnit.MILLISECONDS.toSeconds(nowMs - selected.fixTimeMs)
@@ -537,11 +560,12 @@ class MapLibreRenderer(
             mostRecentDataMarker = map.addMarker(
                 MarkerOptions()
                     .position(target.toLatLng())
-                    .icon(dataAgeIcon)
+                    .icon(dataAgeIcon(fillColor))
                     .title(context.getString(R.string.marker_most_recent_data))
                     .snippet(formatDataAge(context.resources, ageSeconds))
             )
             dotAgeSeconds = ageSeconds
+            dotFillColor = fillColor
             // The dot is created only after a no-selection gap cleared the smoother, so just prime it
             // (records the shown position; no correction).
             dotSmoother.prime(selectedId, target, selected.fixTimeMs)
@@ -556,6 +580,10 @@ class MapLibreRenderer(
             if (ageSeconds != dotAgeSeconds && !existing.isInfoWindowShown) {
                 existing.snippet = formatDataAge(context.resources, ageSeconds)
                 dotAgeSeconds = ageSeconds
+            }
+            if (fillColor != dotFillColor) {
+                existing.icon = dataAgeIcon(fillColor)
+                dotFillColor = fillColor
             }
         }
         dotSelectedId = selectedId
@@ -645,16 +673,29 @@ class MapLibreRenderer(
             map.removeAnnotation(bandPolylines.removeAt(bandPolylines.size - 1))
         }
         // The fast-estimate marker moves in place (keeping any open info window); the fix instant drives
-        // the smoother's correction.
-        updateTripMarker("fast", overlay?.fastEstimatePoint, fastEstimateIcon, "Fast estimate", overlay?.fixTimeMs ?: 0L, nowMs)
+        // the smoother's correction. Its disc is filled with the band's own colour (#1990).
+        updateTripMarker(
+            "fast",
+            overlay?.fastEstimatePoint,
+            ::fastEstimateIcon,
+            overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR,
+            "Fast estimate",
+            overlay?.fixTimeMs ?: 0L,
+            nowMs
+        )
         // Drop smoother state for the marker's role once it's gone (overlay went null on deselect).
         tripSmoother.retainOnly(tripMarkersByRole.keys)
     }
 
+    /**
+     * [icon] resolves lazily from [fillColor] so no icon is built for a role with nothing to draw, and
+     * the marker is re-stamped only when its fill actually changes (#1990) — never per frame.
+     */
     private fun updateTripMarker(
         role: String,
         point: GeoPoint?,
-        icon: Icon,
+        icon: (Int) -> Icon,
+        fillColor: Int,
         title: String,
         fixTimeMs: Long,
         nowMs: Long
@@ -664,28 +705,34 @@ class MapLibreRenderer(
             existing?.let {
                 map.removeAnnotation(it)
                 tripMarkersByRole.remove(role)
+                tripMarkerFills.remove(role)
             }
             return
         }
         if (existing == null) {
             tripMarkersByRole[role] =
-                map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon).title(title))
+                map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon(fillColor)).title(title))
+            tripMarkerFills[role] = fillColor
             tripSmoother.prime(role, point, fixTimeMs)
         } else {
+            if (tripMarkerFills[role] != fillColor) {
+                existing.icon = icon(fillColor)
+                tripMarkerFills[role] = fillColor
+            }
             existing.moveTo(tripSmoother.displayPosition(role, point, fixTimeMs, nowMs).toLatLng())
             if (existing.title != title) existing.title = title
         }
     }
 
-    private val fastEstimateIcon: Icon by lazy {
-        iconFactory.fromBitmap(TripMarkerBitmaps.circle(context, R.drawable.ic_fast_estimate))
-    }
+    // Both trip-marker discs are filled with the band's colour, and both glyphs are tinted to read on it
+    // by the shared bitmap factory — so the band, its origin and its leading end are visibly one object
+    // (#1990). Each distinct fill mints a native sprite id, so they're cached rather than rebuilt.
+    private fun fastEstimateIcon(fillColor: Int): Icon = tripCircleIcon(R.drawable.ic_fast_estimate, fillColor)
 
-    // The signal glyph is light, so tint it gray to read on the white disc (the most-recent-data dot).
-    private val dataAgeIcon: Icon by lazy {
-        iconFactory.fromBitmap(
-            TripMarkerBitmaps.circle(context, R.drawable.ic_signal_indicator, TripMarkerBitmaps.STROKE_COLOR)
-        )
+    private fun dataAgeIcon(fillColor: Int): Icon = tripCircleIcon(R.drawable.ic_signal_indicator, fillColor)
+
+    private fun tripCircleIcon(drawableRes: Int, fillColor: Int): Icon = tripCircleIcons.getOrPut(drawableRes to fillColor) {
+        iconFactory.fromBitmap(TripMarkerBitmaps.circle(context, drawableRes, fillColor))
     }
     fun stopForMarker(marker: Marker): StopMarker? = stopMarkerLayer.stopForMarker(marker)
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -176,6 +177,7 @@ class RouteMapPresentationPlanTest {
         assertEquals(0xFF00FF00.toInt(), trip.color)
         assertEquals(listOf(trip), plan.framingPolylines)
         assertSame(selectedStops, plan.stopPresentation)
+        assertEquals(trip.color, plan.selectedTripColor)
     }
 
     @Test
@@ -199,6 +201,9 @@ class RouteMapPresentationPlanTest {
         // reads via its adjacency colour (the #1899 regression case).
         assertEquals(1, plan.polylines.size)
         assertEquals(adjacencyColor, plan.polylines.single().color)
+        // ...and that adjacency colour, not the route's own, is what the band contrasts (#1990): the
+        // reported colour is the one the line was actually drawn in.
+        assertEquals(adjacencyColor, plan.selectedTripColor)
     }
 
     @Test
@@ -244,6 +249,9 @@ class RouteMapPresentationPlanTest {
 
         assertSame(basePolylines, plan.polylines)
         assertSame(baseStops, plan.stopPresentation)
+        // Nothing was drawn for the selection, so there is no drawn colour to report and the band falls
+        // back to contrasting the base route it actually lies over (#1990).
+        assertNull(plan.selectedTripColor)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/FocusedPillRimColorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/FocusedPillRimColorTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Which colour the focused trip's ETA-pill rim wears (#1990). The rim's *presence* is covered from the
+ * other side by the instrumented `EtaPillFocusOutlineTest`, which asserts semantics rather than colour;
+ * this pins the colour choice, which is the part that can silently regress to the card's stroke.
+ */
+class FocusedPillRimColorTest {
+
+    private val band = 0xFFC05010.toInt()
+    private val routeLine = 0xFF0A5B3E.toInt()
+
+    @Test
+    fun `the band colour wins over the card's route colour`() {
+        assertEquals(band, focusedPillRimColor(selected = true, bandColor = band, cardSelectionColor = routeLine))
+    }
+
+    @Test
+    fun `with no band the pill borrows the card's stroke`() {
+        // No vehicle selected yet, or a trip with no real-time fix to extrapolate: the map has no band
+        // to name, so the pre-#1990 behaviour (#2205's borrowed stroke) is what's left to show.
+        assertEquals(routeLine, focusedPillRimColor(selected = true, bandColor = null, cardSelectionColor = routeLine))
+    }
+
+    @Test
+    fun `an unselected row is never outlined`() {
+        // The band colour is one map-wide value handed to every row, so the gate is what keeps it from
+        // outlining a pill in a row that isn't the focused one.
+        assertNull(focusedPillRimColor(selected = false, bandColor = band, cardSelectionColor = routeLine))
+        assertNull(focusedPillRimColor(selected = false, bandColor = null, cardSelectionColor = routeLine))
+    }
+
+    @Test
+    fun `a selected row with no colour at all stays unoutlined`() {
+        assertNull(focusedPillRimColor(selected = true, bandColor = null, cardSelectionColor = null))
+    }
+}


### PR DESCRIPTION
Fixes #1990.

### 1. Contrast the route **as displayed**

The uncertainty band is tinted to contrast the line it lies over, but it took its basis from `currentRouteColor()` — the *shown route's* colour — captured once, when the vehicle was selected. Two ways that missed the line actually on screen:

- Inside a stop-focus session the selected trip's line is drawn in that stop's **adjacency hue**, not the route's (`selectedTripStyle`, #1902). The band was then complementary to a colour that wasn't drawn anywhere.
- The snapshot went stale: the route's own load landing, or a focus session opening/closing under the selection, recolours the line but not the band.

The plan now reports the colour it actually drew that line in (`RouteMapPresentation.selectedTripColor`) rather than leaving the controller to re-derive the rule — a second copy free to disagree — and the band's per-frame sampler reads it, so a republish that recolours the line recolours the band with it. A publish that drew no selected-trip line falls back to the shown route's colour, which is the line the band then lies over.

`contrastingColor` itself is unchanged; only its input is.

### 2. Fill the data / fast-estimate markers with that colour

The two markers that bound the band — the most-recent-data dot at its origin, the fast estimate at its leading end — were a fixed gray-ringed **white** disc, reading as map furniture rather than as part of the estimate. They now take the band's own colour as their disc fill, and everything drawn *on* the disc (the ring and the glyph) flips to whichever of black/white reads against it via the shared `MarkerRendering.legibleOn` — the same call the vehicle disc and continuation badge make — so no fill can hide a marker's own ring or glyph, as a gray pair chosen for a white disc could.

Both renderers re-stamp an existing marker only when that colour actually changes, never per frame; maplibre gained a `(drawable, fill)` icon cache since every `fromBitmap` mints a native sprite id. The colour rides on `TripOverlay.markerColorArgb` even on a frame with no band at all, because the dot is drawn from the *selection*, not from the band.

`TripMarkerBitmaps` now `mutate()`s the glyph drawable before tinting — it didn't need to when the tint was a single constant, and would now write per-fill tints into the shared `ConstantState`.

### Known remaining nuance, deliberately left

Over a directions ride the ridden span is cased on top of the trip line, so on an interline where a span carries a different route's colour the band contrasts the trip line rather than that span. Tinting the band per underlying segment is a bigger change than this issue asks for.

### Testing

- `RouteMapPresentationPlanTest` — the reported colour is the adjacency hue inside stop focus, the fallback outside it, and null when no selected-trip line was drawn.
- New `TripMarkerBitmapsTest` (instrumented — it's `Canvas` work, so the pixels have to be read back): the disc takes the caller's fill, forced opaque; ring and glyph ink flip black↔white with it, checked on both a light and a dark fill and for both glyphs; distinct fills don't collide in the cache and identical ones reuse one bitmap. 5/5 pass on a Pixel 7 Pro / API 17.
- Both flavors compile clean under `-PwarningsAsErrors=true`; `spotlessCheck` and the JVM unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip markers, recent-data indicators, and selected-trip arrival pills now use uncertainty-band colors.
  * Marker rings and glyphs automatically select contrasting black or white colors for improved readability.
  * Selected-vehicle overlays retain route colors and display consistently, including when no estimate is available.

* **Bug Fixes**
  * Marker fills render opaquely and update correctly when colors change.
  * Improved marker caching prevents stale or incorrectly colored icons.

* **Tests**
  * Added coverage for marker contrast, opacity, caching, pixel rendering, and selected-trip color behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->