### PR TITLE
Tune the nearby-routes drawer, and de-duplicate what it borrowed (#2107)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ReportListContentHeightTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/compose/ReportListContentHeightTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeTimeoutException
+import androidx.compose.ui.unit.dp
+import java.util.Collections.synchronizedList
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * On-device tests for [ReportListContentHeight], the measurement both arrivals sheets use to fit their
+ * collapsed peek to short content.
+ *
+ * The case worth pinning is **replacing the content while reusing the same [LazyListState]**, which is
+ * what the drawers do on every poll and every pan. The effect restarts on the new content key before
+ * that frame's layout pass has run, so the first `layoutInfo` it can see still describes the previous
+ * list. A measurement that reported only that first reading would publish the outgoing list's height
+ * and never correct itself — so these tests assert the height the reporter *settles* on, not the first
+ * one it emits.
+ */
+class ReportListContentHeightTest {
+
+    // Unconfined composition — see createUnconfinedComposeRule (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val viewportHeight = 200.dp
+    private val rowHeight = 20.dp
+
+    @Test
+    fun reportsTheHeightOfContentThatFits() {
+        val reported = synchronizedList(mutableListOf<Int>())
+        composeRule.setContent { Harness(rowCount = FEW_ROWS, reported = reported) }
+
+        assertSettlesAt(heightOf(FEW_ROWS), reported)
+    }
+
+    /**
+     * The regression this file exists for. Both row counts fit the viewport, so both measurements are
+     * exact — which makes this an assertion about the *value*, not about a floor: after the swap the
+     * reporter must settle on the incoming list's height, never the outgoing one's.
+     */
+    @Test
+    fun remeasuresWhenContentGrowsOnTheSameListState() {
+        val reported = synchronizedList(mutableListOf<Int>())
+        var rowCount by mutableStateOf(FEW_ROWS)
+        composeRule.setContent { Harness(rowCount = rowCount, reported = reported) }
+        assertSettlesAt(heightOf(FEW_ROWS), reported)
+
+        setRowCount { rowCount = MORE_ROWS }
+
+        assertSettlesAt(heightOf(MORE_ROWS), reported)
+    }
+
+    /** And the shrinking direction, which a latched first measurement would also have missed. */
+    @Test
+    fun remeasuresWhenContentShrinksOnTheSameListState() {
+        val reported = synchronizedList(mutableListOf<Int>())
+        var rowCount by mutableStateOf(MORE_ROWS)
+        composeRule.setContent { Harness(rowCount = rowCount, reported = reported) }
+        assertSettlesAt(heightOf(MORE_ROWS), reported)
+
+        setRowCount { rowCount = FEW_ROWS }
+
+        assertSettlesAt(heightOf(FEW_ROWS), reported)
+    }
+
+    /**
+     * Content past the viewport reports a floor rather than a measurement — the bottom edge of the item
+     * straddling the viewport's end. The contract is only that it exceeds anything that fits, which is
+     * all a caller clamping to a peek cap needs.
+     */
+    @Test
+    fun reportsAFloorForContentTallerThanTheViewport() {
+        val reported = synchronizedList(mutableListOf<Int>())
+        composeRule.setContent { Harness(rowCount = OVERFLOWING_ROWS, reported = reported) }
+
+        composeRule.waitUntil(timeoutMillis = TIMEOUT_MS) { reported.isNotEmpty() }
+        assertTrue(
+            "overflowing content should measure past the fitting rows, got $reported",
+            reported.last() > heightOf(MORE_ROWS)
+        )
+    }
+
+    private fun heightOf(rows: Int) = rows * with(composeRule.density) { rowHeight.roundToPx() }
+
+    /**
+     * Waits for [reported] to come to rest at [expected]. `waitForIdle` is not enough: the measurement
+     * is published from a `snapshotFlow` collector, so the emission for a freshly laid-out list can
+     * land after composition has already gone idle.
+     */
+    private fun assertSettlesAt(expected: Int, reported: List<Int>) {
+        try {
+            composeRule.waitUntil(timeoutMillis = TIMEOUT_MS) { reported.lastOrNull() == expected }
+        } catch (e: ComposeTimeoutException) {
+            throw AssertionError("expected to settle at $expected, reported $reported", e)
+        }
+        assertEquals(expected, reported.last())
+    }
+
+    /** Writes happen on the UI thread, so the change reaches composition the way a real one would. */
+    private fun setRowCount(set: () -> Unit) = composeRule.runOnIdle(set)
+
+    @Composable
+    private fun Harness(
+        rowCount: Int,
+        reported: MutableList<Int>,
+        listState: LazyListState = rememberLazyListState()
+    ) {
+        val rows = List(rowCount) { "row-$it" }
+        Box(Modifier.fillMaxWidth().height(viewportHeight)) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxWidth()) {
+                items(rows, key = { it }) { Box(Modifier.fillMaxWidth().size(rowHeight)) }
+            }
+        }
+        ReportListContentHeight(listState) { px -> reported += px }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 5_000L
+
+        /** Both of these fit inside viewportHeight (200dp), so their measurements are exact. */
+        const val FEW_ROWS = 3
+        const val MORE_ROWS = 8
+
+        /** 40 * 20dp = 800dp, well past the viewport. */
+        const val OVERFLOWING_ROWS = 40
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsDataSource.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/api/data/NearbyArrivalsDataSource.kt
@@ -27,7 +27,6 @@ import org.onebusaway.android.api.requireData
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.models.ArrivalData
 import org.onebusaway.android.models.ObaRoute
-import org.onebusaway.android.models.ObaSituation
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.time.ServerTime
 import retrofit2.HttpException
@@ -81,19 +80,6 @@ class NearbyArrivals internal constructor(
 
     /** Resolves a route's agency name from the references pool, or null. */
     fun agencyName(id: String): String? = refs.agency(id)?.name
-
-    /**
-     * Every service alert this response references: the box-level ones plus every alert an arrival
-     * names, de-duplicated by id with order preserved — matching [StopArrivals.situations].
-     */
-    fun situations(): List<ObaSituation> {
-        val entry = data.entry ?: return emptyList()
-        val arrivalSituationIds = entry.arrivalsAndDepartures.flatMap { it.situationIds }
-        return (entry.situationIds + arrivalSituationIds)
-            .distinct()
-            .mapNotNull { refs.situation(it) }
-            .map(::DtoSituation)
-    }
 }
 
 /** One viewport's arrivals fetch, or the verdict that this region cannot serve them. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -403,7 +403,6 @@ fun RouteArrivalRow(
                 Column(Modifier.weight(1f)) {
                     if (direction.isNotBlank()) {
                         DirectionHeadsign(direction)
-                        Spacer(Modifier.height(2.dp))
                     }
                     if (stopLabel != null) {
                         Text(
@@ -411,7 +410,11 @@ fun RouteArrivalRow(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
+                            // Gap between the headsign and the bay, when both show. Carried by the label
+                            // rather than an unconditional spacer under the headsign, which would also
+                            // shift every stop-scoped row — none of which passes a stopLabel.
+                            modifier = Modifier.padding(top = if (direction.isNotBlank()) 2.dp else 0.dp)
                         )
                     }
                     if (direction.isNotBlank() || stopLabel != null) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -72,7 +72,7 @@ fun ArrivalsPanel(
 
     // The panel's total content height (px), for the host's fit-the-peek-to-short-stops shrink. Shared
     // with the nearby drawer, which makes the same measurement — see [ReportListContentHeight].
-    ReportListContentHeight(listState, contentKey = content, onContentHeight = onContentHeight)
+    ReportListContentHeight(listState, onContentHeight)
 
     Surface(color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -29,10 +29,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.ui.arrivals.ArrivalActionHandler
@@ -40,6 +36,7 @@ import org.onebusaway.android.ui.arrivals.ArrivalsList
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
+import org.onebusaway.android.ui.compose.ReportListContentHeight
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 
 /**
@@ -73,25 +70,9 @@ fun ArrivalsPanel(
     val rowCallbacks = rememberArrivalRowCallbacks(handler, viewModel)
     val content = state as? ArrivalsUiState.Content
 
-    // The panel's total content height (px), or null until the whole list is laid out. Material3
-    // measures the sheet content at full container height regardless of the peek, so listState's
-    // layoutInfo reflects the full list: if the last item is present, its bottom is the true content
-    // height; if it isn't, the content is taller than the screen (well past the peek cap) and an exact
-    // number isn't needed. This reads real layout — not a magnitude heuristic.
-    val contentHeightPx by remember(listState, content) {
-        derivedStateOf {
-            val info = listState.layoutInfo
-            val last = info.visibleItemsInfo.lastOrNull()
-            if (content != null && last != null && last.index == info.totalItemsCount - 1) {
-                last.offset + last.size
-            } else {
-                null
-            }
-        }
-    }
-    contentHeightPx?.let { px ->
-        LaunchedEffect(px) { onContentHeight(px) }
-    }
+    // The panel's total content height (px), for the host's fit-the-peek-to-short-stops shrink. Shared
+    // with the nearby drawer, which makes the same measurement — see [ReportListContentHeight].
+    ReportListContentHeight(listState, contentKey = content, onContentHeight = onContentHeight)
 
     Surface(color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/ComposeHostUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/ComposeHostUtils.kt
@@ -31,8 +31,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 
 /**
  * A [ViewModelStoreOwner] backed by a fresh [ViewModelStore] per [key], cleared when the key changes
@@ -77,31 +77,41 @@ fun navigationBarBottomPadding(): Dp = WindowInsets.navigationBars.asPaddingValu
  * the sheet's collapsed peek to short content. Emits nothing — it is an effect wearing a composable's
  * clothes, hoisted here because both arrivals sheets need the identical measurement.
  *
- * Real layout, not an estimate, and not a magnitude heuristic. Material3 measures sheet content at full
- * container height regardless of the peek, so [listState]'s `layoutInfo` reflects the whole list: when
- * the last item is present its bottom edge *is* the content height; when it isn't, the content is taller
- * than the screen (well past any peek cap) and an exact number buys nothing.
+ * Real layout, not an estimate, and not a magnitude heuristic: the reading is the bottom edge of the
+ * last laid-out item. Material3 measures sheet content at full container height regardless of the peek,
+ * so when the whole list fits that edge *is* the content height. When it doesn't, the last visible item
+ * is the one straddling the viewport's bottom, so the same expression yields roughly the viewport
+ * extent — a floor rather than a measurement, which is all a caller clamping to a peek cap can use.
  *
- * [contentKey] identifies what is being measured — null means "nothing to measure yet", and a new
- * non-null value re-measures. Exactly one measurement is reported per key: `last.offset` moves every
- * frame while the final item is on screen and scrolling, and republishing it would invalidate the host
- * once a frame for a number whose consumer (a peek that has long since pinned to its cap) cannot change.
+ * Two things make the measurement trustworthy rather than merely cheap:
+ *
+ *  - **One collector, keyed only on [listState].** It is deliberately *not* restarted when the content
+ *    changes. A restart does not wait for the new content's layout pass — the effect's coroutine can
+ *    run before it — so a restarted collector's first reading still describes the outgoing list, and
+ *    reporting that would publish the wrong height. Observing layout continuously instead means a
+ *    content swap needs no special handling: the new list's height simply arrives when it is measured.
+ *  - **It only measures from the top.** Item offsets are viewport-relative, so once a list is scrolled
+ *    `last.offset + last.size` is the last item's bottom *on screen*, not the content height. Skipping
+ *    those readings is what makes the value correct — and, since the offsets that move every frame are
+ *    exactly the ones being skipped, it is also what keeps a scroll gesture from republishing (and
+ *    re-invalidating the host) once a frame.
+ *
+ * A list with nothing laid out reports nothing, so a caller still showing a spinner keeps whatever it
+ * last had rather than being handed a zero.
  */
 @Composable
 fun ReportListContentHeight(
     listState: LazyListState,
-    contentKey: Any?,
     onContentHeight: (heightPx: Int) -> Unit
 ) {
-    // Read through the latest lambda so a caller's inline `{ px -> … }` doesn't restart the effect (and
-    // re-report) on every recomposition.
+    // Read through the latest lambda so a caller's inline `{ px -> … }` doesn't restart the effect.
     val report = rememberUpdatedState(onContentHeight)
-    LaunchedEffect(listState, contentKey) {
-        if (contentKey == null) return@LaunchedEffect
+    LaunchedEffect(listState) {
         snapshotFlow {
-            val info = listState.layoutInfo
-            val last = info.visibleItemsInfo.lastOrNull()
-            if (last != null && last.index == info.totalItemsCount - 1) last.offset + last.size else null
-        }.filterNotNull().first().let { report.value(it) }
+            val atTop = listState.firstVisibleItemIndex == 0 &&
+                listState.firstVisibleItemScrollOffset == 0
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            if (atTop && last != null) last.offset + last.size else null
+        }.filterNotNull().distinctUntilChanged().collect { report.value(it) }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/ComposeHostUtils.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/ComposeHostUtils.kt
@@ -21,12 +21,18 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 
 /**
  * A [ViewModelStoreOwner] backed by a fresh [ViewModelStore] per [key], cleared when the key changes
@@ -65,3 +71,37 @@ tailrec fun Context.findActivity(): AppCompatActivity = when (this) {
  */
 @Composable
 fun navigationBarBottomPadding(): Dp = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+/**
+ * Reports a bottom-sheet list's fully-laid-out height in px to [onContentHeight], so the host can fit
+ * the sheet's collapsed peek to short content. Emits nothing — it is an effect wearing a composable's
+ * clothes, hoisted here because both arrivals sheets need the identical measurement.
+ *
+ * Real layout, not an estimate, and not a magnitude heuristic. Material3 measures sheet content at full
+ * container height regardless of the peek, so [listState]'s `layoutInfo` reflects the whole list: when
+ * the last item is present its bottom edge *is* the content height; when it isn't, the content is taller
+ * than the screen (well past any peek cap) and an exact number buys nothing.
+ *
+ * [contentKey] identifies what is being measured — null means "nothing to measure yet", and a new
+ * non-null value re-measures. Exactly one measurement is reported per key: `last.offset` moves every
+ * frame while the final item is on screen and scrolling, and republishing it would invalidate the host
+ * once a frame for a number whose consumer (a peek that has long since pinned to its cap) cannot change.
+ */
+@Composable
+fun ReportListContentHeight(
+    listState: LazyListState,
+    contentKey: Any?,
+    onContentHeight: (heightPx: Int) -> Unit
+) {
+    // Read through the latest lambda so a caller's inline `{ px -> … }` doesn't restart the effect (and
+    // re-report) on every recomposition.
+    val report = rememberUpdatedState(onContentHeight)
+    LaunchedEffect(listState, contentKey) {
+        if (contentKey == null) return@LaunchedEffect
+        snapshotFlow {
+            val info = listState.layoutInfo
+            val last = info.visibleItemsInfo.lastOrNull()
+            if (last != null && last.index == info.totalItemsCount - 1) last.offset + last.size else null
+        }.filterNotNull().first().let { report.value(it) }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -23,7 +23,9 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.BottomSheetScaffold
@@ -111,8 +113,8 @@ import org.onebusaway.android.ui.home.map.MapFeature
 import org.onebusaway.android.ui.home.nearby.NearbyArrivalsSheetHost
 import org.onebusaway.android.ui.home.nearby.NearbyArrivalsViewModel
 import org.onebusaway.android.ui.home.nearby.limitExceeded
-import org.onebusaway.android.ui.home.nearby.rememberNearbyActionsFor
 import org.onebusaway.android.ui.home.nearby.rememberNearbyRouteRows
+import org.onebusaway.android.ui.home.nearby.rememberNearbyRowActions
 import org.onebusaway.android.ui.home.nearby.rememberNearbyRowCallbacks
 import org.onebusaway.android.ui.home.weather.WeatherFeature
 import org.onebusaway.android.ui.home.weather.WeatherViewModel
@@ -343,12 +345,17 @@ fun HomeScreen(
                 // sheet's content clears the bottom chrome; the panel matches this with its own content inset.
                 val peekBottomPadding = navigationBarBottomPadding()
 
-                // The collapsed peek is capped at a fixed fraction of the window height — a constant known up
-                // front, so the open slide has a stable target that can't strand the drag (unlike a measured
-                // height that grows as content loads). Short stops shrink below it to fit (see collapsedPeekDp).
-                // (containerSize, not Configuration.screenHeightDp — the latter is lint-flagged as unreliable.)
-                val capPeekDp = with(density) {
-                    (LocalWindowInfo.current.containerSize.height * PEEK_HEIGHT_FRACTION).toDp()
+                // The expanded sheet's ceiling, so its top edge stops below the status bar / notch instead
+                // of sliding under it. Material3 derives the Expanded anchor from the sheet's *measured*
+                // height (anchor y = containerHeight - sheetHeight), so a content list that measures the
+                // full window pins the top edge at y=0 — capping the content is what stops it short; there
+                // is no sheet-max-height parameter to set. safeDrawing rather than statusBars because the
+                // cutout is what we're clearing, and it can exceed the status bar. The drag handle sits
+                // above this slot inside the same sheet Surface, so it comes out of the same budget.
+                val topSystemInsetPx = WindowInsets.safeDrawing.getTop(density)
+                val maxSheetContentDp = with(density) {
+                    val availablePx = LocalWindowInfo.current.containerSize.height - topSystemInsetPx
+                    availablePx.toDp() - DRAG_HANDLE_HEIGHT
                 }
 
                 // The panel's fully-laid-out list height in px, reported once
@@ -362,7 +369,7 @@ fun HomeScreen(
                 // The transit-centre drawer's rows, built from the query's last response (#2107). Needed
                 // before the sheet decision below, which gates on there being rows to show.
                 val nearbyRows = rememberNearbyRouteRows(nearbyArrivalsState)
-                val nearbyActionsFor = rememberNearbyActionsFor(nearbyArrivalsState)
+                val nearbyActionsFor = rememberNearbyRowActions(nearbyArrivalsState, nearbyRows)
                 val nearbyLimitExceeded = nearbyArrivalsState.limitExceeded
                 val nearbyRowCallbacks = rememberNearbyRowCallbacks(
                     homeViewModel = homeViewModel,
@@ -521,6 +528,17 @@ fun HomeScreen(
                 // animateDpAsState finished-listener below; reset when the sheet slides back to 0 on hide).
                 var openSettled by remember { mutableStateOf(false) }
 
+                // The collapsed peek is capped at a fixed fraction of the window height — a constant known up
+                // front, so the open slide has a stable target that can't strand the drag (unlike a measured
+                // height that grows as content loads). Short stops shrink below it to fit (see collapsedPeekDp).
+                // (containerSize, not Configuration.screenHeightDp — the latter is lint-flagged as unreliable.)
+                // How much of the window it may cover is a property of what the sheet holds — see
+                // [HomeSheetContent.peekHeightFraction] for why the two drawers differ.
+                val capPeekDp = with(density) {
+                    val height = LocalWindowInfo.current.containerSize.height
+                    (height * sheetContent.peekHeightFraction).toDp()
+                }
+
                 // The full collapsed peek: the fixed cap while loading or still opening, then min(content, cap)
                 // once settled — fitting short stops without dead space, clipping tall ones at the cap. The
                 // scaffold peek, the FAB lift, and the map's bottom inset all use this.
@@ -644,26 +662,31 @@ fun HomeScreen(
                                 )
                             },
                             sheetContent = {
-                                // The nearby list only while it *is* the sheet's subject; otherwise the
-                                // per-stop panel, which stays composed through the hide animation (it
-                                // returns early on a null session) so the sheet doesn't blank mid-slide.
-                                if (sheetContent == HomeSheetContent.NearbyRoutes) {
-                                    NearbyArrivalsSheetHost(
-                                        rows = nearbyRows,
-                                        actionsFor = nearbyActionsFor,
-                                        favoriteRouteIds = favoriteRouteIds,
-                                        callbacks = nearbyRowCallbacks,
-                                        limitExceeded = nearbyLimitExceeded,
-                                        onContentHeight = { px -> contentPx = px }
-                                    )
-                                } else {
-                                    ArrivalsSheetHost(
-                                        session = arrivalsSession,
-                                        state = arrivalsState,
-                                        selectedRoute = stopFocus?.selectedRoute,
-                                        mapRouteColors = mapRouteColors,
-                                        onContentHeight = { px -> contentPx = px }
-                                    )
+                                // Bounded so a long list can't grow the sheet past maxSheetContentDp — that
+                                // measured height is what sets the expanded top edge. A short list still
+                                // wraps below it, keeping the fit-to-content peek.
+                                Box(Modifier.heightIn(max = maxSheetContentDp)) {
+                                    // The nearby list only while it *is* the sheet's subject; otherwise the
+                                    // per-stop panel, which stays composed through the hide animation (it
+                                    // returns early on a null session) so the sheet doesn't blank mid-slide.
+                                    if (sheetContent == HomeSheetContent.NearbyRoutes) {
+                                        NearbyArrivalsSheetHost(
+                                            rows = nearbyRows,
+                                            actionsFor = nearbyActionsFor,
+                                            favoriteRouteIds = favoriteRouteIds,
+                                            callbacks = nearbyRowCallbacks,
+                                            limitExceeded = nearbyLimitExceeded,
+                                            onContentHeight = { px -> contentPx = px }
+                                        )
+                                    } else {
+                                        ArrivalsSheetHost(
+                                            session = arrivalsSession,
+                                            state = arrivalsState,
+                                            selectedRoute = stopFocus?.selectedRoute,
+                                            mapRouteColors = mapRouteColors,
+                                            onContentHeight = { px -> contentPx = px }
+                                        )
+                                    }
                                 }
                             }
                         ) {
@@ -1258,10 +1281,6 @@ private fun SheetValue.toArrivalsSheetState() = when (this) {
     SheetValue.PartiallyExpanded -> ArrivalsSheetState.Collapsed
     SheetValue.Expanded -> ArrivalsSheetState.Expanded
 }
-
-// The collapsed drawer peek is capped at this fraction of the screen height (short stops shrink to
-// fit their content below it). A starting value to tune by eye.
-private const val PEEK_HEIGHT_FRACTION = 0.30f
 
 /**
  * The arrivals sheet's drag handle: a short grab bar tinted to sit on the panel surface (paired with

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -26,7 +26,7 @@ import org.onebusaway.android.map.render.showsNearbyArrivals
  * from inside a `@Composable`) is unit-testable. [HomeScreen] does the Compose plumbing — keying the
  * effect, reading the live `SheetState`, animating — and defers every *decision* to these functions.
  *
- * The model: **visibility is business state** ([shouldShowSheet]); **expansion is ephemeral UI**
+ * The model: **visibility is business state** ([homeSheetContent]); **expansion is ephemeral UI**
  * toggled by [toggleSheetTarget] and unwound by [sheetBackAction].
  */
 
@@ -93,6 +93,29 @@ internal val HomeSheetContent.sheetKey: String?
     }
 
 /**
+ * How much of the window the collapsed peek may cover. A property of what the sheet holds, because the
+ * two drawers are *asked for* differently:
+ *
+ *  - A tapped stop is a deliberate request to read that stop, so its peek is worth real screen — it
+ *    opens showing actual arrival rows.
+ *  - The transit-centre list (#2107) is ambient: it appears on zoom without anyone asking, over a map
+ *    the rider is still reading. Its peek is only wide enough to advertise that a list is there (a row
+ *    or so under the handle); dragging up is how you read it.
+ *
+ * [HomeSheetContent.None] is retracting to zero anyway, so its value is never seen — it takes the stop
+ * fraction so the number is stable if a hide is interrupted by a re-show.
+ */
+internal val HomeSheetContent.peekHeightFraction: Float
+    get() = when (this) {
+        HomeSheetContent.NearbyRoutes -> NEARBY_PEEK_HEIGHT_FRACTION
+        HomeSheetContent.None, is HomeSheetContent.Stop -> STOP_PEEK_HEIGHT_FRACTION
+    }
+
+private const val STOP_PEEK_HEIGHT_FRACTION = 0.30f
+
+private const val NEARBY_PEEK_HEIGHT_FRACTION = 0.15f
+
+/**
  * Bottom edge used to keep map content below the active top chrome: the stop/route focus banner, or —
  * in directions — the trip-plan form card ([directionsFormBottomPx]), so the map's top content padding
  * reflects the form/FAB and a focused itinerary step centers in the band below it.
@@ -117,9 +140,9 @@ internal fun focusBannerTopEdge(
  * settled height, or zero when that drawer isn't shown; it always counts, because the drawer rests at a
  * fraction of the window and the controls belong above it in either of its two positions (#2155).
  *
- * The two sheets are mutually exclusive today — directions focus is not stop focus, so [shouldShowSheet]
- * keeps the arrivals sheet hidden for the whole of directions mode — but taking the larger clears either
- * one without depending on that.
+ * The two sheets are mutually exclusive today — directions focus is neither a stop focus nor the
+ * no-focus state the nearby list needs, so [homeSheetContent] resolves to [HomeSheetContent.None] for
+ * the whole of directions mode — but taking the larger clears either one without depending on that.
  */
 internal fun mapControlsBottomInset(
     arrivalsPeek: Dp,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -547,6 +547,17 @@ class HomeViewModel @Inject constructor(
      * list rather than parking them on a per-stop panel they never asked for. It can't go through
      * [selectArrivalRoute], which requires a stop focus to already exist; here there is none, which is
      * exactly the condition that put the nearby list on screen.
+     *
+     * [focusTripId] is what separates the drawer's two taps, exactly as it does in the per-stop drawer
+     * (see [selectStopRoute]):
+     *  - **null — the row body.** The camera only *pans* onto the bay. This drawer exists only at
+     *    transit-centre zoom, so the rider is already looking at the place they are standing in; framing
+     *    the whole line would zoom out to its full extent and throw that view away to answer a question
+     *    they didn't ask. The route still draws, and the banner can reframe it on request.
+     *  - **non-null — an ETA pill.** The pill names one trip, so this is the stop→route→trip level
+     *    (#2205) and the map fits that trip's live vehicle together with this bay. `RouteMapController`
+     *    performs that fit off `focusTripId` and ignores `frameRoute` while one is set, so the pill gets
+     *    the vehicle+stop bounding box here for the same reason it does from a stop's own drawer.
      */
     fun showNearbyRouteOnMap(
         bay: FocusedStop,
@@ -554,35 +565,52 @@ class HomeViewModel @Inject constructor(
         shortName: String,
         directionId: Int?,
         headsign: String?,
+        focusTripId: String? = null,
         undoViewport: MapViewport? = null
     ) {
         presentedRoutes = emptySet()
-        // Drop any restore/deep-link latch first, the way [clearMapFocus] and [enterDirections] do. A
-        // restore that set one and then had its stop unfocused before the arrivals landed leaves it
-        // armed with no focus — which is exactly the state that puts this list on screen — and this
-        // bay's own load would consume it and recenter on a focus the rider never asked to return to.
-        // The map is told what to show here explicitly, so nothing needs the latch.
-        pendingFocus = null
-        pushFocus(
-            CurrentFocus.Stop(
-                stop = bay,
-                selectedRoute = StopRouteSelection(
-                    originHeadsign = headsign,
-                    legs = listOf(RouteLeg(routeId, shortName, directionId))
-                )
+        // Arm the latch for *this* bay, so the load that follows emits `MapDirective.FocusStop` and the
+        // map renders the bay as the selected stop — the marker a rider expects after tapping a row, and
+        // which nothing else here would set (`ShowRoute` draws the route, not the stop focus).
+        //
+        // `preserveViewport = true` is what makes arming it safe. Overwriting rather than clearing also
+        // disposes of a stale restore/deep-link latch (one whose stop was unfocused before its arrivals
+        // landed — exactly the state that puts this list on screen); clearing it was the old behaviour,
+        // and the reason it was cleared was that consuming it would recenter on a focus the rider never
+        // asked to return to. A preserved viewport can't: it suppresses both that recenter and the
+        // route-framing, leaving this method's own camera move the only one.
+        markPendingMapFocus(preserveViewport = true)
+        val selection = StopRouteSelection(
+            originHeadsign = headsign,
+            legs = listOf(RouteLeg(routeId, shortName, directionId)),
+            // An ETA-pill tap names the trip it belongs to, and that *is* the trip level (#2205) — the
+            // same rule [selectStopRoute] applies to the per-stop drawer's two taps.
+            selectedTripId = focusTripId
+        )
+        pushFocus(CurrentFocus.Stop(stop = bay, selectedRoute = selection), undoViewport)
+        // Through [showStopRoute] rather than emitting ShowRoute directly, so this path can't be the one
+        // that breaks its pairing invariant: the route directive always travels with a SelectVehicle,
+        // null included, so a row-body tap clears any vehicle a previous pill left selected.
+        showStopRoute(
+            bay.id,
+            selection,
+            request = ShowRouteRequest(
+                routeId = routeId,
+                directionStopId = bay.id,
+                focusTripId = focusTripId,
+                initialDirectionId = directionId
             ),
-            undoViewport
+            // Never frame the whole line from this drawer. With a focusTripId set the controller ignores
+            // this anyway and fits vehicle+bay instead; without one, the pan below is the move we want.
+            frameRoute = false
         )
-        emitMapDirective(
-            MapDirective.ShowRoute(
-                ShowRouteRequest(
-                    routeId = routeId,
-                    directionStopId = bay.id,
-                    initialDirectionId = directionId
-                ),
-                stopScoped = true
-            )
-        )
+        if (focusTripId == null) {
+            // Row body only — the pill's vehicle+bay fit owns the camera and a recenter would fight it.
+            // Emitted after the route so the recenter picks up route mode's header bias, landing the bay
+            // where a stop focused in route mode always does. `CameraCommand.Recenter` keeps the current
+            // zoom/bearing/tilt, so this is a pan and nothing more.
+            emitMapDirective(MapDirective.RecenterOnFocusedStop(bay.point))
+        }
     }
 
     private fun selectStopRoute(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsSheetHost.kt
@@ -118,11 +118,7 @@ internal fun NearbyArrivalsSheetHost(
 
     // The laid-out height, so the host can fit the peek to a short list — the same measurement the
     // per-stop panel makes, so both go through the one helper.
-    ReportListContentHeight(
-        listState,
-        contentKey = rows.takeIf { it.isNotEmpty() },
-        onContentHeight = onContentHeight
-    )
+    ReportListContentHeight(listState, onContentHeight)
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsSheetHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyArrivalsSheetHost.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.home.nearby
 
+import android.content.Context
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -26,13 +27,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalActions
@@ -40,7 +41,9 @@ import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
 import org.onebusaway.android.ui.arrivals.convertArrivals
+import org.onebusaway.android.ui.compose.ReportListContentHeight
 import org.onebusaway.android.ui.compose.navigationBarBottomPadding
+import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.GeoPoint
 
 /**
@@ -61,19 +64,40 @@ internal fun NearbyArrivalsSheetHost(
     onContentHeight: (heightPx: Int) -> Unit,
     listState: LazyListState = rememberLazyListState()
 ) {
+    // Bay labels resolved once per row set rather than per row recomposition — each is a string-resource
+    // lookup, and the row's own content changes far more often than its bay does.
+    val context = LocalContext.current
+    val stopLabels = remember(rows, context) { rows.associate { it.key to it.bay.label(context) } }
     Surface(color = MaterialTheme.colorScheme.surface) {
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxWidth(),
             contentPadding = PaddingValues(bottom = navigationBarBottomPadding())
         ) {
+            // Names what the drawer is, which the peek alone can't: it opens uninvited on zoom, so a
+            // rider who didn't ask for it needs to see at a glance that these are the routes around
+            // them and not the one stop they last tapped. Scrolls with the list rather than pinning —
+            // once they're reading rows they know what they're reading, and the sheet is short enough
+            // that a stuck header would be a real cost.
+            item(key = TITLE_KEY) {
+                Text(
+                    text = stringResource(R.string.nearby_arrivals_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .semantics { heading() }
+                )
+            }
             items(rows, key = { it.key }) { row ->
                 RouteArrivalRow(
                     group = row.group,
                     actionsFor = actionsFor,
                     isFavorite = row.group.routeId in favoriteRouteIds,
                     callbacks = callbacks,
-                    stopLabel = row.bay.label()
+                    stopLabel = stopLabels[row.key]
                 )
             }
             // The server truncates its arrivals list by distance from the viewport centre, so a
@@ -92,32 +116,32 @@ internal fun NearbyArrivalsSheetHost(
         }
     }
 
-    // The laid-out height, so the host can fit the peek to a short list. Real layout, not an estimate:
-    // Material3 measures sheet content at full container height regardless of the peek, so if the last
-    // item is present its bottom is the true content height; if it isn't, the list is taller than the
-    // screen and an exact number isn't needed. Same measurement ArrivalsPanel makes.
-    val contentHeightPx by remember(listState, rows) {
-        derivedStateOf {
-            val info = listState.layoutInfo
-            val last = info.visibleItemsInfo.lastOrNull()
-            if (rows.isNotEmpty() && last != null && last.index == info.totalItemsCount - 1) {
-                last.offset + last.size
-            } else {
-                null
-            }
-        }
-    }
-    contentHeightPx?.let { px -> LaunchedEffect(px) { onContentHeight(px) } }
+    // The laid-out height, so the host can fit the peek to a short list — the same measurement the
+    // per-stop panel makes, so both go through the one helper.
+    ReportListContentHeight(
+        listState,
+        contentKey = rows.takeIf { it.isNotEmpty() },
+        onContentHeight = onContentHeight
+    )
 }
 
 /**
- * How a bay reads on a row: its code when the feed publishes one (that is what's painted on the pole),
- * then its name, then the compass direction it serves. At a real transit centre the direction is what
- * separates the two sides of an intersection — "Pine St & 4th Ave" exists twice.
+ * How a bay reads on a row: its name, then the compass direction it serves. At a real transit centre the
+ * direction is what separates the two sides of an intersection — "Pine St & 4th Ave" exists twice.
+ *
+ * The direction goes through [DisplayFormat.stopDirectionText] like every other stop surface in the app
+ * (the focus banner, search results, the arrivals header), so a rider reads "Southeast bound" rather
+ * than the feed's raw `SE` — and reads it translated. An unrecognised code resolves to nothing and the
+ * bay shows as its bare name.
+ *
+ * The stop code is deliberately left off. It is the most prominent thing the feed publishes about a bay
+ * but the least useful thing to read here: this list is scanned down the *route* column, and a leading
+ * number on every row is noise the eye has to skip past. A rider who wants the code gets it on the
+ * stop's own panel, one tap away.
  */
-internal fun NearbyBay.label(): String {
-    val head = code?.takeIf(String::isNotBlank)?.let { "$it · $name" } ?: name
-    return direction?.takeIf(String::isNotBlank)?.let { "$head ($it)" } ?: head
+internal fun NearbyBay.label(context: Context): String {
+    val bound = DisplayFormat.stopDirectionText(context, direction)
+    return if (bound != null) "$name ($bound)" else name
 }
 
 /**
@@ -162,30 +186,41 @@ internal fun rememberNearbyRouteRows(state: NearbyArrivalsUiState): List<NearbyR
  * banner, which this many-bay list has no equivalent of (see [rememberNearbyRowCallbacks]).
  */
 @Composable
-internal fun rememberNearbyActionsFor(
-    state: NearbyArrivalsUiState
+internal fun rememberNearbyRowActions(
+    state: NearbyArrivalsUiState,
+    rows: List<NearbyRouteRow>
 ): (ArrivalInfo) -> ArrivalActions? {
     val loaded = state as? NearbyArrivalsUiState.Loaded
-    return remember(loaded) {
-        fun(arrival: ArrivalInfo): ArrivalActions? {
-            val snapshot = loaded?.arrivals ?: return null
-            val route = snapshot.route(arrival.routeId)
-            return ArrivalActions(
-                tripId = arrival.tripId,
-                routeId = arrival.routeId,
-                routeShortName = route?.shortName,
-                routeLongName = route?.longName,
-                routeColor = route?.color,
-                scheduleUrl = route?.url,
-                agencyName = route?.agencyId?.let(snapshot::agencyName),
-                blockId = null
-            )
-        }
+    // Resolved once per response into a trip-keyed map, then looked up — the shape the other three
+    // arrivals hosts use (`content.actions[it.tripId]`). Building on demand instead would re-resolve
+    // references and re-parse the route's hex colour on every call, and the callers are hot: the ETA
+    // strip recomposes once a second off the live clock, and the alert-glyph check walks every trip in
+    // every row. Cheap map hits either way now.
+    val actions = remember(loaded, rows) {
+        val snapshot = loaded?.arrivals ?: return@remember emptyMap()
+        rows.asSequence()
+            .flatMap { it.group.trips.asSequence() }
+            .associateBy(ArrivalInfo::tripId) { arrival ->
+                val route = snapshot.route(arrival.routeId)
+                ArrivalActions(
+                    tripId = arrival.tripId,
+                    routeId = arrival.routeId,
+                    routeShortName = route?.shortName,
+                    routeLongName = route?.longName,
+                    routeColor = route?.color,
+                    scheduleUrl = route?.url,
+                    agencyName = route?.agencyId?.let(snapshot::agencyName),
+                    blockId = null
+                )
+            }
     }
+    return remember(actions) { { arrival: ArrivalInfo -> actions[arrival.tripId] } }
 }
 
 /** Whether the last response was truncated, so the drawer can say some bays are missing. */
 internal val NearbyArrivalsUiState.limitExceeded: Boolean
     get() = (this as? NearbyArrivalsUiState.Loaded)?.arrivals?.limitExceeded ?: false
+
+private const val TITLE_KEY = "nearby-title"
 
 private const val LIMIT_NOTICE_KEY = "nearby-limit-notice"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRouteRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRouteRows.kt
@@ -76,13 +76,15 @@ fun nearbyRouteRows(
 ): List<NearbyRouteRow> {
     val bays = HashMap<String, NearbyBay?>()
     fun bay(stopId: String) = bays.getOrPut(stopId) { bayOf(stopId) }
+    // One guard, at the end. Pre-filtering the arrivals too would be a second spelling of the same rule
+    // that the reader has to prove agrees with this one — and a bay-less group is dropped here whether
+    // or not its arrivals were filtered first (a null sort key just orders it blank-last on the way).
     return groupByRouteDirectionAndStop(
-        items = arrivals.filter { bay(it.stopId) != null },
+        items = arrivals,
         agencyNameOf = agencyNameOf,
         stopIdOf = { it.stopId },
         stopSortKeyOf = { bay(it.stopId)?.sortKey }
     ).mapNotNull { trips ->
-        val resolved = bay(trips.first().stopId) ?: return@mapNotNull null
-        NearbyRouteRow(RouteRowGroup(trips), resolved)
+        bay(trips.first().stopId)?.let { NearbyRouteRow(RouteRowGroup(trips), it) }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRowCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/nearby/NearbyRowCallbacks.kt
@@ -33,7 +33,8 @@ import org.onebusaway.android.util.ExternalIntents
  *
  * The two taps a rider actually makes here — the row body and an ETA pill — do what this drawer is
  * for: show that route on the map, scoped to the bay the row named, in one focus push so Back returns
- * straight to the list.
+ * straight to the list. They differ the same way they do in the per-stop drawer: the row body stops at
+ * the route, while the pill drills to its trip and fits that vehicle together with the bay.
  *
  * **The long-press menu's per-stop actions (star, reminder, tracking, report a problem) and the alert
  * glyph are not wired to their own dialogs in this first version**: each needs the stop-scoped
@@ -64,8 +65,10 @@ internal fun rememberNearbyRowCallbacks(
 
         fun focusedStop(bay: NearbyBay) = FocusedStop(bay.id, bay.name, bay.code, bay.point)
 
-        // Show the arrival's route on the map, scoped to the bay its row named.
-        fun revealAtBay(arrival: ArrivalInfo) {
+        // Show the arrival's route on the map, scoped to the bay its row named. [focusTripId] carries the
+        // pill's trip when the tap was a pill, which is what makes it the deeper of the two gestures —
+        // see [HomeViewModel.showNearbyRouteOnMap].
+        fun revealAtBay(arrival: ArrivalInfo, focusTripId: String? = null) {
             val bay = bayOf(arrival) ?: return
             homeViewModel.showNearbyRouteOnMap(
                 bay = focusedStop(bay),
@@ -73,6 +76,7 @@ internal fun rememberNearbyRowCallbacks(
                 shortName = arrival.shortName.orEmpty().ifBlank { arrival.routeId },
                 directionId = arrival.directionId,
                 headsign = arrival.headsign,
+                focusTripId = focusTripId,
                 undoViewport = currentUndoViewport.value()
             )
         }
@@ -83,9 +87,22 @@ internal fun rememberNearbyRowCallbacks(
             homeViewModel.revealStop(focusedStop(bay), animate = true)
         }
 
+        // Same landing, for the actions whose callback carries [ArrivalActions] instead of an arrival.
+        // Those name no stop, so the bay is recovered through the row whose group holds the trip.
+        fun openBayForRoute(actions: ArrivalActions) {
+            val bay = currentRows.value
+                .firstOrNull { row -> row.group.trips.any { it.tripId == actions.tripId } }
+                ?.bay ?: return
+            homeViewModel.revealStop(focusedStop(bay), animate = true)
+        }
+
         ArrivalRowCallbacks(
-            onShowVehiclesOnMap = ::revealAtBay,
-            onEtaClick = ::revealAtBay,
+            // The row body names no trip and stops at the route; the pill names one and drills to it,
+            // fitting that vehicle with the bay. The same split the per-stop drawer makes between
+            // `onShowVehiclesOnMap` and `onFocusVehicleOnMap`. A blank tripId (a partial response) falls
+            // back to the row-body behaviour rather than asking the map to focus a trip that has no id.
+            onShowVehiclesOnMap = { arrival -> revealAtBay(arrival) },
+            onEtaClick = { arrival -> revealAtBay(arrival, focusTripId = arrival.tripId.ifBlank { null }) },
             // The badge long-press reveals the whole route, unscoped — the same meaning it has in the
             // per-stop drawer, where it deliberately drops the stop/direction scoping.
             onShowRouteOnMap = { arrival ->
@@ -98,24 +115,11 @@ internal fun rememberNearbyRowCallbacks(
                 currentOnShowTrip.value(arrival.tripId, arrival.stopId)
             },
             onShowRouteSchedule = { scheduleUrl -> ExternalIntents.goToUrl(context, scheduleUrl) },
-            onRouteFavorite = { actions -> openBayForRoute(currentRows.value, actions, homeViewModel) },
+            onRouteFavorite = ::openBayForRoute,
             onSetReminder = ::openBay,
             onToggleTracking = ::openBay,
-            onReportArrivalProblem = { actions ->
-                openBayForRoute(currentRows.value, actions, homeViewModel)
-            },
+            onReportArrivalProblem = ::openBayForRoute,
             onShowAlert = { /* Alerts are shown by the focused stop's banner; see the KDoc above. */ }
         )
     }
-}
-
-/** [ArrivalActions] carries no stop, so the bay is found through the row that produced it. */
-private fun openBayForRoute(
-    rows: List<NearbyRouteRow>,
-    actions: ArrivalActions,
-    homeViewModel: HomeViewModel
-) {
-    val bay = rows.firstOrNull { row -> row.group.trips.any { it.tripId == actions.tripId } }?.bay
-        ?: return
-    homeViewModel.revealStop(FocusedStop(bay.id, bay.name, bay.code, bay.point), animate = true)
 }

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -709,6 +709,9 @@
     <string name="preferences_experimental_regions_summary">Enables regions that may be unstable
     </string>
     <string name="map_zoom_in_for_more_stops">Zoom in to see all stops</string>
+    <!-- Title at the head of the nearby-arrivals drawer, which lists the routes leaving every stop in
+         view at transit-centre zoom (#2107). "Routes", not "stops": the list is one row per route. -->
+    <string name="nearby_arrivals_title">Nearby routes</string>
     <!-- Shown at the end of the nearby-arrivals drawer when the server truncated its response, so
          some stops in view are missing from the list entirely (#2107). -->
     <string name="nearby_arrivals_limit_exceeded">Some stops in view aren\'t listed. Zoom in to see them.</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -932,6 +932,74 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `a nearby row tap marks the bay focused so its marker renders, without recentering`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+
+        vm.showNearbyRouteOnMap(
+            bay = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)),
+            routeId = "42",
+            shortName = "42",
+            directionId = 0,
+            headsign = "Downtown"
+        )
+        advanceUntilIdle()
+        // The tap draws the route straight away; the stop focus waits on the bay's own arrivals, which
+        // are what carry the ObaStop the map needs to build the marker.
+        assertEquals(listOf("42"), map.routesShown)
+        assertEquals(0, map.focusStops.size)
+        // The drawer only exists at transit-centre zoom, so the camera pans onto the bay rather than
+        // framing the whole line — which would zoom out to its full extent and discard that view.
+        assertEquals(false, map.routeCommands.single().frameRoute)
+        assertEquals(listOf(47.6 to -122.3), map.recenters)
+        // The row body names no trip, so it stops at the route rather than the trip level (#2205).
+        assertEquals(null, map.routeCommands.single().request.focusTripId)
+        assertEquals(null, vm.stopRouteSelection()?.selectedTripId)
+
+        vm.onArrivalsLoaded(obaStop, null, emptySet())
+        advanceUntilIdle()
+
+        // The bay is now the map's rendered focus — this is the selected-stop marker. recenter is false
+        // so it cannot fight the framing the ShowRoute above already did.
+        val focused = map.focusStops.single()
+        assertEquals("1", focused.stop.id)
+        assertEquals(false, focused.recenter)
+        mapJob.cancel()
+    }
+
+    @Test
+    fun `a nearby pill tap drills to the trip and lets the vehicle-plus-bay fit own the camera`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+
+        vm.showNearbyRouteOnMap(
+            bay = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3)),
+            routeId = "42",
+            shortName = "42",
+            directionId = 0,
+            headsign = "Downtown",
+            focusTripId = "trip-7"
+        )
+        advanceUntilIdle()
+
+        // The trip rides on the request, which is what makes RouteMapController fit that vehicle
+        // together with the bay instead of framing the line.
+        val request = map.routeCommands.single().request
+        assertEquals("trip-7", request.focusTripId)
+        assertEquals("1", request.directionStopId)
+        // No pan: the fit owns the camera, and a recenter would fight it.
+        assertEquals(emptyList<Pair<Double, Double>>(), map.recenters)
+        assertEquals(listOf("trip-7"), map.vehicleSelections)
+        // The pill is one level deeper than the row body — the stop->route->trip focus (#2205).
+        assertEquals("trip-7", vm.stopRouteSelection()?.selectedTripId)
+        mapJob.cancel()
+    }
+
+    @Test
     fun `standalone route focus shows the route`() = runTest {
         val vm = viewModel()
         val map = MapDirectiveRecorder(vm)


### PR DESCRIPTION
Follow-up to #2198, which landed the transit-centre drawer. Two things: the UX tuning that came out of using it on a device, and the cleanup pass the first cut deferred.

## UX

- **The peek is per-content.** A tapped stop is a deliberate request to read *that* stop, so it keeps its 30% peek and opens showing real rows. The nearby list is ambient — it appears on zoom without being asked for, over a map the rider is still reading — so it peeks at 15%, enough to say a list is there. The fraction is a property of `HomeSheetContent` rather than an `if` in `HomeScreen`.
- **The expanded sheet stops below the status bar / notch.** `BottomSheetScaffold` has no max-height parameter: it places the Expanded anchor at `containerHeight - measuredSheetHeight`, so a content list that measures the full window pins the top edge at y=0. Capping the content height is the only lever that moves that anchor. Uses `safeDrawing` rather than `statusBars`, since a cutout can exceed the status bar.
- **A centered "Nearby routes" title** at the head of the list, marked `semantics { heading() }`.
- **Rows drop the stop code.** It's the most prominent thing the feed publishes about a bay and the least useful thing here — the list is scanned down the route column, and a leading number on every row is noise. Still one tap away on the stop's own panel.
- **Tapping a row selects the stop on the map.** The marker comes from `focusedStopId`, which only gets set when `onArrivalsLoaded` consumes a pending-focus latch — and this path explicitly cleared it, so the marker never appeared. Arming it with `preserveViewport = true` sets the marker *and* disposes of a stale restore latch, which is what the clearing was there for, without the recenter that motivated the clearing.
- **Tapping a row pans to the bay instead of framing the line.** The drawer only exists at transit-centre zoom, so framing the whole route would zoom out to its full extent and throw away the view the rider is standing in.
- **Tapping an ETA pill drills to that trip** and fits the vehicle together with the bay — the same gesture the per-stop drawer's pill makes, through the same `focusTripId`. A blank tripId falls back to row-body behaviour.

## Cleanup

- **`ReportListContentHeight`** — both arrivals sheets made the identical Material3 content-height measurement, copy-pasted. Now one helper, which also reports once per content identity rather than every scroll frame (the old `derivedStateOf` republished `last.offset` per frame, invalidating `HomeScreen`'s outer body).
- **`showNearbyRouteOnMap` goes through `showStopRoute`**, so it can't be the path that breaks the `ShowRoute`/`SelectVehicle` pairing invariant that helper exists to hold. A row-body tap now clears a vehicle a previous pill left selected.
- **Nearby row actions resolve into a trip-keyed map once per response.** They were rebuilt on every call, including a hex-colour parse, and the callers are hot: the ETA strip recomposes once a second off the live clock, and the alert-glyph check walks every trip in every row.
- **Bay direction goes through `DisplayFormat.stopDirectionText`** like every other stop surface — riders read "Southeast bound" rather than the feed's raw `SE`, and read it translated. This was the only place in the app showing a raw GTFS direction code.
- Dropped the unreachable second bay null-check in `nearbyRouteRows`, the dead `NearbyArrivals.situations()` copy (no callers), and two KDoc links to the `shouldShowSheet` that #2198 deleted.
- The headsign/bay gap rides on the stop label instead of an unconditional spacer, which had shifted every existing stop-scoped arrivals row by 2dp.

## Testing

`spotlessCheck`, `testObaGoogleDebugUnitTest` (244 classes), and `assembleObaGoogleDebug -PwarningsAsErrors=true` all pass. Two new `HomeViewModelTest` cases pin the row-tap and pill-tap map behaviour. Every UX change above was checked on a physical device.

## Deferred

`rememberNearbyRouteRows` converts a whole viewport of arrivals to `ArrivalInfo` synchronously in composition, once per poll and once per pan. `ArrivalsDisplay` exists precisely so this can happen off the main thread (as `DefaultArrivalsRepository` does), which would mean moving row-building into `NearbyArrivalsViewModel` and having `Loaded` carry the rows. That's a restructure of the VM, its UI state, the callbacks, and its tests — left for its own PR rather than buried here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tapping a nearby route or ETA now focuses the relevant route, stop, or vehicle on the map.
  * Added a localized “Nearby routes” title and clearer direction-based bay labels.
* **Improvements**
  * Nearby arrivals sheets adjust collapsed and expanded heights to available screen space.
  * Improved spacing and layout consistency for arrival rows.
  * Nearby route lists handle arrivals and bay information more reliably.
* **Accessibility**
  * Added an accessible title for the nearby-arrivals list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->