### PR TITLE
Jump the fast-estimate marker to a newly tapped vehicle (#2222)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -65,6 +65,7 @@ import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineReconciler
 import org.onebusaway.android.map.render.STOP_ROUTE_LABEL_Z_INDEX
+import org.onebusaway.android.map.render.SingleSubjectSmoother
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.TripMarkerBitmaps
 import org.onebusaway.android.map.render.TripOverlay
@@ -795,25 +796,20 @@ class GoogleMapRenderer(
         while (bandPolylines.size > band.size) {
             bandPolylines.removeAt(bandPolylines.size - 1).remove()
         }
-        // The fast-estimate marker owns its smoothing + fixed title; hand it the trip it belongs to (which
-        // scopes that smoothing to one vehicle), the fresh fix + tick clock, and the band's colour to fill
-        // its disc with. A frame with no overlay leaves the marker gone.
-        fastEstimate.update(
-            overlay?.tripId,
-            overlay?.fastEstimatePoint,
-            overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR,
-            overlay?.fixTimeMs ?: 0L,
-            nowMs
-        )
+        // The fast-estimate marker owns its smoothing + fixed title; hand it the overlay it draws (the
+        // trip it belongs to, its point, its fix, and the band's colour to fill its disc with) and the
+        // tick clock. A frame with no overlay leaves the marker gone.
+        fastEstimate.update(overlay, nowMs)
     }
 
     /**
      * The selected vehicle's fast-estimate marker: owns its native [Marker] and its own
-     * [CorrectionSmoother], with a fixed info-window [title] set at creation. [update] creates it on the
-     * first non-null point, removes it on null, and smooths it across a fresh fix *on the same trip*. The
-     * icon resolves lazily on first show via [iconProvider] (so it isn't built until a vehicle is
-     * selected), filled with the band's colour and re-stamped when that colour changes (#1990). Driven
-     * every tick (the overlay sampler runs each frame), so the decay just progresses.
+     * [SingleSubjectSmoother] — so it smooths across a fresh fix on the trip it is drawn for, and jumps
+     * when a tap makes that a different trip (#2222) — with a fixed info-window [title] set at creation.
+     * [update] creates it on the first overlay with a point and removes it when there is none. The icon
+     * resolves lazily on first show via [iconProvider] (so it isn't built until a vehicle is selected),
+     * filled with the band's colour and re-stamped when that colour changes (#1990). Driven every tick
+     * (the overlay sampler runs each frame), so the decay just progresses.
      */
     private inner class TripEstimateMarker(
         private val iconProvider: (Int) -> BitmapDescriptor,
@@ -821,28 +817,19 @@ class GoogleMapRenderer(
         private val zIndex: Float
     ) {
         private var marker: Marker? = null
-        private val smoother = CorrectionSmoother()
+        private val smoother = SingleSubjectSmoother()
 
         // The fill the current icon was stamped with; 0 whenever there is no marker.
         private var iconFillColor: Int = 0
 
-        fun update(tripId: String?, point: GeoPoint?, fillColor: Int, fixTimeMs: Long, nowMs: Long) {
-            val existing = marker
-            if (point == null) {
-                existing?.remove()
-                marker = null
-                iconFillColor = 0
-                smoother.retainOnly(emptySet()) // drop any in-flight correction + forget
+        fun update(overlay: TripOverlay?, nowMs: Long) {
+            val point = overlay?.fastEstimatePoint
+            if (overlay == null || point == null) {
+                dispose()
                 return
             }
-            // Correction state belongs to one vehicle, so keep only the trip this frame draws. Tapping a
-            // different vehicle is a change of subject, not a fresh fix on this one: with the previous
-            // trip's state dropped the smoother has nothing to correct from, and the marker jumps to the
-            // new selection rather than sweeping across the map to it — which read as the band being
-            // re-drawn (#2222). The most-recent-data dot already behaves this way. Between fixes on one
-            // trip the key is stable, so a fresh fix still smooths.
-            val easeKey = tripId.orEmpty()
-            smoother.retainOnly(setOf(easeKey))
+            val fillColor = overlay.markerColorArgb
+            val existing = marker
             if (existing == null) {
                 marker = map.addMarkerOrFail(
                     MarkerOptions()
@@ -853,24 +840,24 @@ class GoogleMapRenderer(
                         .zIndex(zIndex)
                 )
                 iconFillColor = fillColor
-                smoother.prime(easeKey, point, fixTimeMs)
+                smoother.prime(overlay.tripId, point, overlay.fixTimeMs)
                 return
             }
             if (fillColor != iconFillColor) {
                 existing.setIcon(iconProvider(fillColor))
                 iconFillColor = fillColor
             }
-            existing.position = smoother.displayPosition(easeKey, point, fixTimeMs, nowMs).toLatLng()
+            existing.position =
+                smoother.displayPosition(overlay.tripId, point, overlay.fixTimeMs, nowMs).toLatLng()
         }
 
-        /** Remove the marker and drop any in-flight correction — the null-point branch of [update]. */
-        fun dispose() = update(
-            tripId = null,
-            point = null,
-            fillColor = TripMarkerBitmaps.DEFAULT_FILL_COLOR,
-            fixTimeMs = 0L,
-            nowMs = 0L
-        )
+        /** Remove the marker and drop any in-flight correction. */
+        fun dispose() {
+            marker?.remove()
+            marker = null
+            iconFillColor = 0
+            smoother.clear()
+        }
     }
 
     // The overlay/dot icons, cached through [descriptorCache] by a stable per-icon key so each resolves

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -795,9 +795,11 @@ class GoogleMapRenderer(
         while (bandPolylines.size > band.size) {
             bandPolylines.removeAt(bandPolylines.size - 1).remove()
         }
-        // The fast-estimate marker owns its smoothing + fixed title; hand it the fresh fix + tick clock,
-        // and the band's colour to fill its disc with. A frame with no overlay leaves the marker gone.
+        // The fast-estimate marker owns its smoothing + fixed title; hand it the trip it belongs to (which
+        // scopes that smoothing to one vehicle), the fresh fix + tick clock, and the band's colour to fill
+        // its disc with. A frame with no overlay leaves the marker gone.
         fastEstimate.update(
+            overlay?.tripId,
             overlay?.fastEstimatePoint,
             overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR,
             overlay?.fixTimeMs ?: 0L,
@@ -808,10 +810,10 @@ class GoogleMapRenderer(
     /**
      * The selected vehicle's fast-estimate marker: owns its native [Marker] and its own
      * [CorrectionSmoother], with a fixed info-window [title] set at creation. [update] creates it on the
-     * first non-null point, removes it on null, and smooths it across a fresh fix. The icon resolves lazily
-     * on first show via [iconProvider] (so it isn't built until a vehicle is selected), filled with the
-     * band's colour and re-stamped when that colour changes (#1990). Driven every tick (the overlay
-     * sampler runs each frame), so the decay just progresses.
+     * first non-null point, removes it on null, and smooths it across a fresh fix *on the same trip*. The
+     * icon resolves lazily on first show via [iconProvider] (so it isn't built until a vehicle is
+     * selected), filled with the band's colour and re-stamped when that colour changes (#1990). Driven
+     * every tick (the overlay sampler runs each frame), so the decay just progresses.
      */
     private inner class TripEstimateMarker(
         private val iconProvider: (Int) -> BitmapDescriptor,
@@ -824,7 +826,7 @@ class GoogleMapRenderer(
         // The fill the current icon was stamped with; 0 whenever there is no marker.
         private var iconFillColor: Int = 0
 
-        fun update(point: GeoPoint?, fillColor: Int, fixTimeMs: Long, nowMs: Long) {
+        fun update(tripId: String?, point: GeoPoint?, fillColor: Int, fixTimeMs: Long, nowMs: Long) {
             val existing = marker
             if (point == null) {
                 existing?.remove()
@@ -833,6 +835,14 @@ class GoogleMapRenderer(
                 smoother.retainOnly(emptySet()) // drop any in-flight correction + forget
                 return
             }
+            // Correction state belongs to one vehicle, so keep only the trip this frame draws. Tapping a
+            // different vehicle is a change of subject, not a fresh fix on this one: with the previous
+            // trip's state dropped the smoother has nothing to correct from, and the marker jumps to the
+            // new selection rather than sweeping across the map to it — which read as the band being
+            // re-drawn (#2222). The most-recent-data dot already behaves this way. Between fixes on one
+            // trip the key is stable, so a fresh fix still smooths.
+            val easeKey = tripId.orEmpty()
+            smoother.retainOnly(setOf(easeKey))
             if (existing == null) {
                 marker = map.addMarkerOrFail(
                     MarkerOptions()
@@ -843,19 +853,24 @@ class GoogleMapRenderer(
                         .zIndex(zIndex)
                 )
                 iconFillColor = fillColor
-                smoother.prime(ESTIMATE_EASE_KEY, point, fixTimeMs)
+                smoother.prime(easeKey, point, fixTimeMs)
                 return
             }
             if (fillColor != iconFillColor) {
                 existing.setIcon(iconProvider(fillColor))
                 iconFillColor = fillColor
             }
-            existing.position =
-                smoother.displayPosition(ESTIMATE_EASE_KEY, point, fixTimeMs, nowMs).toLatLng()
+            existing.position = smoother.displayPosition(easeKey, point, fixTimeMs, nowMs).toLatLng()
         }
 
         /** Remove the marker and drop any in-flight correction — the null-point branch of [update]. */
-        fun dispose() = update(null, TripMarkerBitmaps.DEFAULT_FILL_COLOR, 0L, 0L)
+        fun dispose() = update(
+            tripId = null,
+            point = null,
+            fillColor = TripMarkerBitmaps.DEFAULT_FILL_COLOR,
+            fixTimeMs = 0L,
+            nowMs = 0L
+        )
     }
 
     // The overlay/dot icons, cached through [descriptorCache] by a stable per-icon key so each resolves
@@ -971,9 +986,6 @@ class GoogleMapRenderer(
         private const val HINT_DASH_LENGTH_PX = 24f
         private const val TRAIL_DASH_LENGTH_PX = HINT_DASH_LENGTH_PX * 2f
         private const val DASH_GAP_LENGTH_PX = 16f
-
-        // The (arbitrary, constant) ease key for a TripEstimateMarker's single-marker easer.
-        private const val ESTIMATE_EASE_KEY = "estimate"
 
         private const val MOST_RECENT_DATA_TITLE = "Most recent data"
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -699,7 +699,8 @@ class RouteMapController(
             // A frame with no extrapolation at all (no shape, or no fix yet) still publishes the colour:
             // the most-recent-data dot is drawn from the selection rather than from the band, and takes
             // the band's colour whether or not there is a band to draw beside it.
-            extrapolation?.toTripOverlay(bandColor) ?: TripOverlay(markerColorArgb = bandColor)
+            extrapolation?.toTripOverlay(tripId, bandColor)
+                ?: TripOverlay(tripId = tripId, markerColorArgb = bandColor)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripOverlayTint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripOverlayTint.kt
@@ -53,10 +53,14 @@ internal fun contrastingColor(color: Int): Int {
  *
  * The undimmed color rides along as [TripOverlay.markerColorArgb], because the markers that bound the
  * band are filled with it (#1990) and a marker takes the band's *color*, not one slice's weight.
+ *
+ * [tripId] names whose extrapolation this is — the producer models one trip at a time and so carries no
+ * id, but the renderer needs one to scope the fast marker's fix smoothing to a single vehicle (#2222).
  */
-internal fun TripExtrapolation.toTripOverlay(bandColorArgb: Int): TripOverlay {
+internal fun TripExtrapolation.toTripOverlay(tripId: String, bandColorArgb: Int): TripOverlay {
     val baseRgb = bandColorArgb and 0x00FFFFFF
     return TripOverlay(
+        tripId = tripId,
         fastEstimatePoint = fastEstimatePoint,
         band = band.map { slice ->
             val alpha = (slice.weight.coerceIn(0f, 1f) * 255f).roundToInt()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripOverlayTint.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripOverlayTint.kt
@@ -54,8 +54,8 @@ internal fun contrastingColor(color: Int): Int {
  * The undimmed color rides along as [TripOverlay.markerColorArgb], because the markers that bound the
  * band are filled with it (#1990) and a marker takes the band's *color*, not one slice's weight.
  *
- * [tripId] names whose extrapolation this is — the producer models one trip at a time and so carries no
- * id, but the renderer needs one to scope the fast marker's fix smoothing to a single vehicle (#2222).
+ * [tripId] names whose extrapolation this is: the producer models one trip at a time and so carries no
+ * id of its own, but the renderer needs one to smooth the fast marker per vehicle (#2222).
  */
 internal fun TripExtrapolation.toTripOverlay(tripId: String, bandColorArgb: Int): TripOverlay {
     val baseRgb = bandColorArgb and 0x00FFFFFF

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CorrectionSmoother.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CorrectionSmoother.kt
@@ -135,3 +135,44 @@ class CorrectionSmoother(private val durationMs: Long = DEFAULT_DURATION_MS) {
         const val MAX_CORRECTION_METERS = 2000.0
     }
 }
+
+/**
+ * A [CorrectionSmoother] for a marker that shows **one subject at a time** — the selected vehicle's
+ * fast-estimate marker, whose correction belongs to the vehicle it is drawn for.
+ *
+ * Changing subject is a change of *what* is being shown, not a fresh fix on the same thing. So the
+ * previous subject's correction is dropped and the marker jumps to the new one, instead of reading its
+ * position as a fix that moved and easing across the map to it — which looked like the uncertainty band
+ * being re-drawn on every tap (#2222). Between fixes on one subject nothing is dropped, so a fresh fix
+ * still smooths exactly as before.
+ *
+ * Wrapping the keyed smoother rather than asking each caller to `retainOnly` its own key is what makes
+ * that mistake unrepresentable: forgetting the call *was* #2222. Callers that genuinely track several
+ * markers at once (the route's vehicles) key [CorrectionSmoother] directly.
+ */
+class SingleSubjectSmoother(private val smoother: CorrectionSmoother = CorrectionSmoother()) {
+
+    private var subject: String? = null
+
+    /** Record [subject]'s initial shown position — see [CorrectionSmoother.prime]. */
+    fun prime(subject: String, point: GeoPoint, fixTimeMs: Long) {
+        switchTo(subject)
+        smoother.prime(subject, point, fixTimeMs)
+    }
+
+    /** The position to display for [subject] this tick — see [CorrectionSmoother.displayPosition]. */
+    fun displayPosition(subject: String, target: GeoPoint, fixTimeMs: Long, nowMs: Long): GeoPoint {
+        switchTo(subject)
+        return smoother.displayPosition(subject, target, fixTimeMs, nowMs)
+    }
+
+    /** Forget the current subject: its marker is gone (nothing is selected). */
+    fun clear() = switchTo(null)
+
+    // Only an actual change touches the state, so the steady per-frame case is one reference compare.
+    private fun switchTo(next: String?) {
+        if (next == subject) return
+        smoother.retainOnly(emptySet())
+        subject = next
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
@@ -43,16 +43,23 @@ data class DataAgeMarker(val point: GeoPoint, val ageMillis: Long)
  * renderers draw the same overlay. On a frame with no usable estimate [fastEstimatePoint] is null and
  * [band] is empty.
  *
+ * @property tripId the trip this frame's overlay describes, or null when nothing is selected. The
+ *   renderer keys the fast marker's fix-correction state on it, so the smoothing is scoped to one
+ *   vehicle: tapping a different one is a change of subject, not a fresh fix on the same subject, and
+ *   the marker jumps to the new selection instead of sweeping across the map to it (#2222). Carried on
+ *   the overlay rather than read from the selection separately, so the identity can't skew from the
+ *   point it belongs to on the frame a tap lands.
  * @property fastEstimatePoint the optimistic (high-quantile) "best case" position, or null
  * @property band the graded uncertainty band over the route shape (empty when no estimate)
  * @property fixTimeMs the latest AVL fix's timestamp — constant between fixes, so a change signals
- *   fresh data; the renderer animates the marker to its new position when it changes
+ *   fresh data; the renderer smooths the marker onto its new position when it changes
  * @property markerColorArgb the band's own colour, opaque — the fill for the markers that bound the
  *   band (the fast estimate at its leading end, the most-recent-data dot at its origin), so the three
  *   read as one data object rather than as unrelated decorations (#1990). Carried even on a frame with
  *   no estimate at all, because the data dot is drawn from the selection, not from the band
  */
 data class TripOverlay(
+    val tripId: String? = null,
     val fastEstimatePoint: GeoPoint? = null,
     val band: List<BandSegment> = emptyList(),
     val fixTimeMs: Long = 0L,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/TripOverlay.kt
@@ -43,12 +43,9 @@ data class DataAgeMarker(val point: GeoPoint, val ageMillis: Long)
  * renderers draw the same overlay. On a frame with no usable estimate [fastEstimatePoint] is null and
  * [band] is empty.
  *
- * @property tripId the trip this frame's overlay describes, or null when nothing is selected. The
- *   renderer keys the fast marker's fix-correction state on it, so the smoothing is scoped to one
- *   vehicle: tapping a different one is a change of subject, not a fresh fix on the same subject, and
- *   the marker jumps to the new selection instead of sweeping across the map to it (#2222). Carried on
- *   the overlay rather than read from the selection separately, so the identity can't skew from the
- *   point it belongs to on the frame a tap lands.
+ * @property tripId the trip this frame's overlay describes — the fast marker's smoothing subject
+ *   ([SingleSubjectSmoother], #2222). Carried on the overlay rather than read from the selection
+ *   separately, so the identity can't skew from the point it belongs to on the frame a tap lands
  * @property fastEstimatePoint the optimistic (high-quantile) "best case" position, or null
  * @property band the graded uncertainty band over the route shape (empty when no estimate)
  * @property fixTimeMs the latest AVL fix's timestamp — constant between fixes, so a change signals
@@ -59,7 +56,7 @@ data class DataAgeMarker(val point: GeoPoint, val ageMillis: Long)
  *   no estimate at all, because the data dot is drawn from the selection, not from the band
  */
 data class TripOverlay(
-    val tripId: String? = null,
+    val tripId: String,
     val fastEstimatePoint: GeoPoint? = null,
     val band: List<BandSegment> = emptyList(),
     val fixTimeMs: Long = 0L,

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -56,6 +56,7 @@ import org.onebusaway.android.map.render.RentalMarker
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineReconciler
+import org.onebusaway.android.map.render.SingleSubjectSmoother
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.TripMarkerBitmaps
 import org.onebusaway.android.map.render.TripOverlay
@@ -186,23 +187,23 @@ class MapLibreRenderer(
     )
 
     // The dynamic layer, tracked by identity so [renderDynamic] can move markers in place: route
-    // vehicles keyed by active trip id, the trip-focus estimate markers keyed by role, and the band's
-    // (interaction-free) polylines re-added each frame.
+    // vehicles keyed by active trip id, the selected vehicle's single fast-estimate marker, and the
+    // band's (interaction-free) polylines re-added each frame.
     private val vehicleMarkersByTripId = HashMap<String, Marker>()
-    private val tripMarkersByRole = HashMap<String, Marker>()
+    private var fastEstimateMarker: Marker? = null
 
-    // The fill each trip marker's icon is currently stamped with, so a role is re-stamped only when its
-    // band colour changes (#1990); dropped with the marker.
-    private val tripMarkerFills = HashMap<String, Int>()
+    // The fill the fast-estimate marker's icon is currently stamped with, so it's re-stamped only when
+    // its band colour changes (#1990). 0 whenever there is no marker.
+    private var fastEstimateFill: Int = 0
     private val bandPolylines = mutableListOf<Polyline>()
 
     private var renderedVehicleScale = routeLineWidthScale(map.cameraPosition.zoom.toFloat())
 
     // Smooth markers across a fresh-AVL jump (a decaying correction on the dead-reckon glide) so a fix
-    // doesn't pop. Both are keyed by trip id: the correction belongs to the vehicle, so selecting another
-    // one starts fresh instead of easing the estimate marker across to it (#2222).
+    // doesn't pop. Route vehicles are keyed by trip id; the fast-estimate marker shows one vehicle at a
+    // time, so it takes the smoother that scopes the correction to that vehicle (#2222).
     private val vehicleSmoother = CorrectionSmoother()
-    private val tripSmoother = CorrectionSmoother()
+    private val fastEstimateSmoother = SingleSubjectSmoother()
 
     // The selected vehicle's most-recent-data dot: a marker at its last actual AVL fix (where the live
     // estimate was last corrected from), shown while a vehicle is selected, with a "Most recent data"
@@ -430,7 +431,7 @@ class MapLibreRenderer(
     /** Releases renderer-owned annotations and extracted style layers before MapView destruction. */
     fun dispose() {
         vehicleSmoother.retainOnly(emptySet())
-        tripSmoother.retainOnly(emptySet())
+        fastEstimateSmoother.clear()
         dotSmoother.retainOnly(emptySet())
         clearPing()
         stopMarkerLayer.dispose()
@@ -443,8 +444,8 @@ class MapLibreRenderer(
 
         staticAnnotations.clear()
         vehicleMarkersByTripId.clear()
-        tripMarkersByRole.clear()
-        tripMarkerFills.clear()
+        fastEstimateMarker = null
+        fastEstimateFill = 0
         tripCircleIcons.evictAll()
         bandPolylines.clear()
         vehicleByMarker.clear()
@@ -693,67 +694,44 @@ class MapLibreRenderer(
         while (bandPolylines.size > band.size) {
             map.removeAnnotation(bandPolylines.removeAt(bandPolylines.size - 1))
         }
-        // Correction state belongs to one vehicle, so keep only the trip this frame draws — and nothing at
-        // all once the overlay is gone (a deselect). Tapping a different vehicle is a change of subject,
-        // not a fresh fix on this one: with the previous trip's state dropped the smoother has nothing to
-        // correct from, and the marker jumps to the new selection rather than sweeping across the map to
-        // it — which read as the band being re-drawn (#2222). The most-recent-data dot already behaves
-        // this way. Between fixes on one trip the key is stable, so a fresh fix still smooths. Dropped
-        // *before* the marker moves, so the very first frame after a tap already jumps.
-        tripSmoother.retainOnly(setOfNotNull(overlay?.tripId))
-        // The fast-estimate marker moves in place (keeping any open info window); the fix instant drives
-        // the smoother's correction. Its disc is filled with the band's own colour (#1990).
-        updateTripMarker(
-            "fast",
-            overlay?.tripId,
-            overlay?.fastEstimatePoint,
-            ::fastEstimateIcon,
-            overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR,
-            "Fast estimate",
-            overlay?.fixTimeMs ?: 0L,
-            nowMs
-        )
+        updateFastEstimateMarker(overlay, nowMs)
     }
 
     /**
-     * [icon] resolves lazily from [fillColor] so no icon is built for a role with nothing to draw, and
-     * the marker is re-stamped only when its fill actually changes (#1990) — never per frame.
-     *
-     * The native marker is tracked by [role] (its job on the map), but its fix correction is keyed by
-     * [tripId] (whose position it is showing), so the smoothing is scoped to one vehicle (#2222).
+     * The selected vehicle's fast-estimate marker: created on the first overlay with a point, removed
+     * when there is none, and moved in place otherwise (keeping any open info window). Its correction is
+     * smoothed per vehicle by [fastEstimateSmoother], so a fresh fix on the trip it draws glides while a
+     * tap onto another trip jumps (#2222). The icon resolves lazily from the band's colour and is
+     * re-stamped only when that colour changes (#1990) — never per frame.
      */
-    private fun updateTripMarker(
-        role: String,
-        tripId: String?,
-        point: GeoPoint?,
-        icon: (Int) -> Icon,
-        fillColor: Int,
-        title: String,
-        fixTimeMs: Long,
-        nowMs: Long
-    ) {
-        val existing = tripMarkersByRole[role]
-        if (point == null) {
-            existing?.let {
-                map.removeAnnotation(it)
-                tripMarkersByRole.remove(role)
-                tripMarkerFills.remove(role)
-            }
+    private fun updateFastEstimateMarker(overlay: TripOverlay?, nowMs: Long) {
+        val point = overlay?.fastEstimatePoint
+        val existing = fastEstimateMarker
+        if (overlay == null || point == null) {
+            existing?.let { map.removeAnnotation(it) }
+            fastEstimateMarker = null
+            fastEstimateFill = 0
+            fastEstimateSmoother.clear()
             return
         }
-        val easeKey = tripId.orEmpty()
+        val fillColor = overlay.markerColorArgb
         if (existing == null) {
-            tripMarkersByRole[role] =
-                map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon(fillColor)).title(title))
-            tripMarkerFills[role] = fillColor
-            tripSmoother.prime(easeKey, point, fixTimeMs)
+            fastEstimateMarker = map.addMarker(
+                MarkerOptions()
+                    .position(point.toLatLng())
+                    .icon(fastEstimateIcon(fillColor))
+                    .title(FAST_ESTIMATE_TITLE)
+            )
+            fastEstimateFill = fillColor
+            fastEstimateSmoother.prime(overlay.tripId, point, overlay.fixTimeMs)
         } else {
-            if (tripMarkerFills[role] != fillColor) {
-                existing.icon = icon(fillColor)
-                tripMarkerFills[role] = fillColor
+            if (fastEstimateFill != fillColor) {
+                existing.icon = fastEstimateIcon(fillColor)
+                fastEstimateFill = fillColor
             }
-            existing.moveTo(tripSmoother.displayPosition(easeKey, point, fixTimeMs, nowMs).toLatLng())
-            if (existing.title != title) existing.title = title
+            existing.moveTo(
+                fastEstimateSmoother.displayPosition(overlay.tripId, point, overlay.fixTimeMs, nowMs).toLatLng()
+            )
         }
     }
 
@@ -822,6 +800,10 @@ class MapLibreRenderer(
     companion object {
         private const val ROUTE_WIDTH_DP = 3f
         private const val TRIP_BAND_WIDTH_DP = 6f
+
+        // The fast-estimate marker's info-window title, fixed at creation (the marker's subject changes,
+        // its job on the map doesn't). Mirrors the Google flavor's TripEstimateMarker title.
+        private const val FAST_ESTIMATE_TITLE = "Fast estimate"
 
         // Sized to hold a whole zoom session's worth of the labels currently on the map, so panning the
         // ramp end to end never evicts a label that is still drawn: a directions itinerary, or a focused

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -199,7 +199,8 @@ class MapLibreRenderer(
     private var renderedVehicleScale = routeLineWidthScale(map.cameraPosition.zoom.toFloat())
 
     // Smooth markers across a fresh-AVL jump (a decaying correction on the dead-reckon glide) so a fix
-    // doesn't pop. Route vehicles keyed by trip id; the trip-focus estimate markers keyed by role.
+    // doesn't pop. Both are keyed by trip id: the correction belongs to the vehicle, so selecting another
+    // one starts fresh instead of easing the estimate marker across to it (#2222).
     private val vehicleSmoother = CorrectionSmoother()
     private val tripSmoother = CorrectionSmoother()
 
@@ -692,10 +693,19 @@ class MapLibreRenderer(
         while (bandPolylines.size > band.size) {
             map.removeAnnotation(bandPolylines.removeAt(bandPolylines.size - 1))
         }
+        // Correction state belongs to one vehicle, so keep only the trip this frame draws — and nothing at
+        // all once the overlay is gone (a deselect). Tapping a different vehicle is a change of subject,
+        // not a fresh fix on this one: with the previous trip's state dropped the smoother has nothing to
+        // correct from, and the marker jumps to the new selection rather than sweeping across the map to
+        // it — which read as the band being re-drawn (#2222). The most-recent-data dot already behaves
+        // this way. Between fixes on one trip the key is stable, so a fresh fix still smooths. Dropped
+        // *before* the marker moves, so the very first frame after a tap already jumps.
+        tripSmoother.retainOnly(setOfNotNull(overlay?.tripId))
         // The fast-estimate marker moves in place (keeping any open info window); the fix instant drives
         // the smoother's correction. Its disc is filled with the band's own colour (#1990).
         updateTripMarker(
             "fast",
+            overlay?.tripId,
             overlay?.fastEstimatePoint,
             ::fastEstimateIcon,
             overlay?.markerColorArgb ?: TripMarkerBitmaps.DEFAULT_FILL_COLOR,
@@ -703,16 +713,18 @@ class MapLibreRenderer(
             overlay?.fixTimeMs ?: 0L,
             nowMs
         )
-        // Drop smoother state for the marker's role once it's gone (overlay went null on deselect).
-        tripSmoother.retainOnly(tripMarkersByRole.keys)
     }
 
     /**
      * [icon] resolves lazily from [fillColor] so no icon is built for a role with nothing to draw, and
      * the marker is re-stamped only when its fill actually changes (#1990) — never per frame.
+     *
+     * The native marker is tracked by [role] (its job on the map), but its fix correction is keyed by
+     * [tripId] (whose position it is showing), so the smoothing is scoped to one vehicle (#2222).
      */
     private fun updateTripMarker(
         role: String,
+        tripId: String?,
         point: GeoPoint?,
         icon: (Int) -> Icon,
         fillColor: Int,
@@ -729,17 +741,18 @@ class MapLibreRenderer(
             }
             return
         }
+        val easeKey = tripId.orEmpty()
         if (existing == null) {
             tripMarkersByRole[role] =
                 map.addMarker(MarkerOptions().position(point.toLatLng()).icon(icon(fillColor)).title(title))
             tripMarkerFills[role] = fillColor
-            tripSmoother.prime(role, point, fixTimeMs)
+            tripSmoother.prime(easeKey, point, fixTimeMs)
         } else {
             if (tripMarkerFills[role] != fillColor) {
                 existing.icon = icon(fillColor)
                 tripMarkerFills[role] = fillColor
             }
-            existing.moveTo(tripSmoother.displayPosition(role, point, fixTimeMs, nowMs).toLatLng())
+            existing.moveTo(tripSmoother.displayPosition(easeKey, point, fixTimeMs, nowMs).toLatLng())
             if (existing.title != title) existing.title = title
         }
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/CorrectionSmootherTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/CorrectionSmootherTest.kt
@@ -22,9 +22,10 @@ import org.junit.Test
 import org.onebusaway.android.util.GeoPoint
 
 /**
- * Unit tests for [CorrectionSmoother]: the decaying-correction marker glide. Coordinates are kept
- * tiny so 1° ≈ 111 km dwarfs the 2 km snap gate only where a test wants it to; otherwise jumps stay
- * well under the gate so they smooth rather than snap.
+ * Unit tests for [CorrectionSmoother] — the decaying-correction marker glide — and for
+ * [SingleSubjectSmoother], the one-marker-at-a-time wrapper the fast-estimate marker uses.
+ * Coordinates are kept tiny so 1° ≈ 111 km dwarfs the 2 km snap gate only where a test wants it to;
+ * otherwise jumps stay well under the gate so they smooth rather than snap.
  */
 class CorrectionSmootherTest {
 
@@ -171,30 +172,48 @@ class CorrectionSmootherTest {
         assertFalse(s.isSettling("gone"))
     }
 
+    private fun singleSubject() = SingleSubjectSmoother(smoother())
+
     /**
-     * The fast-estimate marker's contract (#2222): its state is keyed by the selected trip, so switching
-     * vehicles jumps the marker to the new one while a fresh fix on the *same* vehicle still smooths.
-     * A shared key would instead correct the whole inter-vehicle displacement — the marker sweeping
-     * across the map on a tap.
+     * The fast-estimate marker's contract (#2222): a change of subject is not a fresh fix on the old
+     * one, so the marker jumps to the newly tapped vehicle instead of correcting the whole displacement
+     * between the two — which looked like the band being re-drawn, sweeping across the map.
      */
     @Test
-    fun switchingKeys_jumpsInsteadOfSweepingAcrossTheGap() {
-        val s = smoother()
-        // Vehicle A is being tracked and has just absorbed a fix.
+    fun changingSubject_showsTheNewSubjectExactly() {
+        val s = singleSubject()
+        // Vehicle A is drawn and has just absorbed a fix, so a correction is in flight.
         s.prime("tripA", p(0.0, 0.0), fixTimeMs = 1L)
-        s.displayPosition("tripA", p(0.001, 0.0), fixTimeMs = 2L, nowMs = 100L)
-        assertTrue(s.isSettling("tripA"))
+        val settling = s.displayPosition("tripA", p(0.001, 0.0), fixTimeMs = 2L, nowMs = 100L)
+        assertEquals(0.0, settling.latitude, 1e-9) // still showing where A was
 
-        // Selecting vehicle B: retain only its key, then draw it. Its (nearby, so otherwise smoothable)
-        // position is shown exactly — no correction carried over from where A's marker was.
-        s.retainOnly(setOf("tripB"))
+        // Tap vehicle B: its (nearby, so otherwise smoothable) position is shown exactly.
         val onTap = s.displayPosition("tripB", p(0.005, 0.0), fixTimeMs = 7L, nowMs = 200L)
         assertEquals(0.005, onTap.latitude, 1e-12)
-        assertFalse(s.isSettling("tripB"))
+    }
 
-        // B's own next fix still smooths: it corrects from where B was shown, not from the new target.
-        val bFresh = s.displayPosition("tripB", p(0.006, 0.0), fixTimeMs = 8L, nowMs = 300L)
-        assertEquals(0.005, bFresh.latitude, 1e-9)
-        assertTrue(s.isSettling("tripB"))
+    /** Between fixes on one subject nothing is dropped, so a fresh fix still smooths as before. */
+    @Test
+    fun sameSubject_stillSmoothsAcrossAFreshFix() {
+        val s = singleSubject()
+        s.prime("tripB", p(0.005, 0.0), fixTimeMs = 7L)
+
+        // The fresh fix corrects from where the marker was shown, not from the new target.
+        val fresh = s.displayPosition("tripB", p(0.006, 0.0), fixTimeMs = 8L, nowMs = 300L)
+        assertEquals(0.005, fresh.latitude, 1e-9)
+        // ...and converges onto it by the end of the correction.
+        val settled = s.displayPosition("tripB", p(0.006, 0.0), fixTimeMs = 8L, nowMs = 300L + duration)
+        assertEquals(0.006, settled.latitude, 1e-12)
+    }
+
+    /** Deselecting forgets the subject, so re-selecting the same vehicle later starts fresh too. */
+    @Test
+    fun clear_forgetsTheSubject() {
+        val s = singleSubject()
+        s.prime("tripA", p(0.0, 0.0), fixTimeMs = 1L)
+        s.clear()
+
+        val reselected = s.displayPosition("tripA", p(0.001, 0.0), fixTimeMs = 2L, nowMs = 100L)
+        assertEquals(0.001, reselected.latitude, 1e-12)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/CorrectionSmootherTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/CorrectionSmootherTest.kt
@@ -170,4 +170,31 @@ class CorrectionSmootherTest {
         assertEquals(5.0, out.latitude, 1e-12)
         assertFalse(s.isSettling("gone"))
     }
+
+    /**
+     * The fast-estimate marker's contract (#2222): its state is keyed by the selected trip, so switching
+     * vehicles jumps the marker to the new one while a fresh fix on the *same* vehicle still smooths.
+     * A shared key would instead correct the whole inter-vehicle displacement — the marker sweeping
+     * across the map on a tap.
+     */
+    @Test
+    fun switchingKeys_jumpsInsteadOfSweepingAcrossTheGap() {
+        val s = smoother()
+        // Vehicle A is being tracked and has just absorbed a fix.
+        s.prime("tripA", p(0.0, 0.0), fixTimeMs = 1L)
+        s.displayPosition("tripA", p(0.001, 0.0), fixTimeMs = 2L, nowMs = 100L)
+        assertTrue(s.isSettling("tripA"))
+
+        // Selecting vehicle B: retain only its key, then draw it. Its (nearby, so otherwise smoothable)
+        // position is shown exactly — no correction carried over from where A's marker was.
+        s.retainOnly(setOf("tripB"))
+        val onTap = s.displayPosition("tripB", p(0.005, 0.0), fixTimeMs = 7L, nowMs = 200L)
+        assertEquals(0.005, onTap.latitude, 1e-12)
+        assertFalse(s.isSettling("tripB"))
+
+        // B's own next fix still smooths: it corrects from where B was shown, not from the new target.
+        val bFresh = s.displayPosition("tripB", p(0.006, 0.0), fixTimeMs = 8L, nowMs = 300L)
+        assertEquals(0.005, bFresh.latitude, 1e-9)
+        assertTrue(s.isSettling("tripB"))
+    }
 }


### PR DESCRIPTION
Fixes #2222.

## The bug

The fast-estimate marker's fix smoothing was keyed by a constant — `ESTIMATE_EASE_KEY` in the Google renderer, the `"fast"` role string in maplibre — so its correction state outlived the vehicle it belonged to.

Tapping a different vehicle replaces the overlay sampler without ever passing a null overlay through `renderDynamic`, so the marker survives and `CorrectionSmoother` sees the *new* trip's point under the *old* trip's key. A different `fixTimeMs` less than `MAX_CORRECTION_METERS` (2 km) away looks exactly like a fresh AVL fix, so it captured the whole inter-vehicle displacement as an error and decayed it over 600 ms — the marker sweeping across the map, which read as a new confidence interval being drawn. The most-recent-data marker never did this, because it keys on the selected trip id.

## The fix

Key the fast marker the same way, and put the rule somewhere it can't be forgotten.

- **`SingleSubjectSmoother`** (in `CorrectionSmoother.kt`) wraps the keyed smoother for a marker that shows one subject at a time: a change of subject drops the previous subject's correction, so the marker jumps instead of easing across to it. A fresh fix on the same vehicle still smooths, unchanged. Callers that genuinely track several markers at once (the route's vehicles) keep using `CorrectionSmoother` directly. Wrapping it is what makes the mistake unrepresentable — forgetting the `retainOnly` call *was* this bug.
- **`TripOverlay` carries the trip it describes**, so the identity travels with the point it belongs to. Reading `renderState.selectedVehicleTripId` in the renderers instead would skew by a frame on the tap (new id, old point), which re-creates the sweep from the other side.
- Both renderers' fast-marker updates now take the overlay they draw, and maplibre's role-keyed marker/fill maps become the two fields they always were — the fix removed the last real consumer of role-keying, and the map only ever holds one trip marker.

## Testing

- `SingleSubjectSmoother` is covered in `CorrectionSmootherTest`: subject change shows the new subject exactly, same-subject fresh fix still smooths and converges, and deselect forgets the subject.
- Both flavors compile warning-free under `-PwarningsAsErrors=true`; full JVM unit suite green; `spotlessCheck` clean.
- **Not device-verified** — the behaviour is a map-canvas gesture. Worth exercising by selecting a vehicle, then tapping a nearby one on the same route: the fast marker should blink over, while a fresh poll on one vehicle should still glide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle marker movement by smoothing updates for each selected trip independently.
  * Newly selected vehicles now appear immediately, while ongoing updates remain smooth.
  * Removed stale markers when valid vehicle estimates are unavailable.
  * Ensured marker state is cleared correctly when switching trips or leaving the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->