### PR TITLE
Hide the fast-estimate marker for schedule-replay trips (#2213)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
@@ -19,6 +19,7 @@ import android.location.Location
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlin.time.Duration
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -187,7 +188,7 @@ class TripExtrapolationBuilderTest {
             nowMs = WallTime(0L)
         )!!
 
-        assertEquals(-122.0, extrapolation.vehiclePoint!!.longitude, 1e-6)
+        assertNotNull("the vehicle is still drawn", extrapolation.vehiclePoint)
         assertNull("point mass has no distinct best case", extrapolation.fastEstimatePoint)
         assertTrue("point mass has no spread to band", extrapolation.band.isEmpty())
     }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/extrapolation/test/TripExtrapolationBuilderTest.kt
@@ -27,6 +27,7 @@ import org.onebusaway.android.extrapolation.BAND_SEGMENT_COUNT
 import org.onebusaway.android.extrapolation.ExtrapolationResult
 import org.onebusaway.android.extrapolation.buildTripExtrapolation
 import org.onebusaway.android.extrapolation.data.TripState
+import org.onebusaway.android.extrapolation.math.prob.DiracDistribution
 import org.onebusaway.android.extrapolation.math.prob.ProbDistribution
 import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.Occupancy
@@ -173,6 +174,22 @@ class TripExtrapolationBuilderTest {
         assertNull(
             buildTripExtrapolation(TripState("t"), ExtrapolationResult.Success(UniformDist(1000.0)), WallTime(0L))
         )
+    }
+
+    @Test
+    fun pointMassEstimateDrawsNoFastMarker() {
+        // Schedule replay (grade-separated routes) replays one deterministic trajectory, so its
+        // distribution is a point mass: the q0.90 "fast estimate" is the median, and the marker would
+        // sit on top of the vehicle. It's dropped, leaving only the vehicle point (#2213).
+        val extrapolation = buildTripExtrapolation(
+            TripState("t", polyline = northLine()),
+            ExtrapolationResult.Success(DiracDistribution(1500.0)),
+            nowMs = WallTime(0L)
+        )!!
+
+        assertEquals(-122.0, extrapolation.vehiclePoint!!.longitude, 1e-6)
+        assertNull("point mass has no distinct best case", extrapolation.fastEstimatePoint)
+        assertTrue("point mass has no spread to band", extrapolation.band.isEmpty())
     }
 
     @Test

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolation.kt
@@ -40,8 +40,8 @@ data class WeightedBandSegment(val points: List<GeoPoint>, val weight: Float)
  * the optimistic [fastEstimatePoint] ("best case"), the graded uncertainty [band], the last server
  * fix ([dataAge]), and the latest AVL fix instant ([fixTimeMs], constant between fixes so a change
  * signals fresh data). On a frame with no usable estimate the points are null and the band empty, but
- * [dataAge] still reports the last fix. [fastEstimatePoint] is also null when the extrapolation is a
- * point mass (schedule replay), which has no spread to be optimistic about.
+ * [dataAge] still reports the last fix. A point-mass extrapolation (schedule replay) likewise draws no
+ * [fastEstimatePoint] and no [band] — it has no spread, so there is no uncertainty to show.
  */
 data class TripExtrapolation(
     val vehiclePoint: GeoPoint? = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolation.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolation.kt
@@ -40,7 +40,8 @@ data class WeightedBandSegment(val points: List<GeoPoint>, val weight: Float)
  * the optimistic [fastEstimatePoint] ("best case"), the graded uncertainty [band], the last server
  * fix ([dataAge]), and the latest AVL fix instant ([fixTimeMs], constant between fixes so a change
  * signals fresh data). On a frame with no usable estimate the points are null and the band empty, but
- * [dataAge] still reports the last fix.
+ * [dataAge] still reports the last fix. [fastEstimatePoint] is also null when the extrapolation is a
+ * point mass (schedule replay), which has no spread to be optimistic about.
  */
 data class TripExtrapolation(
     val vehiclePoint: GeoPoint? = null,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -52,7 +52,12 @@ fun buildTripExtrapolation(
         // it draws the live vehicle disc + most-recent-data dot separately — so we skip the extra
         // projection + allocation on its ~20–120Hz path (#1752).
         vehiclePoint = if (includeMarkers) distribution?.let { polyline.pointAtDistance(it.median()) } else null,
-        fastEstimatePoint = distribution?.let { polyline.pointAtDistance(it.quantile(FAST_ESTIMATE_QUANTILE)) },
+        // A point-mass extrapolation (schedule replay, which replays one deterministic trajectory) has
+        // no spread, so its q0.90 is its median: the fast marker would land exactly on the vehicle and
+        // just cover it. Drop it there and draw the vehicle alone (#2213).
+        fastEstimatePoint = distribution
+            ?.takeUnless { it.isPointMass }
+            ?.let { polyline.pointAtDistance(it.quantile(FAST_ESTIMATE_QUANTILE)) },
         band = distribution?.let { weightedBandSegments(it, polyline) } ?: emptyList(),
         dataAge = if (includeMarkers) dataAgeMarker(state, nowMs) else null,
         // A domain-agnostic *change token*, not a displayed instant: the renderer only compares it for

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/TripExtrapolationBuilder.kt
@@ -45,6 +45,11 @@ fun buildTripExtrapolation(
 ): TripExtrapolation? {
     val polyline = state.polyline ?: return null
     val distribution = (result as? ExtrapolationResult.Success)?.distribution
+    // The extrapolation only when it has spread. A point mass (schedule replay, which replays one
+    // deterministic trajectory) has none, so there is no uncertainty to draw: its band would be a
+    // zero-width sliver and its q0.90 "best case" is its median, putting the fast marker exactly on the
+    // vehicle marker and covering it. Both of those consumers draw nothing there (#2213).
+    val spread = distribution?.takeUnless { it.isPointMass }
 
     return TripExtrapolation(
         // The median estimate + data-age marker are only wanted by a caller that draws them itself; the
@@ -52,13 +57,8 @@ fun buildTripExtrapolation(
         // it draws the live vehicle disc + most-recent-data dot separately — so we skip the extra
         // projection + allocation on its ~20–120Hz path (#1752).
         vehiclePoint = if (includeMarkers) distribution?.let { polyline.pointAtDistance(it.median()) } else null,
-        // A point-mass extrapolation (schedule replay, which replays one deterministic trajectory) has
-        // no spread, so its q0.90 is its median: the fast marker would land exactly on the vehicle and
-        // just cover it. Drop it there and draw the vehicle alone (#2213).
-        fastEstimatePoint = distribution
-            ?.takeUnless { it.isPointMass }
-            ?.let { polyline.pointAtDistance(it.quantile(FAST_ESTIMATE_QUANTILE)) },
-        band = distribution?.let { weightedBandSegments(it, polyline) } ?: emptyList(),
+        fastEstimatePoint = spread?.let { polyline.pointAtDistance(it.quantile(FAST_ESTIMATE_QUANTILE)) },
+        band = spread?.let { weightedBandSegments(it, polyline) } ?: emptyList(),
         dataAge = if (includeMarkers) dataAgeMarker(state, nowMs) else null,
         // A domain-agnostic *change token*, not a displayed instant: the renderer only compares it for
         // `!=` (a change means fresh AVL data) — never formats or subtracts it. 0 is the token's own

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/DiracDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/DiracDistribution.kt
@@ -19,8 +19,7 @@ package org.onebusaway.android.extrapolation.math.prob
 class DiracDistribution(val value: Double) : ProbDistribution {
     override val mean: Double
         get() = value
-    override val isPointMass: Boolean
-        get() = true
+    override val isPointMass = true
     override fun pdf(x: Double): Double = 0.0
     override fun cdf(x: Double): Double = if (x >= value) 1.0 else 0.0
     override fun quantile(p: Double): Double = value

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/DiracDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/DiracDistribution.kt
@@ -19,6 +19,8 @@ package org.onebusaway.android.extrapolation.math.prob
 class DiracDistribution(val value: Double) : ProbDistribution {
     override val mean: Double
         get() = value
+    override val isPointMass: Boolean
+        get() = true
     override fun pdf(x: Double): Double = 0.0
     override fun cdf(x: Double): Double = if (x >= value) 1.0 else 0.0
     override fun quantile(p: Double): Double = value

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/ProbDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/ProbDistribution.kt
@@ -19,6 +19,16 @@ package org.onebusaway.android.extrapolation.math.prob
 interface ProbDistribution {
     val mean: Double
 
+    /**
+     * Whether the distribution is a point mass — all its probability sits at one value, so every
+     * quantile returns that same value and there is no spread to report. Declared by the
+     * implementation rather than inferred by comparing quantiles, so consumers that only make sense
+     * for a spread distribution (the uncertainty band, the optimistic "fast estimate") can opt out
+     * on a fact instead of a numeric guess. Continuous distributions leave this false.
+     */
+    val isPointMass: Boolean
+        get() = false
+
     /** The 0.5 [quantile]; shares its contract, including the [Double.NaN] degenerate case. */
     fun median(): Double = quantile(0.5)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/ProbDistribution.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/ProbDistribution.kt
@@ -15,16 +15,18 @@
  */
 package org.onebusaway.android.extrapolation.math.prob
 
-/** A continuous probability distribution. */
+/** A probability distribution, usually but not necessarily continuous (see [isPointMass]). */
 interface ProbDistribution {
     val mean: Double
 
     /**
-     * Whether the distribution is a point mass — all its probability sits at one value, so every
-     * quantile returns that same value and there is no spread to report. Declared by the
-     * implementation rather than inferred by comparing quantiles, so consumers that only make sense
-     * for a spread distribution (the uncertainty band, the optimistic "fast estimate") can opt out
-     * on a fact instead of a numeric guess. Continuous distributions leave this false.
+     * Whether all this distribution's probability sits at one value, so every quantile returns that
+     * same value and there is no spread to report. Consumers that only make sense over a spread —
+     * the uncertainty band, the optimistic "fast estimate" — opt out on this declared fact rather
+     * than inferring it by comparing quantiles.
+     *
+     * Answered per *instance*, not per class: a distribution that collapses at particular parameters
+     * should say so, which is why the false default is only a default.
      */
     val isPointMass: Boolean
         get() = false

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
@@ -43,8 +43,7 @@ data class DataAgeMarker(val point: GeoPoint, val ageMillis: Long)
  * renderers draw the same overlay. On a frame with no usable estimate [fastEstimatePoint] is null and
  * [band] is empty.
  *
- * @property fastEstimatePoint the optimistic (high-quantile) "best case" position, or null — also null
- *   for a point-mass extrapolation (schedule replay), whose best case is its median (#2213)
+ * @property fastEstimatePoint the optimistic (high-quantile) "best case" position, or null
  * @property band the graded uncertainty band over the route shape (empty when no estimate)
  * @property fixTimeMs the latest AVL fix's timestamp — constant between fixes, so a change signals
  *   fresh data; the renderer animates the marker to its new position when it changes

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
@@ -43,7 +43,8 @@ data class DataAgeMarker(val point: GeoPoint, val ageMillis: Long)
  * renderers draw the same overlay. On a frame with no usable estimate [fastEstimatePoint] is null and
  * [band] is empty.
  *
- * @property fastEstimatePoint the optimistic (high-quantile) "best case" position, or null
+ * @property fastEstimatePoint the optimistic (high-quantile) "best case" position, or null — also null
+ *   for a point-mass extrapolation (schedule replay), whose best case is its median (#2213)
  * @property band the graded uncertainty band over the route shape (empty when no estimate)
  * @property fixTimeMs the latest AVL fix's timestamp — constant between fixes, so a change signals
  *   fresh data; the renderer animates the marker to its new position when it changes

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/DiracDistributionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/DiracDistributionTest.kt
@@ -16,7 +16,6 @@
 package org.onebusaway.android.extrapolation.math.prob
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -56,9 +55,4 @@ class DiracDistributionTest {
     @Test fun `median equals value`() = assertEquals(5.0, dist.median(), 0.0)
 
     @Test fun `reports itself as a point mass`() = assertTrue(dist.isPointMass)
-
-    @Test
-    fun `a spread distribution is not a point mass`() {
-        assertFalse(GammaDistribution(alpha = 2.0, scale = 3.0).isPointMass)
-    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/DiracDistributionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/DiracDistributionTest.kt
@@ -16,6 +16,8 @@
 package org.onebusaway.android.extrapolation.math.prob
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DiracDistributionTest {
@@ -52,4 +54,11 @@ class DiracDistributionTest {
     }
 
     @Test fun `median equals value`() = assertEquals(5.0, dist.median(), 0.0)
+
+    @Test fun `reports itself as a point mass`() = assertTrue(dist.isPointMass)
+
+    @Test
+    fun `a spread distribution is not a point mass`() {
+        assertFalse(GammaDistribution(alpha = 2.0, scale = 3.0).isPointMass)
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/GammaDistributionTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/extrapolation/math/prob/GammaDistributionTest.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.extrapolation.math.prob
 import kotlin.math.exp
 import kotlin.math.ln
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -186,6 +187,11 @@ class GammaDistributionTest {
     @Test(expected = IllegalArgumentException::class)
     fun `scale must be positive`() {
         GammaDistribution(1.0, 0.0)
+    }
+
+    @Test
+    fun `a spread distribution is not a point mass`() {
+        assertFalse(GammaDistribution(2.0, 3.0).isPointMass)
     }
 
     /**


### PR DESCRIPTION
Fixes #2213.

## The problem

`ScheduleReplayExtrapolator` — used for grade-separated routes (rail, subway) — replays one deterministic schedule trajectory, so it returns a `DiracDistribution`: a point mass. Every quantile of a point mass is the same value, so the q0.90 "fast estimate" marker was drawn at exactly the median, landing on top of the vehicle marker and covering it. It showed an uncertainty bound where there is no uncertainty.

## The fix

Distributions now declare whether they are a point mass — `ProbDistribution.isPointMass`, default `false`, overridden `true` only by `DiracDistribution`. `buildTripExtrapolation` binds the distribution to a `spread` value only when it has spread, and draws both the fast-estimate marker and the uncertainty band from that. Point-mass trips get neither; the vehicle marker is drawn alone.

An explicit property rather than comparing `quantile(0.90)` against `median()`: the fact is knowable at the source, and the numeric test would be a magnitude guess (and would cost an extra bisect-based `median()` solve per frame on the ~20–120Hz sampler path, which otherwise never computes it).

The band was already coming out empty for a point mass, but incidentally — a zero-width quantile range yields no slices. Routing both consumers through one predicate means the two can't drift apart.

## Layering

The gate sits on the distribution, in the geometry builder. The alternatives are worse: declaring "deterministic" on `ExtrapolationResult` would duplicate a fact the distribution already owns and wouldn't reach `TripTrajectory`, which takes the distribution straight off `Success`; checking at the render layer would mean an epsilon compare of two `GeoPoint`s after the model fact is gone, duplicated across both renderers. `isPointMass` is a mathematical property of the measure, not a rendering hint.

## Testing

- `TripExtrapolationBuilderTest.pointMassEstimateDrawsNoFastMarker` (instrumented — the builder projects through `Polyline`, which needs `android.location.Location`).
- `DiracDistributionTest` / `GammaDistributionTest` pin `isPointMass` on both sides of the default.
- Compiles clean under `-PwarningsAsErrors=true`; `spotlessCheck` passes. The new instrumented test has not been run on a device — left to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved schedule replay handling for exact point predictions.
  * Vehicle markers remain available, while fast-estimate markers and uncertainty bands are omitted when no prediction spread exists.
  * Probability distributions can now identify whether they represent a single exact value.

* **Tests**
  * Added coverage for exact and spread-based prediction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->