### PR TITLE
Rule the directions ETA strip at the walk, not at OTP's shifted access leg

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/arrivals/EtaStripMarkerRenderTest.kt
@@ -71,8 +71,8 @@ class EtaStripMarkerRenderTest {
                 routeBadgeFor = { RouteBadge(it.shortName ?: error("preview route must have a name"), null) },
                 // previewArrival anchors serverNow at 0, so a departure N minutes out sits at N * 60_000.
                 marker = EtaStripMarker(
-                    at = ServerTime(reachStopMinutes * 60_000L),
-                    contentDescription = description,
+                    at = { ServerTime(reachStopMinutes * 60_000L) },
+                    contentDescription = { description },
                     passedStateDescription = passedDescription
                 )
             )

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionStopEtaStripTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/directions/DirectionStopEtaStripTest.kt
@@ -23,6 +23,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.tripresults.ReachStop
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
 import org.onebusaway.android.util.GeoPoint
@@ -58,7 +59,7 @@ class DirectionStopEtaStripTest {
         DirectionStopEtaStrip(
             routeLeg = routeLeg,
             stop = stop,
-            reachStopTime = ServerTime(4 * 60_000L),
+            reachStop = ReachStop.OnArrival(ServerTime(4 * 60_000L)),
             arrivalsViewModelFactory = failingFactory,
             onShowTrip = { _, _ -> },
             onEditReminder = {},

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowAlternativeRoutesTest.kt
@@ -74,7 +74,7 @@ class DirectionRowAlternativeRoutesTest {
         mode = TransitMode.RAIL,
         routeColorHex = "0075C4",
         headsign = "Downtown Redmond",
-        reachStopTime = ServerTime(60_000L),
+        reachStop = ReachStop.OnArrival(ServerTime(60_000L)),
         boardTime = ServerTime(2 * 60_000L),
         exitTime = ServerTime(32 * 60_000L),
         durationMinutes = 30,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowFocusTest.kt
@@ -83,7 +83,7 @@ class DirectionRowFocusTest {
         mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
-        reachStopTime = ServerTime(3 * 60_000L),
+        reachStop = ReachStop.OnArrival(ServerTime(3 * 60_000L)),
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripresults/DirectionRowInterlineBadgeTest.kt
@@ -86,7 +86,7 @@ class DirectionRowInterlineBadgeTest {
         mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
-        reachStopTime = ServerTime(60_000L),
+        reachStop = ReachStop.OnArrival(ServerTime(60_000L)),
         boardTime = ServerTime(2 * 60_000L),
         exitTime = ServerTime(32 * 60_000L),
         durationMinutes = 30,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/ServerTimeTicker.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/ServerTimeTicker.kt
@@ -65,20 +65,20 @@ private fun rememberTickingElapsedTime(): ElapsedTime {
 internal fun liveServerTime(serverTime: ServerTime, anchorElapsed: ElapsedTime, nowElapsed: ElapsedTime): ServerTime = serverTime + (nowElapsed - anchorElapsed).coerceAtLeast(Duration.ZERO)
 
 /**
- * The whole minutes between [now] and [displayTime]: each instant floored to its own minute and
- * *then* subtracted — not the whole minutes of the difference, which disagrees for most of every
- * minute. It is the number the arrivals ETA pill prints, so anything else showing an ETA for the
- * same arrival has to compute it this way or be off by one; sharing the function is what makes that
- * structural instead of a promise in a comment.
+ * The whole minutes between [now] and [displayTime]: each instant floored to its own minute
+ * ([wholeMinute]) and *then* subtracted — not the whole minutes of the difference, which disagrees for
+ * most of every minute. It is the number the arrivals ETA pill prints, so anything else showing an ETA
+ * for the same arrival has to compute it this way or be off by one; sharing the function is what makes
+ * that structural instead of a promise in a comment.
  */
-fun etaMinutes(displayTime: ServerTime, now: ServerTime): Long = displayTime.epochMs / MS_PER_MINUTE - now.epochMs / MS_PER_MINUTE
+fun etaMinutes(displayTime: ServerTime, now: ServerTime): Long = displayTime.wholeMinute - now.wholeMinute
 
 /**
- * The whole minute this instant falls in, counted from the epoch — the same flooring [etaMinutes] does
- * to each of its operands, named so it can be used on its own.
+ * The whole minute this instant falls in, counted from the epoch — the one minute-floor [etaMinutes]
+ * and [untilNextMinute] are both written in terms of.
  *
- * Its use is as a memo key: anything derived from a *ticking* clock but printed only to the minute (a
- * formatted clock time, say) should recompute when this changes rather than on every tick.
+ * On its own it is a memo key: anything derived from a *ticking* clock but printed only to the minute
+ * (a formatted clock time, say) should recompute when this changes rather than on every tick.
  */
 val ServerTime.wholeMinute: Long get() = epochMs / MS_PER_MINUTE
 
@@ -92,6 +92,6 @@ val ServerTime.wholeMinute: Long get() = epochMs / MS_PER_MINUTE
  * coarser leaves the number one minute high for the rest of the interval, which is exactly how two
  * surfaces showing the same arrival come to disagree by one.
  */
-fun untilNextMinute(now: ServerTime): Duration = (MS_PER_MINUTE - now.epochMs % MS_PER_MINUTE).milliseconds
+fun untilNextMinute(now: ServerTime): Duration = ((now.wholeMinute + 1) * MS_PER_MINUTE - now.epochMs).milliseconds
 
 private const val MS_PER_MINUTE = 60 * 1000L

--- a/onebusaway-android/src/main/java/org/onebusaway/android/time/ServerTimeTicker.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/time/ServerTimeTicker.kt
@@ -74,6 +74,15 @@ internal fun liveServerTime(serverTime: ServerTime, anchorElapsed: ElapsedTime, 
 fun etaMinutes(displayTime: ServerTime, now: ServerTime): Long = displayTime.epochMs / MS_PER_MINUTE - now.epochMs / MS_PER_MINUTE
 
 /**
+ * The whole minute this instant falls in, counted from the epoch — the same flooring [etaMinutes] does
+ * to each of its operands, named so it can be used on its own.
+ *
+ * Its use is as a memo key: anything derived from a *ticking* clock but printed only to the minute (a
+ * formatted clock time, say) should recompute when this changes rather than on every tick.
+ */
+val ServerTime.wholeMinute: Long get() = epochMs / MS_PER_MINUTE
+
+/**
  * How long from [now] until every [etaMinutes] measured against it prints one less — i.e. until this
  * clock crosses into its next whole minute. Always positive: on the boundary itself, a whole minute
  * remains until the *next* one.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -77,6 +77,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.rememberLiveServerTime
+import org.onebusaway.android.time.wholeMinute
 import org.onebusaway.android.ui.arrivals.ArrivalActions
 import org.onebusaway.android.ui.arrivals.ArrivalInfo
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
@@ -109,13 +110,20 @@ import org.onebusaway.android.util.DisplayFormat
  * order, so the strip's trips must be chronological for the rule to divide them into a before and an
  * after — which is what the pill order means anyway.
  *
- * [contentDescription] is what a screen reader reads for the rule itself; [passedStateDescription] is
- * what it reads on each pill the rule has passed, since a pill's dimming is otherwise invisible to it
- * and a rule further down the row comes too late to explain a departure already announced.
+ * [at] resolves the moment against the strip's own live clock (the ticking "now" its pills count down
+ * from), so a moment that is *relative* to now — "the rider gets here in a 4-minute walk" (#2227) —
+ * moves with the clock while an absolute one simply ignores the argument. Resolving here rather than
+ * in the caller keeps the strip on the one clock it already ticks (#1781): the rule and the pills it
+ * divides can never read two different nows.
+ *
+ * [contentDescription] is what a screen reader reads for the rule itself, given the resolved moment
+ * (it usually prints it as a clock time); [passedStateDescription] is what it reads on each pill the
+ * rule has passed, since a pill's dimming is otherwise invisible to it and a rule further down the row
+ * comes too late to explain a departure already announced.
  */
-internal data class EtaStripMarker(
-    val at: ServerTime,
-    val contentDescription: String,
+internal class EtaStripMarker(
+    val at: (now: ServerTime) -> ServerTime,
+    val contentDescription: (at: ServerTime) -> String,
     val passedStateDescription: String
 )
 
@@ -162,15 +170,20 @@ internal fun EtaStrip(
     // first pill it precedes (see MarkedItem), so that pill's index is the rule's. Only the initial
     // position: rememberLazyListState reads it once, and a later poll leaves the viewport where the
     // user has it (the LazyRow's keys keep it on the same pills). Unmarked, the strip starts at its
-    // first pill.
+    // first pill. A relative rule (#2227) is resolved here on the poll's own clock rather than the live
+    // one below — this is read before the first tick, and a second of drift cannot move which pill leads.
     state: LazyListState = rememberLazyListState(
-        initialFirstVisibleItemIndex = marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } ?: 0
+        initialFirstVisibleItemIndex = marker
+            ?.at(trips.firstOrNull()?.serverNow ?: ServerTime(0L))
+            ?.let { at -> countBefore(trips, at) { trip -> trip.displayTime } }
+            ?: 0
     )
 ) {
     // All of this strip's trips share one poll (one route/direction group from a single
     // ConvertArrivals pass), so their serverNow is identical — tick ONE shared clock here rather than
-    // a redundant per-pill ticker/coroutine (issue #1781). ServerTime(0) is an inert placeholder for
-    // the (pill-less) empty-trips case; nothing reads it since the pill loop below never runs.
+    // a redundant per-pill ticker/coroutine (issue #1781); the marker rule resolves against this same
+    // clock rather than ticking one of its own. ServerTime(0) is an inert placeholder for the
+    // (pill-less) empty-trips case; nothing reads it since the pill loop below never runs.
     val liveNow = rememberLiveServerTime(trips.firstOrNull()?.serverNow ?: ServerTime(0L))
     // Remembered because reading the live clock above recomposes this whole body once a second, and
     // this would otherwise re-run the caller's lambda over every trip on each of those ticks. It only
@@ -191,9 +204,18 @@ internal fun EtaStrip(
         // there are one or two clock lines.
         ArrivalClock(expected = "0:00", corrects = "0:01".takeIf { clocks.any { clock -> clock.corrects != null } })
     }
-    // Where the marker's moment falls among these departures. Remembered for the same reason: the live
-    // clock recomposes this body every second, but the answer only moves when a poll brings new trips.
-    val markerIndex = remember(trips, marker) { marker?.let { countBefore(trips, it.at) { trip -> trip.displayTime } } }
+    // The marker's moment, and where it falls among these departures. NOT remembered: a moment relative
+    // to now (a walk, #2227) moves with the clock, so the answer legitimately changes tick to tick, and
+    // counting a strip's pills is cheaper than a memo miss. What IS held to the minute is the rule's
+    // spoken text — it prints the moment as a clock time, so it can only change when the minute does,
+    // and formatting it is locale work with no business running every second.
+    val markerAt = marker?.at?.invoke(liveNow)
+    val markerIndex = markerAt?.let { countBefore(trips, it) { trip -> trip.displayTime } }
+    val markerDescription = if (marker != null && markerAt != null) {
+        remember(marker, markerAt.wholeMinute) { marker.contentDescription(markerAt) }
+    } else {
+        null
+    }
 
     // The strip viewport width in px, for the one-viewport chevron jump below.
     var viewportPx by remember { mutableIntStateOf(0) }
@@ -270,7 +292,7 @@ internal fun EtaStrip(
                     // The rule rides inside the item it precedes: a LazyListScope can't emit a lone item
                     // partway through an itemsIndexed block without splitting the trips in two and
                     // duplicating the pill below. Null on every other item, so only one carries it.
-                    MarkedItem(marker?.takeIf { markerIndex == index }) {
+                    MarkedItem(marker, markerDescription?.takeIf { markerIndex == index }) {
                         EtaPillWithMenu(
                             trip = trip,
                             clock = clocks[index],
@@ -293,8 +315,8 @@ internal fun EtaStrip(
                 }
                 // A marker past the last departure — the rider gets to the stop after everything the feed
                 // knows about — closes the strip instead of vanishing.
-                if (marker != null && markerIndex != null && markerIndex >= trips.size) {
-                    item(key = ETA_STRIP_MARKER_TAG) { EtaStripMarkerRule(marker) }
+                if (markerDescription != null && markerIndex != null && markerIndex >= trips.size) {
+                    item(key = ETA_STRIP_MARKER_TAG) { EtaStripMarkerRule(markerDescription) }
                 }
             }
         }
@@ -347,12 +369,20 @@ private val MARKER_WIDTH = 3.dp
  *  is a NUL-joined tuple of OBA ids, so a bare word can't collide with one. */
 internal const val ETA_STRIP_MARKER_TAG = "etaStripMarker"
 
-/** One LazyRow item: [pill], preceded by [marker]'s rule when this is the pill it stands before. Spaced
- *  as two adjacent pills would be, so the rule doesn't crowd the strip's rhythm. A [marker] of null —
- *  every other pill, and every pill on the unmarked arrivals path — emits the pill alone, adding no
- *  layout node of its own. */
+/**
+ * One LazyRow item: [pill], preceded by the strip's [marker] rule when this is the pill it stands
+ * before — [ruleDescription] is the rule's spoken text then, and null on every other pill. Spaced as
+ * two adjacent pills would be, so the rule doesn't crowd the strip's rhythm.
+ *
+ * The item's shape is decided by whether the *strip* has a marker, not by whether the rule stands
+ * here: a marked strip's every pill sits in this Row, with the rule conditionally before it. Deciding
+ * per pill would put the pill under a different parent when the rule arrives or leaves — and a walk
+ * rule (#2227) crosses a pill as the clock runs — which recreates the pill's subtree and drops its
+ * open long-press menu. On the unmarked arrivals path ([marker] null) the pill is emitted alone,
+ * adding no layout node of its own.
+ */
 @Composable
-private fun MarkedItem(marker: EtaStripMarker?, pill: @Composable () -> Unit) {
+private fun MarkedItem(marker: EtaStripMarker?, ruleDescription: String?, pill: @Composable () -> Unit) {
     if (marker == null) {
         pill()
         return
@@ -362,24 +392,24 @@ private fun MarkedItem(marker: EtaStripMarker?, pill: @Composable () -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(PILL_SPACING),
         verticalAlignment = Alignment.Bottom
     ) {
-        EtaStripMarkerRule(marker)
+        if (ruleDescription != null) EtaStripMarkerRule(ruleDescription)
         pill()
     }
 }
 
 /**
  * The marker itself: a full-height rounded rule in the theme's primary colour, standing between the
- * departures on either side of the moment it marks. It names that moment for a screen reader, since a
- * rule says nothing on its own; what the dimming beside it means is said on the dimmed pills
+ * departures on either side of the moment it marks. [description] names that moment for a screen
+ * reader, since a rule says nothing on its own; what the dimming beside it means is said on the dimmed pills
  * ([passedByMarker]), where a screen reader actually meets it.
  */
 @Composable
-private fun EtaStripMarkerRule(marker: EtaStripMarker) {
+private fun EtaStripMarkerRule(description: String) {
     VerticalDivider(
         modifier = Modifier
             .testTag(ETA_STRIP_MARKER_TAG)
             .clip(RoundedCornerShape(MARKER_WIDTH / 2))
-            .semantics { contentDescription = marker.contentDescription },
+            .semantics { contentDescription = description },
         thickness = MARKER_WIDTH,
         color = MaterialTheme.colorScheme.primary
     )
@@ -763,8 +793,8 @@ private fun EtaStripMarkedPreview() {
     EtaStripPreviewFrame(
         trips = northgatePills(4),
         marker = EtaStripMarker(
-            at = ServerTime(16 * 60_000L),
-            contentDescription = "You get to this stop at 3:19pm",
+            at = { ServerTime(16 * 60_000L) },
+            contentDescription = { "You get to this stop at 3:19pm" },
             passedStateDescription = "Leaves before you get here"
         )
     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -1030,7 +1030,7 @@ fun HomeScreen(
                                                 DirectionStopEtaStrip(
                                                     routeLeg = ride.routeLeg,
                                                     stop = stop,
-                                                    reachStopTime = ride.reachStopTime,
+                                                    reachStop = ride.reachStop,
                                                     arrivalsViewModelFactory = arrivalsViewModelFactory,
                                                     onShowTrip = onShowTrip,
                                                     onEditReminder = onEditReminder,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -1019,7 +1019,8 @@ fun HomeScreen(
                                             onFocusLeg = homeViewModel::focusItineraryLegOnMap,
                                             onFocusPoint = homeViewModel::focusItineraryPointOnMap,
                                             // Each transit leg's Board/Alight row shows that stop's live ETA strip inline,
-                                            // ruled at the moment the plan has the rider reach the stop (#2125).
+                                            // ruled at how the plan gets the rider to the stop (#2125): a transfer's
+                                            // arrival, or — for the first ride — the walk from now (#2227).
                                             stopEtaStrip = { ride, stop ->
                                                 // The focused leg's boarding stop: the one strip that reads the
                                                 // hoisted session rather than opening a second one on the stop the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -89,6 +89,7 @@ import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.pickRideDirection
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.time.rememberLiveServerTime
+import org.onebusaway.android.time.wholeMinute
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -134,7 +135,6 @@ import org.onebusaway.android.ui.tripresults.TripResultsSheet
 import org.onebusaway.android.ui.tripresults.TripResultsUiState
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tripresults.focusTransit
-import org.onebusaway.android.ui.tripresults.resolvedAt
 import org.onebusaway.android.ui.tripresults.rideCoveringLegs
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.DisplayFormat
@@ -495,43 +495,48 @@ private fun DirectionStopEtaStripContent(
     val callbacks = rememberArrivalRowCallbacks(session.handler, session.viewModel)
 
     val content = state as? ArrivalsUiState.Content ?: return // nothing until the first load lands
-    val plannedGroup = content.routeGroups.pickRoute(routeLeg.routeId, routeLeg.headsign)
-    val alternativeGroups = routeLeg.alternatives.mapNotNull { alternative ->
-        content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
-            ?.let { alternative to it }
-    }
-    val routeTrips = buildList {
-        plannedGroup?.let { add(routeLeg.etaPlannedBadge(it.representative.lineName) to it.trips) }
-        alternativeGroups.forEach { (alternative, group) ->
-            add(RouteBadge(alternative.shortName, alternative.routeColor) to group.trips)
+    // Remembered as a block because a walk rule ticks (see [rememberReachStopMarker]) and so recomposes
+    // this body every second, while none of this moves between polls: the route lookups, the merge into
+    // one chronological strip, and the badge index are all functions of the poll and the leg alone.
+    val (trips, badgesByTrip) = remember(content.routeGroups, routeLeg) {
+        val plannedGroup = content.routeGroups.pickRoute(routeLeg.routeId, routeLeg.headsign)
+        val alternativeGroups = routeLeg.alternatives.mapNotNull { alternative ->
+            content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
+                ?.let { alternative to it }
         }
+        val routeTrips = buildList {
+            plannedGroup?.let { add(routeLeg.etaPlannedBadge(it.representative.lineName) to it.trips) }
+            alternativeGroups.forEach { (alternative, group) ->
+                add(RouteBadge(alternative.shortName, alternative.routeColor) to group.trips)
+            }
+        }
+        val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
+        interleaved.map { it.first } to interleaved.associate { (trip, badge) -> trip to badge }
     }
-    val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
+    // The rule the strip is ruled at, resolved once so the collapse decision below and the mark drawn
+    // across the pills are the same instant and cannot disagree. Null when the plan puts nothing before
+    // this ride, and when the poll holds no pill at all — there is then no server clock to measure a
+    // walk rule against, and nothing for it to rule on either.
+    val marker = reachStop?.let { stop ->
+        trips.firstOrNull()?.let { rememberReachStopMarker(stop, it.serverNow) }
+    }
     // Collapsed when the rule would land past the last pill — the very count the strip places its rule
     // by, so the line and the rule can't disagree about what is boardable (nothing at all counts:
     // an empty feed has nothing boardable either). Never without a reach time. Once shown anyway the
     // strip stays up for this stop, though a strip that has come to hold a boardable pill needs no reveal.
     var revealed by rememberSaveable { mutableStateOf(false) }
-    // The rule itself, resolved once on the strip's own live clock (#2227), so the collapse decision and
-    // the mark drawn across the pills are the same instant to the second and cannot disagree. Null when
-    // the plan puts nothing before this ride, and when the feed holds no pill at all — there is then no
-    // poll to anchor the clock to, and nothing boardable to rule on either.
-    val marker = reachStop?.let { stop ->
-        interleaved.firstOrNull()?.let { (trip, _) -> rememberReachStopMarker(stop, trip.serverNow) }
-    }
     val nothingBoardable = reachStop != null &&
-        (marker == null || countBefore(interleaved, marker.at) { it.first.displayTime } == interleaved.size)
+        (marker == null || countBefore(trips, marker.at) { it.displayTime } == trips.size)
     if (nothingBoardable && !revealed) {
         NoBoardableDeparturesLine(modifier = modifier.then(rowPadding), onReveal = { revealed = true })
         return
     }
-    if (interleaved.isEmpty()) {
+    if (trips.isEmpty()) {
         NoEtasText(modifier.then(rowPadding))
         return
     }
-    val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }
     EtaStrip(
-        trips = interleaved.map { it.first },
+        trips = trips,
         actionsFor = { content.actions[it.tripId] },
         callbacks = callbacks,
         modifier = modifier.then(rowPadding),
@@ -542,31 +547,34 @@ private fun DirectionStopEtaStripContent(
 }
 
 /**
- * The strip's "you get here at …" rule for [reachStop], resolved against a clock anchored on
- * [serverNow] (this poll's server time) and ticked forward from there.
+ * The strip's "you get here at …" rule for [reachStop], measured against [serverNow] (this poll's
+ * server clock).
  *
- * It has to tick, because a [ReachStop.OnFoot] rule is *now* plus the walk (#2227) — a moment that
- * moves with the clock rather than one the plan fixed. That reads as the rule holding still at the
- * rider's walking distance while the pills flow past it, which is exactly what it means: everything
- * left of the rule is a departure they can no longer walk to in time. A [ReachStop.OnArrival] rule is
- * an absolute moment and simply ignores the tick.
+ * A [ReachStop.OnFoot] rule is *now* plus the walk (#2227), so it is the one shape that has to move
+ * with the clock rather than sit where the plan fixed it, and only it pays for a ticking one. That
+ * reads as the rule holding still at the rider's walking distance while the pills flow past it, which
+ * is exactly what it means: everything left of the rule is a departure they can no longer walk to in
+ * time. A [ReachStop.OnArrival] rule is an absolute moment, ignores the "now" it's handed, and so is
+ * left on the poll clock — a strip past the first ride never ticks at all.
  *
- * The clock string is memoized on the whole minute it falls in, not on the ticking value: it is printed
- * to the minute, and formatting it is locale work that has no business running every second.
+ * This is a second live clock in a subtree where [EtaStrip] already ticks its own, which its #1781
+ * comment is otherwise right to warn against. It is one coroutine on the one strip whose rule walks,
+ * and the alternative — resolving the rule inside [EtaStrip] — would have to carry this rule's clock
+ * string and its string resources into a component shared with the arrivals drawer, which has no plan
+ * and no rule. The clock string is memoized on the whole minute it falls in, not on the ticking value:
+ * it is printed to the minute, and formatting it is locale work with no business running every second.
  */
 @Composable
 private fun rememberReachStopMarker(reachStop: ReachStop, serverNow: ServerTime): EtaStripMarker {
     val context = LocalContext.current
-    val at = reachStop.resolvedAt(rememberLiveServerTime(serverNow))
-    val clock = remember(at.epochMs / MILLIS_PER_MINUTE, context) { DisplayFormat.formatTime(context, at.epochMs) }
+    val at = reachStop.resolvedAt(if (reachStop is ReachStop.OnFoot) rememberLiveServerTime(serverNow) else serverNow)
+    val clock = remember(at.wholeMinute, context) { DisplayFormat.formatTime(context, at.epochMs) }
     return EtaStripMarker(
         at = at,
         contentDescription = stringResource(R.string.directions_stop_eta_reach_stop, clock),
         passedStateDescription = stringResource(R.string.directions_stop_eta_departure_missed)
     )
 }
-
-private const val MILLIS_PER_MINUTE = 60_000L
 
 /**
  * Flattens route-specific, already-ordered arrival lists into one chronological strip. Kotlin's sort

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -87,9 +87,6 @@ import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.pickRideDirection
-import org.onebusaway.android.time.ServerTime
-import org.onebusaway.android.time.rememberLiveServerTime
-import org.onebusaway.android.time.wholeMinute
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -135,6 +132,7 @@ import org.onebusaway.android.ui.tripresults.TripResultsSheet
 import org.onebusaway.android.ui.tripresults.TripResultsUiState
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tripresults.focusTransit
+import org.onebusaway.android.ui.tripresults.resolvedAt
 import org.onebusaway.android.ui.tripresults.rideCoveringLegs
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.DisplayFormat
@@ -495,85 +493,76 @@ private fun DirectionStopEtaStripContent(
     val callbacks = rememberArrivalRowCallbacks(session.handler, session.viewModel)
 
     val content = state as? ArrivalsUiState.Content ?: return // nothing until the first load lands
-    // Remembered as a block because a walk rule ticks (see [rememberReachStopMarker]) and so recomposes
-    // this body every second, while none of this moves between polls: the route lookups, the merge into
-    // one chronological strip, and the badge index are all functions of the poll and the leg alone.
-    val (trips, badgesByTrip) = remember(content.routeGroups, routeLeg) {
-        val plannedGroup = content.routeGroups.pickRoute(routeLeg.routeId, routeLeg.headsign)
-        val alternativeGroups = routeLeg.alternatives.mapNotNull { alternative ->
-            content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
-                ?.let { alternative to it }
-        }
-        val routeTrips = buildList {
-            plannedGroup?.let { add(routeLeg.etaPlannedBadge(it.representative.lineName) to it.trips) }
-            alternativeGroups.forEach { (alternative, group) ->
-                add(RouteBadge(alternative.shortName, alternative.routeColor) to group.trips)
-            }
-        }
-        val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
-        interleaved.map { it.first } to interleaved.associate { (trip, badge) -> trip to badge }
+    val plannedGroup = content.routeGroups.pickRoute(routeLeg.routeId, routeLeg.headsign)
+    val alternativeGroups = routeLeg.alternatives.mapNotNull { alternative ->
+        content.routeGroups.pickRoute(alternative.routeId, alternative.headsign)
+            ?.let { alternative to it }
     }
-    // The rule the strip is ruled at, resolved once so the collapse decision below and the mark drawn
-    // across the pills are the same instant and cannot disagree. Null when the plan puts nothing before
-    // this ride, and when the poll holds no pill at all — there is then no server clock to measure a
-    // walk rule against, and nothing for it to rule on either.
-    val marker = reachStop?.let { stop ->
-        trips.firstOrNull()?.let { rememberReachStopMarker(stop, it.serverNow) }
+    val routeTrips = buildList {
+        plannedGroup?.let { add(routeLeg.etaPlannedBadge(it.representative.lineName) to it.trips) }
+        alternativeGroups.forEach { (alternative, group) ->
+            add(RouteBadge(alternative.shortName, alternative.routeColor) to group.trips)
+        }
     }
-    // Collapsed when the rule would land past the last pill — the very count the strip places its rule
-    // by, so the line and the rule can't disagree about what is boardable (nothing at all counts:
-    // an empty feed has nothing boardable either). Never without a reach time. Once shown anyway the
-    // strip stays up for this stop, though a strip that has come to hold a boardable pill needs no reveal.
+    val interleaved = interleaveRouteItems(routeTrips) { it.displayTime.epochMs }
+    // The rule as of this poll: the strip resolves it again on its own live clock (#2227), which only
+    // ever carries a walk rule *forward*, so this reading collapses the strip no sooner than the strip's
+    // own rule would and the next poll settles it either way. Null when the plan puts nothing before this
+    // ride, and when the poll brought no pill to read its server clock off.
+    val ruleAt = reachStop?.let { stop -> interleaved.firstOrNull()?.let { stop.resolvedAt(it.first.serverNow) } }
+    // Collapsed when the rule lands past the last pill — the very count the strip places its rule by, so
+    // the line and the rule can't disagree about what is boardable (nothing at all counts: an empty feed
+    // has nothing boardable either). Never without a reach time. Once shown anyway the strip stays up for
+    // this stop, though a strip that has come to hold a boardable pill needs no reveal.
     var revealed by rememberSaveable { mutableStateOf(false) }
     val nothingBoardable = reachStop != null &&
-        (marker == null || countBefore(trips, marker.at) { it.displayTime } == trips.size)
+        (ruleAt == null || countBefore(interleaved, ruleAt) { it.first.displayTime } == interleaved.size)
     if (nothingBoardable && !revealed) {
         NoBoardableDeparturesLine(modifier = modifier.then(rowPadding), onReveal = { revealed = true })
         return
     }
-    if (trips.isEmpty()) {
+    if (interleaved.isEmpty()) {
         NoEtasText(modifier.then(rowPadding))
         return
     }
+    val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }
     EtaStrip(
-        trips = trips,
+        trips = interleaved.map { it.first },
         actionsFor = { content.actions[it.tripId] },
         callbacks = callbacks,
         modifier = modifier.then(rowPadding),
         routeBadgeFor = { badgesByTrip[it] },
-        marker = marker,
+        marker = reachStop?.let { rememberReachStopMarker(it) },
         focus = pillFocus
     )
 }
 
 /**
- * The strip's "you get here at …" rule for [reachStop], measured against [serverNow] (this poll's
- * server clock).
+ * The strip's "you get here at …" rule for [reachStop].
  *
- * A [ReachStop.OnFoot] rule is *now* plus the walk (#2227), so it is the one shape that has to move
- * with the clock rather than sit where the plan fixed it, and only it pays for a ticking one. That
- * reads as the rule holding still at the rider's walking distance while the pills flow past it, which
- * is exactly what it means: everything left of the rule is a departure they can no longer walk to in
- * time. A [ReachStop.OnArrival] rule is an absolute moment, ignores the "now" it's handed, and so is
- * left on the poll clock — a strip past the first ride never ticks at all.
+ * The rule is handed to [EtaStrip] as a *resolver* against the strip's own live clock rather than as
+ * an instant: a [ReachStop.OnFoot] is now plus the walk (#2227), so it has to move with the clock, and
+ * the strip is the one place already ticking one (#1781) — its pills and this rule then read the same
+ * now. That reads as the rule holding still at the rider's walking distance while the pills flow past
+ * it, which is exactly what it means: everything left of the rule is a departure they can no longer
+ * walk to in time. A [ReachStop.OnArrival] is an absolute moment and ignores the clock it is handed.
  *
- * This is a second live clock in a subtree where [EtaStrip] already ticks its own, which its #1781
- * comment is otherwise right to warn against. It is one coroutine on the one strip whose rule walks,
- * and the alternative — resolving the rule inside [EtaStrip] — would have to carry this rule's clock
- * string and its string resources into a component shared with the arrivals drawer, which has no plan
- * and no rule. The clock string is memoized on the whole minute it falls in, not on the ticking value:
- * it is printed to the minute, and formatting it is locale work with no business running every second.
+ * Remembered so the marker is one stable object per plan: the strip keys its per-minute spoken text on
+ * it, and the strip's own callers are already stable between polls.
  */
 @Composable
-private fun rememberReachStopMarker(reachStop: ReachStop, serverNow: ServerTime): EtaStripMarker {
+private fun rememberReachStopMarker(reachStop: ReachStop): EtaStripMarker {
     val context = LocalContext.current
-    val at = reachStop.resolvedAt(if (reachStop is ReachStop.OnFoot) rememberLiveServerTime(serverNow) else serverNow)
-    val clock = remember(at.wholeMinute, context) { DisplayFormat.formatTime(context, at.epochMs) }
-    return EtaStripMarker(
-        at = at,
-        contentDescription = stringResource(R.string.directions_stop_eta_reach_stop, clock),
-        passedStateDescription = stringResource(R.string.directions_stop_eta_departure_missed)
-    )
+    val passedStateDescription = stringResource(R.string.directions_stop_eta_departure_missed)
+    return remember(reachStop, context, passedStateDescription) {
+        EtaStripMarker(
+            at = reachStop::resolvedAt,
+            contentDescription = { at ->
+                context.getString(R.string.directions_stop_eta_reach_stop, DisplayFormat.formatTime(context, at.epochMs))
+            },
+            passedStateDescription = passedStateDescription
+        )
+    }
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -87,6 +87,7 @@ import org.onebusaway.android.directions.util.ConversionUtils
 import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.pickRideDirection
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -412,11 +413,12 @@ fun DirectionsResultsSheet(
  * Null when the plan puts nothing before this ride (the rider is at the stop from the start, so every
  * departure is theirs to take) — the strip then draws no rule rather than one placed at a guess.
  *
- * When the feed holds no departure at or after that rule — a plan that leaves later than the
+ * When the feed holds departures but none at or after that rule — a plan that leaves later than the
  * arrivals window reaches, so every pill would be dimmed and the rule would close the strip — the strip
  * collapses to one line saying so, with a tap to show it anyway (#2228). The line is not a threshold
- * on how soon the trip must be: it is exactly the case where the feed has nothing boardable to show, and
- * a later poll that brings a boardable departure puts the strip back on its own.
+ * on how soon the trip must be: it is exactly the case where the feed has departures but none the rider
+ * can board, and a later poll that brings a boardable one puts the strip back on its own. A poll with no
+ * departures at all keeps its own "no upcoming arrivals" line — there is nothing behind a "Show" there.
  */
 @Composable
 internal fun DirectionStopEtaStrip(
@@ -510,19 +512,16 @@ private fun DirectionStopEtaStripContent(
     // own rule would and the next poll settles it either way. Null when the plan puts nothing before this
     // ride, and when the poll brought no pill to read its server clock off.
     val ruleAt = reachStop?.let { stop -> interleaved.firstOrNull()?.let { stop.resolvedAt(it.first.serverNow) } }
-    // Collapsed when the rule lands past the last pill — the very count the strip places its rule by, so
-    // the line and the rule can't disagree about what is boardable (nothing at all counts: an empty feed
-    // has nothing boardable either). Never without a reach time. Once shown anyway the strip stays up for
-    // this stop, though a strip that has come to hold a boardable pill needs no reveal.
+    // Held above the branches so a poll that empties the strip doesn't forget that the rider asked to see
+    // it; a strip that has come to hold a boardable pill needs no reveal in the first place.
     var revealed by rememberSaveable { mutableStateOf(false) }
-    val nothingBoardable = reachStop != null &&
-        (ruleAt == null || countBefore(interleaved, ruleAt) { it.first.displayTime } == interleaved.size)
-    if (nothingBoardable && !revealed) {
-        NoBoardableDeparturesLine(modifier = modifier.then(rowPadding), onReveal = { revealed = true })
+    val stripState = stopEtaStripState(interleaved, ruleAt) { it.first.displayTime }
+    if (stripState == StopEtaStripState.NO_ARRIVALS) {
+        NoEtasText(modifier.then(rowPadding))
         return
     }
-    if (interleaved.isEmpty()) {
-        NoEtasText(modifier.then(rowPadding))
+    if (stripState == StopEtaStripState.NOTHING_BOARDABLE && !revealed) {
+        NoBoardableDeparturesLine(modifier = modifier.then(rowPadding), onReveal = { revealed = true })
         return
     }
     val badgesByTrip = interleaved.associate { (trip, badge) -> trip to badge }
@@ -563,6 +562,39 @@ private fun rememberReachStopMarker(reachStop: ReachStop): EtaStripMarker {
             passedStateDescription = passedStateDescription
         )
     }
+}
+
+/** What a stop's ETA strip has to show for one poll — see [stopEtaStripState] for the precedence. */
+internal enum class StopEtaStripState {
+
+    /** The departures themselves, ruled at the moment the rider gets here when the plan says one. */
+    PILLS,
+
+    /** The poll holds no departure at this stop at all, boardable or not. */
+    NO_ARRIVALS,
+
+    /** It holds departures, and the rider reaches the stop after every one of them (#2228). */
+    NOTHING_BOARDABLE
+}
+
+/**
+ * Which state [items] and the reach rule [ruleAt] put the strip in. Pure, so the precedence between the
+ * two empty-ish states is tested rather than only readable off a pair of early returns.
+ *
+ * [NO_ARRIVALS][StopEtaStripState.NO_ARRIVALS] wins over
+ * [NOTHING_BOARDABLE][StopEtaStripState.NOTHING_BOARDABLE]: a poll with no departures at all has nothing
+ * to reveal, so the collapsed line's "Show" would promise the rider a strip and hand them back the same
+ * sentence. The collapsed line is for a feed that *does* hold departures, every one of them before the
+ * rider can get here.
+ *
+ * Nothing-boardable is decided by the very count the strip places its rule by ([countBefore]), so the
+ * line and the rule can't disagree about what is boardable. Without a rule ([ruleAt] null — the plan
+ * puts nothing before this ride) no departure is out of reach and the pills always stand.
+ */
+internal fun <T> stopEtaStripState(items: List<T>, ruleAt: ServerTime?, timeOf: (T) -> ServerTime): StopEtaStripState = when {
+    items.isEmpty() -> StopEtaStripState.NO_ARRIVALS
+    ruleAt != null && countBefore(items, ruleAt, timeOf) == items.size -> StopEtaStripState.NOTHING_BOARDABLE
+    else -> StopEtaStripState.PILLS
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -88,6 +88,7 @@ import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.pickRideDirection
 import org.onebusaway.android.time.ServerTime
+import org.onebusaway.android.time.rememberLiveServerTime
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.arrivals.RouteRowGroup
@@ -125,6 +126,7 @@ import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.VehicleMode
 import org.onebusaway.android.ui.tripplan.WalkPreference
 import org.onebusaway.android.ui.tripresults.FocusedLeg
+import org.onebusaway.android.ui.tripresults.ReachStop
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
 import org.onebusaway.android.ui.tripresults.TripLogEntry
@@ -132,6 +134,7 @@ import org.onebusaway.android.ui.tripresults.TripResultsSheet
 import org.onebusaway.android.ui.tripresults.TripResultsUiState
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tripresults.focusTransit
+import org.onebusaway.android.ui.tripresults.resolvedAt
 import org.onebusaway.android.ui.tripresults.rideCoveringLegs
 import org.onebusaway.android.util.BikeshareAvailability
 import org.onebusaway.android.util.DisplayFormat
@@ -405,13 +408,13 @@ fun DirectionsResultsSheet(
  * An alternative with no OBA id, or with nothing upcoming at this stop, is simply left out — its name
  * still appears on the card's "or …" line.
  *
- * The strip is live arrivals *as of now*, but the rider is somewhere up the plan, so [reachStopTime] —
- * when the plan has them reach this stop — is ruled across it (#2125): departures before it are ones
- * they can't be here for, and the first pill after the rule is the soonest one they can actually board.
+ * The strip is live arrivals *as of now*, but the rider is somewhere up the plan, so [reachStop] — how
+ * the plan gets them to this stop — is ruled across it (#2125): departures before it are ones they
+ * can't be here for, and the first pill after the rule is the soonest one they can actually board.
  * Null when the plan puts nothing before this ride (the rider is at the stop from the start, so every
  * departure is theirs to take) — the strip then draws no rule rather than one placed at a guess.
  *
- * When the feed holds no departure at or after [reachStopTime] — a plan that leaves later than the
+ * When the feed holds no departure at or after that rule — a plan that leaves later than the
  * arrivals window reaches, so every pill would be dimmed and the rule would close the strip — the strip
  * collapses to one line saying so, with a tap to show it anyway (#2228). The line is not a threshold
  * on how soon the trip must be: it is exactly the case where the feed has nothing boardable to show, and
@@ -421,7 +424,7 @@ fun DirectionsResultsSheet(
 internal fun DirectionStopEtaStrip(
     routeLeg: RouteLegRef,
     stop: RouteStopRef,
-    reachStopTime: ServerTime?,
+    reachStop: ReachStop?,
     arrivalsViewModelFactory: ArrivalsViewModel.Factory,
     onShowTrip: (tripId: String, stopId: String) -> Unit,
     onEditReminder: (ReminderEditorArgs) -> Unit,
@@ -470,7 +473,7 @@ internal fun DirectionStopEtaStrip(
     val session = hoistedSession ?: ownSession ?: return
     DirectionStopEtaStripContent(
         routeLeg = routeLeg,
-        reachStopTime = reachStopTime,
+        reachStop = reachStop,
         session = session,
         rowPadding = rowPadding,
         pillFocus = pillFocus,
@@ -482,7 +485,7 @@ internal fun DirectionStopEtaStrip(
 @Composable
 private fun DirectionStopEtaStripContent(
     routeLeg: RouteLegRef,
-    reachStopTime: ServerTime?,
+    reachStop: ReachStop?,
     session: ArrivalsSession,
     rowPadding: Modifier,
     pillFocus: EtaPillFocus?,
@@ -509,7 +512,15 @@ private fun DirectionStopEtaStripContent(
     // an empty feed has nothing boardable either). Never without a reach time. Once shown anyway the
     // strip stays up for this stop, though a strip that has come to hold a boardable pill needs no reveal.
     var revealed by rememberSaveable { mutableStateOf(false) }
-    val nothingBoardable = reachStopTime != null && countBefore(interleaved, reachStopTime) { it.first.displayTime } == interleaved.size
+    // The rule itself, resolved once on the strip's own live clock (#2227), so the collapse decision and
+    // the mark drawn across the pills are the same instant to the second and cannot disagree. Null when
+    // the plan puts nothing before this ride, and when the feed holds no pill at all — there is then no
+    // poll to anchor the clock to, and nothing boardable to rule on either.
+    val marker = reachStop?.let { stop ->
+        interleaved.firstOrNull()?.let { (trip, _) -> rememberReachStopMarker(stop, trip.serverNow) }
+    }
+    val nothingBoardable = reachStop != null &&
+        (marker == null || countBefore(interleaved, marker.at) { it.first.displayTime } == interleaved.size)
     if (nothingBoardable && !revealed) {
         NoBoardableDeparturesLine(modifier = modifier.then(rowPadding), onReveal = { revealed = true })
         return
@@ -525,23 +536,37 @@ private fun DirectionStopEtaStripContent(
         callbacks = callbacks,
         modifier = modifier.then(rowPadding),
         routeBadgeFor = { badgesByTrip[it] },
-        marker = reachStopTime?.let { rememberReachStopMarker(it) },
+        marker = marker,
         focus = pillFocus
     )
 }
 
-/** The strip's "you get here at …" rule for [reachStopTime]. The clock string is memoized because the
- *  format call is locale work that only changes with the plan, not with each arrivals poll. */
+/**
+ * The strip's "you get here at …" rule for [reachStop], resolved against a clock anchored on
+ * [serverNow] (this poll's server time) and ticked forward from there.
+ *
+ * It has to tick, because a [ReachStop.OnFoot] rule is *now* plus the walk (#2227) — a moment that
+ * moves with the clock rather than one the plan fixed. That reads as the rule holding still at the
+ * rider's walking distance while the pills flow past it, which is exactly what it means: everything
+ * left of the rule is a departure they can no longer walk to in time. A [ReachStop.OnArrival] rule is
+ * an absolute moment and simply ignores the tick.
+ *
+ * The clock string is memoized on the whole minute it falls in, not on the ticking value: it is printed
+ * to the minute, and formatting it is locale work that has no business running every second.
+ */
 @Composable
-private fun rememberReachStopMarker(reachStopTime: ServerTime): EtaStripMarker {
+private fun rememberReachStopMarker(reachStop: ReachStop, serverNow: ServerTime): EtaStripMarker {
     val context = LocalContext.current
-    val clock = remember(reachStopTime, context) { DisplayFormat.formatTime(context, reachStopTime.epochMs) }
+    val at = reachStop.resolvedAt(rememberLiveServerTime(serverNow))
+    val clock = remember(at.epochMs / MILLIS_PER_MINUTE, context) { DisplayFormat.formatTime(context, at.epochMs) }
     return EtaStripMarker(
-        at = reachStopTime,
+        at = at,
         contentDescription = stringResource(R.string.directions_stop_eta_reach_stop, clock),
         passedStateDescription = stringResource(R.string.directions_stop_eta_departure_missed)
     )
 }
+
+private const val MILLIS_PER_MINUTE = 60_000L
 
 /**
  * Flattens route-specific, already-ordered arrival lists into one chronological strip. Kotlin's sort

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -22,7 +22,6 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.routeDisplayShortName
-import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.geoPointOrNull
 
@@ -125,29 +124,29 @@ object TripLogBuilder {
 
     /**
      * How the plan gets the rider to the boarding stop of the transit leg at [legIndex] — see
-     * [ReachStop] for why the answer has two shapes and [ReachStop.OnFoot] for the OTP behaviour that
-     * forces the split.
+     * [ReachStop], which carries the whole rationale for the two shapes.
      *
-     * The rider reaches this stop *on foot* exactly when nothing before this leg is transit: the street
-     * legs from the itinerary's origin (usually one walk; a bikeshare access is a walk to the vehicle
-     * then a ride on it) are the whole of how they get here, and OTP has shifted them, so only their
-     * combined [TripLeg.duration] survives as a fact. Otherwise something *carries* them here and the
-     * plan commits to when it lands — the preceding leg's end, whether that's the inbound ride of a
-     * transfer or the transfer walk off it, neither of which OTP shifts.
+     * All this decides is which shape applies, and the line is whether anything before this leg is
+     * transit. If nothing is, the street legs from the itinerary's origin (usually one walk; a
+     * bikeshare access is a walk to the vehicle then a ride on it) are the whole of how the rider gets
+     * here, and it's their combined [TripLeg.duration] that carries — the leading street run is the one
+     * OTP shifts. Otherwise something *carries* them here and the plan commits to when it lands.
      *
      * When this leg opens the itinerary nothing carries the rider and nothing is walked: they are at the
      * stop from the plan's own start, which a depart-at plan names ([plannedStart], #2228) and stands
      * there as the moment they reach it. An arrive-by plan says nothing about when they set out, and
      * that absence is carried as null rather than substituted for with the ride's own departure — see
-     * [TripLogEntry.Transit.reachStop] for what that would tell the rider.
+     * [TripLogEntry.Transit.reachStop] for what that would tell the rider. The [legIndex] == 0 guard is
+     * what says so — an empty run of preceding legs would otherwise pass the all-street test and
+     * fabricate a zero-length walk.
      */
     private fun List<TripLeg>.reachStopFor(legIndex: Int, plannedStart: ServerTime?): ReachStop? {
         if (legIndex == 0) return plannedStart?.let(ReachStop::OnArrival)
-        val precedingLegs = subList(0, legIndex)
+        val precedingLegs = take(legIndex)
         return if (precedingLegs.all { it.mode?.isOnStreetNonTransit == true }) {
             ReachStop.OnFoot(precedingLegs.fold(Duration.ZERO) { total, leg -> total + leg.duration })
         } else {
-            ReachStop.OnArrival(this[legIndex - 1].endTime)
+            ReachStop.OnArrival(precedingLegs.last().endTime)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import kotlin.time.Duration
 import org.onebusaway.android.directions.model.Direction
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
@@ -105,14 +106,7 @@ object TripLogBuilder {
                         board = board,
                         legPoints = legPoints,
                         legIndex = legIndex,
-                        // When the rider gets to the board stop: the end of the leg that brought them
-                        // there (a walk, or the ride they transfer off). An itinerary that opens on a
-                        // transit leg has no such leg — the rider is at the stop from the plan's start —
-                        // so the plan's own start stands in there, when it has one (a depart-at plan);
-                        // an arrive-by plan says nothing about when they set out, and that absence is
-                        // carried as null rather than substituted for with the ride's own departure: see
-                        // TripLogEntry.Transit.reachStopTime for what that would tell the rider.
-                        reachStopTime = if (legIndex == 0) plannedStart else legs[legIndex - 1].endTime,
+                        reachStop = legs.reachStopFor(legIndex, plannedStart),
                         ref = routeLegRefs.getOrNull(legIndex)
                     )
                 }
@@ -127,6 +121,34 @@ object TripLogBuilder {
             point = geoPointOrNull(last.to.lat, last.to.lon)
         )
         return entries
+    }
+
+    /**
+     * How the plan gets the rider to the boarding stop of the transit leg at [legIndex] — see
+     * [ReachStop] for why the answer has two shapes and [ReachStop.OnFoot] for the OTP behaviour that
+     * forces the split.
+     *
+     * The rider reaches this stop *on foot* exactly when nothing before this leg is transit: the street
+     * legs from the itinerary's origin (usually one walk; a bikeshare access is a walk to the vehicle
+     * then a ride on it) are the whole of how they get here, and OTP has shifted them, so only their
+     * combined [TripLeg.duration] survives as a fact. Otherwise something *carries* them here and the
+     * plan commits to when it lands — the preceding leg's end, whether that's the inbound ride of a
+     * transfer or the transfer walk off it, neither of which OTP shifts.
+     *
+     * When this leg opens the itinerary nothing carries the rider and nothing is walked: they are at the
+     * stop from the plan's own start, which a depart-at plan names ([plannedStart], #2228) and stands
+     * there as the moment they reach it. An arrive-by plan says nothing about when they set out, and
+     * that absence is carried as null rather than substituted for with the ride's own departure — see
+     * [TripLogEntry.Transit.reachStop] for what that would tell the rider.
+     */
+    private fun List<TripLeg>.reachStopFor(legIndex: Int, plannedStart: ServerTime?): ReachStop? {
+        if (legIndex == 0) return plannedStart?.let(ReachStop::OnArrival)
+        val precedingLegs = subList(0, legIndex)
+        return if (precedingLegs.all { it.mode?.isOnStreetNonTransit == true }) {
+            ReachStop.OnFoot(precedingLegs.fold(Duration.ZERO) { total, leg -> total + leg.duration })
+        } else {
+            ReachStop.OnArrival(this[legIndex - 1].endTime)
+        }
     }
 
     private fun walkEntry(
@@ -197,7 +219,7 @@ object TripLogBuilder {
         board: Direction,
         legPoints: List<GeoPoint>,
         legIndex: Int,
-        reachStopTime: ServerTime?,
+        reachStop: ReachStop?,
         ref: RouteLegRef?
     ): TripLogEntry.Transit {
         val routeLeg = ref ?: fallbackRouteLeg(leg)
@@ -207,7 +229,7 @@ object TripLogBuilder {
             mode = leg.mode.transitMode(),
             routeColorHex = leg.routeColor,
             headsign = leg.headsign ?: routeLeg.headsign,
-            reachStopTime = reachStopTime,
+            reachStop = reachStop,
             boardTime = leg.startTime,
             exitTime = leg.endTime,
             durationMinutes = leg.duration.inWholeMinutes,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -15,13 +15,13 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-import kotlin.time.Duration
 import org.onebusaway.android.directions.model.Direction
 import org.onebusaway.android.directions.model.Interlines
 import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.routeDisplayName
 import org.onebusaway.android.directions.model.routeDisplayShortName
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.geoPointOrNull
 
@@ -85,7 +85,7 @@ object TripLogBuilder {
         var cursor = 0
         legs.forEachIndexed { legIndex, leg ->
             val legPoints = leg.legGeometry?.decodedPoints().orEmpty()
-            if (leg.mode?.isOnStreetNonTransit == true) {
+            if (leg.isStreet) {
                 val walk = flatDirections.getOrNull(cursor++) ?: return@forEachIndexed
                 entries += walkEntry(leg, walk, legPoints, legIndex, isTransfer = legs.isTransferAt(legIndex))
             } else {
@@ -126,29 +126,40 @@ object TripLogBuilder {
      * How the plan gets the rider to the boarding stop of the transit leg at [legIndex] — see
      * [ReachStop], which carries the whole rationale for the two shapes.
      *
-     * All this decides is which shape applies, and the line is whether anything before this leg is
-     * transit. If nothing is, the street legs from the itinerary's origin (usually one walk; a
-     * bikeshare access is a walk to the vehicle then a ride on it) are the whole of how the rider gets
-     * here, and it's their combined [TripLeg.duration] that carries — the leading street run is the one
-     * OTP shifts. Otherwise something *carries* them here and the plan commits to when it lands.
+     * All this decides is which shape applies, and the line is whether anything before this leg is a
+     * ride. If nothing is, the street legs from the itinerary's origin (usually one walk; a bikeshare
+     * access is a walk to the vehicle then a ride on it) are the whole of how the rider gets here, and
+     * how long that run takes is what carries — measured as the run's own start-to-end span (both ends
+     * wire-guaranteed) rather than a sum of [TripLeg.duration]s, which the adapters default to zero
+     * when the wire omits one and would then quietly rule the strip at "now". The run's legs abut, so
+     * the two agree whenever a sum is possible. Otherwise something *carries* the rider here and the
+     * plan commits to when it lands.
+     *
+     * Street-vs-ride is [isStreet], the same predicate that sorts every leg into a walk or a transit
+     * entry above, so a leg this builder draws as a ride is never counted as part of the walk here.
      *
      * When this leg opens the itinerary nothing carries the rider and nothing is walked: they are at the
      * stop from the plan's own start, which a depart-at plan names ([plannedStart], #2228) and stands
      * there as the moment they reach it. An arrive-by plan says nothing about when they set out, and
      * that absence is carried as null rather than substituted for with the ride's own departure — see
-     * [TripLogEntry.Transit.reachStop] for what that would tell the rider. The [legIndex] == 0 guard is
-     * what says so — an empty run of preceding legs would otherwise pass the all-street test and
-     * fabricate a zero-length walk.
+     * [TripLogEntry.Transit.reachStop] for what that would tell the rider. The empty-run guard is what
+     * says so: an empty run would otherwise pass the all-street test and fabricate a zero-length walk.
      */
     private fun List<TripLeg>.reachStopFor(legIndex: Int, plannedStart: ServerTime?): ReachStop? {
-        if (legIndex == 0) return plannedStart?.let(ReachStop::OnArrival)
-        val precedingLegs = take(legIndex)
-        return if (precedingLegs.all { it.mode?.isOnStreetNonTransit == true }) {
-            ReachStop.OnFoot(precedingLegs.fold(Duration.ZERO) { total, leg -> total + leg.duration })
+        val precedingLegs = take(legIndex).ifEmpty { return plannedStart?.let(ReachStop::OnArrival) }
+        return if (precedingLegs.all { it.isStreet }) {
+            ReachStop.OnFoot(precedingLegs.last().endTime - precedingLegs.first().startTime)
         } else {
             ReachStop.OnArrival(precedingLegs.last().endTime)
         }
     }
+
+    /**
+     * Whether this leg is one the rider moves themself along (a walk, or a bike/car leg) rather than a
+     * ride — the one split this builder makes, so it is made in one place. A leg whose wire mode the
+     * app doesn't map ([TripLeg.mode] null) falls on the ride side, everywhere alike.
+     */
+    private val TripLeg.isStreet: Boolean get() = mode?.isOnStreetNonTransit == true
 
     private fun walkEntry(
         leg: TripLeg,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -120,6 +120,7 @@ import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.launch
 import org.onebusaway.android.R
 import org.onebusaway.android.app.FeatureFlags
@@ -2282,7 +2283,7 @@ private fun previewTransitLeg(
     mode = mode,
     routeColorHex = routeColorHex,
     headsign = headsign,
-    reachStopTime = ServerTime(3 * 60_000L),
+    reachStop = ReachStop.OnFoot(3.minutes),
     boardTime = ServerTime(4 * 60_000L),
     exitTime = ServerTime(20 * 60_000L),
     durationMinutes = 16,
@@ -2311,7 +2312,7 @@ private fun previewFerryLeg(alerts: List<TripAlertItem> = emptyList()) = preview
     rideEvents = emptyList(),
     alerts = alerts
 ).copy(
-    reachStopTime = ServerTime(20 * 60_000L),
+    reachStop = ReachStop.OnFoot(20.minutes),
     boardTime = ServerTime(24 * 60_000L),
     exitTime = ServerTime(84 * 60_000L),
     durationMinutes = 60,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -244,10 +244,8 @@ sealed interface TripLogEntry {
  *    the plan's own start is that moment instead (#2228) — a "leave at 5pm" plan has them at the stop
  *    at 5pm.
  *  - [OnFoot] — the rider makes their own way here from the itinerary's origin, and all the plan really
- *    knows is [duration]: how long that takes. It emphatically does **not** know when they set off,
- *    because OTP time-shifts the leading access leg to land exactly on the departure it picked — see
- *    [OnFoot] for the measurements. Resolved against the live clock at the point of use, so the rule
- *    means "if you set off now".
+ *    knows is [duration]: how long that takes, not when they set off. See [OnFoot] for why. Resolved
+ *    against the live clock at the point of use, so the rule means "if you set off now".
  *
  * The distinction is a type rather than a nullable "…or use the duration" flag so the two can't be
  * confused at a call site: an absolute instant and an amount of time are not interchangeable, and the
@@ -255,38 +253,45 @@ sealed interface TripLogEntry {
  */
 sealed interface ReachStop {
 
+    /**
+     * The moment the rider reaches the stop, as of [now] — an [OnArrival]'s own instant, or [now] plus
+     * the walk for an [OnFoot]. The one place the two shapes collapse to a comparable instant, so the
+     * ETA strip's rule and anything else that wants one can't disagree about how.
+     */
+    fun resolvedAt(now: ServerTime): ServerTime
+
     /** The rider is at this stop at [at] — the leg that brings them here ends then, or the plan starts then. */
-    data class OnArrival(val at: ServerTime) : ReachStop
+    data class OnArrival(val at: ServerTime) : ReachStop {
+        override fun resolvedAt(now: ServerTime): ServerTime = at
+    }
 
     /**
      * The rider walks (or bikes/scooters) here from the trip's origin, and it takes [duration].
      *
      * Deliberately a duration and not the access leg's own end time. OTP time-shifts the *leading*
-     * street leg of an itinerary as late as it can — it ends exactly at the departure it was planned
-     * for, so the rider never stands waiting — which makes that end time a restatement of `boardTime`
-     * and nothing more. (Measured against the live Puget Sound OTP2 server: across depart-after and
-     * arrive-by searches alike, the first street leg's end equalled the first transit leg's start every
-     * time, with the leg's *start* shifted up to ~34 min past the search time; every later street leg,
-     * by contrast, began exactly when the preceding leg ended, unshifted.) Ruling the strip there is the
-     * "substitute boardTime" mistake [TripLogEntry.Transit] warns about, one indirection removed: it
-     * dims every departure before the planned one, including the ones the rider could comfortably walk
-     * to and catch.
+     * street leg of an itinerary as late as it can — it ends on the departure it was planned for, so
+     * the rider never stands waiting — which makes that end time a restatement of `boardTime` and
+     * nothing more. Ruling the strip there is the "substitute boardTime" mistake [TripLogEntry.Transit]
+     * warns about, one indirection removed: it dims every departure before the planned one, including
+     * the ones the rider could comfortably walk to and catch.
      *
-     * The duration survives that shift untouched, so it is the one fact about the access leg worth
+     * Measured against both of this app's protocols, so the one rule below is not an OTP2 finding
+     * applied to OTP1 on faith — the two servers differ only in rounding:
+     *  - OTP2 (`planConnection`, Puget Sound), depart-after and arrive-by alike: the first street leg's
+     *    end equalled the first transit leg's start every time, its *start* shifted up to ~34 min past
+     *    `searchDateTime`.
+     *  - OTP1 (REST `/plan`, same region): the same, landing 1 s before the board, with starts shifted
+     *    up to ~25 min past `plan.date`.
+     * Every later street leg, on both, began exactly when the preceding leg ended — unshifted, which is
+     * why [OnArrival] can keep taking that leg's end at face value.
+     *
+     * The duration survives the shift untouched, so it is the one fact about the access leg worth
      * carrying: added to the live clock it answers the question the strip is actually asked — of these
      * departures, which can I still get to?
      */
-    data class OnFoot(val duration: Duration) : ReachStop
-}
-
-/**
- * The moment this rider reaches the stop, as of [now] — [ReachStop.OnArrival]'s own instant, or [now]
- * plus the walk for [ReachStop.OnFoot]. The one place the two shapes collapse to a comparable instant,
- * so the ETA strip's rule and anything else that wants one can't disagree about how.
- */
-fun ReachStop.resolvedAt(now: ServerTime): ServerTime = when (this) {
-    is ReachStop.OnArrival -> at
-    is ReachStop.OnFoot -> now + duration
+    data class OnFoot(val duration: Duration) : ReachStop {
+        override fun resolvedAt(now: ServerTime): ServerTime = now + duration
+    }
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripresults
 
 import androidx.annotation.StringRes
+import kotlin.time.Duration
 import org.onebusaway.android.R
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.map.RiddenSpan
@@ -196,16 +197,16 @@ sealed interface TripLogEntry {
      * [routeDisplayShortName][org.onebusaway.android.directions.model.routeDisplayShortName]. [mode] is
      * what the rider boards, and picks the Board node's glyph — a ferry leg must not read as a bus.
      *
-     * [reachStopTime] and [boardTime] are different moments and both matter: the rider gets to the stop
-     * at the first (the end of whatever leg precedes this one) and the vehicle leaves at the second. The
-     * gap between them is the planned wait, and it's what the Board node's live ETA strip marks (#2125) —
-     * without it the strip reads as if the rider were standing at the stop already. When nothing
-     * precedes the ride, the plan's own start stands in (#2228): a "leave at 5pm" plan puts the rider at
-     * the stop at 5pm, so read at 3pm every departure before then is genuinely out of reach — the strip
-     * says so instead of offering them. It is **null** only when the plan doesn't say when the rider sets
-     * out (an arrive-by plan that opens on transit). Substituting [boardTime] there would dim every
-     * departure earlier than the one the plan happened to pick — including the ones a rider already at
-     * the stop could catch — which is the opposite of the truth.
+     * [reachStop] and [boardTime] are different things and both matter: the rider gets to the stop by
+     * the first and the vehicle leaves at the second. The gap between them is the planned wait, and it's
+     * what the Board node's live ETA strip marks (#2125) — without it the strip reads as if the rider
+     * were standing at the stop already. When nothing precedes the ride, the plan's own start stands in
+     * (#2228): a "leave at 5pm" plan puts the rider at the stop at 5pm, so read at 3pm every departure
+     * before then is genuinely out of reach — the strip says so instead of offering them. [reachStop] is
+     * **null** only when the plan doesn't say when the rider sets out (an arrive-by plan that opens on
+     * transit). Substituting [boardTime] there would dim every departure earlier than the one the plan
+     * happened to pick — including the ones a rider already at the stop could catch — which is the
+     * opposite of the truth.
      */
     data class Transit(
         val routeShortName: String?,
@@ -213,7 +214,7 @@ sealed interface TripLogEntry {
         val mode: TransitMode,
         val routeColorHex: String?,
         val headsign: String?,
-        val reachStopTime: ServerTime?,
+        val reachStop: ReachStop?,
         val boardTime: ServerTime,
         val exitTime: ServerTime,
         val durationMinutes: Long,
@@ -231,6 +232,61 @@ sealed interface TripLogEntry {
         /** This ride as the map's focus target — every leg of a folded chain; see [FocusedLeg]. */
         val focus: FocusedLeg get() = FocusedLeg(legPoints, legIndices)
     }
+}
+
+/**
+ * How the plan gets the rider to a ride's boarding stop — the thing the Board node's live ETA strip
+ * rules itself at (#2125). Two shapes, because the plan knows two genuinely different things (#2227):
+ *
+ *  - [OnArrival] — an absolute moment the plan actually commits to, so the rule stands there. Usually
+ *    the end of the leg that delivers the rider to this stop: the inbound ride of a transfer, or the
+ *    walk they make across that transfer. When the ride opens the itinerary nothing delivers them and
+ *    the plan's own start is that moment instead (#2228) — a "leave at 5pm" plan has them at the stop
+ *    at 5pm.
+ *  - [OnFoot] — the rider makes their own way here from the itinerary's origin, and all the plan really
+ *    knows is [duration]: how long that takes. It emphatically does **not** know when they set off,
+ *    because OTP time-shifts the leading access leg to land exactly on the departure it picked — see
+ *    [OnFoot] for the measurements. Resolved against the live clock at the point of use, so the rule
+ *    means "if you set off now".
+ *
+ * The distinction is a type rather than a nullable "…or use the duration" flag so the two can't be
+ * confused at a call site: an absolute instant and an amount of time are not interchangeable, and the
+ * bug this replaces was precisely one being read as the other.
+ */
+sealed interface ReachStop {
+
+    /** The rider is at this stop at [at] — the leg that brings them here ends then, or the plan starts then. */
+    data class OnArrival(val at: ServerTime) : ReachStop
+
+    /**
+     * The rider walks (or bikes/scooters) here from the trip's origin, and it takes [duration].
+     *
+     * Deliberately a duration and not the access leg's own end time. OTP time-shifts the *leading*
+     * street leg of an itinerary as late as it can — it ends exactly at the departure it was planned
+     * for, so the rider never stands waiting — which makes that end time a restatement of `boardTime`
+     * and nothing more. (Measured against the live Puget Sound OTP2 server: across depart-after and
+     * arrive-by searches alike, the first street leg's end equalled the first transit leg's start every
+     * time, with the leg's *start* shifted up to ~34 min past the search time; every later street leg,
+     * by contrast, began exactly when the preceding leg ended, unshifted.) Ruling the strip there is the
+     * "substitute boardTime" mistake [TripLogEntry.Transit] warns about, one indirection removed: it
+     * dims every departure before the planned one, including the ones the rider could comfortably walk
+     * to and catch.
+     *
+     * The duration survives that shift untouched, so it is the one fact about the access leg worth
+     * carrying: added to the live clock it answers the question the strip is actually asked — of these
+     * departures, which can I still get to?
+     */
+    data class OnFoot(val duration: Duration) : ReachStop
+}
+
+/**
+ * The moment this rider reaches the stop, as of [now] — [ReachStop.OnArrival]'s own instant, or [now]
+ * plus the walk for [ReachStop.OnFoot]. The one place the two shapes collapse to a comparable instant,
+ * so the ETA strip's rule and anything else that wants one can't disagree about how.
+ */
+fun ReachStop.resolvedAt(now: ServerTime): ServerTime = when (this) {
+    is ReachStop.OnArrival -> at
+    is ReachStop.OnFoot -> now + duration
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -244,8 +244,8 @@ sealed interface TripLogEntry {
  *    the plan's own start is that moment instead (#2228) — a "leave at 5pm" plan has them at the stop
  *    at 5pm.
  *  - [OnFoot] — the rider makes their own way here from the itinerary's origin, and all the plan really
- *    knows is [duration]: how long that takes, not when they set off. See [OnFoot] for why. Resolved
- *    against the live clock at the point of use, so the rule means "if you set off now".
+ *    knows is [OnFoot.duration]: how long that takes, not when they set off. Resolved against the live
+ *    clock at the point of use (the ETA strip's own), so the rule means "if you set off now".
  *
  * The distinction is a type rather than a nullable "…or use the duration" flag so the two can't be
  * confused at a call site: an absolute instant and an amount of time are not interchangeable, and the
@@ -253,45 +253,45 @@ sealed interface TripLogEntry {
  */
 sealed interface ReachStop {
 
-    /**
-     * The moment the rider reaches the stop, as of [now] — an [OnArrival]'s own instant, or [now] plus
-     * the walk for an [OnFoot]. The one place the two shapes collapse to a comparable instant, so the
-     * ETA strip's rule and anything else that wants one can't disagree about how.
-     */
-    fun resolvedAt(now: ServerTime): ServerTime
-
     /** The rider is at this stop at [at] — the leg that brings them here ends then, or the plan starts then. */
-    data class OnArrival(val at: ServerTime) : ReachStop {
-        override fun resolvedAt(now: ServerTime): ServerTime = at
-    }
+    data class OnArrival(val at: ServerTime) : ReachStop
 
     /**
-     * The rider walks (or bikes/scooters) here from the trip's origin, and it takes [duration].
+     * The rider walks (or bikes) here from the trip's origin, and it takes [duration].
      *
      * Deliberately a duration and not the access leg's own end time. OTP time-shifts the *leading*
-     * street leg of an itinerary as late as it can — it ends on the departure it was planned for, so
+     * street run of an itinerary as late as it can — it ends on the departure it was planned for, so
      * the rider never stands waiting — which makes that end time a restatement of `boardTime` and
      * nothing more. Ruling the strip there is the "substitute boardTime" mistake [TripLogEntry.Transit]
      * warns about, one indirection removed: it dims every departure before the planned one, including
-     * the ones the rider could comfortably walk to and catch.
+     * the ones the rider could comfortably walk to and catch. The duration survives the shift
+     * untouched, so it is the one fact about the access leg worth carrying.
      *
-     * Measured against both of this app's protocols, so the one rule below is not an OTP2 finding
-     * applied to OTP1 on faith — the two servers differ only in rounding:
-     *  - OTP2 (`planConnection`, Puget Sound), depart-after and arrive-by alike: the first street leg's
-     *    end equalled the first transit leg's start every time, its *start* shifted up to ~34 min past
-     *    `searchDateTime`.
-     *  - OTP1 (REST `/plan`, same region): the same, landing 1 s before the board, with starts shifted
-     *    up to ~25 min past `plan.date`.
-     * Every later street leg, on both, began exactly when the preceding leg ended — unshifted, which is
-     * why [OnArrival] can keep taking that leg's end at face value.
+     * That the shift happens is read from the producers, not inferred from responses: OTP1's
+     * `GraphPath(State, optimize)` "re-traverses all edges backward in order to remove excess waiting
+     * time from the final itinerary" (`routing/spt/GraphPath.java`, dev-1.x), and OTP2's Raptor path
+     * builder time-shifts the access leg "to arrive just in time to board the next transit"
+     * (`PathBuilderLeg.timeShiftAccessTime`, dev-2.x). Both were also confirmed against this app's two
+     * protocols on the same region — the access run's end equalled the first transit leg's start (OTP1
+     * lands 1 s before it), and every later street leg began exactly when its predecessor ended, which
+     * is why [OnArrival] can keep taking that leg's end at face value.
      *
-     * The duration survives the shift untouched, so it is the one fact about the access leg worth
-     * carrying: added to the live clock it answers the question the strip is actually asked — of these
-     * departures, which can I still get to?
+     * Failure mode: a server that did *not* shift the access run would still be served correctly here —
+     * "now plus the walk" is the right rule regardless of where the plan put the walk — so the shape
+     * degrades benignly; the only thing lost would be the option of trusting that server's end time,
+     * which nothing depends on.
      */
-    data class OnFoot(val duration: Duration) : ReachStop {
-        override fun resolvedAt(now: ServerTime): ServerTime = now + duration
-    }
+    data class OnFoot(val duration: Duration) : ReachStop
+}
+
+/**
+ * The moment the rider reaches the stop, as of [now] — an [ReachStop.OnArrival]'s own instant, or
+ * [now] plus the walk for a [ReachStop.OnFoot]. The one place the two shapes collapse to a comparable
+ * instant, so the ETA strip's rule and anything else that wants one can't disagree about how.
+ */
+fun ReachStop.resolvedAt(now: ServerTime): ServerTime = when (this) {
+    is ReachStop.OnArrival -> at
+    is ReachStop.OnFoot -> now + duration
 }
 
 /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/StopEtaStripStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/StopEtaStripStateTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * JVM tests for [stopEtaStripState]: which of the directions ETA strip's three states a poll's
+ * departures and the rider's reach rule make, and — the part worth pinning — which wins when a poll is
+ * both empty and past the rule.
+ */
+class StopEtaStripStateTest {
+
+    private fun minutes(vararg values: Long) = values.map { ServerTime(it * 60_000L) }
+
+    private fun stateOf(departures: List<ServerTime>, ruleAt: ServerTime?) = stopEtaStripState(departures, ruleAt) { it }
+
+    @Test
+    fun `a departure the rider can still get to leaves the pills standing`() {
+        assertEquals(StopEtaStripState.PILLS, stateOf(minutes(4, 20), ServerTime(10 * 60_000L)))
+    }
+
+    @Test
+    fun `a departure exactly at the rule is one the rider can board`() {
+        // The strip's own boundary: a plan whose walk is timed to the vehicle must not rule out the very
+        // departure it boards, so an at-the-moment pill keeps the strip up.
+        assertEquals(StopEtaStripState.PILLS, stateOf(minutes(10), ServerTime(10 * 60_000L)))
+    }
+
+    @Test
+    fun `every departure before the rule collapses the strip`() {
+        assertEquals(StopEtaStripState.NOTHING_BOARDABLE, stateOf(minutes(4, 6), ServerTime(10 * 60_000L)))
+    }
+
+    @Test
+    fun `a poll with no departures says so rather than offering to show them`() {
+        // Both empty and (vacuously) past the rule. The empty state wins: a "Show" here would promise the
+        // rider a strip and hand them back the same sentence.
+        assertEquals(StopEtaStripState.NO_ARRIVALS, stateOf(emptyList(), ServerTime(10 * 60_000L)))
+    }
+
+    @Test
+    fun `a rider already at the stop is never ruled out of a departure`() {
+        // No rule at all (the plan puts nothing before this ride), so nothing is out of reach — including
+        // departures already in the past, which the strip shows as the arrivals drawer does.
+        assertEquals(StopEtaStripState.PILLS, stateOf(minutes(-2, 4), null))
+    }
+
+    @Test
+    fun `an empty poll without a rule is still the empty state`() {
+        assertEquals(StopEtaStripState.NO_ARRIVALS, stateOf(emptyList(), null))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/BoardableRoutesTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/BoardableRoutesTest.kt
@@ -104,7 +104,7 @@ class BoardableRoutesTest {
         mode = TransitMode.BUS,
         routeColorHex = null,
         headsign = headsign,
-        reachStopTime = null,
+        reachStop = null,
         boardTime = ServerTime(0L),
         exitTime = ServerTime(60_000L),
         durationMinutes = 1,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ReachStopTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ReachStopTest.kt
@@ -21,7 +21,7 @@ import org.junit.Test
 import org.onebusaway.android.time.ServerTime
 
 /**
- * JVM tests for [ReachStop.resolvedAt] — the one place the two shapes of "how the rider gets to this
+ * JVM tests for [resolvedAt] — the one place the two shapes of "how the rider gets to this
  * stop" collapse to a comparable instant, and so the whole of what putting a clock to them means.
  */
 class ReachStopTest {

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ReachStopTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ReachStopTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import kotlin.time.Duration.Companion.minutes
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.time.ServerTime
+
+/**
+ * JVM tests for [ReachStop.resolvedAt] — the one place the two shapes of "how the rider gets to this
+ * stop" collapse to a comparable instant, and so the whole of what putting a clock to them means.
+ */
+class ReachStopTest {
+
+    @Test
+    fun aWalkKeepsItsDistanceAsTheClockRuns() {
+        // Measured *from now*, so the rule holds still at the rider's walking distance while the strip's
+        // pills flow past it — which is what "if you set off now" means (#2227).
+        val onFoot = ReachStop.OnFoot(4.minutes)
+
+        assertEquals(ServerTime(14 * 60_000L), onFoot.resolvedAt(ServerTime(10 * 60_000L)))
+        assertEquals(ServerTime(24 * 60_000L), onFoot.resolvedAt(ServerTime(20 * 60_000L)))
+    }
+
+    @Test
+    fun anArrivalStandsWhereThePlanPutIt() {
+        // An absolute moment the plan commits to, so the clock it is handed makes no difference — which
+        // is also why a strip ruled at one never needs a ticking clock.
+        val onArrival = ReachStop.OnArrival(ServerTime(14 * 60_000L))
+
+        assertEquals(ServerTime(14 * 60_000L), onArrival.resolvedAt(ServerTime(10 * 60_000L)))
+        assertEquals(ServerTime(14 * 60_000L), onArrival.resolvedAt(ServerTime(20 * 60_000L)))
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/RideCoveringLegsTest.kt
@@ -46,7 +46,7 @@ class RideCoveringLegsTest {
         mode = TransitMode.BUS,
         routeColorHex = null,
         headsign = "Downtown",
-        reachStopTime = ServerTime(3 * 60_000L),
+        reachStop = ReachStop.OnArrival(ServerTime(3 * 60_000L)),
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.ui.tripresults
 
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -296,12 +297,20 @@ class TripLogBuilderTest {
     @Test
     fun aMultiLegAccess_reachesTheStopByTheWholeWayThere() {
         // A bikeshare access is two street legs — walk to the vehicle, then ride it to the stop — and
-        // the rider's way there is both of them, so the walk-time the rule uses is their sum.
-        val toTheBike = walkLeg.copy(duration = 3.minutes)
-        val onTheBike = walkLeg.copy(mode = TripMode.BICYCLE, duration = 7.minutes, rentedVehicle = true)
+        // the rider's way there is both of them, so the walk-time the rule uses spans the whole run:
+        // from the walk's start to the ride's end, whatever the legs' own durations say (the adapters
+        // zero an omitted one, which a sum would swallow silently).
+        val toTheBike = walkLeg.copy(startTime = ServerTime(0L), endTime = ServerTime(3 * 60_000L), duration = 3.minutes)
+        val onTheBike = walkLeg.copy(
+            mode = TripMode.BICYCLE,
+            startTime = ServerTime(3 * 60_000L),
+            endTime = ServerTime(10 * 60_000L),
+            duration = Duration.ZERO, // omitted on the wire
+            rentedVehicle = true
+        )
         val transit = TripLogBuilder
             .build(
-                legs = listOf(toTheBike, onTheBike, transitLeg),
+                legs = listOf(toTheBike, onTheBike, transitLeg.copy(startTime = ServerTime(10 * 60_000L))),
                 flatDirections = listOf(walkDir, walkDir, boardDir, alightDir),
                 routeLegRefs = listOf(null, null, transitRef)
             )

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -271,36 +271,79 @@ class TripLogBuilderTest {
     }
 
     @Test
-    fun transitEntry_reachesTheStopWhenTheLegBeforeItEnds() {
-        // The rider is at the board stop when the walk that got them there finishes — 4 minutes in —
-        // which is a different moment from the ride's own departure whenever the plan builds in a wait.
-        // The Board row's ETA strip rules the live departures at this instant (#2125).
+    fun theAccessWalk_reachesTheStopByItsDurationRatherThanItsPlannedEnd() {
+        // The rider walks to the first ride's stop, and it takes 4 minutes. That duration — NOT the
+        // walk's own end time — is what the strip's rule is built from (#2227): OTP shifts the leading
+        // street leg to end exactly at the departure it picked, so `walkLeg.endTime` here is just
+        // `boardTime` restated, and ruling there dims every earlier departure the rider could have
+        // walked to and caught.
         val transit = TripLogBuilder
             .build(
-                legs = listOf(walkLeg, transitLeg.copy(startTime = ServerTime(9 * 60_000L))),
+                legs = listOf(
+                    walkLeg.copy(startTime = ServerTime(5 * 60_000L), endTime = ServerTime(9 * 60_000L)),
+                    transitLeg.copy(startTime = ServerTime(9 * 60_000L))
+                ),
                 flatDirections = listOf(walkDir, boardDir, alightDir),
                 routeLegRefs = listOf(null, transitRef)
             )
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(walkLeg.endTime, transit.reachStopTime)
+        assertEquals(ReachStop.OnFoot(4.minutes), transit.reachStop)
         assertEquals(ServerTime(9 * 60_000L), transit.boardTime)
     }
 
     @Test
+    fun aMultiLegAccess_reachesTheStopByTheWholeWayThere() {
+        // A bikeshare access is two street legs — walk to the vehicle, then ride it to the stop — and
+        // the rider's way there is both of them, so the walk-time the rule uses is their sum.
+        val toTheBike = walkLeg.copy(duration = 3.minutes)
+        val onTheBike = walkLeg.copy(mode = TripMode.BICYCLE, duration = 7.minutes, rentedVehicle = true)
+        val transit = TripLogBuilder
+            .build(
+                legs = listOf(toTheBike, onTheBike, transitLeg),
+                flatDirections = listOf(walkDir, walkDir, boardDir, alightDir),
+                routeLegRefs = listOf(null, null, transitRef)
+            )
+            .filterIsInstance<TripLogEntry.Transit>()
+            .single()
+
+        assertEquals(ReachStop.OnFoot(10.minutes), transit.reachStop)
+    }
+
+    @Test
+    fun aTransfer_reachesTheStopWhenTheLegBeforeItEnds() {
+        // Past the first ride the rider is *carried* to the stop, and OTP leaves those legs unshifted —
+        // a transfer walk starts exactly when the inbound ride lands — so the preceding leg's end is a
+        // real moment the plan commits to, and the rule stands there.
+        val transfer = walkLeg.copy(startTime = ServerTime(20 * 60_000L), endTime = ServerTime(24 * 60_000L))
+        val second = transitLeg.copy(startTime = ServerTime(30 * 60_000L), endTime = ServerTime(40 * 60_000L))
+        val transit = TripLogBuilder
+            .build(
+                legs = listOf(transitLeg, transfer, second),
+                flatDirections = listOf(boardDir, alightDir, walkDir, boardDir, alightDir),
+                routeLegRefs = listOf(transitRef, null, transitRef)
+            )
+            .filterIsInstance<TripLogEntry.Transit>()
+            .last()
+
+        assertEquals(ReachStop.OnArrival(ServerTime(24 * 60_000L)), transit.reachStop)
+    }
+
+    @Test
     fun anItineraryOpeningOnTransit_reachesItsFirstStopAtThePlansStart() {
-        // Nothing precedes the ride, so the rider is at the stop from the plan's start — for a "leave at
-        // 5pm" plan, 5pm — which is what a depart-at plan names (#2228). Not the ride's own departure:
-        // that would dim every earlier one, including the ones a rider already there could catch.
-        // Earlier than the leg's own departure (4 min), so a build that reached for that instead would fail.
+        // Nothing precedes the ride and nothing is walked, so the rider is at the stop from the plan's
+        // start — for a "leave at 5pm" plan, 5pm — which is what a depart-at plan names (#2228). Not the
+        // ride's own departure: that would dim every earlier one, including the ones a rider already
+        // there could catch. Earlier than the leg's own departure (4 min), so a build that reached for
+        // that instead would fail.
         val start = ServerTime(2 * 60_000L)
         val transit = TripLogBuilder
             .build(listOf(transitLeg), listOf(boardDir, alightDir), listOf(transitRef), plannedStart = start)
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(start, transit.reachStopTime)
+        assertEquals(ReachStop.OnArrival(start), transit.reachStop)
     }
 
     @Test
@@ -312,13 +355,27 @@ class TripLogBuilderTest {
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertNull(transit.reachStopTime)
+        assertNull(transit.reachStop)
+    }
+
+    @Test
+    fun aWalkRule_holdsAtTheRidersWalkingDistanceWhileAnArrivalRuleStandsStill() {
+        // What the two shapes mean once a clock is put to them: a walk is measured *from now*, so the
+        // rule keeps its distance as the clock runs and the pills flow past it; an arrival is an
+        // absolute moment and ignores the clock entirely.
+        val onFoot = ReachStop.OnFoot(4.minutes)
+        assertEquals(ServerTime(14 * 60_000L), onFoot.resolvedAt(ServerTime(10 * 60_000L)))
+        assertEquals(ServerTime(24 * 60_000L), onFoot.resolvedAt(ServerTime(20 * 60_000L)))
+
+        val onArrival = ReachStop.OnArrival(ServerTime(14 * 60_000L))
+        assertEquals(ServerTime(14 * 60_000L), onArrival.resolvedAt(ServerTime(10 * 60_000L)))
+        assertEquals(ServerTime(14 * 60_000L), onArrival.resolvedAt(ServerTime(20 * 60_000L)))
     }
 
     @Test
     fun thePlansStart_standsInOnlyForARideNothingPrecedes() {
-        // With a walk ahead of the ride, the walk's end is when the rider gets to the stop; the plan's
-        // start is when they left home, and must not displace it.
+        // With a walk ahead of the ride, the walk is how the rider gets to the stop; the plan's start is
+        // when they left home, and must not displace it.
         val transit = TripLogBuilder
             .build(
                 legs = listOf(walkLeg, transitLeg),
@@ -329,7 +386,7 @@ class TripLogBuilderTest {
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(walkLeg.endTime, transit.reachStopTime)
+        assertEquals(ReachStop.OnFoot(walkLeg.duration), transit.reachStop)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -359,20 +359,6 @@ class TripLogBuilderTest {
     }
 
     @Test
-    fun aWalkRule_holdsAtTheRidersWalkingDistanceWhileAnArrivalRuleStandsStill() {
-        // What the two shapes mean once a clock is put to them: a walk is measured *from now*, so the
-        // rule keeps its distance as the clock runs and the pills flow past it; an arrival is an
-        // absolute moment and ignores the clock entirely.
-        val onFoot = ReachStop.OnFoot(4.minutes)
-        assertEquals(ServerTime(14 * 60_000L), onFoot.resolvedAt(ServerTime(10 * 60_000L)))
-        assertEquals(ServerTime(24 * 60_000L), onFoot.resolvedAt(ServerTime(20 * 60_000L)))
-
-        val onArrival = ReachStop.OnArrival(ServerTime(14 * 60_000L))
-        assertEquals(ServerTime(14 * 60_000L), onArrival.resolvedAt(ServerTime(10 * 60_000L)))
-        assertEquals(ServerTime(14 * 60_000L), onArrival.resolvedAt(ServerTime(20 * 60_000L)))
-    }
-
-    @Test
     fun thePlansStart_standsInOnlyForARideNothingPrecedes() {
         // With a walk ahead of the ride, the walk is how the rider gets to the stop; the plan's start is
         // when they left home, and must not displace it.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogRowsTest.kt
@@ -66,7 +66,7 @@ class TripLogRowsTest {
         mode = TransitMode.BUS,
         routeColorHex = "1B6EF3",
         headsign = "Rainier Beach",
-        reachStopTime = ServerTime(3 * 60_000L),
+        reachStop = ReachStop.OnArrival(ServerTime(3 * 60_000L)),
         boardTime = ServerTime(4 * 60_000L),
         exitTime = ServerTime(20 * 60_000L),
         durationMinutes = 16,


### PR DESCRIPTION
Fixes #2227.

## What was wrong

The directions drawer rules a stop's ETA strip at the moment the rider reaches it, dimming the departures they can't be there for (#2125). That rule stood far too late, dimming departures the rider could comfortably walk to and catch.

**Neither cause the issue guessed at holds.** Both sides of the comparison already prefer real-time over schedule — `ArrivalInfo.displayTime` is the prediction whenever the feed has one, and `Otp2PlanAdapters` reads `estimated.time ?: scheduledTime` — so a late-but-catchable vehicle *is* compared at its predicted time. And this deployment's OTP applies no board slack: a walk leg ends at exactly the second the bus leaves, not a minute or two before.

## The real cause

OTP time-shifts an itinerary's **leading street leg** as late as it can, so the rider never stands waiting at the stop. Measured against the live Puget Sound OTP2 server (`sound-transit-otp.ibi-transit.com`), across depart-after and arrive-by searches alike, **the first street leg's end equalled the first transit leg's start every single time**, with the leg's *start* shifted up to ~34 minutes past the search time. Every later street leg, by contrast, began exactly when the preceding leg ended, unshifted.

A depart-now search at 18:26:28, three of the itineraries it returned:

| access walk | duration | earliest the rider could be at the stop | what the plan says | shift |
|---|---|---|---|---|
| 18:31:33 → 18:36:13 | 280s | 18:31:08 | 18:36:13 = board | 5 min |
| 18:42:22 → 18:44:52 | 150s | 18:28:58 | 18:44:52 = board | **16 min** |
| 19:00:56 → 19:05:36 | 280s | 18:31:08 | 19:05:36 = board | **34 min** |

So `legs[i - 1].endTime` — the horizon the builder carried — was `boardTime` wearing a disguise. That is exactly the "substitute `boardTime`" mistake `TripLogEntry.Transit`'s own doc already warns about, one indirection removed: it dims every departure before the planned one *by construction*. In row 2, sixteen minutes of perfectly catchable departures were greyed out as "leaves before you get here".

A transfer's horizon was right all along, and stays as it was.

## The fix

What survives the shift is the leg's **duration**. So the horizon becomes a type carrying the two shapes the plan actually knows, `ReachStop`:

- `OnArrival(at)` — the rider is delivered here by the preceding leg; an absolute moment the plan commits to. Unchanged behaviour, and now the only case that keeps an instant.
- `OnFoot(duration)` — the rider makes their own way here from the origin, and only how long it takes is knowable. Resolved against the live clock at the point of use, so the rule means "if you set off now".

It's a type rather than a nullable "…or use the duration" flag so an instant and an amount of time can't be swapped at a call site — which is precisely the bug being replaced.

Making the walk case live is what the strip is actually asked: *of these departures, which can I still get to?* It also reads well — the rule holds still at the rider's walking distance while the pills flow past it, rather than jumping around. The marker's clock string is memoized on the whole minute it falls in, so the per-second tick costs no locale formatting.

## Testing

- `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` — green. New coverage in `TripLogBuilderTest`: the access walk carries its duration rather than its planned end, a two-leg (bikeshare) access sums both legs, a transfer still carries the preceding leg's end, and `resolvedAt` pins down what each shape does once a clock is put to it.
- `./gradlew :onebusaway-android:compileObaGoogleDebugKotlin -PwarningsAsErrors=true` and `compileObaGoogleDebugAndroidTestKotlin` — clean.
- `./gradlew spotlessCheck` — clean.
- Instrumented tests not run locally (no device attached to this machine); the touched androidTest files are fixture updates only and compile clean. CI will run them.
- OTP behaviour measured live against both of the app's protocols (OTP2 `planConnection` and OTP1 REST `/plan`) before relying on it.

## Notes for review

**The shift is load-bearing elsewhere — deliberately not normalized at the adapter.** Three other consumers read the shifted leading-leg start *correctly*, as "the latest you can leave": `ItineraryWinners.LATEST_DEPARTURE` (that category *is* the shift), the option card's `start – end` range, and `TripPlanMonitor.itineraryDeparture`. Re-basing it in `Otp2PlanAdapters`/`TripPlanAdapters` would delete the first outright. So this fixes the one consumer that misread it, in that consumer.

The same applies to the trip log's own `Terminal(START)` — "Leaving 6:32" is the latest-leave reading and stays as it is, which is why the drawer now shows an absolute leave time and a relative "you get here" rule. That's intended, not an inconsistency.

**Applied to both protocols on measurement, not on faith.** `TripLogBuilder` receives only `List<TripLeg>` — `TripItinerary` deliberately erases which protocol produced it — so a uniform rule is the only rule expressible at that layer. Rather than assume, OTP1 was measured too: same shift, landing 1 s before the board, starts pushed up to ~25 min past `plan.date`. Both measurements are recorded at `ReachStop.OnFoot`.

**Known follow-up, out of scope.** `TripMonitorDecider.hasDeparted` tears down delay monitoring at the shifted latest-leave instant — one access-leg duration before the vehicle actually boards, which is exactly the window a "your bus is delayed" notice is most actionable. The natural bound is the first transit leg's `startTime`. Not touched here.

**Not changed:** the a11y string `"You get to this stop at %1$s"` now labels a moment that re-resolves as the clock runs, and arguably should say "if you set off now". Left alone — it's a user-visible string change with translations attached, not a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved arrival-time tracking for transit, walking access, transfers, and transit-only trips.
  - ETA displays now update using the live server clock and distinguish unavailable departures from departures that cannot currently be boarded.
  - ETA markers provide more accurate timing and accessibility descriptions, including for trips beyond the final listed departure.

- **Bug Fixes**
  - Corrected minute-boundary calculations for consistent countdowns and next-minute updates.
  - Improved arrival positioning based on actual stop-reach timing rather than planned itinerary times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->