### PR TITLE
Make the drilled-into vehicle one focus rung everywhere (#2224)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -426,9 +426,9 @@ class MapViewModel @Inject constructor(
     /**
      * Select the vehicle running [tripId] (null clears), driving its most-recent-data marker, exact
      * shape/stops, extrapolation confidence band and block continuation. The map's only vehicle-selection
-     * entry point: over a stop's focused route, Home drives it from its stop→route→trip focus level
-     * (#2205) so the selection is undone by the same background tap that peels that level; elsewhere a
-     * vehicle tap sets it directly.
+     * entry point, and it is never called from a tap: Home drives it from the trip rung of whichever
+     * focus draws the route — a stop's, a standalone one, or a directions leg's (#2205, #2224) — so the
+     * selection is a projection of that focus and is undone by the same background tap that peels it.
      */
     fun selectVehicleTrip(tripId: String?) {
         renderState.setSelectedVehicle(tripId)
@@ -438,10 +438,10 @@ class MapViewModel @Inject constructor(
      * Whether tapping the vehicle on [tripId] is a *second* tap on the one already selected — the host
      * opens its trip details on that tap (#2194).
      *
-     * Asked here because this holds the selection whichever route it arrived by: over a stop's focused
-     * route Home drives it as a focus level (#2205), elsewhere [selectVehicleTrip] sets it directly, and
-     * both land in the same render state. An adapter answering it for itself would be reading state it
-     * doesn't own, a poll behind.
+     * Asked here because this holds the selection whichever route it arrived by: every route-bearing
+     * focus drives it through the same [selectVehicleTrip] directive, and all of them land in this one
+     * render state. An adapter answering it for itself would be reading state it doesn't own, a poll
+     * behind.
      */
     fun isVehicleReTap(tripId: String?): Boolean = isVehicleReTap(renderState.selectedVehicleTripId.value, tripId)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ShowRouteRequest.kt
@@ -26,11 +26,17 @@ package org.onebusaway.android.map
  * @property directionStopId when non-null (the arrivals "show vehicles on map" launch), the stop whose
  *   direction the map narrows to; null shows the whole route. It's also the *originating stop* framed
  *   alongside the vehicle by [focusTripId].
- * @property focusTripId when non-null (the arrivals **ETA-pill** tap), the trip whose live vehicle the
- *   map fits into view together with the originating stop ([directionStopId]) — a one-shot framing of the
- *   vehicle↔stop relationship. When no live vehicle is running that trip, the map shows the route and
- *   raises the "vehicle isn't on the map" toast. A plain arrival-row tap leaves this null (frame the whole
- *   route); only the ETA pill sets it.
+ * @property focusTripId when non-null (the arrivals **ETA-pill** tap, or a coach-number search hit), the
+ *   trip whose live vehicle the map fits into view together with the originating stop
+ *   ([directionStopId]) — a one-shot framing of the vehicle↔stop relationship. When no live vehicle is
+ *   running that trip, the map shows the route and raises the "vehicle isn't on the map" toast. A plain
+ *   arrival-row tap leaves this null (frame the whole route); only the ETA pill sets it.
+ *
+ *   **A camera instruction, never retained state.** Which trip the rider is drilled into is a rung of the
+ *   focus itself (`CurrentFocus.selectedTripId`, #2224), minted from this field by the gesture that
+ *   carries it and kept there afterwards. Every replay path — an arrivals poll, a back-restore — sends a
+ *   request with this null, so returning to a focus redraws its route without re-flying the camera to the
+ *   vehicle and re-pinging it.
  * @property initialDirectionId when non-null (a route-continuation or adjacency-badge tap), the GTFS
  *   direction to show instead of the route's default — validated against the loaded route's directions
  *   by [RouteMapController], falling back to the default when it doesn't match.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -296,6 +296,23 @@ internal fun focusedPillRimColor(
     cardSelectionColor: Int?
 ): Int? = if (selected) bandColor ?: cardSelectionColor else null
 
+/** The focused pill's rim width, shared by both producers of an [EtaPillFocus] so they can't drift. */
+private val FOCUSED_PILL_RIM = 2.dp
+
+/**
+ * The focused-pill treatment for [tripId] drawn in [rimColor], or null when nothing is drilled into or
+ * there is no colour to draw it in.
+ *
+ * The one place an [EtaPillFocus] is built, for both surfaces that show a focused pill: a stop's arrivals
+ * row (above) and a directions leg's inline ETA strip (#2224). The rung the two read is the same one —
+ * `CurrentFocus.selectedTripId` — so what they draw for it should be the same too.
+ */
+internal fun etaPillFocus(tripId: String?, rimColor: Int?): EtaPillFocus? {
+    val trip = tripId ?: return null
+    val color = rimColor ?: return null
+    return EtaPillFocus(trip, BorderStroke(FOCUSED_PILL_RIM, Color(color)))
+}
+
 /**
  * One arrivals row for a single (route, direction): the route badge on the left, and on the right
  * the direction name over a horizontally-scrollable strip of per-trip ETA pills (soonest first).
@@ -360,9 +377,10 @@ fun RouteArrivalRow(
     val selectionBorder = selectionColor
         ?.takeIf { selected }
         ?.let { BorderStroke(2.dp, Color(it)) }
-    val pillBorder = focusedPillRimColor(selected, selectedTripBandColor, selectionColor)
-        ?.let { BorderStroke(2.dp, Color(it)) }
-    val pillFocus = pillBorder?.let { border -> selectedTripId?.let { EtaPillFocus(it, border) } }
+    val pillFocus = etaPillFocus(
+        selectedTripId,
+        focusedPillRimColor(selected, selectedTripBandColor, selectionColor)
+    )
     ArrivalCard(modifier, border = selectionBorder) {
         Box(Modifier.fillMaxWidth()) {
             Row(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -296,11 +296,14 @@ internal fun EtaStrip(
 }
 
 /**
- * The trip a row is drilled into (the stop→route→trip focus, #2205) and the stroke to outline its pill
- * with. One value rather than two loose parameters, so a pill can never be told which trip is focused
- * without also being told what to draw for it. [outline] is literally the row card's own selection
- * border — the same object, built once by [RouteArrivalRow] — so the pill reads as belonging to the
- * outlined row and the two can't drift in width or colour.
+ * The trip this strip is drilled into (the trip rung of the current focus, #2205/#2224) and the stroke
+ * to outline its pill with. One value rather than two loose parameters, so a pill can never be told
+ * which trip is focused without also being told what to draw for it.
+ *
+ * Built in exactly one place — `etaPillFocus` — for both surfaces that show a focused pill: a stop's
+ * arrivals row, where [outline] is the row card's own selection stroke so the pill reads as belonging to
+ * the outlined row, and a directions leg's inline strip, which has no row card and wears the band tint
+ * alone. Sharing the builder is what keeps the two from drifting in width or colour.
  *
  * [tripId] is a vehicle, not one arrival instance — see the match site in [EtaStrip] for why that is
  * narrower than the strip's own item key, and why it has to be.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocus.kt
@@ -26,7 +26,16 @@ sealed interface CurrentFocus {
         val stop: FocusedStop,
         val selectedRoute: StopRouteSelection? = null
     ) : CurrentFocus
-    data class Route(val target: RouteTarget) : CurrentFocus
+
+    /**
+     * A route opened on its own — from search, recents, a deep link, a coach-number hit, or the
+     * arrivals row menu's unscoped "Show route on map". [selectedTripId] is the trip drilled into over
+     * it, the same rung a stop's route selection and a directions leg's carry (#2224).
+     */
+    data class Route(
+        val target: RouteTarget,
+        val selectedTripId: String? = null
+    ) : CurrentFocus
     data class BikeStation(val id: String) : CurrentFocus
 
     /**
@@ -48,20 +57,28 @@ sealed interface DirectionsSubFocus {
 
     /**
      * A transit leg examined as its route: the map recontextualized onto that route with the traveled
-     * board→alight segment drawn thick over it. Holds the exact [ShowRouteRequest] that produced this
-     * focus (route id, the boarding stop the direction is narrowed to, the ridden `highlightedSegment`,
-     * and — for a followed vehicle — its `focusTripId`) so restoring after a back-press replays it
-     * faithfully. (Each stop's live ETAs are shown inline in the drawer's Board/Alight rows, not here.)
+     * board→alight segment drawn thick over it. Holds the [ShowRouteRequest] that produced this focus —
+     * route id, the boarding stop the direction is narrowed to, the ridden spans — so restoring after a
+     * back-press replays it faithfully. Everything it holds is durable; the one field it deliberately
+     * drops is `focusTripId` (see [selectedTripId]). (Each stop's live ETAs are shown inline in the
+     * drawer's Board/Alight rows, not here.)
      *
      * [boardStop] is where the rider gets on. It is carried on the focus, rather than read off whichever
      * itinerary row happens to be composed, because the map's ride selection reads the boarding stop's
      * live arrivals: HOME hoists one arrivals session for this stop, so the session's lifetime is the
      * focus rather than a `LazyColumn` row's and scrolling the itinerary cannot change what the map
      * draws. Null when the leg's OTP→OBA stop resolution failed or it carries no location.
+     *
+     * [selectedTripId] is the trip drilled into over this leg's route — the same rung a stop's route
+     * selection carries (#2224), entered by tapping that trip's ETA pill in the leg's inline strip or
+     * its vehicle on the map. It is held *here* rather than left inside [request]'s `focusTripId`
+     * precisely because that field is a one-shot camera instruction: the stored [request] carries none,
+     * so replaying it on a back-restore re-draws the route without re-flying and re-pinging the vehicle.
      */
     data class Route(
         val request: ShowRouteRequest,
-        val boardStop: FocusedStop? = null
+        val boardStop: FocusedStop? = null,
+        val selectedTripId: String? = null
     ) : DirectionsSubFocus
 
     /**
@@ -82,29 +99,65 @@ internal val CurrentFocus.keepsDrawnItinerary: Boolean
     get() = this is CurrentFocus.Directions && subFocus !is DirectionsSubFocus.Route
 
 /**
+ * The trip drilled into over whichever route this focus draws, or null when none is — including on the
+ * focuses that draw no route at all.
+ *
+ * The one answer to "which vehicle is the rider looking at", for all three surfaces that can show one
+ * (#2224): a stop's route selection, a route opened on its own, and a directions leg's route. It used
+ * to exist only on the first; the other two carried the tapped trip in a [ShowRouteRequest.focusTripId]
+ * that everything else treats as a one-shot camera instruction, or nowhere at all — which left the
+ * map's [org.onebusaway.android.map.render.MapRenderState.selectedVehicleTripId] as an unowned second
+ * truth there, invisible to Back, to the background tap, and to `SavedStateHandle`.
+ *
+ * (Reading it off a value already typed as [CurrentFocus.Route] resolves to that class's own member
+ * instead of this extension. Same answer either way — the member *is* what this reads.)
+ */
+internal val CurrentFocus.selectedTripId: String?
+    get() = when (val focus = this) {
+        is CurrentFocus.Stop -> focus.selectedRoute?.selectedTripId
+        is CurrentFocus.Route -> focus.selectedTripId
+        is CurrentFocus.Directions -> (focus.subFocus as? DirectionsSubFocus.Route)?.selectedTripId
+        CurrentFocus.None, is CurrentFocus.BikeStation -> null
+    }
+
+/**
+ * This focus with [tripId] drilled into over the route it draws, or null when it draws no route and so
+ * has nothing to drill into. The write half of [selectedTripId]; the two enumerate the same three
+ * holders, so a fourth route-bearing focus can't be added to one and forgotten in the other.
+ */
+internal fun CurrentFocus.withSelectedTrip(tripId: String?): CurrentFocus? = when (val focus = this) {
+    is CurrentFocus.Stop -> focus.selectedRoute?.let { focus.copy(selectedRoute = it.copy(selectedTripId = tripId)) }
+    is CurrentFocus.Route -> focus.copy(selectedTripId = tripId)
+    is CurrentFocus.Directions -> (focus.subFocus as? DirectionsSubFocus.Route)
+        ?.let { focus.copy(subFocus = it.copy(selectedTripId = tripId)) }
+    CurrentFocus.None, is CurrentFocus.BikeStation -> null
+}
+
+/**
  * This focus with its innermost attention layer removed, or null when there is nothing left to peel.
- * The one definition of the focus ladder: a stop's route selection sits under its drilled-into trip
- * (#2205), a directions overview under its focused leg, and every top-level focus under the root.
+ * The one definition of the focus ladder: a drilled-into trip sits under every route this app can draw
+ * (#2205, #2224), a stop's route selection under that trip, a directions overview under its focused leg,
+ * and every top-level focus under the root.
  *
  * Both consumers read it from here rather than each spelling the levels out: a background tap peels one
  * rung ([org.onebusaway.android.ui.home.HomeViewModel.unfocusMapOneLevel]), and a focus restored after
  * process death — where only the deepest rung is persisted — rebuilds its undo history by walking the
  * whole ladder. A new level therefore has to be added in one place for both to agree.
  */
-internal fun CurrentFocus.peeledOneLevel(): CurrentFocus? = when (this) {
-    CurrentFocus.None -> null
-    is CurrentFocus.Stop -> when {
-        selectedRoute == null -> CurrentFocus.None
-        // The trip drilled into is the innermost rung, so it goes first — the route stays drawn and
-        // only its confidence band and pill outline are given up.
-        selectedRoute.selectedTripId != null ->
-            CurrentFocus.Stop(stop, selectedRoute.copy(selectedTripId = null))
-        else -> CurrentFocus.Stop(stop)
+internal fun CurrentFocus.peeledOneLevel(): CurrentFocus? {
+    // The drilled-into trip is the innermost rung wherever a route is drawn, so it goes first — the
+    // route stays drawn and only its confidence band and pill outline are given up. Expressed once here
+    // rather than per focus kind, which is what keeps a background tap in a directions leg or a
+    // standalone route from skipping the rung and tearing the whole route down (#2224).
+    if (selectedTripId != null) return withSelectedTrip(null)
+    return when (this) {
+        CurrentFocus.None -> null
+        is CurrentFocus.Stop -> if (selectedRoute == null) CurrentFocus.None else CurrentFocus.Stop(stop)
+        // A focused leg — its route, or an on-street leg framed on its own — becomes the plain itinerary
+        // overview; a plain overview exits.
+        is CurrentFocus.Directions -> if (subFocus == null) CurrentFocus.None else CurrentFocus.Directions()
+        is CurrentFocus.Route, is CurrentFocus.BikeStation -> CurrentFocus.None
     }
-    // A focused leg — its route, or an on-street leg framed on its own — becomes the plain itinerary
-    // overview; a plain overview exits.
-    is CurrentFocus.Directions -> if (subFocus == null) CurrentFocus.None else CurrentFocus.Directions()
-    is CurrentFocus.Route, is CurrentFocus.BikeStation -> CurrentFocus.None
 }
 
 val CurrentFocus.focusedStop: FocusedStop?
@@ -114,9 +167,10 @@ val CurrentFocus.focusedBikeStationId: String?
     get() = (this as? CurrentFocus.BikeStation)?.id
 
 /**
- * Durable route identity. It names no trip: within stop focus the drilled-into trip is a level of its own
- * ([StopRouteSelection.selectedTripId], #2205), and the [ShowRouteRequest.focusTripId] this mints is the
- * one-shot "fit that vehicle" camera instruction a drill-in gesture passes, not retained state.
+ * Durable route identity. It names no trip: the drilled-into trip is a level of its own on whichever
+ * focus draws the route ([selectedTripId], #2205/#2224), and the [ShowRouteRequest.focusTripId] this
+ * mints is the one-shot "fit that vehicle" camera instruction a drill-in gesture passes, not retained
+ * state.
  */
 data class RouteTarget(
     val routeId: String,
@@ -163,7 +217,8 @@ data class StopRouteSelection(
      * A level of its own rather than a render-only vehicle selection, so a background tap peels it before
      * the route (see [peeledOneLevel]) — which is what makes the map's
      * [org.onebusaway.android.map.render.MapRenderState.selectedVehicleTripId] a projection of this focus
-     * rather than a second, independently-mutated truth.
+     * rather than a second, independently-mutated truth. Read generically as [CurrentFocus.selectedTripId],
+     * which is where the other two route-bearing focuses hold the same rung (#2224).
      */
     val selectedTripId: String? = null
 ) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -51,11 +51,14 @@ internal object CurrentFocusPersistence {
         return when (state.get<String>(KEY_FOCUS_KIND)) {
             FOCUS_STOP -> stop?.let { CurrentFocus.Stop(it, readStopRoute(state)) }
                 ?: CurrentFocus.None
-            FOCUS_ROUTE -> readRouteTarget(state)?.let { CurrentFocus.Route(it) } ?: CurrentFocus.None
+            FOCUS_ROUTE -> readRouteTarget(state)
+                ?.let { CurrentFocus.Route(it, state[KEY_ROUTE_SELECTED_TRIP]) }
+                ?: CurrentFocus.None
             FOCUS_BIKE -> state.get<String>(KEY_BIKE_STATION)?.let { CurrentFocus.BikeStation(it) }
                 ?: CurrentFocus.None
             // A restored directions focus returns to the itinerary overview; the transient leg
-            // sub-focus isn't persisted.
+            // sub-focus isn't persisted — and with it goes the trip rung it would have carried, since
+            // there is no leg left to have drilled into.
             FOCUS_DIRECTIONS -> CurrentFocus.Directions()
             FOCUS_NONE -> CurrentFocus.None
             else -> readLegacyFocus(state, stop)
@@ -91,7 +94,9 @@ internal object CurrentFocusPersistence {
         state[KEY_ROUTE_LEG_DIRECTIONS] = selected?.legs
             ?.map { it.directionId ?: NO_DIRECTION }
             ?.toIntArray()
-        state[KEY_ROUTE_SELECTED_TRIP] = selected?.selectedTripId
+        // The drilled-into trip off whichever focus holds it (#2224) — one key, because the focus kinds
+        // that can carry the rung are mutually exclusive and only the current one is ever written.
+        state[KEY_ROUTE_SELECTED_TRIP] = focus.selectedTripId
     }
 
     private fun readLegacyFocus(state: SavedStateHandle, stop: FocusedStop?): CurrentFocus {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -76,6 +76,7 @@ import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
+import org.onebusaway.android.ui.arrivals.components.etaPillFocus
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
@@ -966,6 +967,12 @@ fun HomeScreen(
                                             // Each transit leg's Board/Alight row shows that stop's live ETA strip inline,
                                             // ruled at the moment the plan has the rider reach the stop (#2125).
                                             stopEtaStrip = { ride, stop ->
+                                                // The focused leg's boarding stop: the one strip that reads the
+                                                // hoisted session rather than opening a second one on the stop the
+                                                // map is already polling — and so the one strip whose pills can be
+                                                // the map's drilled-into vehicle (#2224).
+                                                val isRideBoardStop =
+                                                    stop.stopId != null && stop.stopId == rideBoardStop?.id
                                                 DirectionStopEtaStrip(
                                                     routeLeg = ride.routeLeg,
                                                     stop = stop,
@@ -976,11 +983,14 @@ fun HomeScreen(
                                                     onFocusVehicle = { request ->
                                                         homeViewModel.focusDirectionsRouteVehicle(request, ride.routeLeg, ride.legPoints)
                                                     },
-                                                    // The focused leg's Board row reads the hoisted session rather than
-                                                    // opening a second one on the stop the map is already polling.
-                                                    hoistedSession = rideArrivalsSession?.takeIf {
-                                                        stop.stopId != null && stop.stopId == rideBoardStop?.id
-                                                    }
+                                                    hoistedSession = rideArrivalsSession?.takeIf { isRideBoardStop },
+                                                    // Same rung and same rim colour the arrivals drawer outlines its
+                                                    // focused pill with, so a pill tapped here and one tapped there
+                                                    // look alike as well as behaving alike.
+                                                    pillFocus = etaPillFocus(
+                                                        rideRouteFocus?.selectedTripId?.takeIf { isRideBoardStop },
+                                                        selectedTripBandColor
+                                                    )
                                                 )
                                             },
                                             // Its own settled height (peek vs expanded), not a measured

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -421,19 +421,13 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * **The one place a [MapDirective.ShowRoute] is emitted** (#2205, #2224). It always travels with the
-     * [MapDirective.SelectVehicle] that projects [selectedTripId] — the drilled-into trip rung of the
-     * focus being shown — onto the map, so the map's vehicle selection (what draws the extrapolation
-     * band, the exact shape/stops, the fast-estimate marker and the block continuation) can never become
-     * a second, independently-mutated truth. That is what had drifted: the stop path paired the two and
-     * the standalone-route and directions-leg paths did not, so the same gesture drew three different
-     * things depending on how the rider reached the route.
+     * Show [request]'s route with [selectedTripId] drilled into over it — the drilled-into trip rung of
+     * the focus being shown (#2205, #2224), which the map projects as its vehicle selection (what draws
+     * the extrapolation band, the exact shape/stops, the fast-estimate marker and the block
+     * continuation).
      *
-     * The selection is emitted *after* the route directive so it survives the teardown a route change
-     * performs, and unconditionally (null included) so no path can leave a previous trip selected.
-     *
-     * Keep this the only construction site of [MapDirective.ShowRoute]: a new surface that builds one
-     * for itself is exactly how the pairing was lost the first time.
+     * The two travel as one directive rather than a pair the caller has to remember to send, so the
+     * selection cannot become a second, independently-mutated truth — see [MapDirective.ShowRoute].
      */
     private fun showRoute(
         request: ShowRouteRequest,
@@ -441,17 +435,15 @@ class HomeViewModel @Inject constructor(
         stopScoped: Boolean = false,
         frameRoute: Boolean = true,
         withinDirections: Boolean = false
-    ) {
-        emitMapDirective(
-            MapDirective.ShowRoute(
-                request,
-                stopScoped = stopScoped,
-                frameRoute = frameRoute,
-                withinDirections = withinDirections
-            )
+    ) = emitMapDirective(
+        MapDirective.ShowRoute(
+            request,
+            selectedTripId = selectedTripId,
+            stopScoped = stopScoped,
+            frameRoute = frameRoute,
+            withinDirections = withinDirections
         )
-        emitMapDirective(MapDirective.SelectVehicle(selectedTripId))
-    }
+    )
 
     /**
      * Show a stop-scoped route on the map together with its trip level — the stop-shaped entry into
@@ -1381,9 +1373,17 @@ sealed interface MapDirective {
      * Enter route mode for [request]'s route (the "show vehicles on map" action). [withinDirections]
      * marks a drill-in from a trip plan's leg, which keeps the rest of the trip drawn beneath the route
      * as de-emphasized context (#2048).
+     *
+     * [selectedTripId] is which of that route's vehicles the focus is drilled into (#2205, #2224), null
+     * for none. **It carries no default on purpose.** The route and the vehicle drilled into over it are
+     * one map state, and sending them apart is how they drifted: the stop path paired them and the
+     * standalone-route and directions-leg paths did not, leaving the map's selection an unowned second
+     * truth on those two. Making it a required field means a surface added later cannot show a route
+     * without answering the question — the compiler asks, so no comment has to.
      */
     data class ShowRoute(
         val request: ShowRouteRequest,
+        val selectedTripId: String?,
         val stopScoped: Boolean,
         val frameRoute: Boolean = true,
         val withinDirections: Boolean = false
@@ -1423,9 +1423,10 @@ sealed interface MapDirective {
     data object ClearSelectedRoute : MapDirective
 
     /**
-     * Select the vehicle running [tripId] — what draws its extrapolation confidence band — or clear the
-     * selection with null. The stop→route→trip focus level (#2205) is the authority here, so this rides
-     * alongside every stop-scoped [ShowRoute] rather than the map setting it alone from a vehicle tap.
+     * Move the vehicle selection — what draws the extrapolation confidence band — to [tripId], or clear
+     * it with null, over a route the map is *already* showing. The trip rung of the focus (#2205, #2224)
+     * is the authority here; entering or replaying a route carries its own selection on [ShowRoute], so
+     * this is only for the transitions that move the rung without redrawing the route beneath it.
      */
     data class SelectVehicle(val tripId: String?) : MapDirective
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -421,12 +421,41 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * Show a stop-scoped route on the map together with its trip level (#2205): every entry into — or
-     * replay of — a stop's route selection goes through here, so the route directive can never be sent
-     * without the [MapDirective.SelectVehicle] that makes the map's vehicle selection (what draws the
-     * extrapolation band) a projection of the focus. The selection is emitted after the route directive
-     * so it survives the teardown a route change performs, and unconditionally (null included) so no
-     * path can leave a previous trip selected on the map.
+     * **The one place a [MapDirective.ShowRoute] is emitted** (#2205, #2224). It always travels with the
+     * [MapDirective.SelectVehicle] that projects [selectedTripId] — the drilled-into trip rung of the
+     * focus being shown — onto the map, so the map's vehicle selection (what draws the extrapolation
+     * band, the exact shape/stops, the fast-estimate marker and the block continuation) can never become
+     * a second, independently-mutated truth. That is what had drifted: the stop path paired the two and
+     * the standalone-route and directions-leg paths did not, so the same gesture drew three different
+     * things depending on how the rider reached the route.
+     *
+     * The selection is emitted *after* the route directive so it survives the teardown a route change
+     * performs, and unconditionally (null included) so no path can leave a previous trip selected.
+     *
+     * Keep this the only construction site of [MapDirective.ShowRoute]: a new surface that builds one
+     * for itself is exactly how the pairing was lost the first time.
+     */
+    private fun showRoute(
+        request: ShowRouteRequest,
+        selectedTripId: String?,
+        stopScoped: Boolean = false,
+        frameRoute: Boolean = true,
+        withinDirections: Boolean = false
+    ) {
+        emitMapDirective(
+            MapDirective.ShowRoute(
+                request,
+                stopScoped = stopScoped,
+                frameRoute = frameRoute,
+                withinDirections = withinDirections
+            )
+        )
+        emitMapDirective(MapDirective.SelectVehicle(selectedTripId))
+    }
+
+    /**
+     * Show a stop-scoped route on the map together with its trip level — the stop-shaped entry into
+     * [showRoute], used by every entry into and replay of a stop's route selection.
      *
      * [request] defaults to the selection's own, which carries no `focusTripId` even when a trip *is*
      * focused: that field is a one-shot camera instruction (fit the vehicle with the stop, and ping it),
@@ -438,10 +467,7 @@ class HomeViewModel @Inject constructor(
         selection: StopRouteSelection,
         request: ShowRouteRequest = selection.target(stopId).toRequest(),
         frameRoute: Boolean = true
-    ) {
-        emitMapDirective(MapDirective.ShowRoute(request, stopScoped = true, frameRoute = frameRoute))
-        emitMapDirective(MapDirective.SelectVehicle(selection.selectedTripId))
-    }
+    ) = showRoute(request, selection.selectedTripId, stopScoped = true, frameRoute = frameRoute)
 
     /** Animate the map's camera back onto the focused stop, if one is focused (else a no-op). */
     fun recenterOnFocusedStop(undoViewport: MapViewport? = null) {
@@ -480,13 +506,21 @@ class HomeViewModel @Inject constructor(
     /** Enter route focus from a route-oriented surface (search, recents, deep link, route info) or an
      *  unscoped drawer reveal (the row menu's "Show route on map", via [selectArrivalRoute]). */
     fun focusStandaloneRoute(request: ShowRouteRequest, undoViewport: MapViewport? = null) {
-        pushFocus(CurrentFocus.Route(request.toRouteTarget()), undoViewport)
-        emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false))
+        // A request naming a trip — an ETA pill, or a coach-number search hit drilling into the ride
+        // that vehicle is running — lands one rung deeper, exactly as it does over a focused stop
+        // (#2224). The request keeps its `focusTripId` so the camera still fits vehicle+stop; the rung
+        // below is what the focus retains once that one-shot fit is spent.
+        val focus = CurrentFocus.Route(request.toRouteTarget(), selectedTripId = request.focusTripId)
+        pushFocus(focus, undoViewport)
+        showRoute(request, focus.selectedTripId)
     }
 
     /** Persist a direction chosen from the standalone route banner (null = the whole route). */
     fun selectStandaloneRouteDirection(directionId: Int?) {
         val focus = _currentFocus.value as? CurrentFocus.Route ?: return
+        // The trip rung does not survive the switch: the map filters a vehicle running the other
+        // direction out of the overlay and drops its own selection (`RouteMapController.selectDirection`),
+        // so the focus must stop claiming it rather than drift from what is drawn.
         replaceFocus(CurrentFocus.Route(focus.target.copy(directionId = directionId)))
     }
 
@@ -505,9 +539,11 @@ class HomeViewModel @Inject constructor(
                 showStopRoute(focus.stop.id, next)
             }
             is CurrentFocus.Route -> {
+                // No trip rung carries over: the continuation is a *different* trip of that block and
+                // this tap doesn't name its id — the same rule [StopRouteSelection.continueTo] applies.
                 val target = RouteTarget(routeId, directionId = directionId)
                 pushFocus(CurrentFocus.Route(target), undoViewport)
-                emitMapDirective(MapDirective.ShowRoute(target.toRequest(), stopScoped = false))
+                showRoute(target.toRequest(), selectedTripId = null)
             }
             else -> Unit
         }
@@ -638,29 +674,29 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * A vehicle tapped on the map enters the stop→route→trip level (#2205) — the same state its ETA pill
-     * reaches — so the band it raises can be unwound by a background tap instead of lingering as a
-     * render-only selection. Returns false when there is no stop→route focus to deepen (standalone route
-     * focus, directions), leaving the tap to the map's own vehicle selection — so the same two gestures
-     * unwind differently by how the route was reached: over a focused stop a background tap gives up
-     * just the band, while in standalone route focus it still gives up the whole route.
+     * A vehicle tapped on the map enters the trip rung over whatever route is drawn (#2205, #2224) — the
+     * same state its ETA pill reaches — so the band it raises is unwound by a background tap instead of
+     * lingering as a render-only selection. Applies alike over a focused stop's route, a route opened on
+     * its own, and a directions leg's route: vehicles are only ever drawn in one of those three, and a
+     * tap now means the same thing in each.
      *
      * [tripId] is the tapped vehicle's active trip, which the wire leaves nullable: a vehicle running no
      * identifiable trip has nothing to drill into, so it lands back at the plain route level rather than
      * letting the focus and the map's selection drift apart.
      */
-    fun selectFocusedRouteTrip(tripId: String?): Boolean {
-        val focus = _currentFocus.value as? CurrentFocus.Stop ?: return false
-        val selected = focus.selectedRoute ?: return false
-        pushFocus(focus.copy(selectedRoute = selected.copy(selectedTripId = tripId)))
+    fun selectFocusedRouteTrip(tripId: String?) {
+        // Null only when the current focus draws no route — no vehicle can have been tapped there, so
+        // there is nothing to record and nothing to tell the map.
+        val target = _currentFocus.value.withSelectedTrip(tripId) ?: return
+        pushFocus(target)
         emitMapDirective(MapDirective.SelectVehicle(tripId))
-        return true
     }
 
     /**
-     * A background-map tap drops one attention layer: trip-over-route-over-stop becomes the plain
-     * route-over-stop; route-over-stop becomes the plain stop; a focused itinerary leg becomes the plain
-     * itinerary overview; any plain stop, standalone route, or bike focus returns to the unfocused root.
+     * A background-map tap drops one attention layer: a drilled-into vehicle becomes the plain route it
+     * runs on — over a focused stop, a standalone route, or a directions leg alike (#2224);
+     * route-over-stop becomes the plain stop; a focused itinerary leg becomes the plain itinerary
+     * overview; any plain stop, standalone route, or bike focus returns to the unfocused root.
      */
     fun unfocusMapOneLevel() {
         val focus = _currentFocus.value
@@ -670,10 +706,10 @@ class HomeViewModel @Inject constructor(
         if (stageDirectionsExitConfirmation(focus, target)) return
         pushFocus(target)
         when {
-            // Peeled the trip only: the route is still focused, so drop the vehicle selection (and with
-            // it the band) rather than tearing route mode down.
-            target is CurrentFocus.Stop && target.selectedRoute != null ->
-                emitMapDirective(MapDirective.SelectVehicle(null))
+            // Peeled the trip only: the route is still drawn, so drop the vehicle selection (and with it
+            // the band) rather than tearing route mode down. Asked of the focus we came *from*, which is
+            // what makes it one branch for all three route-bearing focuses instead of one per kind.
+            focus.selectedTripId != null -> emitMapDirective(MapDirective.SelectVehicle(null))
             target is CurrentFocus.Stop -> emitMapDirective(MapDirective.ClearSelectedRoute)
             // Popped a leg sub-focus back to the whole trip.
             target is CurrentFocus.Directions -> emitMapDirective(itineraryOverviewDirective(focus))
@@ -1018,16 +1054,30 @@ class HomeViewModel @Inject constructor(
      * Enter the route-subordinate-to-directions focus for [request]: push the itinerary overview as the
      * back target (with [undoViewport] to restore) and load the route with its ridden segment. Shared by
      * the leg-row tap and the inline-ETA vehicle tap so both spend the same request faithfully.
+     *
+     * A request naming a trip (the ETA-pill tap) also enters the trip rung over that route, so a pill
+     * tapped in a directions leg reaches the same state one tapped in a stop's drawer does (#2224): the
+     * band, the exact shape/stops, the outlined pill, and a background tap that gives the vehicle up
+     * before the leg.
      */
     private fun enterDirectionsRouteFocus(
         request: ShowRouteRequest,
         boardStop: FocusedStop? = null,
         undoViewport: MapViewport? = null
     ) {
-        pushFocus(CurrentFocus.Directions(DirectionsSubFocus.Route(request, boardStop)), undoViewport)
+        val subFocus = DirectionsSubFocus.Route(
+            // The *stored* request drops the focusTripId: it is the one-shot "fit this vehicle and ping
+            // it" instruction this gesture asked for, and replaying it from the back stack would re-fly
+            // and re-ping a vehicle the rider is merely returning to. The rung below is what survives.
+            request = request.copy(focusTripId = null),
+            boardStop = boardStop,
+            selectedTripId = request.focusTripId
+        )
+        pushFocus(CurrentFocus.Directions(subFocus), undoViewport)
         // withinDirections: this route is drilled into *from* a trip plan, so the map keeps the rest of
-        // the trip beneath it as de-emphasized context (#2048).
-        emitMapDirective(MapDirective.ShowRoute(request, stopScoped = false, withinDirections = true))
+        // the trip beneath it as de-emphasized context (#2048). The request emitted is the caller's own,
+        // focusTripId included — this is the drill-in gesture, so it gets its fit.
+        showRoute(request, subFocus.selectedTripId, withinDirections = true)
         // A stop id is enough to anchor the route direction, but the hoisted arrivals session also
         // needs a point because it is built from FocusedStop. Classify that no-session case explicitly
         // as Unserved instead of leaving ride selection Pending (which would hide every vehicle).
@@ -1202,18 +1252,24 @@ class HomeViewModel @Inject constructor(
             entry.viewport?.let { emitMapDirective(MapDirective.RestoreViewport(it)) }
             return
         }
+        // Only the trip rung moved (#2205, #2224) — the two focuses are identical but for which vehicle
+        // is drilled into. The route beneath is already drawn, so just move the selection rather than
+        // reloading and reframing it. Asked of the whole focus rather than per kind, which is what stops
+        // a Back out of a drilled-into vehicle in directions or standalone route focus from yanking the
+        // camera out to the route's extent (these arrive with no saved viewport, so [frameFocus] is true).
+        if (from.withSelectedTrip(target.selectedTripId) == target) {
+            emitMapDirective(MapDirective.SelectVehicle(target.selectedTripId))
+            return
+        }
         val returnsToSameStop = from is CurrentFocus.Stop &&
             target is CurrentFocus.Stop &&
             from.stop.id == target.stop.id
         if (returnsToSameStop) {
             val selected = target.selectedRoute
-            when {
-                selected == null -> emitMapDirective(MapDirective.ClearSelectedRoute)
-                // Only the trip level moved (#2205): the same route is already drawn, so just move the
-                // vehicle selection rather than reloading and reframing the route beneath it.
-                from.selectedRoute?.legs == selected.legs ->
-                    emitMapDirective(MapDirective.SelectVehicle(selected.selectedTripId))
-                else -> showStopRoute(target.stop.id, selected, frameRoute = frameFocus)
+            if (selected == null) {
+                emitMapDirective(MapDirective.ClearSelectedRoute)
+            } else {
+                showStopRoute(target.stop.id, selected, frameRoute = frameFocus)
             }
         } else {
             when (target) {
@@ -1221,25 +1277,23 @@ class HomeViewModel @Inject constructor(
                     markPendingMapFocus(preserveViewport = !frameFocus)
                     emitMapDirective(MapDirective.ClearFocus)
                 }
-                is CurrentFocus.Route -> {
-                    emitMapDirective(
-                        MapDirective.ShowRoute(
-                            target.target.toRequest(),
-                            stopScoped = false,
-                            frameRoute = frameFocus
-                        )
-                    )
-                }
+                is CurrentFocus.Route -> showRoute(
+                    // No focusTripId: the restored rung below draws the vehicle back without re-flying
+                    // the camera to it or re-pinging it, exactly as a stop's route replay does.
+                    target.target.toRequest(),
+                    target.selectedTripId,
+                    frameRoute = frameFocus
+                )
                 is CurrentFocus.Directions -> when (val subFocus = target.subFocus) {
                     // Back into a route sub-focus: re-show that leg's route on the map, over the trip
-                    // it belongs to (still drawn, or restored by the sheet's own reconcile).
-                    is DirectionsSubFocus.Route -> emitMapDirective(
-                        MapDirective.ShowRoute(
-                            subFocus.request,
-                            stopScoped = false,
-                            frameRoute = frameFocus,
-                            withinDirections = true
-                        )
+                    // it belongs to (still drawn, or restored by the sheet's own reconcile), with
+                    // whichever vehicle was drilled into selected again. The stored request carries no
+                    // focusTripId, so this redraws without re-flying or re-pinging (#2224).
+                    is DirectionsSubFocus.Route -> showRoute(
+                        subFocus.request,
+                        subFocus.selectedTripId,
+                        frameRoute = frameFocus,
+                        withinDirections = true
                     )
                     // Back into an on-street leg focus: re-apply it exactly as the drawer's tap does.
                     is DirectionsSubFocus.Leg -> applyLegFocus(subFocus.leg, from)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -91,6 +91,7 @@ import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
+import org.onebusaway.android.ui.arrivals.components.EtaPillFocus
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
@@ -419,7 +420,14 @@ internal fun DirectionStopEtaStrip(
     onEditReminder: (ReminderEditorArgs) -> Unit,
     onFocusVehicle: (ShowRouteRequest) -> Unit,
     modifier: Modifier = Modifier,
-    hoistedSession: ArrivalsSession? = null
+    hoistedSession: ArrivalsSession? = null,
+    /**
+     * The trip this strip's stop is drilled into on the map, if any (#2224) — the directions half of the
+     * treatment a stop's arrivals row gives its focused pill. Only ever non-null on the focused leg's
+     * boarding-stop strip, which is the one the map's vehicle was tapped from; every other strip on the
+     * itinerary is showing some other stop's departures and has no drilled-into vehicle to mark.
+     */
+    pillFocus: EtaPillFocus? = null
 ) {
     val stopId = stop.stopId
     val point = stop.point
@@ -458,6 +466,7 @@ internal fun DirectionStopEtaStrip(
         reachStopTime = reachStopTime,
         session = session,
         rowPadding = rowPadding,
+        pillFocus = pillFocus,
         modifier = modifier
     )
 }
@@ -469,6 +478,7 @@ private fun DirectionStopEtaStripContent(
     reachStopTime: ServerTime?,
     session: ArrivalsSession,
     rowPadding: Modifier,
+    pillFocus: EtaPillFocus?,
     modifier: Modifier
 ) {
     val state by session.viewModel.state.collectAsStateWithLifecycle()
@@ -498,7 +508,8 @@ private fun DirectionStopEtaStripContent(
         callbacks = callbacks,
         modifier = modifier.then(rowPadding),
         routeBadgeFor = { badgesByTrip[it] },
-        marker = reachStopTime?.let { rememberReachStopMarker(it) }
+        marker = reachStopTime?.let { rememberReachStopMarker(it) },
+        focus = pillFocus
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -350,13 +350,18 @@ fun MapFeature(
             when (directive) {
                 is MapDirective.RecenterOnFocusedStop ->
                     mapViewModel.recenterOnFocusedStop(directive.point)
-                is MapDirective.ShowRoute ->
+                is MapDirective.ShowRoute -> {
                     mapViewModel.toRoute(
                         directive.request,
                         directive.stopScoped,
                         directive.frameRoute,
                         directive.withinDirections
                     )
+                    // After the route, always, and null included: entering a route tears the previous
+                    // session's selection down, so this is what restores the focus's own — and what
+                    // stops a route change from leaving a previous trip selected (#2224).
+                    mapViewModel.selectVehicleTrip(directive.selectedTripId)
+                }
                 is MapDirective.RestoreViewport ->
                     mapViewModel.restoreViewport(directive.viewport)
                 MapDirective.FrameRoute -> mapViewModel.frameRoute()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -260,14 +260,11 @@ fun MapFeature(
                     )
                     return
                 }
-                // Over a stop's focused route the tapped vehicle is a focus level of its own (#2205), so
-                // HOME owns the transition and the selection arrives as its directive; a background tap
-                // then unwinds it. Anywhere else (standalone route focus, directions) the tap stays what
-                // it has always been: a bare render selection with nothing to unwind. Same ask-HOME-then-
-                // render shape as the stop and bike taps above.
-                if (!homeViewModel.selectFocusedRouteTrip(tripId)) {
-                    mapViewModel.selectVehicleTrip(tripId)
-                }
+                // The tapped vehicle is a focus level of its own wherever a route is drawn — over a
+                // focused stop, a standalone route, or a directions leg (#2205, #2224) — so HOME owns the
+                // transition and the selection arrives as its directive; a background tap then unwinds
+                // it. Same ask-HOME-then-render shape as the stop and bike taps above.
+                homeViewModel.selectFocusedRouteTrip(tripId)
             }
 
             override fun onRouteContinuationClick(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/CurrentFocusLadderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/CurrentFocusLadderTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.ui.tripresults.FocusedLeg
+import org.onebusaway.android.util.GeoPoint
+
+/**
+ * The focus ladder ([peeledOneLevel]) and the trip rung that sits on every rung of it that draws a route
+ * ([selectedTripId] / [withSelectedTrip]).
+ *
+ * The rung used to exist only over a focused stop, so the same gesture unwound differently depending on
+ * how the rider reached the route (#2224). These cases are written per focus kind on purpose: the point
+ * of the change is that the three answers are the *same*, and a per-kind test is what catches a fourth
+ * route-bearing focus being added without one.
+ */
+class CurrentFocusLadderTest {
+
+    private val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
+    private val selection = StopRouteSelection(
+        originHeadsign = "Downtown",
+        legs = listOf(RouteLeg("65", "65", 0))
+    )
+    private val stopRoute = CurrentFocus.Stop(stop, selection)
+    private val standaloneRoute = CurrentFocus.Route(RouteTarget("65", directionId = 0))
+    private val legRoute = CurrentFocus.Directions(
+        DirectionsSubFocus.Route(ShowRouteRequest("65", "board"), boardStop = stop)
+    )
+
+    /** Every focus that draws a route, in the plain (nothing drilled into) state. */
+    private val routeBearing = listOf(stopRoute, standaloneRoute, legRoute)
+
+    @Test
+    fun `every route-bearing focus can hold and report a trip`() {
+        routeBearing.forEach { focus ->
+            assertNull(focus.toString(), focus.selectedTripId)
+            assertEquals(focus.toString(), "trip", focus.withSelectedTrip("trip")?.selectedTripId)
+        }
+    }
+
+    @Test
+    fun `a focus that draws no route has nothing to drill into`() {
+        listOf(
+            CurrentFocus.None,
+            CurrentFocus.BikeStation("dock"),
+            // A stop with no route selected draws no route either, so no vehicle can be tapped over it.
+            CurrentFocus.Stop(stop),
+            CurrentFocus.Directions(),
+            CurrentFocus.Directions(DirectionsSubFocus.Leg(FocusedLeg(listOf(GeoPoint(47.6, -122.3)), setOf(1))))
+        ).forEach { focus ->
+            assertNull(focus.toString(), focus.selectedTripId)
+            assertNull(focus.toString(), focus.withSelectedTrip("trip"))
+        }
+    }
+
+    @Test
+    fun `the trip is the innermost rung wherever a route is drawn`() {
+        routeBearing.forEach { focus ->
+            val drilledIn = focus.withSelectedTrip("trip")
+            // One peel gives up the vehicle and leaves the route exactly as it was.
+            assertEquals(focus.toString(), focus, drilledIn?.peeledOneLevel())
+        }
+    }
+
+    @Test
+    fun `a stop's ladder runs trip then route then stop then root`() {
+        assertEquals(
+            listOf(
+                CurrentFocus.Stop(stop, selection),
+                CurrentFocus.Stop(stop),
+                CurrentFocus.None
+            ),
+            CurrentFocus.Stop(stop, selection.copy(selectedTripId = "trip")).rungsBelow()
+        )
+    }
+
+    @Test
+    fun `a standalone route's ladder runs trip then route then root`() {
+        assertEquals(
+            listOf(standaloneRoute, CurrentFocus.None),
+            standaloneRoute.copy(selectedTripId = "trip").rungsBelow()
+        )
+    }
+
+    @Test
+    fun `a directions leg's ladder runs trip then leg then overview then root`() {
+        val subFocus = DirectionsSubFocus.Route(ShowRouteRequest("65", "board"), boardStop = stop)
+        assertEquals(
+            listOf(
+                legRoute,
+                CurrentFocus.Directions(),
+                CurrentFocus.None
+            ),
+            CurrentFocus.Directions(subFocus.copy(selectedTripId = "trip")).rungsBelow()
+        )
+    }
+
+    /** Every rung under this focus, outermost last — the walk `HomeViewModel` rebuilds undo history with. */
+    private fun CurrentFocus.rungsBelow(): List<CurrentFocus> = generateSequence(this) { it.peeledOneLevel() }.drop(1).toList()
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -77,7 +77,17 @@ private class MapDirectiveRecorder(private val vm: HomeViewModel) {
     val clearFocusCount get() = sent.count { it is MapDirective.ClearFocus }
     val focusStops get() = sent.filterIsInstance<MapDirective.FocusStop>()
     val viewportRestores get() = sent.filterIsInstance<MapDirective.RestoreViewport>()
-    val vehicleSelections get() = sent.filterIsInstance<MapDirective.SelectVehicle>().map { it.tripId }
+
+    // Every vehicle selection the map is told to make, in order, whichever directive carried it: showing
+    // a route always names one (#2224), and SelectVehicle moves it over a route already drawn. Nulls are
+    // meaningful (a cleared selection), so the per-directive lists are flattened rather than mapNotNull'd.
+    val vehicleSelections: List<String?> get() = sent.mapNotNull { directive ->
+        when (directive) {
+            is MapDirective.ShowRoute -> listOf(directive.selectedTripId)
+            is MapDirective.SelectVehicle -> listOf(directive.tripId)
+            else -> null
+        }
+    }.flatten()
     val lastBottomPadding get() = vm.mapBottomPadding.value
 
     suspend fun collect() {
@@ -445,15 +455,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        val leg = rideLeg()
-        vm.enterDirectionsShowing()
-        map.sent.clear()
-
-        vm.focusDirectionsRouteVehicle(
-            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
-            routeLeg = leg,
-            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
-        )
+        vm.tapLegVehicle()
         advanceUntilIdle()
 
         assertEquals("tapped", vm.directionsRouteFocus()?.selectedTripId)
@@ -475,13 +477,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        val leg = rideLeg()
-        vm.enterDirectionsShowing()
-        vm.focusDirectionsRouteVehicle(
-            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
-            routeLeg = leg,
-            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
-        )
+        vm.tapLegVehicle()
         advanceUntilIdle()
         map.sent.clear()
 
@@ -509,13 +505,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        val leg = rideLeg()
-        vm.enterDirectionsShowing()
-        vm.focusDirectionsRouteVehicle(
-            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
-            routeLeg = leg,
-            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
-        )
+        vm.tapLegVehicle()
         advanceUntilIdle()
 
         // Away to a stop, then back — the branch that has to redraw the route rather than just reselect.
@@ -538,13 +528,7 @@ class HomeViewModelTest {
         val map = MapDirectiveRecorder(vm)
         val job = launch { map.collect() }
         advanceUntilIdle()
-        val leg = rideLeg()
-        vm.enterDirectionsShowing()
-        vm.focusDirectionsRouteVehicle(
-            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
-            routeLeg = leg,
-            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
-        )
+        vm.tapLegVehicle()
         vm.unfocusMapOneLevel()
         advanceUntilIdle()
         map.sent.clear()
@@ -560,6 +544,21 @@ class HomeViewModelTest {
     // A tapped on-street leg. Only [legIndices] distinguishes one from another to the focus model, so the
     // geometry is shared; [walkLeg] gives each test the leg it needs without restating the coordinates.
     private fun walkLeg(vararg legIndices: Int) = FocusedLeg(listOf(GeoPoint(47.6, -122.3), GeoPoint(47.61, -122.31)), legIndices.toSet())
+
+    /**
+     * Enter directions and tap the pill for [tripId] in [rideLeg]'s inline ETA strip — the drill-in
+     * gesture every trip-rung test below starts from (#2224). Emits no route directive of its own before
+     * the tap, so a test can read the tap's own request straight off the recorder.
+     */
+    private fun HomeViewModel.tapLegVehicle(tripId: String = "tapped") {
+        val leg = rideLeg()
+        enterDirectionsShowing()
+        focusDirectionsRouteVehicle(
+            request = ShowRouteRequest(leg.routeId!!, leg.board!!.stopId, focusTripId = tripId),
+            routeLeg = leg,
+            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
+        )
+    }
 
     /** Directions focus with [itinerary] drawn — the state every leg-focus test starts from. */
     private fun HomeViewModel.enterDirectionsShowing(itinerary: TripItinerary = TripItinerary()) = itinerary.also {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -552,11 +552,15 @@ class HomeViewModelTest {
      */
     private fun HomeViewModel.tapLegVehicle(tripId: String = "tapped") {
         val leg = rideLeg()
+        // Bound once each: [rideLeg] always supplies them, and asserting that twice for the same stop
+        // is the redundant `!!` the compiler rejects under -PwarningsAsErrors.
+        val board = leg.board!!
+        val alight = leg.alight!!
         enterDirectionsShowing()
         focusDirectionsRouteVehicle(
-            request = ShowRouteRequest(leg.routeId!!, leg.board!!.stopId, focusTripId = tripId),
+            request = ShowRouteRequest(leg.routeId!!, board.stopId, focusTripId = tripId),
             routeLeg = leg,
-            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
+            fallbackPoints = listOf(board.point!!, alight.point!!)
         )
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -88,6 +88,9 @@ private class MapDirectiveRecorder(private val vm: HomeViewModel) {
 /** The route selection under the current stop focus, or null when nothing is focused that deeply. */
 private fun HomeViewModel.stopRouteSelection(): StopRouteSelection? = (currentFocus.value as? CurrentFocus.Stop)?.selectedRoute
 
+/** The drilled-into leg's route sub-focus, or null when no leg is focused that deeply. */
+private fun HomeViewModel.directionsRouteFocus(): DirectionsSubFocus.Route? = (currentFocus.value as? CurrentFocus.Directions)?.subFocus as? DirectionsSubFocus.Route
+
 /**
  * Unit tests for [HomeViewModel]: focus coordination, the arrivals-sheet → map effects, and region resolution.
  * Mirrors the established ViewModel test pattern (MainDispatcherRule + runTest + hand-written fakes).
@@ -424,6 +427,132 @@ class HomeViewModelTest {
         vm.focusDirectionsRouteVehicleInFocusedLeg(ShowRouteRequest(routeId = "40_1LINE"))
         advanceUntilIdle()
 
+        assertTrue(map.routeRequests.isEmpty())
+        job.cancel()
+    }
+
+    // -- the trip rung over a directions leg's route (#2224) --
+
+    /**
+     * #2224: a pill tapped in a directions leg used to only fly the camera — the tapped trip lived in the
+     * request's one-shot `focusTripId` and nothing selected the vehicle, so the map drew no band, no
+     * exact shape, and a second tap on it wasn't a re-tap. Now it enters the same rung a pill in the
+     * arrivals drawer does.
+     */
+    @Test
+    fun `a pill tap in a directions leg enters the trip level`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val leg = rideLeg()
+        vm.enterDirectionsShowing()
+        map.sent.clear()
+
+        vm.focusDirectionsRouteVehicle(
+            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
+            routeLeg = leg,
+            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
+        )
+        advanceUntilIdle()
+
+        assertEquals("tapped", vm.directionsRouteFocus()?.selectedTripId)
+        assertEquals(listOf("tapped"), map.vehicleSelections)
+        // The gesture's own request still asks the camera to fit and ping that vehicle...
+        assertEquals("tapped", map.routeRequests.single().focusTripId)
+        // ...but the request the focus *stores* carries no such one-shot instruction to replay.
+        assertEquals(null, vm.directionsRouteFocus()?.request?.focusTripId)
+        job.cancel()
+    }
+
+    /**
+     * #2224: the background tap used to skip straight from a pill-focused vehicle to the itinerary
+     * overview, because directions had no trip rung to peel.
+     */
+    @Test
+    fun `a background tap in a directions leg gives up the vehicle before the leg`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val leg = rideLeg()
+        vm.enterDirectionsShowing()
+        vm.focusDirectionsRouteVehicle(
+            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
+            routeLeg = leg,
+            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
+        )
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        // Still on the leg's route, just no longer on one of its vehicles.
+        assertEquals(null, vm.directionsRouteFocus()?.selectedTripId)
+        assertEquals("40_2LINE", vm.directionsRouteFocus()?.request?.routeId)
+        assertEquals(listOf(null), map.vehicleSelections)
+
+        // Only the next tap drops back to the itinerary overview.
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Directions(), vm.currentFocus.value)
+        job.cancel()
+    }
+
+    /**
+     * #2224: `restoreMapAfterBack` used to replay the sub-focus's stored request verbatim,
+     * `focusTripId` included — so returning to a leg re-flew the camera to the vehicle and re-pinged it.
+     */
+    @Test
+    fun `back into a directions leg restores its vehicle without re-pinging it`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val leg = rideLeg()
+        vm.enterDirectionsShowing()
+        vm.focusDirectionsRouteVehicle(
+            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
+            routeLeg = leg,
+            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
+        )
+        advanceUntilIdle()
+
+        // Away to a stop, then back — the branch that has to redraw the route rather than just reselect.
+        vm.revealStop(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
+        advanceUntilIdle()
+        map.sent.clear()
+
+        assertTrue(vm.navigateBackFocus())
+        advanceUntilIdle()
+        assertEquals("tapped", vm.directionsRouteFocus()?.selectedTripId)
+        assertEquals(listOf("tapped"), map.vehicleSelections)
+        assertEquals(listOf<String?>(null), map.routeRequests.map { it.focusTripId })
+        job.cancel()
+    }
+
+    /** #2224: peeling the trip rung reselects rather than reloading the route it is drawn over. */
+    @Test
+    fun `back onto a directions leg's vehicle only moves the selection`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+        val leg = rideLeg()
+        vm.enterDirectionsShowing()
+        vm.focusDirectionsRouteVehicle(
+            request = ShowRouteRequest("40_2LINE", "40_board", focusTripId = "tapped"),
+            routeLeg = leg,
+            fallbackPoints = listOf(leg.board!!.point!!, leg.alight!!.point!!)
+        )
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        map.sent.clear()
+
+        assertTrue(vm.navigateBackFocus())
+        advanceUntilIdle()
+        assertEquals("tapped", vm.directionsRouteFocus()?.selectedTripId)
+        assertEquals(listOf("tapped"), map.vehicleSelections)
         assertTrue(map.routeRequests.isEmpty())
         job.cancel()
     }
@@ -1375,14 +1504,19 @@ class HomeViewModelTest {
         advanceUntilIdle()
         val stop = FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3))
         vm.onStopFocused(stop)
-        // Plain stop focus: there is no route to deepen, so the map keeps its own selection.
-        assertEquals(false, vm.selectFocusedRouteTrip("trip"))
+        map.sent.clear()
+        // Plain stop focus draws no route, so no vehicle can have been tapped: nothing to record and
+        // nothing to tell the map.
+        vm.selectFocusedRouteTrip("trip")
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Stop(stop), vm.currentFocus.value)
+        assertEquals(emptyList<String?>(), map.vehicleSelections)
 
         vm.requestShowFocusedStopRouteOnMap("65", directionId = 0)
         advanceUntilIdle()
         map.sent.clear()
 
-        assertEquals(true, vm.selectFocusedRouteTrip("trip"))
+        vm.selectFocusedRouteTrip("trip")
         advanceUntilIdle()
         assertEquals("trip", vm.stopRouteSelection()?.selectedTripId)
         assertEquals(listOf("trip"), map.vehicleSelections)
@@ -1394,6 +1528,88 @@ class HomeViewModelTest {
         assertEquals(null, vm.stopRouteSelection()?.selectedTripId)
         assertEquals(listOf(null), map.vehicleSelections)
         assertEquals(emptyList<String>(), map.routesShown)
+        mapJob.cancel()
+    }
+
+    /**
+     * #2224: the trip rung used to exist only over a focused stop, so the same gesture unwound
+     * differently depending on how the rider reached the route. Standalone route focus fell through to
+     * an unowned render selection — invisible to Back, to the background tap, and to `SavedStateHandle`.
+     */
+    @Test
+    fun `a tapped vehicle in standalone route focus enters the trip level`() = runTest {
+        val state = SavedStateHandle()
+        val vm = viewModel(savedState = state)
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        vm.focusStandaloneRoute(ShowRouteRequest("65"))
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.selectFocusedRouteTrip("trip")
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Route(RouteTarget("65"), selectedTripId = "trip"), vm.currentFocus.value)
+        assertEquals(listOf("trip"), map.vehicleSelections)
+        // It survives process death, like the stop-scoped rung does.
+        assertEquals("trip", viewModel(savedState = state).currentFocus.value.selectedTripId)
+
+        // A background tap gives up the vehicle and leaves the route drawn — where it used to tear the
+        // whole route down in one gesture.
+        map.sent.clear()
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Route(RouteTarget("65")), vm.currentFocus.value)
+        assertEquals(listOf(null), map.vehicleSelections)
+        assertEquals(0, map.clearFocusCount)
+
+        // Only the next one leaves the route.
+        vm.unfocusMapOneLevel()
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        mapJob.cancel()
+    }
+
+    /** #2224: a coach-number search hit names the trip its vehicle is running — that *is* the rung. */
+    @Test
+    fun `a standalone route revealed on a trip enters the trip level`() = runTest {
+        val vm = viewModel()
+        vm.focusStandaloneRoute(ShowRouteRequest("65", focusTripId = "trip"))
+
+        assertEquals(CurrentFocus.Route(RouteTarget("65"), selectedTripId = "trip"), vm.currentFocus.value)
+    }
+
+    /** #2224: a direction switch filters the drilled-into vehicle out, so the rung goes with it. */
+    @Test
+    fun `switching direction drops the standalone route trip level`() = runTest {
+        val vm = viewModel()
+        vm.focusStandaloneRoute(ShowRouteRequest("65", focusTripId = "trip"))
+
+        vm.selectStandaloneRouteDirection(1)
+
+        assertEquals(CurrentFocus.Route(RouteTarget("65", directionId = 1)), vm.currentFocus.value)
+    }
+
+    /**
+     * #2224: back into a standalone route focus restores its drilled-into vehicle by selecting it, not by
+     * replaying the one-shot camera fit — the same replay rule the stop-scoped path already followed.
+     */
+    @Test
+    fun `back into a standalone route restores its trip without refitting the vehicle`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val mapJob = launch { map.collect() }
+        advanceUntilIdle()
+        vm.focusStandaloneRoute(ShowRouteRequest("65", focusTripId = "trip"))
+        vm.onStopFocused(FocusedStop("stop", "Main St", "100", GeoPoint(47.6, -122.3)))
+        advanceUntilIdle()
+        map.sent.clear()
+
+        assertTrue(vm.navigateBackFocus())
+        advanceUntilIdle()
+        assertEquals(CurrentFocus.Route(RouteTarget("65"), selectedTripId = "trip"), vm.currentFocus.value)
+        assertEquals(listOf("trip"), map.vehicleSelections)
+        assertEquals(listOf<String?>(null), map.routeRequests.map { it.focusTripId })
         mapJob.cancel()
     }
 


### PR DESCRIPTION
Fixes #2224.

Tapping an ETA pill, or tapping a vehicle on the map, means the same thing everywhere in the app: *drill into this vehicle's trip*. It was implemented three times, and only one of them was a focus level — so Back, the map-background tap, process death, and the map/pill presentation all behaved differently depending on how the rider reached the route.

## Before

**Over a focused stop** it was a real rung (`StopRouteSelection.selectedTripId`, #2205): an undo entry, `peeledOneLevel` giving up the trip before the route, `SavedStateHandle` persistence, and a `showStopRoute` that paired every `ShowRoute` with a `SelectVehicle` so the map's selection was a *projection* of the focus.

**In a directions leg** the tapped trip rode inside the request's one-shot `focusTripId` and no `SelectVehicle` was ever sent. A pill tap flew the camera and pinged, and nothing else — no band, no exact shape/stops, no continuation, no outlined pill, and the vehicle was not selected so tapping it again wasn't a re-tap and wouldn't open TripDetails. Back and the background tap skipped straight to the itinerary overview, and `restoreMapAfterBack` replayed the stored `focusTripId`, re-flying the camera and re-pinging the vehicle.

**In standalone route focus** there was no rung at all: the tap fell through to `mapViewModel.selectVehicleTrip(...)`, a bare render selection no state machine owned — not undoable, not persisted, dropped on back-restore. Sharpest case: search by coach number reveals the route with a `focusTripId` under a comment calling it "the same route-mode-with-a-focused-vehicle view an arrivals ETA-pill tap opens", but `toRouteTarget()` threw the trip away, so it flew to the vehicle and selected nothing.

The divergence was blessed in KDoc (`selectFocusedRouteTrip`: "over a focused stop a background tap gives up just the band, while in standalone route focus it still gives up the whole route"). That asymmetry was the bug, not the contract.

## After

The trip rung is hoisted onto the focus ladder itself. `CurrentFocus.Route` and `DirectionsSubFocus.Route` each carry `selectedTripId`; `CurrentFocus.selectedTripId` / `withSelectedTrip()` are the one read/write pair over all three holders, and `peeledOneLevel()` peels the trip first wherever a route is drawn — expressed once, not per focus kind.

- `MapDirective.ShowRoute` now carries a **required** `selectedTripId` (no default), so a surface added later cannot show a route without saying which of its vehicles is drilled into. The pairing is enforced by the type rather than by each caller remembering to send two directives, and the ordering guarantee (selection after the route, so it survives the teardown a route change performs) lives in `MapFeature`'s handler where the two calls are inseparable. `SelectVehicle` stays for the transitions that move the rung over a route already drawn.
- Requests **stored** on a focus drop their `focusTripId` — it is a one-shot camera instruction, not retained state — so a back-restore redraws without refitting or re-pinging.
- `restoreMapAfterBack` gained a generic "only the trip rung moved → just reselect" early return, which also stops a Back out of a drilled-into vehicle in directions or standalone route focus from reframing to the whole-route extent.
- `selectFocusedRouteTrip` is total (no `Boolean`), and `MapFeature`'s bare-selection fallback is deleted.
- The directions ETA strip outlines its focused pill, built through the same `etaPillFocus()` the arrivals drawer uses.

## Deliberate behaviour changes

- **This reverses a documented #2205 decision:** a background tap in standalone route focus now gives up the vehicle before the route, where it used to tear the whole route down in one gesture.
- **A pill tap in directions is visibly richer:** band, trip overlay, fast-estimate marker, continuation, outlined pill, and tap-again-to-open-details — none of which it had.

Back still walks *visited* history while the background tap walks the *ladder*; that split is unchanged, and now behaves identically on all three surfaces.

## Testing

- New `CurrentFocusLadderTest` (6 cases) pins the ladder per focus kind, so a fourth route-bearing focus added without the rung fails.
- 7 new `HomeViewModelTest` cases: the standalone-route rung, persistence across process death, the two-step background tap, and the directions leg's rung, background tap, and both back-restore paths (reselect vs. redraw).
- `compileObaGoogleDebugKotlin` and `compileObaGoogleDebugAndroidTestKotlin` clean under `-PwarningsAsErrors=true`; full `testObaGoogleDebugUnitTest` suite green; `spotlessApply` run.

**Not yet exercised on device** — the instrumented suite wasn't run locally. Worth a manual pass on: pill tap in a directions leg → background tap → Back; and a coach-number search hit → background tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vehicle selection now works consistently from stop arrivals, standalone routes, directions legs, and coach-number search results.
  * Selected vehicles remain highlighted across route views and can be restored when returning to the app.
  * ETA strips now identify the selected vehicle in relevant stop and directions views.
  * Back navigation and map taps can remove vehicle selection without leaving the route view.

* **Bug Fixes**
  * Prevented route redraws and direction changes from refocusing vehicles or retaining stale selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->