### PR TITLE
Collapse the directions ETA strip when nothing is boardable, and fix its layout (#2228)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
@@ -17,12 +17,16 @@ package org.onebusaway.android.ui.arrivals
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -56,8 +60,8 @@ class EtaStripMarkerRenderTest {
      * Each pill wears its route's badge so a pill can be located by a string no other node holds — an ETA
      * or clock-time match would risk colliding with a neighbour's subline.
      */
-    private fun setContent(vararg names: String, reachStopMinutes: Long) = composeRule.setContent {
-        Box(Modifier.fillMaxWidth()) {
+    private fun setContent(vararg names: String, reachStopMinutes: Long, width: Dp? = null) = composeRule.setContent {
+        Box(if (width == null) Modifier.fillMaxWidth() else Modifier.width(width)) {
             EtaStrip(
                 trips = names.mapIndexed { i, name ->
                     previewArrival(name, "Rainier Beach", etaMinutes = 3L + i * 8, tripId = "trip_$i")
@@ -109,6 +113,22 @@ class EtaStripMarkerRenderTest {
         val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
 
         assertTrue("rule at ${rule.left} must follow route A", boundsOf("A").right <= rule.left)
+    }
+
+    @Test
+    fun anOverflowingStripOpensWithTheRuleAtItsLeftEdge() {
+        // Six departures in a strip too narrow to show them all; the rider gets there after the first
+        // two. The strip opens on the rule (#2228) — the catchable departures lead, and the two already
+        // ruled out sit behind the "earlier" chevron rather than taking the first two slots.
+        setContent("A", "B", "C", "D", "E", "F", reachStopMinutes = 14, width = 200.dp)
+
+        val rule = composeRule.onNodeWithTag(ETA_STRIP_MARKER_TAG).getUnclippedBoundsInRoot()
+        val firstCatchable = boundsOf("C")
+
+        composeRule.onNodeWithText("A").assertIsNotDisplayed()
+        composeRule.onNodeWithText("B").assertIsNotDisplayed()
+        assertTrue("rule ending at ${rule.right} must precede route C at ${firstCatchable.left}", rule.right <= firstCatchable.left)
+        assertTrue("rule at ${rule.left} must open the strip, not sit past its first slot", rule.left < 40.dp)
     }
 
     @Test

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
@@ -61,7 +61,7 @@ class EtaStripMarkerRenderTest {
      * or clock-time match would risk colliding with a neighbour's subline.
      */
     private fun setContent(vararg names: String, reachStopMinutes: Long, width: Dp? = null) = composeRule.setContent {
-        Box(if (width == null) Modifier.fillMaxWidth() else Modifier.width(width)) {
+        Box(width?.let { Modifier.width(it) } ?: Modifier.fillMaxWidth()) {
             EtaStrip(
                 trips = names.mapIndexed { i, name ->
                     previewArrival(name, "Rainier Beach", etaMinutes = 3L + i * 8, tripId = "trip_$i")

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/NoBoardableDeparturesLineTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/NoBoardableDeparturesLineTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.util.DisplayFormat
+
+/**
+ * The one-line stand-in for a Board row's ETA strip when the feed has nothing the rider can board
+ * (#2228): it names when they get to the stop, and its "Show" hands over to the strip.
+ */
+class NoBoardableDeparturesLineTest {
+
+    // See createUnconfinedComposeRule for why Unconfined composition is used here (issue #1792).
+    @get:Rule
+    val composeRule = createUnconfinedComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun namesTheReachTime_andShowRevealsTheStrip() {
+        val reach = ServerTime(1_800_000_000_000L)
+        var reveals = 0
+        composeRule.setContent {
+            NoBoardableDeparturesLine(reachStopTime = reach, onReveal = { reveals++ })
+        }
+
+        val clock = DisplayFormat.formatTime(context, reach.epochMs)
+        composeRule.onNodeWithText(context.getString(R.string.directions_stop_eta_none_boardable, clock)).assertIsDisplayed()
+        composeRule.onNodeWithText(context.getString(R.string.directions_stop_eta_show_anyway)).performClick()
+        assertEquals(1, reveals)
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/NoBoardableDeparturesLineTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/NoBoardableDeparturesLineTest.kt
@@ -23,13 +23,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
-import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
-import org.onebusaway.android.util.DisplayFormat
 
 /**
  * The one-line stand-in for a Board row's ETA strip when the feed has nothing the rider can board
- * (#2228): it names when they get to the stop, and its "Show" hands over to the strip.
+ * (#2228): it says so, and its "Show" hands over to the strip.
  */
 class NoBoardableDeparturesLineTest {
 
@@ -40,15 +38,13 @@ class NoBoardableDeparturesLineTest {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
-    fun namesTheReachTime_andShowRevealsTheStrip() {
-        val reach = ServerTime(1_800_000_000_000L)
+    fun saysSo_andShowRevealsTheStrip() {
         var reveals = 0
         composeRule.setContent {
-            NoBoardableDeparturesLine(reachStopTime = reach, onReveal = { reveals++ })
+            NoBoardableDeparturesLine(onReveal = { reveals++ })
         }
 
-        val clock = DisplayFormat.formatTime(context, reach.epochMs)
-        composeRule.onNodeWithText(context.getString(R.string.directions_stop_eta_none_boardable, clock)).assertIsDisplayed()
+        composeRule.onNodeWithText(context.getString(R.string.directions_stop_eta_none_boardable)).assertIsDisplayed()
         composeRule.onNodeWithText(context.getString(R.string.directions_stop_eta_show_anyway)).performClick()
         assertEquals(1, reveals)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -142,13 +142,17 @@ internal fun <T> anyAtOrAfter(items: List<T>, moment: ServerTime, timeOf: (T) ->
 
 /**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. Pills are shown
- * in feed order from the first one; the strip never auto-scrolls, so a trip whose ETA has gone
- * negative just keeps counting down in place. When the pills overflow the row, a chevron appears at
- * that edge to signal there's more to scroll to; tapping it moves the strip one viewport that
- * direction (or to the end, whichever is closer). The chevron's own tap target is a narrow side
- * gutter separate from the pills, so it never blocks the strip's own drag-to-scroll.
+ * in feed order; the strip never auto-scrolls, so a trip whose ETA has gone negative just keeps
+ * counting down in place. When the pills overflow the row, a chevron appears at that edge to signal
+ * there's more to scroll to; tapping it moves the strip one viewport that direction (or to the end,
+ * whichever is closer). The chevron's own tap target is a narrow side gutter separate from the pills,
+ * so it never blocks the strip's own drag-to-scroll.
  *
- * [marker] optionally rules one moment across the strip — see [EtaStripMarker].
+ * [marker] optionally rules one moment across the strip — see [EtaStripMarker]. A marked strip *opens*
+ * with the rule at its left edge (#2228): the departures the rider can catch are what the row is for,
+ * so they lead, and the ones already ruled out sit behind the "earlier" chevron. This is only where the
+ * strip starts — a fixed initial position, not a glide, so it can't contend with the user's own scroll
+ * (the #1801/#1974 class) — and it holds where the user leaves it thereafter.
  */
 @Composable
 internal fun EtaStrip(
@@ -161,9 +165,9 @@ internal fun EtaStrip(
     marker: EtaStripMarker? = null,
     /** The trip this strip's row is drilled into, if any — see [EtaPillFocus]. */
     focus: EtaPillFocus? = null,
-    // Hoisted for previews/tests ONLY (both real call sites use the default) so a caller can start
-    // the strip mid-scroll.
-    state: LazyListState = rememberLazyListState()
+    // Hoisted for previews/tests ONLY (both real call sites leave it null) so a caller can start the
+    // strip mid-scroll. Null means the strip's own state, which starts at the marker (see below).
+    state: LazyListState? = null
 ) {
     // All of this strip's trips share one poll (one route/direction group from a single
     // ConvertArrivals pass), so their serverNow is identical — tick ONE shared clock here rather than
@@ -192,21 +196,26 @@ internal fun EtaStrip(
     // Where the marker's moment falls among these departures. Remembered for the same reason: the live
     // clock recomposes this body every second, but the answer only moves when a poll brings new trips.
     val markerIndex = remember(trips, marker) { marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } }
+    // Opens on the marker's item — the rule rides at the front of the first pill it precedes (see
+    // MarkedItem), so that pill's index is the rule's. Only the initial position: rememberLazyListState
+    // reads it once, and a later poll leaves the viewport where the user has it (the LazyRow's keys keep
+    // it on the same pills). Unmarked, the strip starts at its first pill.
+    val listState = state ?: rememberLazyListState(initialFirstVisibleItemIndex = markerIndex ?: 0)
 
     // The strip viewport width in px, for the one-viewport chevron jump below.
     var viewportPx by remember { mutableIntStateOf(0) }
 
     // Read directly — LazyListState.canScroll* are already snapshot-backed and only flip at the
     // scrollable/not boundary.
-    val canScrollForward = state.canScrollForward
-    val canScrollBackward = state.canScrollBackward
+    val canScrollForward = listState.canScrollForward
+    val canScrollBackward = listState.canScrollBackward
 
     // Jumps the strip one viewport toward the given direction; animateScrollBy clamps at the content
     // ends, giving "or to the end, whichever is closer" for free.
     val scope = rememberCoroutineScope()
     fun jumpArrow(forward: Boolean) {
         val delta = if (forward) viewportPx.toFloat() else -viewportPx.toFloat()
-        scope.launch { state.animateScrollBy(delta) }
+        scope.launch { listState.animateScrollBy(delta) }
     }
 
     // Sized to its own tallest child (the reference pill frame) so the gutters' fillMaxHeight has a
@@ -246,7 +255,7 @@ internal fun EtaStrip(
             }
         ) {
             LazyRow(
-                state = state,
+                state = listState,
                 modifier = Modifier.onSizeChanged { viewportPx = it.width },
                 horizontalArrangement = Arrangement.spacedBy(PILL_SPACING),
                 // Bottom-align so a smaller pill sits on the same baseline as the full-size ones.
@@ -716,7 +725,7 @@ private fun northgatePills(count: Int) = List(count) { previewArrival("40", "Nor
 private fun EtaStripPreviewFrame(
     trips: List<ArrivalInfo>,
     marker: EtaStripMarker? = null,
-    state: LazyListState = rememberLazyListState()
+    state: LazyListState? = null
 ) {
     ObaTheme {
         Surface(color = MaterialTheme.colorScheme.surfaceContainer) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -133,6 +133,14 @@ internal data class EtaStripMarker(
 internal fun <T> countBefore(items: List<T>, moment: ServerTime, timeOf: (T) -> ServerTime): Int = items.count { timeOf(it) < moment }
 
 /**
+ * Whether any of [items] falls at or after [moment] — i.e. whether a strip ruled at [moment] would have
+ * at least one pill the rule has not passed. The complement of [countBefore]'s boundary (an item exactly
+ * at the moment counts, for the same reason), so the two can never disagree about which side a pill is
+ * on. Vacuously false for no items: a feed with nothing in it has nothing boardable either.
+ */
+internal fun <T> anyAtOrAfter(items: List<T>, moment: ServerTime, timeOf: (T) -> ServerTime): Boolean = items.any { timeOf(it) >= moment }
+
+/**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. Pills are shown
  * in feed order from the first one; the strip never auto-scrolls, so a trip whose ETA has gone
  * negative just keeps counting down in place. When the pills overflow the row, a chevron appears at
@@ -201,7 +209,13 @@ internal fun EtaStrip(
         scope.launch { state.animateScrollBy(delta) }
     }
 
-    Row(modifier, verticalAlignment = Alignment.Bottom) {
+    // Sized to its own tallest child (the reference pill frame) so the gutters' fillMaxHeight has a
+    // bound to fill and their chevrons centre on the pills. Without it a host that hands the strip no
+    // height bound (the directions drawer's log row) leaves each gutter at its icon's height, and the
+    // bottom alignment below drops the chevrons to the strip's foot (#2228). The frame answers the
+    // intrinsic query this asks (see ReferencePillHeightFrame), and the arrivals row's own
+    // IntrinsicSize.Min host nests over it fine.
+    Row(modifier.height(IntrinsicSize.Min), verticalAlignment = Alignment.Bottom) {
         // Left gutter: a chevron back toward earlier arrivals, shown once the strip is scrolled off its
         // start. Reserved (like the right gutter) so toggling it never reflows the pills.
         ScrollChevronGutter(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -133,14 +133,6 @@ internal data class EtaStripMarker(
 internal fun <T> countBefore(items: List<T>, moment: ServerTime, timeOf: (T) -> ServerTime): Int = items.count { timeOf(it) < moment }
 
 /**
- * Whether any of [items] falls at or after [moment] — i.e. whether a strip ruled at [moment] would have
- * at least one pill the rule has not passed. The complement of [countBefore]'s boundary (an item exactly
- * at the moment counts, for the same reason), so the two can never disagree about which side a pill is
- * on. Vacuously false for no items: a feed with nothing in it has nothing boardable either.
- */
-internal fun <T> anyAtOrAfter(items: List<T>, moment: ServerTime, timeOf: (T) -> ServerTime): Boolean = items.any { timeOf(it) >= moment }
-
-/**
  * The horizontally-scrollable strip of per-trip ETA pills below the direction name. Pills are shown
  * in feed order; the strip never auto-scrolls, so a trip whose ETA has gone negative just keeps
  * counting down in place. When the pills overflow the row, a chevron appears at that edge to signal
@@ -165,9 +157,15 @@ internal fun EtaStrip(
     marker: EtaStripMarker? = null,
     /** The trip this strip's row is drilled into, if any — see [EtaPillFocus]. */
     focus: EtaPillFocus? = null,
-    // Hoisted for previews/tests ONLY (both real call sites leave it null) so a caller can start the
-    // strip mid-scroll. Null means the strip's own state, which starts at the marker (see below).
-    state: LazyListState? = null
+    // Hoisted for previews/tests ONLY (both real call sites use the default) so a caller can start
+    // the strip mid-scroll. The default opens on the marker's item — the rule rides at the front of the
+    // first pill it precedes (see MarkedItem), so that pill's index is the rule's. Only the initial
+    // position: rememberLazyListState reads it once, and a later poll leaves the viewport where the
+    // user has it (the LazyRow's keys keep it on the same pills). Unmarked, the strip starts at its
+    // first pill.
+    state: LazyListState = rememberLazyListState(
+        initialFirstVisibleItemIndex = marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } ?: 0
+    )
 ) {
     // All of this strip's trips share one poll (one route/direction group from a single
     // ConvertArrivals pass), so their serverNow is identical — tick ONE shared clock here rather than
@@ -196,34 +194,27 @@ internal fun EtaStrip(
     // Where the marker's moment falls among these departures. Remembered for the same reason: the live
     // clock recomposes this body every second, but the answer only moves when a poll brings new trips.
     val markerIndex = remember(trips, marker) { marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } }
-    // Opens on the marker's item — the rule rides at the front of the first pill it precedes (see
-    // MarkedItem), so that pill's index is the rule's. Only the initial position: rememberLazyListState
-    // reads it once, and a later poll leaves the viewport where the user has it (the LazyRow's keys keep
-    // it on the same pills). Unmarked, the strip starts at its first pill.
-    val listState = state ?: rememberLazyListState(initialFirstVisibleItemIndex = markerIndex ?: 0)
 
     // The strip viewport width in px, for the one-viewport chevron jump below.
     var viewportPx by remember { mutableIntStateOf(0) }
 
     // Read directly — LazyListState.canScroll* are already snapshot-backed and only flip at the
     // scrollable/not boundary.
-    val canScrollForward = listState.canScrollForward
-    val canScrollBackward = listState.canScrollBackward
+    val canScrollForward = state.canScrollForward
+    val canScrollBackward = state.canScrollBackward
 
     // Jumps the strip one viewport toward the given direction; animateScrollBy clamps at the content
     // ends, giving "or to the end, whichever is closer" for free.
     val scope = rememberCoroutineScope()
     fun jumpArrow(forward: Boolean) {
         val delta = if (forward) viewportPx.toFloat() else -viewportPx.toFloat()
-        scope.launch { listState.animateScrollBy(delta) }
+        scope.launch { state.animateScrollBy(delta) }
     }
 
-    // Sized to its own tallest child (the reference pill frame) so the gutters' fillMaxHeight has a
-    // bound to fill and their chevrons centre on the pills. Without it a host that hands the strip no
-    // height bound (the directions drawer's log row) leaves each gutter at its icon's height, and the
-    // bottom alignment below drops the chevrons to the strip's foot (#2228). The frame answers the
-    // intrinsic query this asks (see ReferencePillHeightFrame), and the arrivals row's own
-    // IntrinsicSize.Min host nests over it fine.
+    // Bound to the tallest child so the gutters' fillMaxHeight has something to fill (and their
+    // chevrons centre on the pills) even when the host gives no height bound — the directions drawer's
+    // log row, where the bottom alignment otherwise dropped them to the foot (#2228).
+    // ReferencePillHeightFrame answers the intrinsic query.
     Row(modifier.height(IntrinsicSize.Min), verticalAlignment = Alignment.Bottom) {
         // Left gutter: a chevron back toward earlier arrivals, shown once the strip is scrolled off its
         // start. Reserved (like the right gutter) so toggling it never reflows the pills.
@@ -255,7 +246,7 @@ internal fun EtaStrip(
             }
         ) {
             LazyRow(
-                state = listState,
+                state = state,
                 modifier = Modifier.onSizeChanged { viewportPx = it.width },
                 horizontalArrangement = Arrangement.spacedBy(PILL_SPACING),
                 // Bottom-align so a smaller pill sits on the same baseline as the full-size ones.
@@ -725,7 +716,7 @@ private fun northgatePills(count: Int) = List(count) { previewArrival("40", "Nor
 private fun EtaStripPreviewFrame(
     trips: List<ArrivalInfo>,
     marker: EtaStripMarker? = null,
-    state: LazyListState? = null
+    state: LazyListState = rememberLazyListState()
 ) {
     ObaTheme {
         Surface(color = MaterialTheme.colorScheme.surfaceContainer) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -94,6 +94,7 @@ import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.arrivals.components.EtaPillFocus
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
+import org.onebusaway.android.ui.arrivals.components.anyAtOrAfter
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
@@ -409,6 +410,12 @@ fun DirectionsResultsSheet(
  * they can't be here for, and the first pill after the rule is the soonest one they can actually board.
  * Null when the plan puts nothing before this ride (the rider is at the stop from the start, so every
  * departure is theirs to take) — the strip then draws no rule rather than one placed at a guess.
+ *
+ * When the feed holds no departure at or after [reachStopTime] — a plan that leaves later than the
+ * arrivals window reaches, so every pill would be dimmed and the rule would close the strip — the strip
+ * collapses to one line saying so, with a tap to show it anyway (#2228). The line is not a threshold
+ * on how soon the trip must be: it is exactly the case where the feed has nothing boardable to show, and
+ * a later poll that brings a boardable departure puts the strip back on its own.
  */
 @Composable
 internal fun DirectionStopEtaStrip(
@@ -431,8 +438,10 @@ internal fun DirectionStopEtaStrip(
 ) {
     val stopId = stop.stopId
     val point = stop.point
-    // Left-justified to the content column; the old start indent was a holdover from the indented-sub-row design.
-    val rowPadding = Modifier.fillMaxWidth().padding(end = 12.dp, top = 2.dp, bottom = 8.dp)
+    // Spans the content column edge to edge: the log row already insets its content from the sheet's
+    // edges, so no inset of its own on either side (an extra end inset used to stop the strip well
+    // short of the column, #2228; the old start indent was a holdover from the indented-sub-row design).
+    val rowPadding = Modifier.fillMaxWidth().padding(top = 2.dp, bottom = 8.dp)
     // Without an OBA id + location there is no stop to query, so draw nothing at all. "No upcoming
     // arrivals" is reserved for a stop we *did* look up (below) — saying it here would report an
     // unidentifiable stop as one with no service.
@@ -497,6 +506,14 @@ private fun DirectionStopEtaStripContent(
         }
     }
     val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
+    // Whether the rider can board anything the feed knows about; always, without a reach time. Once
+    // shown anyway the strip stays up for this stop, though a strip that has come to hold a boardable
+    // pill needs no reveal.
+    var revealed by rememberSaveable { mutableStateOf(false) }
+    if (reachStopTime != null && !revealed && !anyAtOrAfter(interleaved, reachStopTime) { it.first.displayTime }) {
+        NoBoardableDeparturesLine(reachStopTime = reachStopTime, modifier = rowPadding, onReveal = { revealed = true })
+        return
+    }
     if (interleaved.isEmpty()) {
         NoEtasText(rowPadding)
         return
@@ -549,6 +566,29 @@ internal fun RouteLegRef.etaPlannedBadge(fallbackLineName: String): RouteBadge =
  *  Delegates to [pickRideDirection] rather than repeating the rule, so the strip and the map's ride
  *  selection resolve a leg to the same direction group by construction. */
 private fun List<RouteRowGroup>.pickRoute(routeId: String?, headsign: String?): RouteRowGroup? = pickRideDirection(routeId, headsign, routeIdOf = { it.routeId }, headsignOf = { it.headsign })
+
+/**
+ * The collapsed strip for a stop the feed has nothing boardable at yet: the rider gets there at
+ * [reachStopTime], after every departure the poll knows about. Tapping "Show" hands over to the strip
+ * proper via [onReveal].
+ */
+@Composable
+internal fun NoBoardableDeparturesLine(reachStopTime: ServerTime, modifier: Modifier = Modifier, onReveal: () -> Unit) {
+    val context = LocalContext.current
+    // Locale work that only changes with the plan, not with each arrivals poll.
+    val clock = remember(reachStopTime, context) { DisplayFormat.formatTime(context, reachStopTime.epochMs) }
+    Row(modifier, verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = stringResource(R.string.directions_stop_eta_none_boardable, clock),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        TextButton(onClick = onReveal) {
+            Text(stringResource(R.string.directions_stop_eta_show_anyway))
+        }
+    }
+}
 
 @Composable
 private fun NoEtasText(modifier: Modifier) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -511,7 +511,7 @@ private fun DirectionStopEtaStripContent(
     // pill needs no reveal.
     var revealed by rememberSaveable { mutableStateOf(false) }
     if (reachStopTime != null && !revealed && !anyAtOrAfter(interleaved, reachStopTime) { it.first.displayTime }) {
-        NoBoardableDeparturesLine(reachStopTime = reachStopTime, modifier = rowPadding, onReveal = { revealed = true })
+        NoBoardableDeparturesLine(modifier = rowPadding, onReveal = { revealed = true })
         return
     }
     if (interleaved.isEmpty()) {
@@ -568,19 +568,16 @@ internal fun RouteLegRef.etaPlannedBadge(fallbackLineName: String): RouteBadge =
 private fun List<RouteRowGroup>.pickRoute(routeId: String?, headsign: String?): RouteRowGroup? = pickRideDirection(routeId, headsign, routeIdOf = { it.routeId }, headsignOf = { it.headsign })
 
 /**
- * The collapsed strip for a stop the feed has nothing boardable at yet: the rider gets there at
- * [reachStopTime], after every departure the poll knows about. Tapping "Show" hands over to the strip
- * proper via [onReveal].
+ * The collapsed strip for a stop the feed has nothing boardable at yet: the rider gets there after
+ * every departure the poll knows about. Tapping "Show" hands over to the strip proper via [onReveal].
+ * The line names only the fact — the row's own time column already says when the rider boards.
  */
 @Composable
-internal fun NoBoardableDeparturesLine(reachStopTime: ServerTime, modifier: Modifier = Modifier, onReveal: () -> Unit) {
-    val context = LocalContext.current
-    // Locale work that only changes with the plan, not with each arrivals poll.
-    val clock = remember(reachStopTime, context) { DisplayFormat.formatTime(context, reachStopTime.epochMs) }
+internal fun NoBoardableDeparturesLine(modifier: Modifier = Modifier, onReveal: () -> Unit) {
     Row(modifier, verticalAlignment = Alignment.CenterVertically) {
         Text(
-            text = stringResource(R.string.directions_stop_eta_none_boardable, clock),
-            style = MaterialTheme.typography.bodySmall,
+            text = stringResource(R.string.directions_stop_eta_none_boardable),
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(1f)
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -511,11 +511,11 @@ private fun DirectionStopEtaStripContent(
     var revealed by rememberSaveable { mutableStateOf(false) }
     val nothingBoardable = reachStopTime != null && countBefore(interleaved, reachStopTime) { it.first.displayTime } == interleaved.size
     if (nothingBoardable && !revealed) {
-        NoBoardableDeparturesLine(modifier = rowPadding, onReveal = { revealed = true })
+        NoBoardableDeparturesLine(modifier = modifier.then(rowPadding), onReveal = { revealed = true })
         return
     }
     if (interleaved.isEmpty()) {
-        NoEtasText(rowPadding)
+        NoEtasText(modifier.then(rowPadding))
         return
     }
     val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -94,7 +94,7 @@ import org.onebusaway.android.ui.arrivals.RouteRowGroup
 import org.onebusaway.android.ui.arrivals.components.EtaPillFocus
 import org.onebusaway.android.ui.arrivals.components.EtaStrip
 import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
-import org.onebusaway.android.ui.arrivals.components.anyAtOrAfter
+import org.onebusaway.android.ui.arrivals.components.countBefore
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
@@ -438,9 +438,7 @@ internal fun DirectionStopEtaStrip(
 ) {
     val stopId = stop.stopId
     val point = stop.point
-    // Spans the content column edge to edge: the log row already insets its content from the sheet's
-    // edges, so no inset of its own on either side (an extra end inset used to stop the strip well
-    // short of the column, #2228; the old start indent was a holdover from the indented-sub-row design).
+    // Edge to edge: the log row already insets its content from the sheet's edges (#2228).
     val rowPadding = Modifier.fillMaxWidth().padding(top = 2.dp, bottom = 8.dp)
     // Without an OBA id + location there is no stop to query, so draw nothing at all. "No upcoming
     // arrivals" is reserved for a stop we *did* look up (below) — saying it here would report an
@@ -506,11 +504,13 @@ private fun DirectionStopEtaStripContent(
         }
     }
     val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
-    // Whether the rider can board anything the feed knows about; always, without a reach time. Once
-    // shown anyway the strip stays up for this stop, though a strip that has come to hold a boardable
-    // pill needs no reveal.
+    // Collapsed when the rule would land past the last pill — the very count the strip places its rule
+    // by, so the line and the rule can't disagree about what is boardable (nothing at all counts:
+    // an empty feed has nothing boardable either). Never without a reach time. Once shown anyway the
+    // strip stays up for this stop, though a strip that has come to hold a boardable pill needs no reveal.
     var revealed by rememberSaveable { mutableStateOf(false) }
-    if (reachStopTime != null && !revealed && !anyAtOrAfter(interleaved, reachStopTime) { it.first.displayTime }) {
+    val nothingBoardable = reachStopTime != null && countBefore(interleaved, reachStopTime) { it.first.displayTime } == interleaved.size
+    if (nothingBoardable && !revealed) {
         NoBoardableDeparturesLine(modifier = rowPadding, onReveal = { revealed = true })
         return
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripplan
 
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.time.ServerTime
 
 /**
  * A JVM-pure projection of a trip-plan endpoint (a [org.onebusaway.android.directions.util.CustomAddress]),
@@ -144,7 +145,20 @@ data class TripPlanParams(
     val walkPreference: WalkPreference = WalkPreference.MEDIUM,
     val cyclingPreference: CyclingPreference = CyclingPreference.DEFAULT,
     val bikePreference: BikePreference = BikePreference.MEDIUM
-)
+) {
+    /**
+     * When the plan puts the rider at its starting point: the requested departure of a depart-at plan,
+     * and null for an arrive-by one, which fixes when the trip *ends* and says nothing about when the
+     * rider sets out. The trip log uses it as when the rider is at the first stop of an itinerary that
+     * opens on transit (#2228) — the plan's own "you get here" for a ride nothing precedes.
+     *
+     * Minted as [ServerTime] because it is the instant the plan was made against ([dateTimeMillis] is
+     * what the planner is asked to depart at), and the plan's leg times come back on that same timeline
+     * as server-domain instants; it is compared only with those and with the stop's arrival predictions.
+     */
+    val plannedStart: ServerTime?
+        get() = if (arriving) null else ServerTime(dateTimeMillis)
+}
 
 /** The trip-plan form (origin/destination, when, and the advanced options). */
 data class TripPlanFormState(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -50,9 +50,8 @@ object TripLogBuilder {
 
     /**
      * [routeLegRefs] is aligned to [legs]: the resolved route/stop identity per transit leg, else null.
-     * [plannedStart] is when the plan puts the rider at its starting point ([TripPlanParams.plannedStart]
-     * [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart]) — what stands in for "the end of
-     * the leg before" when the itinerary opens on transit; null when the plan doesn't say (arrive-by).
+     * [plannedStart] is [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart] — what stands in
+     * for "the end of the leg before" when the itinerary opens on transit; null when the plan doesn't say.
      */
     fun build(
         legs: List<TripLeg>,
@@ -113,7 +112,7 @@ object TripLogBuilder {
                         // an arrive-by plan says nothing about when they set out, and that absence is
                         // carried as null rather than substituted for with the ride's own departure: see
                         // TripLogEntry.Transit.reachStopTime for what that would tell the rider.
-                        reachStopTime = legs.getOrNull(legIndex - 1)?.endTime ?: plannedStart.takeIf { legIndex == 0 },
+                        reachStopTime = if (legIndex == 0) plannedStart else legs[legIndex - 1].endTime,
                         ref = routeLegRefs.getOrNull(legIndex)
                     )
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -48,11 +48,17 @@ import org.onebusaway.android.util.geoPointOrNull
  */
 object TripLogBuilder {
 
-    /** [routeLegRefs] is aligned to [legs]: the resolved route/stop identity per transit leg, else null. */
+    /**
+     * [routeLegRefs] is aligned to [legs]: the resolved route/stop identity per transit leg, else null.
+     * [plannedStart] is when the plan puts the rider at its starting point ([TripPlanParams.plannedStart]
+     * [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart]) — what stands in for "the end of
+     * the leg before" when the itinerary opens on transit; null when the plan doesn't say (arrive-by).
+     */
     fun build(
         legs: List<TripLeg>,
         flatDirections: List<Direction>,
-        routeLegRefs: List<RouteLegRef?>
+        routeLegRefs: List<RouteLegRef?>,
+        plannedStart: ServerTime? = null
     ): List<TripLogEntry> {
         if (legs.isEmpty()) return emptyList()
         val entries = ArrayList<TripLogEntry>(legs.size + 2)
@@ -102,11 +108,12 @@ object TripLogBuilder {
                         legIndex = legIndex,
                         // When the rider gets to the board stop: the end of the leg that brought them
                         // there (a walk, or the ride they transfer off). An itinerary that opens on a
-                        // transit leg has no such leg — the rider is at the stop from the start — and
-                        // that is a genuine absence, not a moment to substitute for: see
-                        // TripLogEntry.Transit.reachStopTime for what standing in the ride's own
-                        // departure would tell the rider.
-                        reachStopTime = legs.getOrNull(legIndex - 1)?.endTime,
+                        // transit leg has no such leg — the rider is at the stop from the plan's start —
+                        // so the plan's own start stands in there, when it has one (a depart-at plan);
+                        // an arrive-by plan says nothing about when they set out, and that absence is
+                        // carried as null rather than substituted for with the ride's own departure: see
+                        // TripLogEntry.Transit.reachStopTime for what that would tell the rider.
+                        reachStopTime = legs.getOrNull(legIndex - 1)?.endTime ?: plannedStart.takeIf { legIndex == 0 },
                         ref = routeLegRefs.getOrNull(legIndex)
                     )
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -50,9 +50,8 @@ interface TripResultsRepository {
     suspend fun summarize(itineraries: List<TripItinerary>): Result<List<ItineraryOption>>
 
     /**
-     * Builds the trip-log timeline entries for a single itinerary. [plannedStart] is when the plan puts
-     * the rider at its starting point ([TripPlanParams.plannedStart]
-     * [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart]), or null when it doesn't say.
+     * Builds the trip-log timeline entries for a single itinerary. [plannedStart] is
+     * [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart], or null when the plan doesn't say.
      */
     suspend fun directionsFor(itinerary: TripItinerary, plannedStart: ServerTime?): Result<List<TripLogEntry>>
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -33,6 +33,7 @@ import org.onebusaway.android.directions.model.substitutableRoutes
 import org.onebusaway.android.directions.util.DirectionsGenerator
 import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusSegment
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.geoPointOrNull
 import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.runCatchingCancellable
@@ -48,8 +49,12 @@ interface TripResultsRepository {
     /** Summarizes each itinerary into an option card ([ItineraryOption]). */
     suspend fun summarize(itineraries: List<TripItinerary>): Result<List<ItineraryOption>>
 
-    /** Builds the trip-log timeline entries for a single itinerary. */
-    suspend fun directionsFor(itinerary: TripItinerary): Result<List<TripLogEntry>>
+    /**
+     * Builds the trip-log timeline entries for a single itinerary. [plannedStart] is when the plan puts
+     * the rider at its starting point ([TripPlanParams.plannedStart]
+     * [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart]), or null when it doesn't say.
+     */
+    suspend fun directionsFor(itinerary: TripItinerary, plannedStart: ServerTime?): Result<List<TripLogEntry>>
 }
 
 class DefaultTripResultsRepository @Inject constructor(
@@ -80,7 +85,8 @@ class DefaultTripResultsRepository @Inject constructor(
     )
 
     override suspend fun directionsFor(
-        itinerary: TripItinerary
+        itinerary: TripItinerary,
+        plannedStart: ServerTime?
     ): Result<List<TripLogEntry>> = withContext(Dispatchers.IO) {
         runCatchingCancellable {
             // The legacy generator supplies the localized step / intermediate-stop text (needs a Context
@@ -93,7 +99,7 @@ class DefaultTripResultsRepository @Inject constructor(
             // the chain leader, #2000); the builder folds the same continuation legs into the leader's
             // Transit entry so the two agree.
             val routeLegRefs = resolveRouteLegRefs(itinerary.legs, itinerary.substitutableRoutes())
-            TripLogBuilder.build(itinerary.legs, flat, routeLegRefs)
+            TripLogBuilder.build(itinerary.legs, flat, routeLegRefs, plannedStart)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1028,7 +1028,7 @@ fun TripResultsSheet(
     // highlighting a trip the map isn't showing.
     LaunchedEffect(itineraries) {
         val index = initialOptionIndex.coerceIn(0, (itineraries.size - 1).coerceAtLeast(0))
-        resultsViewModel.setItineraries(itineraries, initialIndex = index)
+        resultsViewModel.setItineraries(itineraries, initialIndex = index, plannedStart = params?.plannedStart)
         itineraries.getOrNull(index)?.let { showItinerary(it) }
         if (!fromSnapshot) maybeStartTripUpdates(activity, params, itineraries, index)
         onOptionsSeeded()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1122,6 +1122,8 @@ private val RAIL_WIDTH = 34.dp
 private val RAIL_SPLIT = 22.dp // node centre, measured from the row's top — where the spine's colour flips
 private val ROW_TOP = 10.dp
 private val ROW_BOTTOM = 10.dp
+private val CONTENT_START_GAP = 8.dp // between the spine cell and the content column
+private val CONTENT_END_INSET = 10.dp // the content column's (and a footer's) inset from the row's end
 private val RAIL_STROKE = 3.dp
 private val BAND_RADIUS = 13.dp
 private val BAND_INSET = 2.dp
@@ -1314,12 +1316,21 @@ private fun LogRow(
 
         is RowContent.BoardHeader -> {
             val transit = content.entry
-            LogRowScaffold(model, onClick = null, onToggleExpand = { onToggle(i) }) {
+            LogRowScaffold(
+                model = model,
+                onClick = null,
+                onToggleExpand = { onToggle(i) },
+                // The board stop's live ETA strip, under the whole row rather than in the content
+                // column, so it runs to the row's edge instead of stopping short at the expand chevron
+                // (#2228). The whole ride, not just its route/stop: the strip also rules the plan's own
+                // arrival at this stop across the live ETAs (#2125), and a pill tap frames the ride's
+                // geometry on the map.
+                footer = transit.routeLeg.board?.let { stop -> { stopEtaStrip(transit, stop) } }
+            ) {
                 BoardContent(
                     entry = transit,
                     onFocus = { focusTransit(transit, onFocusRouteLeg, onFocusLeg, onFocusPoint) },
-                    onFocusPoint = onFocusPoint,
-                    stopEtaStrip = stopEtaStrip
+                    onFocusPoint = onFocusPoint
                 )
             }
         }
@@ -1383,6 +1394,11 @@ internal fun focusTransit(
  * The spine and the leg's band are drawn by the row itself ([drawRowChrome]) rather than by a
  * full-height child, so the row needs no intrinsic measurement and each one can stand alone as a lazy
  * list item.
+ *
+ * [footer] is a second band of content laid *under* the content column and the expand chevron's
+ * segment, spanning from the content column's start to the row's own end inset — for content that wants
+ * the row's full width and has no business being narrowed by the chevron (the board row's ETA strip,
+ * #2228). It stays inside the row's chrome, so the leg's band and spine run behind it as one.
  */
 @Composable
 private fun LogRowScaffold(
@@ -1391,6 +1407,7 @@ private fun LogRowScaffold(
     onClickLabel: String? = null,
     compact: Boolean = false,
     onToggleExpand: (() -> Unit)? = null,
+    footer: (@Composable () -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val context = LocalContext.current
@@ -1408,7 +1425,7 @@ private fun LogRowScaffold(
         is RowContent.WalkHeader -> null to deltaText(c.entry.durationMinutes, context)
         else -> null to null
     }
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             // drawWithCache, not drawBehind: the dash effect and every Dp→px conversion are resolved
@@ -1423,71 +1440,82 @@ private fun LogRowScaffold(
                 } else {
                     Modifier
                 }
-            ),
-        verticalAlignment = Alignment.Top
-    ) {
-        // Centered in the time column — halfway between the screen edge and the spine.
-        Column(
-            modifier = Modifier
-                .width(timeWidth)
-                .padding(top = rowTop),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(2.dp)
-        ) {
-            time?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.labelMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    // The column is sized for the common short time; a locale with a wide am/pm marker
-                    // ("12:00 nachm.") wraps rather than losing the clock time to an ellipsis.
-                    maxLines = 2
-                )
-            }
-            delta?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.labelSmall,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.outline,
-                    maxLines = 1
-                )
-            }
-        }
-        Box(Modifier.width(RAIL_WIDTH)) {
-            LogNode(model.content, model.nodeColors)
-        }
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .defaultMinSize(
-                    minHeight = when {
-                        compact -> 0.dp
-                        // A tappable row keeps the platform's minimum touch target.
-                        onClick != null -> ROW_MIN_TOUCH_HEIGHT
-                        else -> ROW_MIN_HEIGHT
-                    }
-                )
-                .padding(
-                    start = 8.dp,
-                    top = if (compact) 0.dp else rowTop,
-                    bottom = if (compact) 0.dp else ROW_BOTTOM,
-                    end = 10.dp
-                ),
-            content = content
-        )
-        // Its own segment at the row's right edge — centred on the row's full height, not just the
-        // header line's — rather than sharing the content column's Row and bumping that line's height
-        // out to the chevron's touch target (#2040).
-        if (model.expandable && onToggleExpand != null) {
-            ExpandChevron(
-                expanded = model.expanded,
-                onToggle = onToggleExpand,
-                label = expandLabel(model),
-                modifier = Modifier.align(Alignment.CenterVertically)
             )
+    ) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+            // Centered in the time column — halfway between the screen edge and the spine.
+            Column(
+                modifier = Modifier
+                    .width(timeWidth)
+                    .padding(top = rowTop),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                time?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        // The column is sized for the common short time; a locale with a wide am/pm marker
+                        // ("12:00 nachm.") wraps rather than losing the clock time to an ellipsis.
+                        maxLines = 2
+                    )
+                }
+                delta?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.outline,
+                        maxLines = 1
+                    )
+                }
+            }
+            Box(Modifier.width(RAIL_WIDTH)) {
+                LogNode(model.content, model.nodeColors)
+            }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .defaultMinSize(
+                        minHeight = when {
+                            compact -> 0.dp
+                            // A tappable row keeps the platform's minimum touch target.
+                            onClick != null -> ROW_MIN_TOUCH_HEIGHT
+                            else -> ROW_MIN_HEIGHT
+                        }
+                    )
+                    .padding(
+                        start = CONTENT_START_GAP,
+                        top = if (compact) 0.dp else rowTop,
+                        // A footer takes over the row's bottom inset, so the two read as one block.
+                        bottom = if (compact || footer != null) 0.dp else ROW_BOTTOM,
+                        end = CONTENT_END_INSET
+                    ),
+                content = content
+            )
+            // Its own segment at the row's right edge — centred on the content's full height, not just the
+            // header line's — rather than sharing the content column's Row and bumping that line's height
+            // out to the chevron's touch target (#2040). A footer sits below this segment, not beside it.
+            if (model.expandable && onToggleExpand != null) {
+                ExpandChevron(
+                    expanded = model.expanded,
+                    onToggle = onToggleExpand,
+                    label = expandLabel(model),
+                    modifier = Modifier.align(Alignment.CenterVertically)
+                )
+            }
+        }
+        footer?.let {
+            Box(
+                Modifier.padding(
+                    start = timeWidth + RAIL_WIDTH + CONTENT_START_GAP,
+                    end = CONTENT_END_INSET,
+                    bottom = ROW_BOTTOM
+                )
+            ) { it() }
         }
     }
 }
@@ -1953,14 +1981,14 @@ private fun ColumnScope.StepDistanceContent(distanceMeters: Double) {
 private fun ColumnScope.BoardContent(
     entry: TripLogEntry.Transit,
     onFocus: () -> Unit,
-    onFocusPoint: (GeoPoint) -> Unit,
-    stopEtaStrip: @Composable (TripLogEntry.Transit, RouteStopRef) -> Unit
+    onFocusPoint: (GeoPoint) -> Unit
 ) {
     // The route/headsign block highlights the leg on the map; expanding its steps is the scaffold's
-    // own chevron segment (#2040), not a side effect of this tap. The board stop + ETA strip below is a
-    // third, separate tap target that zooms to the stop. Because this control is this inner block rather
-    // than the whole row, the scaffold's touch-target floor doesn't reach it — so it carries its own. (Its
-    // content clears 48dp on its own in practice; this is the guarantee, not the usual case.)
+    // own chevron segment (#2040), not a side effect of this tap. The board stop below is a third,
+    // separate tap target that zooms to the stop (its live ETA strip is the row's footer). Because this
+    // control is this inner block rather than the whole row, the scaffold's touch-target floor doesn't
+    // reach it — so it carries its own. (Its content clears 48dp on its own in practice; this is the
+    // guarantee, not the usual case.)
     Column(
         Modifier
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)
@@ -1993,9 +2021,6 @@ private fun ColumnScope.BoardContent(
             stopName = stop.name,
             onClick = { stop.point?.let(onFocusPoint) }
         )
-        // The whole ride, not just its route/stop: the strip also rules the plan's own arrival at this
-        // stop across the live ETAs (#2125), and a pill tap frames the ride's geometry on the map.
-        stopEtaStrip(entry, stop)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1985,10 +1985,9 @@ private fun ColumnScope.BoardContent(
 ) {
     // The route/headsign block highlights the leg on the map; expanding its steps is the scaffold's
     // own chevron segment (#2040), not a side effect of this tap. The board stop below is a third,
-    // separate tap target that zooms to the stop (its live ETA strip is the row's footer). Because this
-    // control is this inner block rather than the whole row, the scaffold's touch-target floor doesn't
-    // reach it — so it carries its own. (Its content clears 48dp on its own in practice; this is the
-    // guarantee, not the usual case.)
+    // separate tap target that zooms to the stop. Because this control is this inner block rather than
+    // the whole row, the scaffold's touch-target floor doesn't reach it — so it carries its own. (Its
+    // content clears 48dp on its own in practice; this is the guarantee, not the usual case.)
     Column(
         Modifier
             .defaultMinSize(minHeight = ROW_MIN_TOUCH_HEIGHT)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -199,11 +199,13 @@ sealed interface TripLogEntry {
      * [reachStopTime] and [boardTime] are different moments and both matter: the rider gets to the stop
      * at the first (the end of whatever leg precedes this one) and the vehicle leaves at the second. The
      * gap between them is the planned wait, and it's what the Board node's live ETA strip marks (#2125) —
-     * without it the strip reads as if the rider were standing at the stop already. It is **null** when
-     * nothing precedes the ride: the plan then puts the rider at the stop from the start, so there is no
-     * wait, and — crucially — no departure is out of their reach. Substituting [boardTime] there would
-     * dim every departure earlier than the one the plan happened to pick, which for a "leave at 5pm" plan
-     * read at 3pm is the whole strip, and is the opposite of the truth.
+     * without it the strip reads as if the rider were standing at the stop already. When nothing
+     * precedes the ride, the plan's own start stands in (#2228): a "leave at 5pm" plan puts the rider at
+     * the stop at 5pm, so read at 3pm every departure before then is genuinely out of reach — the strip
+     * says so instead of offering them. It is **null** only when the plan doesn't say when the rider sets
+     * out (an arrive-by plan that opens on transit). Substituting [boardTime] there would dim every
+     * departure earlier than the one the plan happened to pick — including the ones a rider already at
+     * the stop could catch — which is the opposite of the truth.
      */
     data class Transit(
         val routeShortName: String?,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
@@ -53,7 +53,7 @@ class TripResultsViewModel @Inject constructor(
 
     /**
      * Seeds the results from a completed plan. [initialIndex] restores the prior option selection;
-     * [plannedStart] is the plan's own starting moment, if it names one (see [TripResultsRepository.directionsFor]).
+     * [plannedStart] is [org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart].
      */
     fun setItineraries(itineraries: List<TripItinerary>, initialIndex: Int, plannedStart: ServerTime? = null) {
         this.itineraries = itineraries

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.onebusaway.android.directions.model.TripItinerary
+import org.onebusaway.android.time.ServerTime
 
 /**
  * Holds the trip-planning results: the option cards, which one is selected, and the selected
@@ -48,11 +49,16 @@ class TripResultsViewModel @Inject constructor(
 
     private var itineraries: List<TripItinerary> = emptyList()
     private var selectedIndex: Int = 0
+    private var plannedStart: ServerTime? = null
 
-    /** Seeds the results from a completed plan. [initialIndex] restores the prior option selection. */
-    fun setItineraries(itineraries: List<TripItinerary>, initialIndex: Int) {
+    /**
+     * Seeds the results from a completed plan. [initialIndex] restores the prior option selection;
+     * [plannedStart] is the plan's own starting moment, if it names one (see [TripResultsRepository.directionsFor]).
+     */
+    fun setItineraries(itineraries: List<TripItinerary>, initialIndex: Int, plannedStart: ServerTime? = null) {
         this.itineraries = itineraries
         this.selectedIndex = initialIndex.coerceIn(0, (itineraries.size - 1).coerceAtLeast(0))
+        this.plannedStart = plannedStart
         load()
     }
 
@@ -75,7 +81,7 @@ class TripResultsViewModel @Inject constructor(
                 onSuccess = { options ->
                     val selected = itineraries.getOrNull(selectedIndex)
                     val directions = selected
-                        ?.let { repository.directionsFor(it).getOrDefault(emptyList()) }
+                        ?.let { repository.directionsFor(it, plannedStart).getOrDefault(emptyList()) }
                         .orEmpty()
                     _state.value = TripResultsUiState.Success(
                         options = options,

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1008,8 +1008,8 @@
     <string name="directions_stop_eta_departure_missed">Leaves before you get here</string>
     <!-- The one-line stand-in for a Board row's live ETA strip when the arrivals feed holds no departure at
          or after the moment the plan has the rider reach that stop (a trip planned for later than the feed
-         reaches). %1$s is a clock time, e.g. "3:19pm". -->
-    <string name="directions_stop_eta_none_boardable">You get here at %1$s · no live departures for then yet</string>
+         reaches). -->
+    <string name="directions_stop_eta_none_boardable">No live departures yet</string>
     <!-- Button on that line that shows the strip anyway (its departures all dimmed as already missed). -->
     <string name="directions_stop_eta_show_anyway">Show</string>
     <!-- Content descriptions for the chevron on a service-alert banner above the directions, which

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1006,6 +1006,12 @@
     <!-- Spoken state of each departure drawn before that rule: one leaving before the rider can be at
          the stop. Read on the departure itself, since its dimmed appearance says nothing aloud. -->
     <string name="directions_stop_eta_departure_missed">Leaves before you get here</string>
+    <!-- The one-line stand-in for a Board row's live ETA strip when the arrivals feed holds no departure at
+         or after the moment the plan has the rider reach that stop (a trip planned for later than the feed
+         reaches). %1$s is a clock time, e.g. "3:19pm". -->
+    <string name="directions_stop_eta_none_boardable">You get here at %1$s · no live departures for then yet</string>
+    <!-- Button on that line that shows the strip anyway (its departures all dimmed as already missed). -->
+    <string name="directions_stop_eta_show_anyway">Show</string>
     <!-- Content descriptions for the chevron on a service-alert banner above the directions, which
          expands the alert to its full description. -->
     <string name="directions_alert_show_details">Show alert details</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/CountBeforeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/CountBeforeTest.kt
@@ -16,6 +16,8 @@
 package org.onebusaway.android.ui.arrivals.components
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 
@@ -57,5 +59,30 @@ class CountBeforeTest {
     @Test
     fun `an empty strip has nothing to rule`() {
         assertEquals(0, ruleAt(emptyList(), ServerTime(9 * 60_000L)))
+    }
+
+    // anyAtOrAfter — whether the ruled strip keeps a boardable pill at all (#2228). Its boundary must be
+    // the complement of countBefore's, so it is checked against the same departures.
+
+    private fun boardable(departures: List<ServerTime>, moment: ServerTime) = anyAtOrAfter(departures, moment) { it }
+
+    @Test
+    fun `a departure after the moment is boardable`() {
+        assertTrue(boardable(minutes(2, 9, 17), ServerTime(10 * 60_000L)))
+    }
+
+    @Test
+    fun `a departure exactly at the moment is boardable, like the rule leaves it`() {
+        assertTrue(boardable(minutes(2, 9), ServerTime(9 * 60_000L)))
+    }
+
+    @Test
+    fun `nothing is boardable when the rider arrives after everything the feed knows`() {
+        assertFalse(boardable(minutes(2, 9, 17), ServerTime(60 * 60_000L)))
+    }
+
+    @Test
+    fun `nothing is boardable in an empty feed`() {
+        assertFalse(boardable(emptyList(), ServerTime(9 * 60_000L)))
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/CountBeforeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/components/CountBeforeTest.kt
@@ -16,8 +16,6 @@
 package org.onebusaway.android.ui.arrivals.components
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 
@@ -59,30 +57,5 @@ class CountBeforeTest {
     @Test
     fun `an empty strip has nothing to rule`() {
         assertEquals(0, ruleAt(emptyList(), ServerTime(9 * 60_000L)))
-    }
-
-    // anyAtOrAfter — whether the ruled strip keeps a boardable pill at all (#2228). Its boundary must be
-    // the complement of countBefore's, so it is checked against the same departures.
-
-    private fun boardable(departures: List<ServerTime>, moment: ServerTime) = anyAtOrAfter(departures, moment) { it }
-
-    @Test
-    fun `a departure after the moment is boardable`() {
-        assertTrue(boardable(minutes(2, 9, 17), ServerTime(10 * 60_000L)))
-    }
-
-    @Test
-    fun `a departure exactly at the moment is boardable, like the rule leaves it`() {
-        assertTrue(boardable(minutes(2, 9), ServerTime(9 * 60_000L)))
-    }
-
-    @Test
-    fun `nothing is boardable when the rider arrives after everything the feed knows`() {
-        assertFalse(boardable(minutes(2, 9, 17), ServerTime(60 * 60_000L)))
-    }
-
-    @Test
-    fun `nothing is boardable in an empty feed`() {
-        assertFalse(boardable(emptyList(), ServerTime(9 * 60_000L)))
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -293,7 +293,8 @@ class TripLogBuilderTest {
         // Nothing precedes the ride, so the rider is at the stop from the plan's start — for a "leave at
         // 5pm" plan, 5pm — which is what a depart-at plan names (#2228). Not the ride's own departure:
         // that would dim every earlier one, including the ones a rider already there could catch.
-        val start = ServerTime(4 * 60_000L)
+        // Earlier than the leg's own departure (4 min), so a build that reached for that instead would fail.
+        val start = ServerTime(2 * 60_000L)
         val transit = TripLogBuilder
             .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef), plannedStart = start)
             .filterIsInstance<TripLogEntry.Transit>()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -289,17 +289,46 @@ class TripLogBuilderTest {
     }
 
     @Test
-    fun anItineraryOpeningOnTransit_hasNoArrivalAtTheStopToMark() {
-        // Nothing precedes the ride, so the rider is at the stop from the start: there is no wait, and
-        // no departure is out of their reach. Standing the ride's own departure in would dim every
-        // earlier one — for a "leave at 5pm" plan read at 3pm, the whole strip — so the absence is
-        // carried as null rather than substituted for.
+    fun anItineraryOpeningOnTransit_reachesItsFirstStopAtThePlansStart() {
+        // Nothing precedes the ride, so the rider is at the stop from the plan's start — for a "leave at
+        // 5pm" plan, 5pm — which is what a depart-at plan names (#2228). Not the ride's own departure:
+        // that would dim every earlier one, including the ones a rider already there could catch.
+        val start = ServerTime(4 * 60_000L)
+        val transit = TripLogBuilder
+            .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef), plannedStart = start)
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertEquals(start, transit.reachStopTime)
+    }
+
+    @Test
+    fun anItineraryOpeningOnTransit_withNoPlannedStart_hasNoArrivalAtTheStopToMark() {
+        // An arrive-by plan fixes when the trip ends and says nothing about when the rider sets out, so
+        // there is no moment to mark: the absence is carried as null rather than substituted for.
         val transit = TripLogBuilder
             .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef))
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
         assertNull(transit.reachStopTime)
+    }
+
+    @Test
+    fun thePlansStart_standsInOnlyForARideNothingPrecedes() {
+        // With a walk ahead of the ride, the walk's end is when the rider gets to the stop; the plan's
+        // start is when they left home, and must not displace it.
+        val transit = TripLogBuilder
+            .build(
+                legs = listOf(walkLeg, transitLeg),
+                flatDirections = listOf(walkDir, boardDir, alightDir),
+                routeLegRefs = listOf(null, transitRef),
+                plannedStart = ServerTime(0L)
+            )
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertEquals(walkLeg.endTime, transit.reachStopTime)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripResultsViewModelTest.kt
@@ -56,13 +56,29 @@ class TripResultsViewModelTest {
     ) : TripResultsRepository {
         val directionsForCalls = mutableListOf<TripItinerary>()
         override suspend fun summarize(itineraries: List<TripItinerary>) = summary
-        override suspend fun directionsFor(itinerary: TripItinerary): Result<List<TripLogEntry>> {
+        val plannedStarts = mutableListOf<ServerTime?>()
+        override suspend fun directionsFor(itinerary: TripItinerary, plannedStart: ServerTime?): Result<List<TripLogEntry>> {
             directionsForCalls.add(itinerary)
+            plannedStarts.add(plannedStart)
             return directions
         }
     }
 
     private fun itineraries(count: Int): List<TripItinerary> = List(count) { TripItinerary() }
+
+    @Test
+    fun `the plan's start rides along to every directions build`() = runTest {
+        val repository = FakeTripResultsRepository(Result.success(options))
+        val viewModel = TripResultsViewModel(repository)
+        val start = ServerTime(1_700_000_000_000L)
+
+        viewModel.setItineraries(itineraries(2), initialIndex = 0, plannedStart = start)
+        advanceUntilIdle()
+        viewModel.selectOption(1)
+        advanceUntilIdle()
+
+        assertEquals(listOf(start, start), repository.plannedStarts)
+    }
 
     @Test
     fun `initial state is Loading before itineraries are set`() = runTest {


### PR DESCRIPTION
Closes #2228.

## The design problem
A transit leg's Board row rules the stop's live ETA strip at the moment the plan has the rider reach the stop (#2125). For a plan that leaves later than the arrivals window reaches, every pill falls before that rule: the whole strip is dimmed and the rule closes it — a strip that says nothing but looks broken.

Of the options on the issue, this takes the data-driven one: when the feed holds **no departure at or after the reach time** (including no departures at all), the strip collapses to one line — *"No live departures yet"* — with a **Show** that brings the strip up anyway. This is not a threshold on how soon the trip must be: it is exactly the case where the feed has nothing boardable to show (the arrivals window itself), and a poll that brings a boardable departure restores the strip on its own. Without a reach time (the rider is at the stop from the start) nothing changes.

The decision is a pure `anyAtOrAfter` beside `countBefore` (same at-the-moment boundary, so the line and the rule can never disagree), JVM-tested in `CountBeforeTest`; the line has a small render test.

## Transit-first itineraries get a rule too
An itinerary that opens on a transit leg had `reachStopTime = null` (#2125's deliberate absence), so a depart-later plan showed the current departures in full colour, unruled — and the collapse above couldn't see it. A depart-at plan does name when the rider is at its start: the requested departure. `TripPlanParams.plannedStart` mints it (`ServerTime`, the instant the plan was made against — same timeline as the leg times; null for arrive-by, which fixes only when the trip ends), and it rides through `TripResultsViewModel` → `TripResultsRepository.directionsFor` → `TripLogBuilder.build`, which uses it as the reach-stop moment for a ride nothing precedes. A ride with a walk/transfer before it keeps that leg's end. Consequence for a transit-first "leave now" plan: already-departed pills dim and sit behind the "earlier" chevron, and the strip opens on the next departure. `TripLogBuilderTest` / `TripResultsViewModelTest` cover it.

## Opens at the rule
A marked strip now **opens with the rule at its left edge**: the departures the rider can catch lead, and the ones already ruled out sit behind the "earlier" chevron. This is only the initial position (`rememberLazyListState(initialFirstVisibleItemIndex = markerIndex)`, read once) — no glide, so nothing to contend with the user's own scroll (the #1801/#1974 class) — and it holds where the user leaves it after that. Render test: `EtaStripMarkerRenderTest.anOverflowingStripOpensWithTheRuleAtItsLeftEdge`.

## The two presentation fixes
- **Chevrons centred.** `ScrollChevronGutter` fills its height; the arrivals host bounds that with `IntrinsicSize.Min` while the directions log row does not, so the gutter was its icon's height and the strip's bottom alignment dropped it to the foot. The strip's own `Row` is now `IntrinsicSize.Min`, so it holds under either host (`ReferencePillHeightFrame` already answers the intrinsic).
- **Full width.** Two layers: the directions strip added a 12dp end inset on top of the log row's own content inset (dropped); and the board row's whole content column is narrowed by the leg's expand chevron, so `LogRowScaffold` gains a `footer` slot laid *under* the content column and the chevron's segment — from the content column's start to the row's end inset, still inside the row's chrome so the band and spine run behind it as one — and the board row's strip is that footer. The expand chevron centres on the header/board-stop content above it (the #2040 comment is updated).

## Verification
- Compiles clean with `-PwarningsAsErrors=true` (main + test source sets), spotless clean.
- JVM `CountBeforeTest` (9), `TripLogBuilderTest` (16), `TripResultsViewModelTest` (8) green; on-device (Pixel 7 Pro): `ui.tripresults` (37), `ui.arrivals` (16), `ui.home.directions` (10) — 63/63 green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directions now indicate when no live departures are available at the planned arrival time.
  * Added a “Show anyway” option to reveal available departure information.
  * Improved ETA strip layout, marker positioning, and visibility of departure information.
  * Updated trip results to display ETA information across the available content width.
  * Improved trip timing so first-leg arrival information reflects the planned departure time.

* **Tests**
  * Added coverage for departure availability, marker positioning, trip timing, and the “Show anyway” interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
