### PR TITLE
Resolve each vehicle marker against the poll it came from

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/VehicleIconAllocationTest.kt
@@ -93,6 +93,7 @@ class VehicleIconAllocationTest {
                     point = v.point,
                     isRealtime = v.status.isLocationRealtime,
                     status = v.status,
+                    source = response,
                     fixTimeMs = v.fixTimeMs
                 )
             }
@@ -129,11 +130,11 @@ class VehicleIconAllocationTest {
             for ((index, vehicle) in vehicles.withIndex()) {
                 val filling = withOccupancy(vehicle, OCCUPANCY_CYCLE[(poll + index) % OCCUPANCY_CYCLE.size])
                 counts.requests++
-                val key = VehicleBitmaps.iconKey(context, filling, response)
+                val key = VehicleBitmaps.iconKey(context, filling)
                 counts.keys.add(key)
                 cache.get(key) {
                     counts.bitmapDecodes++
-                    VehicleBitmaps.vehicleBitmap(context, filling, response)
+                    VehicleBitmaps.vehicleBitmap(context, filling)
                 }
             }
         }
@@ -203,8 +204,8 @@ class VehicleIconAllocationTest {
         val samples = vehicles.flatMap { vehicle ->
             OCCUPANCY_CYCLE.map { occupancy ->
                 val reporting = withOccupancy(vehicle, occupancy)
-                VehicleBitmaps.iconKey(context, reporting, response) to
-                    VehicleBitmaps.vehicleBitmap(context, reporting, response)
+                VehicleBitmaps.iconKey(context, reporting) to
+                    VehicleBitmaps.vehicleBitmap(context, reporting)
             }
         }
         val byKey = samples.groupBy({ it.first }, { it.second })
@@ -237,14 +238,14 @@ class VehicleIconAllocationTest {
         val live = withLiveness(vehicle, isRealtime = true)
         val stale = withLiveness(vehicle, isRealtime = false)
 
-        val liveKey = VehicleBitmaps.iconKey(context, live, response)
-        val staleKey = VehicleBitmaps.iconKey(context, stale, response)
+        val liveKey = VehicleBitmaps.iconKey(context, live)
+        val staleKey = VehicleBitmaps.iconKey(context, stale)
         assertNotEquals("liveness must be part of the icon key", liveKey, staleKey)
 
         val counts = Counts()
         val cache = BitmapDescriptorCache(CACHE_SIZE) { counts.allocations++ }
-        cache.get(liveKey) { VehicleBitmaps.vehicleBitmap(context, live, response) }
-        cache.get(staleKey) { VehicleBitmaps.vehicleBitmap(context, stale, response) }
+        cache.get(liveKey) { VehicleBitmaps.vehicleBitmap(context, live) }
+        cache.get(staleKey) { VehicleBitmaps.vehicleBitmap(context, stale) }
         assertEquals("a changed disc color must mint a second descriptor", 2, counts.allocations)
     }
 
@@ -261,13 +262,13 @@ class VehicleIconAllocationTest {
 
         assertEquals(
             "schedule deviation must not reach the marker icon",
-            VehicleBitmaps.iconKey(context, early, response),
-            VehicleBitmaps.iconKey(context, late, response)
+            VehicleBitmaps.iconKey(context, early),
+            VehicleBitmaps.iconKey(context, late)
         )
         assertTrue(
             "an early and a late vehicle must render the identical disc",
-            VehicleBitmaps.vehicleBitmap(context, early, response)
-                .sameAs(VehicleBitmaps.vehicleBitmap(context, late, response))
+            VehicleBitmaps.vehicleBitmap(context, early)
+                .sameAs(VehicleBitmaps.vehicleBitmap(context, late))
         )
     }
 
@@ -284,8 +285,8 @@ class VehicleIconAllocationTest {
 
         assertNotEquals(
             "the band colour must be part of the icon key",
-            VehicleBitmaps.iconKey(context, unselected, response),
-            VehicleBitmaps.iconKey(context, selected, response)
+            VehicleBitmaps.iconKey(context, unselected),
+            VehicleBitmaps.iconKey(context, selected)
         )
         assertEquals(
             "the selected vehicle's disc must be drawn in the band's colour",
@@ -305,8 +306,8 @@ class VehicleIconAllocationTest {
 
         assertEquals(
             "a band colour must not reach a scheduled vehicle's disc",
-            VehicleBitmaps.iconKey(context, scheduled, response),
-            VehicleBitmaps.iconKey(context, scheduled.copy(bandColor = 0xFFC05010.toInt()), response)
+            VehicleBitmaps.iconKey(context, scheduled),
+            VehicleBitmaps.iconKey(context, scheduled.copy(bandColor = 0xFFC05010.toInt()))
         )
     }
 
@@ -354,14 +355,14 @@ class VehicleIconAllocationTest {
         val empty = withOccupancy(vehicle, Occupancy.EMPTY)
         val full = withOccupancy(vehicle, Occupancy.FULL)
 
-        val emptyKey = VehicleBitmaps.iconKey(context, empty, response)
-        val fullKey = VehicleBitmaps.iconKey(context, full, response)
+        val emptyKey = VehicleBitmaps.iconKey(context, empty)
+        val fullKey = VehicleBitmaps.iconKey(context, full)
         assertNotEquals("occupancy must be part of the icon key", emptyKey, fullKey)
 
         val counts = Counts()
         val cache = BitmapDescriptorCache(CACHE_SIZE) { counts.allocations++ }
-        cache.get(emptyKey) { VehicleBitmaps.vehicleBitmap(context, empty, response) }
-        cache.get(fullKey) { VehicleBitmaps.vehicleBitmap(context, full, response) }
+        cache.get(emptyKey) { VehicleBitmaps.vehicleBitmap(context, empty) }
+        cache.get(fullKey) { VehicleBitmaps.vehicleBitmap(context, full) }
         assertEquals("a changed fill level must mint a second descriptor", 2, counts.allocations)
     }
 
@@ -378,13 +379,13 @@ class VehicleIconAllocationTest {
 
         assertNotEquals(
             "a vehicle reporting no occupancy must not share an icon with an empty one",
-            VehicleBitmaps.iconKey(context, unreported, response),
-            VehicleBitmaps.iconKey(context, empty, response)
+            VehicleBitmaps.iconKey(context, unreported),
+            VehicleBitmaps.iconKey(context, empty)
         )
         assertTrue(
             "...and must not render the same bitmap either",
-            !VehicleBitmaps.vehicleBitmap(context, unreported, response)
-                .sameAs(VehicleBitmaps.vehicleBitmap(context, empty, response))
+            !VehicleBitmaps.vehicleBitmap(context, unreported)
+                .sameAs(VehicleBitmaps.vehicleBitmap(context, empty))
         )
     }
 
@@ -401,13 +402,13 @@ class VehicleIconAllocationTest {
 
         assertEquals(
             "occupancy must not reach a scheduled vehicle's icon",
-            VehicleBitmaps.iconKey(context, plain, response),
-            VehicleBitmaps.iconKey(context, crowded, response)
+            VehicleBitmaps.iconKey(context, plain),
+            VehicleBitmaps.iconKey(context, crowded)
         )
         assertTrue(
             "a scheduled vehicle renders the identical tabless disc whatever occupancy says",
-            VehicleBitmaps.vehicleBitmap(context, plain, response)
-                .sameAs(VehicleBitmaps.vehicleBitmap(context, crowded, response))
+            VehicleBitmaps.vehicleBitmap(context, plain)
+                .sameAs(VehicleBitmaps.vehicleBitmap(context, crowded))
         )
     }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/VehicleMarkerTextTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/VehicleMarkerTextTest.kt
@@ -54,7 +54,7 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = FakeTrip(headsign = "Ballard"), route = FakeRoute(shortName = "44"))
         assertEquals(
             "44 - Ballard - " + context.getString(R.string.realtime_standing_room),
-            vehicleTitle(context, vehicle(Occupancy.STANDING_ROOM_ONLY), response)
+            vehicleTitle(context, vehicle(Occupancy.STANDING_ROOM_ONLY, response))
         )
     }
 
@@ -68,7 +68,7 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = null, route = FakeRoute(shortName = "44"))
         assertEquals(
             context.getString(R.string.vehicle_marker_unidentified) + " - " + context.getString(R.string.realtime_full),
-            vehicleTitle(context, vehicle(Occupancy.FULL), response)
+            vehicleTitle(context, vehicle(Occupancy.FULL, response))
         )
     }
 
@@ -78,7 +78,7 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = FakeTrip(headsign = "Ballard"), route = null)
         assertEquals(
             "Ballard - " + context.getString(R.string.realtime_full),
-            vehicleTitle(context, vehicle(Occupancy.FULL), response)
+            vehicleTitle(context, vehicle(Occupancy.FULL, response))
         )
     }
 
@@ -91,7 +91,7 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = FakeTrip(headsign = null), route = FakeRoute(shortName = null))
         assertEquals(
             context.getString(R.string.vehicle_marker_unidentified) + " - " + context.getString(R.string.realtime_full),
-            vehicleTitle(context, vehicle(Occupancy.FULL), response)
+            vehicleTitle(context, vehicle(Occupancy.FULL, response))
         )
     }
 
@@ -101,7 +101,7 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = null, route = null)
         assertEquals(
             context.getString(R.string.vehicle_marker_unidentified),
-            vehicleTitle(context, vehicle(occupancy = null), response)
+            vehicleTitle(context, vehicle(occupancy = null, response = response))
         )
     }
 
@@ -111,7 +111,7 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = FakeTrip(headsign = "Ballard"), route = FakeRoute(shortName = "44"))
         assertEquals(
             "44 - Ballard",
-            vehicleTitle(context, vehicle(Occupancy.FULL, isRealtime = false), response)
+            vehicleTitle(context, vehicle(Occupancy.FULL, response, isRealtime = false))
         )
     }
 
@@ -125,19 +125,24 @@ class VehicleMarkerTextTest {
         val response = routeTrips(trip = FakeTrip(headsign = "Ballard"), route = FakeRoute(shortName = "44"))
         assertEquals(
             "44 - Ballard - " + context.getString(R.string.realtime_empty),
-            vehicleTitle(context, vehicle(Occupancy.EMPTY), response)
+            vehicleTitle(context, vehicle(Occupancy.EMPTY, response))
         )
         assertEquals(
             "44 - Ballard",
-            vehicleTitle(context, vehicle(occupancy = null), response)
+            vehicleTitle(context, vehicle(occupancy = null, response = response))
         )
     }
 
-    private fun vehicle(occupancy: Occupancy?, isRealtime: Boolean = true): VehicleMarker = VehicleMarker(
+    private fun vehicle(
+        occupancy: Occupancy?,
+        response: RouteTrips,
+        isRealtime: Boolean = true
+    ): VehicleMarker = VehicleMarker(
         activeTripId = "trip1",
         point = GeoPoint(47.6, -122.3),
         isRealtime = isRealtime,
-        status = FakeStatus(occupancy)
+        status = FakeStatus(occupancy),
+        source = response
     )
 
     /** A [RouteTrips] whose references pool holds at most the given trip/route. */

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -76,7 +76,6 @@ import org.onebusaway.android.map.render.rentalZoomBand
 import org.onebusaway.android.map.render.routeLineWidthScale
 import org.onebusaway.android.map.render.vehicleTitle
 import org.onebusaway.android.map.rental.rentalChargeFraction
-import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.MyTextUtils
@@ -141,12 +140,6 @@ class GoogleMapRenderer(
     // The zoom the route-badge icons above were last stamped at. Synced to the live camera by each static
     // redraw and moved by each settle, so the scale a label draws at always answers the camera it's under.
     private var renderedBadgeZoom = map.cameraPosition.zoom
-
-    // The latest trips-for-route poll, kept so a scale change can re-stamp the retained markers' icons
-    // without waiting for the next one. Plain state rather than a StateFlow (matching the maplibre
-    // flavor): the vehicle bubble that used to collect it, to re-render itself from each fresh poll, is
-    // gone — the marker carries what it said (#2194).
-    private var lastVehicleResponse: RouteTrips? = null
 
     // The non-route static annotations added by the last [renderStatic], removed (not map.clear()) on
     // the next so the retained route and per-frame dynamic layers survive a static redraw.
@@ -627,8 +620,7 @@ class GoogleMapRenderer(
      * published rather than being inferred from the per-frame motion sample.
      */
     fun reconcileVehicles(set: MapVehicles?) {
-        reconcileVehicleMarkers(set?.markers.orEmpty(), set?.response)
-        lastVehicleResponse = set?.response
+        reconcileVehicleMarkers(set?.markers.orEmpty())
     }
 
     // Per-frame motion: move each already-reconciled marker to its smoothed extrapolated position (a
@@ -730,7 +722,7 @@ class GoogleMapRenderer(
     }
 
     /** Add/remove vehicle markers to match [markers], (re)setting their icons, titles, and tap data. */
-    private fun reconcileVehicleMarkers(markers: List<VehicleMarker>, response: RouteTrips?) {
+    private fun reconcileVehicleMarkers(markers: List<VehicleMarker>) {
         val liveIds = markers.mapTo(HashSet()) { it.activeTripId }
         vehicleSmoother.retainOnly(liveIds)
         val gone = vehicleMarkersByTripId.iterator()
@@ -742,43 +734,41 @@ class GoogleMapRenderer(
                 gone.remove()
             }
         }
-        if (response == null) return
         for (vehicle in markers) {
             val existing = vehicleMarkersByTripId[vehicle.activeTripId]
             if (existing == null) {
                 val marker = map.addMarkerOrFail(
                     MarkerOptions()
                         .position(vehicle.point.toLatLng())
-                        .icon(vehicleIcon(vehicle, response))
+                        .icon(vehicleIcon(vehicle))
                         // Center the disc badge on the vehicle location, so it sits on the route
                         // centerline like the trip map's estimate marker rather than floating off it (#1752).
                         // A plain center anchor is right for both marker shapes: the bitmap reserves the
                         // occupancy tab's depth above the disc as well as below, so its center *is* the
                         // disc's center whether or not a tab is drawn (see [VehicleBitmaps]).
                         .anchor(0.5f, 0.5f)
-                        .title(vehicleTitle(context, vehicle, response))
+                        .title(vehicleTitle(context, vehicle))
                         .zIndex(VEHICLE_Z_INDEX)
                 )
                 vehicleMarkersByTripId[vehicle.activeTripId] = marker
                 vehicleByMarker[marker] = vehicle
             } else {
-                existing.setIcon(vehicleIcon(vehicle, response))
-                existing.title = vehicleTitle(context, vehicle, response)
+                existing.setIcon(vehicleIcon(vehicle))
+                existing.title = vehicleTitle(context, vehicle)
                 vehicleByMarker[existing] = vehicle
             }
         }
     }
 
-    private fun vehicleIcon(vehicle: VehicleMarker, response: RouteTrips): BitmapDescriptor = descriptorCache.get(VehicleBitmaps.iconKey(context, vehicle, response, renderedVehicleScale)) {
-        VehicleBitmaps.vehicleBitmap(context, vehicle, response, renderedVehicleScale)
+    private fun vehicleIcon(vehicle: VehicleMarker): BitmapDescriptor = descriptorCache.get(VehicleBitmaps.iconKey(context, vehicle, renderedVehicleScale)) {
+        VehicleBitmaps.vehicleBitmap(context, vehicle, renderedVehicleScale)
     }
 
     /** Re-stamp retained vehicle markers only when the settle-time detail scale changes. */
     private fun updateVehicleScale(scale: Float) {
         if (scale == renderedVehicleScale) return
         renderedVehicleScale = scale
-        val response = lastVehicleResponse ?: return
-        for ((marker, vehicle) in vehicleByMarker) marker.setIcon(vehicleIcon(vehicle, response))
+        for ((marker, vehicle) in vehicleByMarker) marker.setIcon(vehicleIcon(vehicle))
     }
 
     private fun updateTripOverlay(overlay: TripOverlay?, nowMs: Long) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -626,10 +626,9 @@ class RouteMapController(
         // HSV round trip we'd otherwise repeat for every marker on the 20 Hz sampler.
         val selectedId = renderState.selectedVehicleTripId.value
         val bandColor = selectedId?.let { contrastingColor(selectedTripLineColor) }
-        return MapVehicles(
-            markers = vehicles.map { (vehicle, source) -> vehicle.toMarker(source, colors, selectedId, bandColor) },
-            response = poll.response
-        )
+        // Each marker keeps the poll it came out of, not just the leader's: that pairing is what lets the
+        // renderer resolve an extra route's vehicle at all (see [VehicleMarker.source]).
+        return MapVehicles(vehicles.map { (vehicle, source) -> vehicle.toMarker(source, colors, selectedId, bandColor) })
     }
 
     // The vehicle set to push whenever it changes (a poll, a direction switch, the load resolving the
@@ -1333,6 +1332,7 @@ class RouteMapController(
         point = point,
         isRealtime = isRealtime,
         status = status,
+        source = response,
         fixTimeMs = fixTimeMs,
         bearing = bearing,
         dataFixPoint = dataFixPoint,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -199,17 +199,31 @@ data class RoutePolyline(
 data class GenericMarker(val point: GeoPoint, val hue: Float?)
 
 /**
- * One real-time vehicle marker. [status] is the raw io/elements status (the renderer derives the
- * icon, color, occupancy pips, and title from it, paired with the shared [MapVehicles.response]);
- * [activeTripId] is the stable key used for marker identity + animation; [isRealtime] is the
- * draw-time decision (from whatever produced the drawn point — the extrapolation anchor or the current
- * status) that selects the live-vs-scheduled icon.
+ * One real-time vehicle marker. [status] is the raw io/elements status (the renderer derives the icon,
+ * color, occupancy pips, and title from it, resolved against [source]); [activeTripId] is the stable key
+ * used for marker identity + animation; [isRealtime] is the draw-time decision (from whatever produced
+ * the drawn point — the extrapolation anchor or the current status) that selects the live-vs-scheduled
+ * icon.
  */
 data class VehicleMarker(
     val activeTripId: String,
     val point: GeoPoint,
     val isRealtime: Boolean,
     val status: ObaTripStatus,
+    /**
+     * The poll this vehicle came out of — the references pool its trip, and through it its route type and
+     * name, resolve from.
+     *
+     * Carried per vehicle rather than once for the set, because a set is not always one poll's worth of
+     * vehicles: a route-focus session with interchangeable routes (#2042) or a stay-aboard interline
+     * (#2000) merges the leader poll with an extra poll per extra route, and a poll's references answer
+     * for its **own** vehicles. Held as one shared response, every extra route's vehicle missed both hops
+     * and silently took the default bus glyph and an "unidentified" accessible name — a 2 Line train drawn
+     * as a bus while the 1 Line beside it drew correctly. #2043 fixed the same mismatch for the disc
+     * *colour* by pairing each vehicle with its poll; this is that pairing kept on the marker, so the
+     * renderer cannot reach for the wrong pool.
+     */
+    val source: RouteTrips,
     // The latest fix's instant — constant between fixes (so [point] is extrapolated forward from it),
     // changing when fresh AVL data arrives. The renderer animates the marker across the fix jump.
     val fixTimeMs: Long = 0L,
@@ -518,18 +532,15 @@ data class MapRenderSnapshot(
 }
 
 /**
- * The route-mode vehicle **set**: which vehicles exist and the [response] their icons and titles
- * derive from. This is discrete state — it changes only at events (a new poll, a direction switch,
- * leaving route mode), so it's *pushed* (see [MapRenderState.vehicleSet]) and the renderer reconciles
- * markers from each emission. Per-frame *motion* is a separate concern (see
+ * The route-mode vehicle **set**: which vehicles exist, each carrying the poll it came out of (see
+ * [VehicleMarker.source]). This is discrete state — it changes only at events (a new poll, a direction
+ * switch, leaving route mode), so it's *pushed* (see [MapRenderState.vehicleSet]) and the renderer
+ * reconciles markers from each emission. Per-frame *motion* is a separate concern (see
  * [MapRenderState.vehiclesSampler]); the [markers] here carry only a seed position for a freshly-added
  * marker, which the motion sampler immediately supersedes. The selected vehicle is tracked separately
  * (see [MapRenderState.selectedVehicleTripId]).
  */
-data class MapVehicles(
-    val markers: List<VehicleMarker> = emptyList(),
-    val response: RouteTrips? = null
-)
+data class MapVehicles(val markers: List<VehicleMarker> = emptyList())
 
 /**
  * Produces a renderable frame [T] — the trip-focus overlay or the live vehicle layer — for a frame

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -210,11 +210,10 @@ object VehicleBitmaps {
     fun vehicleBitmap(
         context: Context,
         vehicle: VehicleMarker,
-        response: RouteTrips,
         sizeScale: Float = 1f
     ): Bitmap = getBitmap(
         context,
-        vehicleType(vehicle, response),
+        vehicleType(vehicle),
         discColor(context, vehicle),
         occupancyBucket(vehicle),
         sizeScale
@@ -242,18 +241,23 @@ object VehicleBitmaps {
     fun iconKey(
         context: Context,
         vehicle: VehicleMarker,
-        response: RouteTrips,
         sizeScale: Float = 1f
     ): String = "veh:" +
         createBitmapCacheKey(
-            vehicleType(vehicle, response),
+            vehicleType(vehicle),
             discColor(context, vehicle),
             occupancyBucket(vehicle),
             sizeScale
         )
 
-    /** The vehicle's route type, normalizing cablecar to tram so both the bitmap and key paths agree. */
-    private fun vehicleType(vehicle: VehicleMarker, response: RouteTrips): Int = routeTypeFor(response, vehicle.status.activeTripId)
+    /**
+     * The vehicle's route type, normalizing cablecar to tram so both the bitmap and key paths agree.
+     *
+     * Resolved against the vehicle's **own** poll ([VehicleMarker.source]) rather than a pool handed in
+     * beside it: a set can merge several route polls, and another route's references answer for this
+     * vehicle only by luck — which is exactly how a whole line's trains came to be drawn as buses.
+     */
+    private fun vehicleType(vehicle: VehicleMarker): Int = routeTypeFor(vehicle.source, vehicle.status.activeTripId)
 
     /**
      * The route type behind [activeTripId], or [DEFAULT_VEHICLE_TYPE] when it can't be resolved.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -74,8 +74,9 @@ object VehicleBitmaps {
     // it was 8 heading octants x 4 pip levels = 32 icons per (mode, disc colour), and is now 5 fullness
     // states (absent + 0..3 filled) — a handful for one route once its scheduled vehicles are counted, and
     // stop-focus/continuation views draw several routes at once, so this is sized for a few of those
-    // rather than one. Overflow only costs a re-render. The Google flavor has a second-level
-    // BitmapDescriptor cache in front of this; maplibre doesn't, which is why the bound lives here.
+    // rather than one. Overflow only costs a re-render. Both flavors put a second-level icon cache in
+    // front of this, keyed by [iconKey] — the Google flavor's BitmapDescriptor cache and maplibre's
+    // vehicleIcons — since re-wrapping even a cached Bitmap mints a fresh native texture/sprite.
     private const val MAX_CACHE_BYTES = 4 * 1024 * 1024
 
     /** The composited marker fills a square this many dp on a side (the former raster's size). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleMarkerText.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleMarkerText.kt
@@ -33,9 +33,10 @@ import org.onebusaway.android.util.getRouteDisplayName
  * accessible name is exactly the thing that must not quietly drift between flavors (only the `oba`
  * *Google* variant runs in the routine test grid, so a maplibre-side divergence would be invisible).
  */
-internal fun vehicleTitle(context: Context, vehicle: VehicleMarker, response: RouteTrips): String {
-    val trip = response.trip(vehicle.status.activeTripId)
-    val route = trip?.let { response.route(it.routeId) }
+internal fun vehicleTitle(context: Context, vehicle: VehicleMarker): String {
+    // Resolved against the vehicle's own poll, for the reason [VehicleMarker.source] gives.
+    val trip = vehicle.source.trip(vehicle.status.activeTripId)
+    val route = trip?.let { vehicle.source.route(it.routeId) }
     // Assembled from whatever resolved rather than bailing on the first null, because the marker is
     // drawn either way: a vehicle mid-block-interline reports an activeTripId this route's poll never
     // fetched (#2020), and it still gets a default-glyph marker with its pips. Returning "" there left

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -229,6 +229,23 @@ class MapLibreRenderer(
     // is there: a marker holds its own reference to the Icon it was given. Freed in [dispose].
     private val tripCircleIcons = LruCache<Pair<Int, Int>, Icon>(TRIP_ICON_CACHE_SIZE)
 
+    // Vehicle marker icons by [VehicleBitmaps.iconKey] — the maplibre counterpart of the Google flavor's
+    // descriptorCache on the same path, keyed the same way, and cached for the reason [routeBadgeIcons]
+    // and [tripCircleIcons] are: `iconFactory.fromBitmap` mints a fresh native sprite id per call (two
+    // icons made from equal bitmaps never dedupe) and `Marker.icon =` does not release the icon it
+    // replaces. [VehicleBitmaps]'s own LRU bounds the *bitmaps*, which is why this flavor got away
+    // without a second level for so long — but that cache hands back the same Bitmap, and re-wrapping it
+    // still registers another sprite. So a reconcile re-stamping every retained vehicle each poll, and
+    // [updateVehicleScale] re-stamping them on each camera settle, leaked a sprite per vehicle per pass
+    // for the life of the map — an unbounded climb toward the SDK's TooManyIconsException on a long
+    // session in route mode. Freed in [dispose].
+    //
+    // Sized like the badges rather than the trip glyphs: a busy route's vehicles span several fullness
+    // states per disc colour, and a stop-focus or continuation view draws several routes' worth at once.
+    // Evicting is safe for the same reason it is there — a marker holds its own reference to the Icon it
+    // was given, so a still-drawn vehicle keeps its sprite and an evicted key is merely re-minted.
+    private val vehicleIcons = LruCache<String, Icon>(VEHICLE_ICON_CACHE_SIZE)
+
     // The one-shot "ping" ripple (#1764): a ring-bitmap marker grown + faded over [MapPing.DURATION],
     // recentered each frame on trip [pingTripId]'s vehicle marker so it follows the icon as it settles (the
     // classic annotation API has no circle). [pingStart] is null until the first tick stamps it; null id = no ping.
@@ -430,6 +447,7 @@ class MapLibreRenderer(
         tripCircleIcons.evictAll()
         bandPolylines.clear()
         vehicleByMarker.clear()
+        vehicleIcons.evictAll()
         rentalByMarker.clear()
         rentalIcons.clear()
         pinnedTripByMarker = null
@@ -627,9 +645,12 @@ class MapLibreRenderer(
     // no-adjustment-available constraint is why the bitmap reserves the occupancy tab's depth above the
     // disc as well as below: it keeps the disc on the bitmap's center even for a marker whose tab hangs
     // off the bottom, so this flavor needs no anchor it cannot express (see [VehicleBitmaps]).
-    private fun vehicleIcon(vehicle: VehicleMarker): Icon = iconFactory.fromBitmap(
-        VehicleBitmaps.vehicleBitmap(context, vehicle, renderedVehicleScale)
-    )
+    private fun vehicleIcon(vehicle: VehicleMarker): Icon {
+        val key = VehicleBitmaps.iconKey(context, vehicle, renderedVehicleScale)
+        return vehicleIcons.get(key)
+            ?: iconFactory.fromBitmap(VehicleBitmaps.vehicleBitmap(context, vehicle, renderedVehicleScale))
+                .also { vehicleIcons.put(key, it) }
+    }
 
     /** Re-stamp retained vehicle markers only when the settle-time detail scale changes. */
     private fun updateVehicleScale(scale: Float) {
@@ -801,6 +822,12 @@ class MapLibreRenderer(
         // Far smaller than the badge cache because only one vehicle is selected at a time, so exactly two
         // of these are ever on the map at once; this is reuse across selections, not a working set.
         private const val TRIP_ICON_CACHE_SIZE = 16
+
+        // A busy route's vehicles span the five fullness states across the handful of disc colours a
+        // stop-focus or continuation view draws at once, times the settle-time detail scales
+        // [routeLineWidthScale] resolves to. Sized like the badges rather than the trip glyphs because
+        // this is a genuine working set, not reuse across selections.
+        private const val VEHICLE_ICON_CACHE_SIZE = 256
     }
 }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -66,7 +66,6 @@ import org.onebusaway.android.map.render.rentalZoomBand
 import org.onebusaway.android.map.render.routeLineWidthScale
 import org.onebusaway.android.map.render.vehicleTitle
 import org.onebusaway.android.map.rental.rentalChargeFraction
-import org.onebusaway.android.models.RouteTrips
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.MyTextUtils
@@ -188,8 +187,7 @@ class MapLibreRenderer(
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route
     // vehicles keyed by active trip id, the trip-focus estimate markers keyed by role, and the band's
-    // (interaction-free) polylines re-added each frame. [lastVehicleResponse] is the current poll, set on
-    // each vehicle-set reconcile, so a scale change can re-stamp the retained markers' icons.
+    // (interaction-free) polylines re-added each frame.
     private val vehicleMarkersByTripId = HashMap<String, Marker>()
     private val tripMarkersByRole = HashMap<String, Marker>()
 
@@ -197,7 +195,6 @@ class MapLibreRenderer(
     // band colour changes (#1990); dropped with the marker.
     private val tripMarkerFills = HashMap<String, Int>()
     private val bandPolylines = mutableListOf<Polyline>()
-    private var lastVehicleResponse: RouteTrips? = null
 
     private var renderedVehicleScale = routeLineWidthScale(map.cameraPosition.zoom.toFloat())
 
@@ -439,7 +436,6 @@ class MapLibreRenderer(
         routeBadgeByMarker.clear()
         routeBadgeIcons.evictAll()
         mostRecentDataMarker = null
-        lastVehicleResponse = null
     }
 
     /** Start a one-shot ping ripple on trip [tripId]'s vehicle; the driver calls [tickPing] to animate it (#1764). */
@@ -504,8 +500,7 @@ class MapLibreRenderer(
      * published rather than being inferred from the per-frame motion sample.
      */
     fun reconcileVehicles(set: MapVehicles?) {
-        reconcileVehicleMarkers(set?.markers.orEmpty(), set?.response)
-        lastVehicleResponse = set?.response
+        reconcileVehicleMarkers(set?.markers.orEmpty())
     }
 
     // Per-frame motion: move each already-reconciled marker to its smoothed extrapolated position — no set
@@ -597,7 +592,7 @@ class MapLibreRenderer(
     }
 
     /** Add/remove vehicle markers to match [markers], (re)setting their icons, titles, and tap data. */
-    private fun reconcileVehicleMarkers(markers: List<VehicleMarker>, response: RouteTrips?) {
+    private fun reconcileVehicleMarkers(markers: List<VehicleMarker>) {
         val liveIds = markers.mapTo(HashSet()) { it.activeTripId }
         vehicleSmoother.retainOnly(liveIds)
         val gone = vehicleMarkersByTripId.iterator()
@@ -609,20 +604,19 @@ class MapLibreRenderer(
                 gone.remove()
             }
         }
-        if (response == null) return
         for (vehicle in markers) {
             val existing = vehicleMarkersByTripId[vehicle.activeTripId]
             if (existing == null) {
                 val marker = map.addMarker(
                     MarkerOptions().position(vehicle.point.toLatLng())
-                        .icon(vehicleIcon(vehicle, response))
-                        .title(vehicleTitle(context, vehicle, response))
+                        .icon(vehicleIcon(vehicle))
+                        .title(vehicleTitle(context, vehicle))
                 )
                 vehicleMarkersByTripId[vehicle.activeTripId] = marker
                 vehicleByMarker[marker] = vehicle
             } else {
-                existing.icon = vehicleIcon(vehicle, response)
-                existing.title = vehicleTitle(context, vehicle, response)
+                existing.icon = vehicleIcon(vehicle)
+                existing.title = vehicleTitle(context, vehicle)
                 vehicleByMarker[existing] = vehicle
             }
         }
@@ -633,16 +627,15 @@ class MapLibreRenderer(
     // no-adjustment-available constraint is why the bitmap reserves the occupancy tab's depth above the
     // disc as well as below: it keeps the disc on the bitmap's center even for a marker whose tab hangs
     // off the bottom, so this flavor needs no anchor it cannot express (see [VehicleBitmaps]).
-    private fun vehicleIcon(vehicle: VehicleMarker, response: RouteTrips): Icon = iconFactory.fromBitmap(
-        VehicleBitmaps.vehicleBitmap(context, vehicle, response, renderedVehicleScale)
+    private fun vehicleIcon(vehicle: VehicleMarker): Icon = iconFactory.fromBitmap(
+        VehicleBitmaps.vehicleBitmap(context, vehicle, renderedVehicleScale)
     )
 
     /** Re-stamp retained vehicle markers only when the settle-time detail scale changes. */
     private fun updateVehicleScale(scale: Float) {
         if (scale == renderedVehicleScale) return
         renderedVehicleScale = scale
-        val response = lastVehicleResponse ?: return
-        for ((marker, vehicle) in vehicleByMarker) marker.icon = vehicleIcon(vehicle, response)
+        for ((marker, vehicle) in vehicleByMarker) marker.icon = vehicleIcon(vehicle)
     }
 
     /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/VehicleBitmapsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/VehicleBitmapsTest.kt
@@ -66,7 +66,7 @@ class VehicleBitmapsTest {
 
     @Test
     fun resolvesTheRouteTypeWhenReferencesCarryTripAndRoute() {
-        val response = routeTrips(trip = FakeTrip("trip1", "routeA"), route = FakeRoute(ObaRoute.TYPE_FERRY))
+        val response = pool(mapOf("trip1" to "routeA"), mapOf("routeA" to ObaRoute.TYPE_FERRY))
         assertEquals(ObaRoute.TYPE_FERRY, VehicleBitmaps.routeTypeFor(response, "trip1"))
     }
 
@@ -77,29 +77,53 @@ class VehicleBitmapsTest {
      */
     @Test
     fun missingTripFallsBackToTheDefaultGlyphInsteadOfThrowing() {
-        val response = routeTrips(trip = null, route = FakeRoute(ObaRoute.TYPE_RAIL))
+        val response = pool(emptyMap(), mapOf("routeA" to ObaRoute.TYPE_RAIL))
         assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, "absent-trip"))
     }
 
     /** The trip resolved but its route didn't — the second half of the old `!!` chain. */
     @Test
     fun missingRouteFallsBackToTheDefaultGlyphInsteadOfThrowing() {
-        val response = routeTrips(trip = FakeTrip("trip1", "routeA"), route = null)
+        val response = pool(mapOf("trip1" to "routeA"), emptyMap())
         assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, "trip1"))
     }
 
     /** A blank/absent id (cf. #2003, where OBA sends "" rather than null for block-edge trip ids). */
     @Test
     fun blankOrNullTripIdFallsBackToTheDefaultGlyph() {
-        val response = routeTrips(trip = null, route = null)
+        val response = pool(emptyMap(), emptyMap())
         assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, ""))
         assertEquals(ObaRoute.TYPE_BUS, VehicleBitmaps.routeTypeFor(response, null))
+    }
+
+    /**
+     * The bug this pairing exists to prevent: a vehicle set can merge several route polls (interchangeable
+     * routes #2042, stay-aboard interlines #2000), and a poll's references answer for **its own** vehicles.
+     * Resolved against a sibling route's pool a train silently becomes a bus — which is exactly what a Link
+     * 2 Line train did on a "whichever comes first" leg while the 1 Line beside it drew correctly.
+     *
+     * So this asserts both halves: own pool → tram, sibling pool → the bus fallback. The second is not an
+     * endorsement of that outcome; it pins that the wrong pool is *silently* wrong, which is why each
+     * marker carries the poll it came out of ([VehicleMarker.source]) rather than the set sharing one.
+     */
+    @Test
+    fun aPollResolvesOnlyItsOwnVehicles() {
+        val linkTypes = mapOf("routeOne" to ObaRoute.TYPE_TRAM, "routeTwo" to ObaRoute.TYPE_TRAM)
+        val onePoll = pool(mapOf("trip-1line" to "routeOne"), linkTypes)
+        val twoPoll = pool(mapOf("trip-2line" to "routeTwo"), linkTypes)
+
+        assertEquals(ObaRoute.TYPE_TRAM, VehicleBitmaps.routeTypeFor(twoPoll, "trip-2line"))
+        assertEquals(
+            "another route's poll cannot answer for this vehicle",
+            ObaRoute.TYPE_BUS,
+            VehicleBitmaps.routeTypeFor(onePoll, "trip-2line")
+        )
     }
 
     /** Cablecar still collapses onto tram when it *is* resolvable, fallback path notwithstanding. */
     @Test
     fun resolvedCablecarStillNormalizesToTram() {
-        val response = routeTrips(trip = FakeTrip("trip1", "routeA"), route = FakeRoute(ObaRoute.TYPE_CABLECAR))
+        val response = pool(mapOf("trip1" to "routeA"), mapOf("routeA" to ObaRoute.TYPE_CABLECAR))
         assertEquals(ObaRoute.TYPE_TRAM, VehicleBitmaps.routeTypeFor(response, "trip1"))
     }
 
@@ -145,11 +169,14 @@ class VehicleBitmapsTest {
         assertEquals("the fullest bucket must fill the row", VehicleBitmaps.MAX_PIPS, OccupancyBucket.FULL.pips)
     }
 
-    /** A [RouteTrips] whose references pool holds at most the given trip/route. */
-    private fun routeTrips(trip: ObaTrip?, route: ObaRoute?): RouteTrips = object : RouteTrips {
+    /**
+     * A [RouteTrips] standing in for one poll's references: it resolves the trips it was fetched with
+     * and nothing else, which is what makes the wrong poll a wrong answer.
+     */
+    private fun pool(routeIdByTripId: Map<String, String>, routeTypes: Map<String, Int>): RouteTrips = object : RouteTrips {
         override val trips: List<ObaTripDetails> = emptyList()
-        override fun trip(tripId: String?): ObaTrip? = trip.takeIf { !tripId.isNullOrEmpty() }
-        override fun route(routeId: String): ObaRoute? = route
+        override fun trip(tripId: String?): ObaTrip? = routeIdByTripId[tripId]?.let { FakeTrip(tripId.orEmpty(), it) }
+        override fun route(routeId: String): ObaRoute? = routeTypes[routeId]?.let { FakeRoute(it) }
         override val currentTimeMs: Long = 0L
     }
 


### PR DESCRIPTION
On a "whichever comes first" Link leg, every 2 Line train on the map draws with the **bus** glyph, while the 1 Line beside it draws correctly as a tram. The same vehicles announce themselves to a screen reader as "unidentified".

### It isn't the API

Puget Sound reports `40_2LINE` as `type: 0` (tram), and a live `trips-for-route/40_2LINE` poll resolves cleanly — all 16 entries' `status.activeTripId` are present in `references.trips`, each mapping to a route with `type: 0`.

### What was wrong

A vehicle **set** is not always one poll's worth of vehicles. A route-focus session with interchangeable routes (#2042) or a stay-aboard interline (#2000) merges the leader poll with an extra poll per extra route — `RouteMapController.sampleVehicles` builds `leaderVehicles + extraVehicles`, pairing each vehicle with the poll it came out of.

`MapVehicles` then dropped that pairing and published `response = poll.response`, the leader's alone. Both renderers resolved *every* marker's `trip` → `route` against it:

```
vehicleIcon(vehicle, response) → VehicleBitmaps.routeTypeFor(response, activeTripId)
vehicleTitle(context, vehicle, response)
```

A poll's references answer for its **own** vehicles. Measured on the live feed: the 1 Line's poll carries 18 of its own trips and only 2 of the 2 Line's 16 — so nearly every 2 Line vehicle missed both hops and took `DEFAULT_VEHICLE_TYPE` (bus) and the `vehicle_marker_unidentified` fallback. Both fallbacks are correct for their real cases (#2020, #2003); this made a routine outcome of them.

#2043 fixed this exact mismatch for the disc **colour** by pairing each vehicle with its poll and resolving in the controller. The type/name half was never carried the rest of the way.

### The fix

`VehicleMarker` gains `source: RouteTrips` — the poll the vehicle came out of — beside the already-per-vehicle `routeColor`/`bandColor`. `sampleVehicles` keeps the pairing it already had instead of dropping it at the last step.

Because the marker now holds a non-null pool, `vehicleBitmap` / `iconKey` / `vehicleTitle` read `vehicle.source` rather than taking a pool alongside the vehicle it has to agree with. Net effect is a **deletion**:

- `MapVehicles` is back to `data class MapVehicles(val markers: List<VehicleMarker>)`
- both renderers lose `lastVehicleResponse`, its assignment, and the parameter threading — including MapLibre's reset in `clearAll`, which the Google flavor had no counterpart for
- passing the wrong pool (or none) is no longer expressible at the render layer

141 insertions, 109 deletions across 9 files.

### Tests

- `VehicleBitmapsTest.aPollResolvesOnlyItsOwnVehicles` — two Link polls; the 2 Line trip resolves tram against its own pool and falls back to bus against the 1 Line's. The bug, pinned at the pure seam.
- Folded the file's id-*insensitive* `routeTrips` fake into the id-keyed `pool`. The two differed in exactly the property this change is about, so a later test reaching for the older helper would have been structurally unable to reproduce the bug.

`./gradlew spotlessApply` applied; both flavours compile clean under `-PwarningsAsErrors=true`; full JVM unit suite passes.

### Not in this PR

`RouteMapController` already resolves `routeColor` per vehicle and puts the answer on the marker. Route type, display name, and headsign could ride the same way, and then no `RouteTrips` would reach the render layer at all. That needs `routeColorMemo` broadened into an identity memo (otherwise three more reference hops land on the 20 Hz sampler), which is a design change to the identity pipeline rather than a bug fix — worth doing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle marker rendering by associating each vehicle with its own trip information.
  * Vehicle icons and titles now remain accurate when vehicles come from multiple routes or polling responses.
  * Improved refresh behavior when map scale changes or vehicle data updates.
  * Improved icon caching for more consistent map performance.
  * Preserved fallback handling for missing trip, route, and vehicle details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->