### PR TITLE
Take the light end of the route case to near-white (#2226)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -155,7 +155,7 @@ class GoogleMapRenderer(
         setWidth = { line, width -> line.width = width },
         // Resolved per line rather than once, and here rather than by the producer: a case's colour follows the
         // theme, because the basemap it separates its line from does (see [mapRouteLineCaseColor]).
-        caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) },
+        caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context), it.case) },
         caseExtraWidth = { it.case.extraWidthDp * density }
     )
 
@@ -383,7 +383,7 @@ class GoogleMapRenderer(
     private fun endCapFor(polyline: RoutePolyline, mark: RouteLineMark): CustomCap? = when (mark) {
         RouteLineMark.NONE -> null
         RouteLineMark.BULB -> endpointBulbCap(polyline.resolvedColor)
-        RouteLineMark.INTERLINE_CUT -> interlineSeamCap(polyline.resolvedColor)
+        RouteLineMark.INTERLINE_CUT -> interlineSeamCap(polyline)
     }
 
     /** A circle 2x the stroke width, scaled by Maps together with the line at every zoom. */
@@ -404,10 +404,11 @@ class GoogleMapRenderer(
     /**
      * The interline cutover slash ([InterlineSeamMark]), drawn in the cut line's own case colour — resolved
      * here rather than by the producer because it follows the theme, exactly as a line's case does (see
-     * [mapRouteLineCaseColor]).
+     * [mapRouteLineCaseColor]). The whole line is passed, not just its colour, because that colour is the
+     * line's *case* colour and so depends on the weight of case it wears.
      */
-    private fun interlineSeamCap(lineColor: Int): CustomCap {
-        val color = mapRouteLineCaseColor(lineColor, ThemeUtils.isInDarkMode(context))
+    private fun interlineSeamCap(polyline: RoutePolyline): CustomCap {
+        val color = mapRouteLineCaseColor(polyline.resolvedColor, ThemeUtils.isInDarkMode(context), polyline.case)
         val descriptor = descriptorCache.get("interline-seam:$color") { InterlineSeamMark.bitmap(color) }
         return CustomCap(descriptor, InterlineSeamMark.REFERENCE_WIDTH_PX)
     }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -144,6 +144,12 @@ class GoogleMapRenderer(
     private val staticMarkers = mutableListOf<Marker>()
     private val staticPolylines = mutableListOf<Polyline>()
 
+    // A line's case colour, read at draw time rather than carried on the line: it follows the theme, because
+    // the basemap it separates its line from does (see [mapRouteLineCaseColor]). Shared by everything that
+    // draws in it — the case itself, and the interline cut, which is why they can't drift apart.
+    private val caseColorOf: (RoutePolyline) -> Int =
+        { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context), it.case) }
+
     // Whole-route lines are reconciled independently from the combined static snapshot: stop list,
     // focus, or bike changes retain these native polylines. The flavor-neutral reconcile/width bookkeeping
     // lives in the shared [RoutePolylineReconciler] (#1906); only the four gms-specific line operations
@@ -153,9 +159,7 @@ class GoogleMapRenderer(
         createLine = ::addRoutePolyline,
         removeLines = { lines -> lines.forEach { it.remove() } },
         setWidth = { line, width -> line.width = width },
-        // Resolved per line rather than once, and here rather than by the producer: a case's colour follows the
-        // theme, because the basemap it separates its line from does (see [mapRouteLineCaseColor]).
-        caseColorOf = { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context), it.case) },
+        caseColorOf = caseColorOf,
         caseExtraWidth = { it.case.extraWidthDp * density }
     )
 
@@ -402,13 +406,12 @@ class GoogleMapRenderer(
     }
 
     /**
-     * The interline cutover slash ([InterlineSeamMark]), drawn in the cut line's own case colour — resolved
-     * here rather than by the producer because it follows the theme, exactly as a line's case does (see
-     * [mapRouteLineCaseColor]). The whole line is passed, not just its colour, because that colour is the
-     * line's *case* colour and so depends on the weight of case it wears.
+     * The interline cutover slash ([InterlineSeamMark]), drawn in the cut line's own case colour — through
+     * the very [caseColorOf] the case itself is drawn with, so the two cannot answer differently. The whole
+     * line is passed, not just its colour, because a case colour depends on the weight of case it wears.
      */
     private fun interlineSeamCap(polyline: RoutePolyline): CustomCap {
-        val color = mapRouteLineCaseColor(polyline.resolvedColor, ThemeUtils.isInDarkMode(context), polyline.case)
+        val color = caseColorOf(polyline)
         val descriptor = descriptorCache.get("interline-seam:$color") { InterlineSeamMark.bitmap(color) }
         return CustomCap(descriptor, InterlineSeamMark.REFERENCE_WIDTH_PX)
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -113,7 +113,7 @@ internal fun TripLeg.legKind(): ItineraryLegKind = when {
  * read from the drawer's ordered rows and from the leg's endpoint bulbs instead.
  *
  * A ride also carries [RouteLineCase.OUTLINE] for that reason — every ride, so the edge says nothing about
- * selection; the rider's selected leg steps up to [RouteLineCase.SELECTION] ([withCase]). A mode leg has no
+ * selection; the rider's selected leg steps up to [RouteLineCase.SELECTION]. A mode leg has no
  * case, as it has no fading to compensate for.
  */
 internal fun itineraryLegStyle(
@@ -211,7 +211,7 @@ internal fun itineraryLegCaps(legs: List<TripLeg>): List<ItineraryLegCaps> {
 }
 
 /**
- * The drawn itinerary composed around a leg focus (#2048): the focused leg(s) cased ([withCase]) and
+ * The drawn itinerary composed around a leg focus (#2048): the focused leg(s) cased ([RouteLineCase.SELECTION]) and
  * re-appended last so they draw on top. Focusing a leg therefore *marks* it within the whole journey rather
  * than erasing — or restyling — the rest of the trip, so the rider keeps where this leg sits in the journey,
  * which is exactly what a leg drawn alone can't say.
@@ -230,7 +230,7 @@ internal fun itineraryLegCaps(legs: List<TripLeg>): List<ItineraryLegCaps> {
 internal fun List<ItineraryLegLine>.withLegFocus(focusedLegIndices: Set<Int>): List<RoutePolyline> {
     val (focused, rest) = partition { it.legIndex in focusedLegIndices }
     if (focused.isEmpty()) return map { it.line }
-    return rest.map { it.line } + focused.map { it.line.withCase() }
+    return rest.map { it.line } + focused.map { it.line.copy(case = RouteLineCase.SELECTION) }
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -76,10 +76,21 @@ internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(s
  *
  * These are near-black and near-white, and that is the point: the case is a **separator**, not a second
  * colour. The sRGB gamut holds little chroma at either end of the tone scale, so a case here keeps only a
- * trace of its line's hue — measured across the leg hues, as little as chroma 13 where its line carries 75.
- * That is a deliberate trade: maximum tonal contrast is what makes a 1.5dp edge visible at all, and the
- * line's own colour is already saying which route it is. (Its *hue* does survive, within a couple of degrees,
- * so what colour is left is the right one.)
+ * trace of its line's hue. That is a deliberate trade: maximum tonal contrast is what makes a 1.5dp edge
+ * visible at all, and the line's own colour is already saying which route it is.
+ *
+ * The light end has to go *further* than "light" to get there, which is what #2226 was: at tone 90 the gamut
+ * still holds plenty of chroma for the warm and green hues — a green line at chroma 68 cased at chroma 68 —
+ * so the case came out as a lighter, still-saturated version of its own line rather than an edge on it. Since
+ * selection is said with case *thickness* (#2082), a case a rider can't pick out from its line is a highlight
+ * they can't read, and dark mode was the theme wearing it. At tone 98 the gamut squeezes the same cases under
+ * chroma 27, and the gap to a basemap-palette line (tone 55) is 43 against the dark end's 45 — so neither
+ * theme's case is the weak one any more.
+ *
+ * What the tones cost is at that light end: a hue with nearly no chroma left to carry it can land some way off
+ * its line's, where the dark end holds every hue within a degree or two. That is the right trade for a channel
+ * with nothing left in it — a case is read as an edge, not as a colour — and it is why the tones are asymmetric
+ * in *what they preserve* as well as in their distance from the middle.
  *
  * Absolute tones rather than an offset from [lineColor]'s own tone: what a case has to contrast with is the
  * basemap, which sits at a fixed value per theme, so the target is a property of the theme and not of the line
@@ -143,7 +154,8 @@ private const val MAP_ROUTE_CHROMA = 75.0
 private const val MAP_ROUTE_TONE = 55.0
 
 // The two ends of the tone scale a case is pinned to, chosen for maximum contrast with the basemap it has to
-// separate its line from. Not symmetric about MAP_ROUTE_TONE, and not meant to be: each is as far as it can
-// usefully go without becoming literal black or white.
+// separate its line from — and, since a case's thickness is what marks selection, with that line as well
+// (#2226). Not symmetric about MAP_ROUTE_TONE, and not meant to be: each is as far as it can usefully go
+// without becoming literal black or white, which the dark end reaches sooner than the light one.
 private const val MAP_ROUTE_CASE_TONE_DARK = 10.0
-private const val MAP_ROUTE_CASE_TONE_LIGHT = 90.0
+private const val MAP_ROUTE_CASE_TONE_LIGHT = 98.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -115,6 +115,12 @@ internal fun mapRouteLineCaseColor(lineColor: Int, darkMode: Boolean, case: Rout
 /**
  * How far out the tone scale [case] goes, for the theme it is drawn in.
  *
+ * [RouteLineCase.APPROACH] answers with the *selection* tone, not one of its own, and that is the whole
+ * reason it is a separate weight rather than a separate colour: the approach and the ride it leads into have
+ * to read as one route line stepping down at the boarding point, which they only do if their cases are the
+ * same colour. What differs between them is width, which is a statement about the lines (one is 3.5dp and
+ * one is 15dp) and not about what they mean.
+ *
  * [RouteLineCase.NONE] answers alongside the outline rather than being rejected, because an uncased line can
  * still need this colour: the interline cutover slash is drawn in its line's case colour whether or not that
  * line asked for an edge of its own (see `InterlineSeamMark`), and a hairline joint's casing is what that
@@ -122,7 +128,7 @@ internal fun mapRouteLineCaseColor(lineColor: Int, darkMode: Boolean, case: Rout
  */
 private fun caseTone(case: RouteLineCase, darkMode: Boolean): Double = when (case) {
     RouteLineCase.NONE, RouteLineCase.OUTLINE -> if (darkMode) MAP_ROUTE_CASE_TONE_LIGHT else MAP_ROUTE_CASE_TONE_DARK
-    RouteLineCase.SELECTION -> if (darkMode) MAP_SELECTION_CASE_TONE_LIGHT else MAP_SELECTION_CASE_TONE_DARK
+    RouteLineCase.APPROACH, RouteLineCase.SELECTION -> if (darkMode) MAP_SELECTION_CASE_TONE_LIGHT else MAP_SELECTION_CASE_TONE_DARK
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.map
 
 import android.annotation.SuppressLint
 import com.google.android.material.color.utilities.Hct
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.util.routeBadgeChipColor
 import org.onebusaway.android.util.routeCasingColor
 import org.onebusaway.android.util.routeColorHctOrNull
@@ -64,9 +65,15 @@ internal fun mapRouteLineColor(hue: Double): Int = Hct.from(hue, MAP_ROUTE_CHROM
 internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(source)?.let { mapRouteLineColor(it.hue) }
 
 /**
- * The case (halo) drawn beneath a selected line of colour [lineColor] (#2082): that line's own hue and chroma
- * taken to the far end of the tone scale *away from the basemap* — [MAP_ROUTE_CASE_TONE_DARK] on the light
- * basemap, [MAP_ROUTE_CASE_TONE_LIGHT] when [darkMode].
+ * The case (halo) drawn beneath a line of colour [lineColor] wearing [case] (#2082): that line's own hue and
+ * chroma taken to the far end of the tone scale *away from the basemap* — the dark end on the light basemap,
+ * the light end when [darkMode].
+ *
+ * How far out along that scale is [case]'s to say. A [RouteLineCase.SELECTION] takes the very end of it and a
+ * [RouteLineCase.OUTLINE] stops just short, so the rider's selected leg is the *brightest* edge on the map as
+ * well as the heaviest — selection said on two channels rather than on thickness alone. The headroom left
+ * above the outline's own tone is small (see the constants), so this is a nudge on top of the weight step and
+ * not a second signal that could carry selection by itself.
  *
  * The direction is deliberately the opposite of the halo convention for map *labels*, which carry the
  * background's own value to punch glyphs out of busy detail. Tried that way first and the case vanished on
@@ -101,10 +108,20 @@ internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(s
  * This is the one deliberate exception to this file's theme independence (see above) — precisely because its
  * whole job is to hold the line apart from a backdrop that itself flips.
  */
-internal fun mapRouteLineCaseColor(lineColor: Int, darkMode: Boolean): Int = routeCasingColor(
-    lineColor,
-    if (darkMode) MAP_ROUTE_CASE_TONE_LIGHT else MAP_ROUTE_CASE_TONE_DARK
-)
+internal fun mapRouteLineCaseColor(lineColor: Int, darkMode: Boolean, case: RouteLineCase): Int = routeCasingColor(lineColor, caseTone(case, darkMode))
+
+/**
+ * How far out the tone scale [case] goes, for the theme it is drawn in.
+ *
+ * [RouteLineCase.NONE] answers alongside the outline rather than being rejected, because an uncased line can
+ * still need this colour: the interline cutover slash is drawn in its line's case colour whether or not that
+ * line asked for an edge of its own (see `InterlineSeamMark`), and a hairline joint's casing is what that
+ * mark is. Nothing reads a NONE line's case *as a case* — the renderers only pair one when [case] isn't NONE.
+ */
+private fun caseTone(case: RouteLineCase, darkMode: Boolean): Double = when (case) {
+    RouteLineCase.NONE, RouteLineCase.OUTLINE -> if (darkMode) MAP_ROUTE_CASE_TONE_LIGHT else MAP_ROUTE_CASE_TONE_DARK
+    RouteLineCase.SELECTION -> if (darkMode) MAP_SELECTION_CASE_TONE_LIGHT else MAP_SELECTION_CASE_TONE_DARK
+}
 
 /**
  * Which policy renders a route line's colour, handed to whatever produces the lines rather than read from
@@ -153,9 +170,21 @@ fun directionsRouteLinePalette(dark: Boolean) = RouteLinePalette { routeBadgeChi
 private const val MAP_ROUTE_CHROMA = 75.0
 private const val MAP_ROUTE_TONE = 55.0
 
-// The two ends of the tone scale a case is pinned to, chosen for maximum contrast with the basemap it has to
-// separate its line from — and, since a case's thickness is what marks selection, with that line as well
-// (#2226). Not symmetric about MAP_ROUTE_TONE, and not meant to be: each is as far as it can usefully go
+// The two ends of the tone scale an ordinary case is pinned to, chosen for maximum contrast with the basemap
+// it has to separate its line from — and, since a case's thickness is what marks selection, with that line as
+// well (#2226). Not symmetric about MAP_ROUTE_TONE, and not meant to be: each is as far as it can usefully go
 // without becoming literal black or white, which the dark end reaches sooner than the light one.
 private const val MAP_ROUTE_CASE_TONE_DARK = 10.0
 private const val MAP_ROUTE_CASE_TONE_LIGHT = 98.0
+
+// ...and the ends themselves, which the rider's selected leg takes: literal black and white, since selection
+// is the one thing worth spending the last of the scale on.
+//
+// Note how little that last step is worth on its own. #2226 took the ordinary case out to where the gamut has
+// almost nothing left, so a selected case sits 1.05:1 from an outline in dark mode and 1.10:1 in light — a
+// difference a rider will not read as a difference. It is here because a selection may as well have the end
+// of the scale, not because brightness now carries the signal: the weight step (0.75dp → 1.5dp per side) is
+// still what says "this is the one you're looking at". Buying real brightness separation would mean pulling
+// MAP_ROUTE_CASE_TONE_LIGHT back down toward 90 to open the gap, which is exactly what #2226 closed.
+private const val MAP_SELECTION_CASE_TONE_DARK = 5.0
+private const val MAP_SELECTION_CASE_TONE_LIGHT = 100.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -84,8 +84,8 @@ internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(s
  * a line needs here is the contrast a label already has from its own ink.
  *
  * These are near-black and near-white, and that is the point: the case is a **separator**, not a second
- * colour. That is a deliberate trade — maximum tonal contrast is what makes a 1.5dp edge visible at all, and
- * the line's own colour is already saying which route it is.
+ * colour. That is a deliberate trade — maximum tonal contrast is what makes an edge this thin visible at all,
+ * and the line's own colour is already saying which route it is.
  *
  * How much of that colour survives is not the same at the two ends, and #2226 is what the difference costs. At
  * the dark end sRGB holds little chroma, so a case there really is a near-black hairline. At the light end it
@@ -104,8 +104,8 @@ internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(s
  * Absolute tones rather than an offset from [lineColor]'s own tone: what a case has to contrast with is the
  * basemap, which sits at a fixed value per theme, so the target is a property of the theme and not of the line
  * it wraps. The re-tone itself is [routeCasingColor], shared with the continuation badge's outline so the map's
- * two casings can't drift apart on which channels survive; only the tones differ, and deliberately — a 1.5dp
- * hairline needs far more contrast than a badge outline.
+ * two casings can't drift apart on which channels survive; only the tones differ, and deliberately — a
+ * hairline a dp or two wide needs far more contrast than a badge outline.
  *
  * This is the one deliberate exception to this file's theme independence (see above) — precisely because its
  * whole job is to hold the line apart from a backdrop that itself flips.
@@ -189,7 +189,7 @@ private const val MAP_ROUTE_CASE_TONE_LIGHT = 90.0
 // dark map tone 100 leaves the gamut with no chroma to give, so the selected case comes back white while
 // every outline around it stays tinted with the route it wraps; being the only colourless edge on screen is
 // a categorical difference, not a 1.29:1 one. On the light map tone 5 keeps its hue and reads as depth
-// instead. Either way this rides on top of the weight step (0.75dp → 1.5dp per side), which remains the
+// instead. Either way this rides on top of the weight step (0.75dp → 2.25dp per side), which remains the
 // primary thing saying "this is the one you're looking at".
 private const val MAP_SELECTION_CASE_TONE_DARK = 5.0
 private const val MAP_SELECTION_CASE_TONE_LIGHT = 100.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapRouteColors.kt
@@ -69,11 +69,13 @@ internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(s
  * chroma taken to the far end of the tone scale *away from the basemap* — the dark end on the light basemap,
  * the light end when [darkMode].
  *
- * How far out along that scale is [case]'s to say. A [RouteLineCase.SELECTION] takes the very end of it and a
- * [RouteLineCase.OUTLINE] stops just short, so the rider's selected leg is the *brightest* edge on the map as
- * well as the heaviest — selection said on two channels rather than on thickness alone. The headroom left
- * above the outline's own tone is small (see the constants), so this is a nudge on top of the weight step and
- * not a second signal that could carry selection by itself.
+ * How far out along that scale is [case]'s to say, and this is the map's second selection signal (#2226). A
+ * [RouteLineCase.OUTLINE] — the hairline every directions ride wears — stops where a case still carries a
+ * trace of its line's hue. A [RouteLineCase.SELECTION], the case the rider's own leg wears, goes to the
+ * literal end and comes back achromatic. So the selected leg's edge is not merely *lighter* than the edges
+ * around it on the dark basemap: it is the only white one, where the rest are tinted with the routes they
+ * wrap. That categorical difference is what a rider actually picks out, and it is why the two tones can sit
+ * as close as 1.29:1 and still read apart.
  *
  * The direction is deliberately the opposite of the halo convention for map *labels*, which carry the
  * background's own value to punch glyphs out of busy detail. Tried that way first and the case vanished on
@@ -82,22 +84,22 @@ internal fun mapRouteLineColorOrNull(source: Int?): Int? = routeColorHctOrNull(s
  * a line needs here is the contrast a label already has from its own ink.
  *
  * These are near-black and near-white, and that is the point: the case is a **separator**, not a second
- * colour. The sRGB gamut holds little chroma at either end of the tone scale, so a case here keeps only a
- * trace of its line's hue. That is a deliberate trade: maximum tonal contrast is what makes a 1.5dp edge
- * visible at all, and the line's own colour is already saying which route it is.
+ * colour. That is a deliberate trade — maximum tonal contrast is what makes a 1.5dp edge visible at all, and
+ * the line's own colour is already saying which route it is.
  *
- * The light end has to go *further* than "light" to get there, which is what #2226 was: at tone 90 the gamut
- * still holds plenty of chroma for the warm and green hues — a green line at chroma 68 cased at chroma 68 —
- * so the case came out as a lighter, still-saturated version of its own line rather than an edge on it. Since
- * selection is said with case *thickness* (#2082), a case a rider can't pick out from its line is a highlight
- * they can't read, and dark mode was the theme wearing it. At tone 98 the gamut squeezes the same cases under
- * chroma 27, and the gap to a basemap-palette line (tone 55) is 43 against the dark end's 45 — so neither
- * theme's case is the weak one any more.
+ * How much of that colour survives is not the same at the two ends, and #2226 is what the difference costs. At
+ * the dark end sRGB holds little chroma, so a case there really is a near-black hairline. At the light end it
+ * holds a great deal for the warm and green hues — a green line at chroma 68 cases at chroma 68 — so an outline
+ * on the dark basemap comes out as a lighter, still-saturated version of its own line. That is fine for what an
+ * outline is *for* (holding a faded ride off the basemap; it has never said anything about selection), and it
+ * was fatal for the thing selection was being said with, since a case a rider can't pick out from its line
+ * leaves nothing for its thickness to be read against. Hence the split: the selection case goes all the way to
+ * tone 100, where the gamut has nothing left to give it and it lands on white.
  *
- * What the tones cost is at that light end: a hue with nearly no chroma left to carry it can land some way off
- * its line's, where the dark end holds every hue within a degree or two. That is the right trade for a channel
- * with nothing left in it — a case is read as an edge, not as a colour — and it is why the tones are asymmetric
- * in *what they preserve* as well as in their distance from the middle.
+ * So the selection case is the one route colour on this map that keeps *no* hue at all, deliberately, and the
+ * asymmetry runs the other way at the light basemap: tone 5 is still dark enough to carry a hue, so there the
+ * selected case is a deeper version of its line rather than a colourless one. The signal in each theme is
+ * whatever that theme's end of the scale can offer — white on the dark map, depth on the light one.
  *
  * Absolute tones rather than an offset from [lineColor]'s own tone: what a case has to contrast with is the
  * basemap, which sits at a fixed value per theme, so the target is a property of the theme and not of the line
@@ -171,20 +173,23 @@ private const val MAP_ROUTE_CHROMA = 75.0
 private const val MAP_ROUTE_TONE = 55.0
 
 // The two ends of the tone scale an ordinary case is pinned to, chosen for maximum contrast with the basemap
-// it has to separate its line from — and, since a case's thickness is what marks selection, with that line as
-// well (#2226). Not symmetric about MAP_ROUTE_TONE, and not meant to be: each is as far as it can usefully go
-// without becoming literal black or white, which the dark end reaches sooner than the light one.
-private const val MAP_ROUTE_CASE_TONE_DARK = 10.0
-private const val MAP_ROUTE_CASE_TONE_LIGHT = 98.0
-
-// ...and the ends themselves, which the rider's selected leg takes: literal black and white, since selection
-// is the one thing worth spending the last of the scale on.
+// it has to separate its line from. Not symmetric about MAP_ROUTE_TONE, and not meant to be: each is as far as
+// a case can go while still reading as *this line's* edge, keeping enough of its hue to say so.
 //
-// Note how little that last step is worth on its own. #2226 took the ordinary case out to where the gamut has
-// almost nothing left, so a selected case sits 1.05:1 from an outline in dark mode and 1.10:1 in light — a
-// difference a rider will not read as a difference. It is here because a selection may as well have the end
-// of the scale, not because brightness now carries the signal: the weight step (0.75dp → 1.5dp per side) is
-// still what says "this is the one you're looking at". Buying real brightness separation would mean pulling
-// MAP_ROUTE_CASE_TONE_LIGHT back down toward 90 to open the gap, which is exactly what #2226 closed.
+// Deliberately left short of the ends below, which is the whole of #2226: an outline that had already spent
+// the scale would leave a selection nothing to step up into. What an outline gives up by stopping here it
+// gives up knowingly — on the dark basemap the warm and green hues case at nearly their line's own chroma,
+// so a green ride wears a green edge. It reads as an edge because it is a lighter one, and it never had to
+// carry selection.
+private const val MAP_ROUTE_CASE_TONE_DARK = 10.0
+private const val MAP_ROUTE_CASE_TONE_LIGHT = 90.0
+
+// ...and the ends themselves, which the rider's selected leg takes. The step is small in tone alone — 1.29:1
+// against an outline on the dark basemap, 1.10:1 on the light one — and that is not what carries it. On the
+// dark map tone 100 leaves the gamut with no chroma to give, so the selected case comes back white while
+// every outline around it stays tinted with the route it wraps; being the only colourless edge on screen is
+// a categorical difference, not a 1.29:1 one. On the light map tone 5 keeps its hue and reads as depth
+// instead. Either way this rides on top of the weight step (0.75dp → 1.5dp per side), which remains the
+// primary thing saying "this is the one you're looking at".
 private const val MAP_SELECTION_CASE_TONE_DARK = 5.0
 private const val MAP_SELECTION_CASE_TONE_LIGHT = 100.0

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.map
 
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.models.ObaStop
@@ -144,8 +145,9 @@ internal fun routePolylinesWithSegment(
             color = colorOf(span),
             points = span.points,
             widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
+            case = RouteLineCase.SELECTION,
             startMark = if (span.startsCutover) RouteLineMark.INTERLINE_CUT else RouteLineMark.NONE
-        ).withCase()
+        )
     }
     if (overlay.isEmpty()) return itineraryContext + base
     return base.asSelectedRouteApproach() + itineraryContext + overlay

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -56,19 +56,6 @@ internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyli
 }
 
 /**
- * The line the rider has selected, wrapped in the heavier [RouteLineCase.SELECTION] case — the map's one way
- * of saying "this is the one you're looking at" (#2082). Selection deliberately changes nothing else: a leg
- * keeps the weight, colour and dash that say what *kind* of line it is, so drilling into it doesn't restyle
- * the trip around it.
- *
- * It overwrites whatever case the line already carried, which for a directions ride is the hairline
- * [RouteLineCase.OUTLINE] every ride wears: selection is the *step up* in edge weight, so a line that already
- * has an edge simply gets a heavier one. The case's colour is the renderer's to resolve, since it depends on
- * the current theme (see [mapRouteLineCaseColor]).
- */
-internal fun RoutePolyline.withCase(): RoutePolyline = copy(case = RouteLineCase.SELECTION)
-
-/**
  * The selected transit route upstream of the boarding point — where the vehicle is coming from — drawn as
  * part of the selected line rather than as background: solid, cased like the ride it leads into, at its own
  * thinnest itinerary weight ([ITINERARY_APPROACH_WIDTH_PROFILE]).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -73,6 +73,12 @@ internal fun RoutePolyline.withCase(): RoutePolyline = copy(case = RouteLineCase
  * part of the selected line rather than as background: solid, cased like the ride it leads into, at its own
  * thinnest itinerary weight ([ITINERARY_APPROACH_WIDTH_PROFILE]).
  *
+ * "Cased like the ride" is a colour and not a width: it takes [RouteLineCase.APPROACH], which draws in the
+ * selection colour at a lighter weight. The two read as one line stepping down at the boarding point, which
+ * is the point, while the case still fits the 3.5dp line it wraps — a full [RouteLineCase.SELECTION] would
+ * add more width than the approach line has, and the thinnest line on the map would draw as a selection band
+ * with a coloured core.
+ *
  * It was previously the map's faintest dashed line, a hair thinner than the receded itinerary legs beside
  * it, so the rider read two near-identical thin strokes meaning quite different things (#2082). Chevrons
  * stay off: the approach is where the vehicle comes from, not a span the rider travels.
@@ -81,8 +87,9 @@ internal fun List<RoutePolyline>.asSelectedRouteApproach(): List<RoutePolyline> 
     line.copy(
         widthProfile = ITINERARY_APPROACH_WIDTH_PROFILE,
         directional = false,
-        dash = RouteLineDash.NONE
-    ).withCase()
+        dash = RouteLineDash.NONE,
+        case = RouteLineCase.APPROACH
+    )
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -81,6 +81,11 @@ val DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
  * won't travel it, and it's here to say where the vehicle arrives from. Its case, not its width, is what
  * connects it to the ride — which is what lets it be this thin without being mistaken for context.
  *
+ * Thin enough that a [RouteLineCase.SELECTION] is now wider than it is (4.5dp added to a 3.5dp line), so the
+ * approach draws as a selection band with a coloured core rather than as a line with an edge. That follows
+ * from the paragraph above rather than contradicting it: the case is what this line is recognised by, and a
+ * heavier one says so louder. It is the only profile that inverts, and `RouteLineWidthProfileTest` pins that.
+ *
  * It used to be the map's faintest line (2dp) *and* dashed, which put it within a hair of the receded
  * itinerary legs around it — the two competed instead of reading as different things (#2082).
  */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/DetailZoomRamp.kt
@@ -81,10 +81,10 @@ val DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE = ROUTE_LINE_WIDTH_PROFILE.copy(
  * won't travel it, and it's here to say where the vehicle arrives from. Its case, not its width, is what
  * connects it to the ride — which is what lets it be this thin without being mistaken for context.
  *
- * Thin enough that a [RouteLineCase.SELECTION] is now wider than it is (4.5dp added to a 3.5dp line), so the
- * approach draws as a selection band with a coloured core rather than as a line with an edge. That follows
- * from the paragraph above rather than contradicting it: the case is what this line is recognised by, and a
- * heavier one says so louder. It is the only profile that inverts, and `RouteLineWidthProfileTest` pins that.
+ * Thin enough that it is what bounds a case's width: it takes [RouteLineCase.APPROACH] rather than the full
+ * [RouteLineCase.SELECTION] precisely because a selection case adds 4.5dp, more than this line's own 3.5dp,
+ * and the thinnest line on the map would then draw as a band with a coloured core instead of a line with an
+ * edge. Same colour, lighter weight. `RouteLineWidthProfileTest` pins the pairing.
  *
  * It used to be the map's faintest line (2dp) *and* dashed, which put it within a hair of the receded
  * itinerary legs around it — the two competed instead of reading as different things (#2082).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/InterlineSeamMark.kt
@@ -63,7 +63,7 @@ object InterlineSeamMark {
     /**
      * The mark's weight where the line it cuts is at its full width, which for every line that carries one
      * today is [ITINERARY_RIDE_WIDTH_PROFILE]'s close-zoom thickness. A ruled line, in the same family as the
-     * cases around these lines ([RouteLineCase.OUTLINE] is 0.75dp per side, [RouteLineCase.SELECTION] 1.5dp)
+     * cases around these lines ([RouteLineCase.OUTLINE] is 0.75dp per side, [RouteLineCase.SELECTION] 2.25dp)
      * — because that is what it is: the casing of the joint, not a symbol laid over the corridor.
      *
      * Expressed as a ratio of the line's width rather than in absolute dp, since the bitmap scales as a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -87,23 +87,30 @@ enum class RouteLineDash {
  *  - [OUTLINE] — a hairline edge that holds a directions ride off the basemap. Every ride in a drawn
  *    itinerary carries it, so it says nothing about selection; it is there because a faded, badge-toned
  *    line has less of its own contrast to spend against the map than a full-strength one does.
- *  - [SELECTION] — the heavier case marking the line the rider has selected (#2082). Selection used to be
- *    said with a width, but the map already spends width on what a line *is* (a ride, an on-street leg,
- *    route context), so saying two things with one channel left neither legible. It stays legible against
- *    [OUTLINE] because it is three times the weight of it — selection is now a *heavier* edge, not the only
- *    edge. Two weights read as one edge and a thicker one; three read as an edge and a band, which is what
- *    this wants, since the thing it competes with for attention is the line it wraps and not the basemap.
+ *  - [APPROACH] — the selected line's *approach*: where the vehicle is coming from, upstream of where the
+ *    rider boards. It draws in the selection colour, so the approach and the ride read as one route line
+ *    stepping down at the boarding point, but at a lighter weight, because it wraps the thinnest line on the
+ *    map ([ITINERARY_APPROACH_WIDTH_PROFILE], 3.5dp) and a full selection case there would be wider than the
+ *    line inside it.
+ *  - [SELECTION] — the heaviest case, marking the line the rider has actually selected (#2082). Selection
+ *    used to be said with a width, but the map already spends width on what a line *is* (a ride, an
+ *    on-street leg, route context), so saying two things with one channel left neither legible. It stays
+ *    legible against [OUTLINE] because it is three times the weight of it — selection is now a *heavier*
+ *    edge, not the only edge. Two weights read as one edge and a thicker one; three read as an edge and a
+ *    band, which is what this wants, since the thing it competes with for attention is the line it wraps and
+ *    not the basemap.
  *
  * The widths are deliberately *not* on the zoom ramp: a case is an outline, and an outline that thins with
  * its line stops separating it from the basemap at exactly the zoom where the line is hardest to pick out.
  *
- * [SELECTION] is wide enough to out-measure one line it wraps — the itinerary approach, at 3.5dp — which is
- * accepted for the reason that profile gives: the approach is recognised by its case rather than by its
- * width. See [ITINERARY_APPROACH_WIDTH_PROFILE]; `RouteLineWidthProfileTest` pins it as the only one.
+ * Every one of them stays finer than the thinnest line that asks for it, so a case always reads as that
+ * line's edge and never as a second line under it — which is the whole reason [APPROACH] exists as its own
+ * weight rather than the approach simply taking [SELECTION]. `RouteLineWidthProfileTest` pins that pairing.
  */
 enum class RouteLineCase(val widthDp: Float) {
     NONE(0f),
     OUTLINE(0.75f),
+    APPROACH(1.5f),
     SELECTION(2.25f);
 
     /** What this case adds to its line's *total* width — both sides. Derived here so no caller has to

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -98,7 +98,9 @@ enum class RouteLineDash {
  *    legible against [OUTLINE] because it is three times the weight of it — selection is now a *heavier*
  *    edge, not the only edge. Two weights read as one edge and a thicker one; three read as an edge and a
  *    band, which is what this wants, since the thing it competes with for attention is the line it wraps and
- *    not the basemap.
+ *    not the basemap. Asking for it changes nothing else about a line: it keeps the weight, colour and dash
+ *    that say what *kind* of line it is, so drilling into one doesn't restyle the trip around it. It simply
+ *    replaces the [OUTLINE] a directions ride already wore, selection being the step up in edge weight.
  *
  * The widths are deliberately *not* on the zoom ramp: a case is an outline, and an outline that thins with
  * its line stops separating it from the basemap at exactly the zoom where the line is hardest to pick out.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -90,15 +90,21 @@ enum class RouteLineDash {
  *  - [SELECTION] — the heavier case marking the line the rider has selected (#2082). Selection used to be
  *    said with a width, but the map already spends width on what a line *is* (a ride, an on-street leg,
  *    route context), so saying two things with one channel left neither legible. It stays legible against
- *    [OUTLINE] because it is twice the weight of it — selection is now a *heavier* edge, not the only edge.
+ *    [OUTLINE] because it is three times the weight of it — selection is now a *heavier* edge, not the only
+ *    edge. Two weights read as one edge and a thicker one; three read as an edge and a band, which is what
+ *    this wants, since the thing it competes with for attention is the line it wraps and not the basemap.
  *
  * The widths are deliberately *not* on the zoom ramp: a case is an outline, and an outline that thins with
  * its line stops separating it from the basemap at exactly the zoom where the line is hardest to pick out.
+ *
+ * [SELECTION] is wide enough to out-measure one line it wraps — the itinerary approach, at 3.5dp — which is
+ * accepted for the reason that profile gives: the approach is recognised by its case rather than by its
+ * width. See [ITINERARY_APPROACH_WIDTH_PROFILE]; `RouteLineWidthProfileTest` pins it as the only one.
  */
 enum class RouteLineCase(val widthDp: Float) {
     NONE(0f),
     OUTLINE(0.75f),
-    SELECTION(1.5f);
+    SELECTION(2.25f);
 
     /** What this case adds to its line's *total* width — both sides. Derived here so no caller has to
      *  remember that [widthDp] is per-side. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -112,7 +112,7 @@ enum class RouteLineDash {
 enum class RouteLineCase(val widthDp: Float) {
     NONE(0f),
     OUTLINE(0.75f),
-    APPROACH(1.5f),
+    APPROACH(1f),
     SELECTION(2.25f);
 
     /** What this case adds to its line's *total* width — both sides. Derived here so no caller has to

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/RouteColors.kt
@@ -191,7 +191,7 @@ private const val BADGE_CHIP_TEXT_TONE_DARK = 20.0
  * (`mapRouteLineCaseColor`, #2082) and a continuation badge's outline
  * ([org.onebusaway.android.map.render.ContinuationBadgeBitmaps.routeBadgeOutlineColor]).
  *
- * The two deliberately pick *different* tones — a 1.5dp hairline under a route line needs far more contrast
+ * The two deliberately pick *different* tones — a hairline under a route line needs far more contrast
  * than a badge's outline — so the tone stays the caller's decision. What they share is this: which channels
  * survive, and the opaque-alpha normalization ahead of the conversion, exactly as [routeColorHctOrNull] does
  * it. Written once so the two casings can't drift apart on either.

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -109,7 +109,7 @@ class MapLibreRenderer(
     // the basemap it separates its line from does (see [mapRouteLineCaseColor]). Shared by everything that
     // draws in it — the case itself, and the interline cut, which is why they can't drift apart.
     private val caseColorOf: (RoutePolyline) -> Int =
-        { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context)) }
+        { mapRouteLineCaseColor(it.resolvedColor, ThemeUtils.isInDarkMode(context), it.case) }
 
     // The marks on a route line's ends, drawn as style layers because the classic polyline annotation has no
     // configurable cap: the endpoint bulbs, and the interline cutover slashes (#2127). Rendered together

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -333,13 +333,13 @@ class ItineraryLegStyleTest {
             val line = Hct.fromInt(itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).color)
 
             listOf(false to 10.0, true to 98.0).forEach { (darkMode, expectedTone) ->
-                val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode))
+                val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode, RouteLineCase.OUTLINE))
                 assertEquals("$kind case tone (darkMode=$darkMode)", expectedTone, case.tone, CHANNEL_TOLERANCE)
             }
             assertEquals(
                 "$kind case hue",
                 line.hue,
-                Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = false)).hue,
+                Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = false, case = RouteLineCase.OUTLINE)).hue,
                 HUE_TOLERANCE_DEGREES
             )
         }
@@ -357,7 +357,7 @@ class ItineraryLegStyleTest {
         // for the blues and wrong for the greens, which is exactly what this one was.
         (0 until 360 step 10).forEach { hue ->
             val line = Hct.fromInt(mapRouteLineColor(hue.toDouble()))
-            val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = true))
+            val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = true, case = RouteLineCase.OUTLINE))
 
             assertTrue(
                 "hue $hue: case tone ${case.tone} is only ${case.tone - line.tone} above its line's ${line.tone}",
@@ -366,6 +366,48 @@ class ItineraryLegStyleTest {
             assertTrue(
                 "hue $hue: case kept chroma ${case.chroma} of its line's ${line.chroma} — a colour, not an edge",
                 case.chroma <= MAX_LIGHT_CASE_CHROMA
+            )
+        }
+    }
+
+    @Test
+    fun `the selected leg's case takes the very end of the scale, an outline stops short of it`() {
+        // Selection is said with case weight (#2082); this adds the last of the tone scale to it, so the leg
+        // the rider is looking at wears the brightest edge on the map as well as the heaviest.
+        //
+        // The step is deliberately tiny and the test says so, because #2226 already spent nearly all of that
+        // scale on the ordinary case: what is left above it is 2 tones. Asserted as an *ordering* rather than
+        // a contrast bar for exactly that reason — there is no perceptual claim here to make, only the policy
+        // one that a selection is never cased less far out than an outline beside it.
+        val line = Hct.fromInt(mapRouteLineColor(hue = 250.0))
+
+        assertEquals(100.0, caseTone(line, darkMode = true, case = RouteLineCase.SELECTION), CHANNEL_TOLERANCE)
+        assertEquals(5.0, caseTone(line, darkMode = false, case = RouteLineCase.SELECTION), CHANNEL_TOLERANCE)
+
+        // Away from the basemap in both themes, which is the direction the whole policy is about: brighter
+        // than the outline on the dark map, deeper than it on the light one.
+        assertTrue(
+            caseTone(line, darkMode = true, case = RouteLineCase.SELECTION) >
+                caseTone(line, darkMode = true, case = RouteLineCase.OUTLINE)
+        )
+        assertTrue(
+            caseTone(line, darkMode = false, case = RouteLineCase.SELECTION) <
+                caseTone(line, darkMode = false, case = RouteLineCase.OUTLINE)
+        )
+    }
+
+    @Test
+    fun `an uncased line answers with the outline's tone, for the interline cut that reads it`() {
+        // The cutover slash takes its line's case colour whether or not that line wears a case (see
+        // `InterlineSeamMark`) — it *is* a hairline joint's casing. So NONE resolves rather than throwing or
+        // falling through to the selection tone, and it resolves to the hairline's own.
+        val line = Hct.fromInt(mapRouteLineColor(hue = 250.0))
+
+        listOf(false, true).forEach { darkMode ->
+            assertEquals(
+                caseTone(line, darkMode, case = RouteLineCase.OUTLINE),
+                caseTone(line, darkMode, case = RouteLineCase.NONE),
+                CHANNEL_TOLERANCE
             )
         }
     }
@@ -402,7 +444,7 @@ class ItineraryLegStyleTest {
         }
     }
 
-    private fun caseTone(line: Hct, darkMode: Boolean) = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode)).tone
+    private fun caseTone(line: Hct, darkMode: Boolean, case: RouteLineCase = RouteLineCase.OUTLINE) = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode, case)).tone
 
     /** A walk → ride → walk trip as drawn lines, at the given leg indices. */
     private fun tripOf(walk: Int, ride: Int, walk2: Int) = listOf(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -319,73 +319,62 @@ class ItineraryLegStyleTest {
     }
 
     @Test
-    fun `a case goes to the end of the tone scale away from the basemap`() {
+    fun `an outline goes to the end of the tone scale away from the basemap, keeping its line's hue`() {
         // A case goes *against* the basemap — near-black on the light map, near-white on the dark one.
         // Device-checked twice over: tinting it toward the map put it at the map's own value and it vanished,
         // and a mid-way tone was still too weak at this width to register.
         //
-        // At those tones sRGB holds little chroma, so a case ends up mostly a separator rather than a second
-        // colour — a deliberate trade for contrast. The dark end still has room to carry the line's *hue*, so
-        // it does, and that is asserted here: the trace of colour left on it is its own line's and not a
-        // neighbouring one's. The light end deliberately goes past where there is a hue left to keep — see
-        // the #2226 case below, which is what put it there.
+        // An outline stops short of the very end, keeping enough chroma to read as *this line's* edge, so the
+        // hue is asserted in both themes. The end itself belongs to the selection case below.
         ItineraryLegKind.entries.forEach { kind ->
             val line = Hct.fromInt(itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).color)
 
-            listOf(false to 10.0, true to 98.0).forEach { (darkMode, expectedTone) ->
+            listOf(false to 10.0, true to 90.0).forEach { (darkMode, expectedTone) ->
                 val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode, RouteLineCase.OUTLINE))
                 assertEquals("$kind case tone (darkMode=$darkMode)", expectedTone, case.tone, CHANNEL_TOLERANCE)
+                assertEquals("$kind case hue (darkMode=$darkMode)", line.hue, case.hue, HUE_TOLERANCE_DEGREES)
             }
-            assertEquals(
-                "$kind case hue",
-                line.hue,
-                Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = false, case = RouteLineCase.OUTLINE)).hue,
-                HUE_TOLERANCE_DEGREES
-            )
         }
     }
 
     @Test
-    fun `the light end of the case scale clears its own line, whatever the line's hue`() {
+    fun `the selected leg's case clears its own line on the dark basemap, whatever the line's hue`() {
         // #2226: selection is said with case *thickness* (#2082), which a rider can only read when the case is
-        // visibly not the line. The light end sat at tone 90 — 35 above a map line against the dark end's 45
-        // below it — and at that tone sRGB still holds a saturated version of the warm and green hues, so a
-        // green line got a green case and the highlight didn't register in dark mode.
+        // visibly not the line. The selected leg used to case at the outline's own tone 90, and at that tone
+        // sRGB still holds a saturated version of the warm and green hues — so a green line got a green case
+        // and the highlight didn't register in dark mode.
         //
         // Swept over the hue circle rather than run on the three leg colours because that is where it failed:
         // how much chroma survives a re-tone is a property of the hue's own gamut, so a policy can be correct
-        // for the blues and wrong for the greens, which is exactly what this one was.
+        // for the blues and wrong for the greens, which is exactly what the old one was. Tone 100 is past the
+        // end of every hue's gamut, which is what makes this hold for all of them at once.
         (0 until 360 step 10).forEach { hue ->
             val line = Hct.fromInt(mapRouteLineColor(hue.toDouble()))
-            val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = true, case = RouteLineCase.OUTLINE))
+            val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = true, case = RouteLineCase.SELECTION))
 
             assertTrue(
                 "hue $hue: case tone ${case.tone} is only ${case.tone - line.tone} above its line's ${line.tone}",
-                case.tone - line.tone >= MIN_LIGHT_CASE_TONE_STEP
+                case.tone - line.tone >= MIN_SELECTION_CASE_TONE_STEP
             )
             assertTrue(
                 "hue $hue: case kept chroma ${case.chroma} of its line's ${line.chroma} — a colour, not an edge",
-                case.chroma <= MAX_LIGHT_CASE_CHROMA
+                case.chroma <= MAX_SELECTION_CASE_CHROMA
             )
         }
     }
 
     @Test
     fun `the selected leg's case takes the very end of the scale, an outline stops short of it`() {
-        // Selection is said with case weight (#2082); this adds the last of the tone scale to it, so the leg
-        // the rider is looking at wears the brightest edge on the map as well as the heaviest.
-        //
-        // The step is deliberately tiny and the test says so, because #2226 already spent nearly all of that
-        // scale on the ordinary case: what is left above it is 2 tones. Asserted as an *ordering* rather than
-        // a contrast bar for exactly that reason — there is no perceptual claim here to make, only the policy
-        // one that a selection is never cased less far out than an outline beside it.
+        // The second half of #2226: what separates the rider's leg from the rides beside it is not the tone
+        // step (1.29:1 on the dark basemap, 1.10:1 on the light one — neither is a difference on its own) but
+        // that on the dark map only the selected case is *colourless*, every outline around it staying tinted
+        // with the route it wraps. That is asserted by the hue-circle case above; asserted here is the policy
+        // it rests on — a selection is never cased less far out than an outline beside it, in either theme.
         val line = Hct.fromInt(mapRouteLineColor(hue = 250.0))
 
         assertEquals(100.0, caseTone(line, darkMode = true, case = RouteLineCase.SELECTION), CHANNEL_TOLERANCE)
         assertEquals(5.0, caseTone(line, darkMode = false, case = RouteLineCase.SELECTION), CHANNEL_TOLERANCE)
 
-        // Away from the basemap in both themes, which is the direction the whole policy is about: brighter
-        // than the outline on the dark map, deeper than it on the light one.
         assertTrue(
             caseTone(line, darkMode = true, case = RouteLineCase.SELECTION) >
                 caseTone(line, darkMode = true, case = RouteLineCase.OUTLINE)
@@ -575,11 +564,11 @@ class ItineraryLegStyleTest {
         // slightly under it. Wide enough to absorb that, far too narrow to hide a different policy.
         const val CHANNEL_TOLERANCE = 2.0
 
-        // What the light end of the case scale has to clear to read as an edge on its line rather than as a
-        // lighter shade of it (#2226): a tonal step of the dark end's order, and little enough of the line's
-        // own chroma left that no hue comes back saturated. The tones sit at 43 and under 27 respectively, so
-        // these are floors on the policy and not restatements of it.
-        const val MIN_LIGHT_CASE_TONE_STEP = 40.0
-        const val MAX_LIGHT_CASE_CHROMA = 30.0
+        // What the selected leg's case has to clear on the dark basemap to read as an edge on its line rather
+        // than as a lighter shade of it (#2226): a tonal step of the dark end's order, and so little of the
+        // line's own chroma left that no hue comes back tinted at all. The policy delivers 45 and 2.9, so
+        // these are floors on it and not restatements of it — an outline's tone 90 fails both.
+        const val MIN_SELECTION_CASE_TONE_STEP = 40.0
+        const val MAX_SELECTION_CASE_CHROMA = 10.0
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -319,22 +319,54 @@ class ItineraryLegStyleTest {
     }
 
     @Test
-    fun `a case goes to the end of the tone scale away from the basemap, keeping its line's hue`() {
+    fun `a case goes to the end of the tone scale away from the basemap`() {
         // A case goes *against* the basemap — near-black on the light map, near-white on the dark one.
         // Device-checked twice over: tinting it toward the map put it at the map's own value and it vanished,
         // and a mid-way tone was still too weak at this width to register.
         //
         // At those tones sRGB holds little chroma, so a case ends up mostly a separator rather than a second
-        // colour — a deliberate trade for contrast. What must survive is the *hue*, so the trace of colour
-        // that's left is its own line's and not a neighbouring one's.
+        // colour — a deliberate trade for contrast. The dark end still has room to carry the line's *hue*, so
+        // it does, and that is asserted here: the trace of colour left on it is its own line's and not a
+        // neighbouring one's. The light end deliberately goes past where there is a hue left to keep — see
+        // the #2226 case below, which is what put it there.
         ItineraryLegKind.entries.forEach { kind ->
             val line = Hct.fromInt(itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).color)
 
-            listOf(false to 10.0, true to 90.0).forEach { (darkMode, expectedTone) ->
+            listOf(false to 10.0, true to 98.0).forEach { (darkMode, expectedTone) ->
                 val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode))
                 assertEquals("$kind case tone (darkMode=$darkMode)", expectedTone, case.tone, CHANNEL_TOLERANCE)
-                assertEquals("$kind case hue (darkMode=$darkMode)", line.hue, case.hue, HUE_TOLERANCE_DEGREES)
             }
+            assertEquals(
+                "$kind case hue",
+                line.hue,
+                Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = false)).hue,
+                HUE_TOLERANCE_DEGREES
+            )
+        }
+    }
+
+    @Test
+    fun `the light end of the case scale clears its own line, whatever the line's hue`() {
+        // #2226: selection is said with case *thickness* (#2082), which a rider can only read when the case is
+        // visibly not the line. The light end sat at tone 90 — 35 above a map line against the dark end's 45
+        // below it — and at that tone sRGB still holds a saturated version of the warm and green hues, so a
+        // green line got a green case and the highlight didn't register in dark mode.
+        //
+        // Swept over the hue circle rather than run on the three leg colours because that is where it failed:
+        // how much chroma survives a re-tone is a property of the hue's own gamut, so a policy can be correct
+        // for the blues and wrong for the greens, which is exactly what this one was.
+        (0 until 360 step 10).forEach { hue ->
+            val line = Hct.fromInt(mapRouteLineColor(hue.toDouble()))
+            val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = true))
+
+            assertTrue(
+                "hue $hue: case tone ${case.tone} is only ${case.tone - line.tone} above its line's ${line.tone}",
+                case.tone - line.tone >= MIN_LIGHT_CASE_TONE_STEP
+            )
+            assertTrue(
+                "hue $hue: case kept chroma ${case.chroma} of its line's ${line.chroma} — a colour, not an edge",
+                case.chroma <= MAX_LIGHT_CASE_CHROMA
+            )
         }
     }
 
@@ -500,5 +532,12 @@ class ItineraryLegStyleTest {
         // Chroma likewise clamps to the gamut: a hue that can't hold the full chroma at this tone lands
         // slightly under it. Wide enough to absorb that, far too narrow to hide a different policy.
         const val CHANNEL_TOLERANCE = 2.0
+
+        // What the light end of the case scale has to clear to read as an edge on its line rather than as a
+        // lighter shade of it (#2226): a tonal step of the dark end's order, and little enough of the line's
+        // own chroma left that no hue comes back saturated. The tones sit at 43 and under 27 respectively, so
+        // these are floors on the policy and not restatements of it.
+        const val MIN_LIGHT_CASE_TONE_STEP = 40.0
+        const val MAX_LIGHT_CASE_CHROMA = 30.0
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -330,7 +330,7 @@ class ItineraryLegStyleTest {
             val line = Hct.fromInt(itineraryLegStyle(kind, routeColor = null, palette = DIRECTIONS).color)
 
             listOf(false to 10.0, true to 90.0).forEach { (darkMode, expectedTone) ->
-                val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode, RouteLineCase.OUTLINE))
+                val case = caseHct(line, darkMode)
                 assertEquals("$kind case tone (darkMode=$darkMode)", expectedTone, case.tone, CHANNEL_TOLERANCE)
                 assertEquals("$kind case hue (darkMode=$darkMode)", line.hue, case.hue, HUE_TOLERANCE_DEGREES)
             }
@@ -350,7 +350,7 @@ class ItineraryLegStyleTest {
         // end of every hue's gamut, which is what makes this hold for all of them at once.
         (0 until 360 step 10).forEach { hue ->
             val line = Hct.fromInt(mapRouteLineColor(hue.toDouble()))
-            val case = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode = true, case = RouteLineCase.SELECTION))
+            val case = caseHct(line, darkMode = true, case = RouteLineCase.SELECTION)
 
             assertTrue(
                 "hue $hue: case tone ${case.tone} is only ${case.tone - line.tone} above its line's ${line.tone}",
@@ -370,19 +370,13 @@ class ItineraryLegStyleTest {
         // that on the dark map only the selected case is *colourless*, every outline around it staying tinted
         // with the route it wraps. That is asserted by the hue-circle case above; asserted here is the policy
         // it rests on — a selection is never cased less far out than an outline beside it, in either theme.
-        val line = Hct.fromInt(mapRouteLineColor(hue = 250.0))
+        val onDark = caseTone(ANY_MAP_LINE, darkMode = true, case = RouteLineCase.SELECTION)
+        val onLight = caseTone(ANY_MAP_LINE, darkMode = false, case = RouteLineCase.SELECTION)
 
-        assertEquals(100.0, caseTone(line, darkMode = true, case = RouteLineCase.SELECTION), CHANNEL_TOLERANCE)
-        assertEquals(5.0, caseTone(line, darkMode = false, case = RouteLineCase.SELECTION), CHANNEL_TOLERANCE)
-
-        assertTrue(
-            caseTone(line, darkMode = true, case = RouteLineCase.SELECTION) >
-                caseTone(line, darkMode = true, case = RouteLineCase.OUTLINE)
-        )
-        assertTrue(
-            caseTone(line, darkMode = false, case = RouteLineCase.SELECTION) <
-                caseTone(line, darkMode = false, case = RouteLineCase.OUTLINE)
-        )
+        assertEquals(100.0, onDark, CHANNEL_TOLERANCE)
+        assertEquals(5.0, onLight, CHANNEL_TOLERANCE)
+        assertTrue(onDark > caseTone(ANY_MAP_LINE, darkMode = true, case = RouteLineCase.OUTLINE))
+        assertTrue(onLight < caseTone(ANY_MAP_LINE, darkMode = false, case = RouteLineCase.OUTLINE))
     }
 
     @Test
@@ -390,12 +384,25 @@ class ItineraryLegStyleTest {
         // The cutover slash takes its line's case colour whether or not that line wears a case (see
         // `InterlineSeamMark`) — it *is* a hairline joint's casing. So NONE resolves rather than throwing or
         // falling through to the selection tone, and it resolves to the hairline's own.
-        val line = Hct.fromInt(mapRouteLineColor(hue = 250.0))
-
         listOf(false, true).forEach { darkMode ->
             assertEquals(
-                caseTone(line, darkMode, case = RouteLineCase.OUTLINE),
-                caseTone(line, darkMode, case = RouteLineCase.NONE),
+                caseTone(ANY_MAP_LINE, darkMode, case = RouteLineCase.OUTLINE),
+                caseTone(ANY_MAP_LINE, darkMode, case = RouteLineCase.NONE),
+                CHANNEL_TOLERANCE
+            )
+        }
+    }
+
+    @Test
+    fun `the approach cases in the selection's colour, which is why it is a weight and not a colour`() {
+        // The approach and the ride it leads into have to read as one route line stepping down at the
+        // boarding point, and they only do while their cases are the same colour — so APPROACH is a lighter
+        // *weight* of the selection case, never a tone of its own. Nothing else checks this: the two live in
+        // the same `when` arm, and moving one out would compile and pass everything but this.
+        listOf(false, true).forEach { darkMode ->
+            assertEquals(
+                caseTone(ANY_MAP_LINE, darkMode, case = RouteLineCase.SELECTION),
+                caseTone(ANY_MAP_LINE, darkMode, case = RouteLineCase.APPROACH),
                 CHANNEL_TOLERANCE
             )
         }
@@ -433,7 +440,10 @@ class ItineraryLegStyleTest {
         }
     }
 
-    private fun caseTone(line: Hct, darkMode: Boolean, case: RouteLineCase = RouteLineCase.OUTLINE) = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode, case)).tone
+    /** [line]'s case as an [Hct], the one spelling of that conversion in this file. */
+    private fun caseHct(line: Hct, darkMode: Boolean, case: RouteLineCase = RouteLineCase.OUTLINE) = Hct.fromInt(mapRouteLineCaseColor(line.toInt(), darkMode, case))
+
+    private fun caseTone(line: Hct, darkMode: Boolean, case: RouteLineCase = RouteLineCase.OUTLINE) = caseHct(line, darkMode, case).tone
 
     /** A walk → ride → walk trip as drawn lines, at the given leg indices. */
     private fun tripOf(walk: Int, ride: Int, walk2: Int) = listOf(
@@ -556,6 +566,10 @@ class ItineraryLegStyleTest {
         val DIRECTIONS: RouteLinePalette = directionsRouteLinePalette(dark = false)
 
         val BASEMAP: RouteLinePalette = BASEMAP_ROUTE_LINE_PALETTE
+
+        // A map-palette line of no particular hue, for the cases that are about the *tone* a case lands on —
+        // which is a property of the theme and the weight, never of the line (see the case just below).
+        val ANY_MAP_LINE: Hct = Hct.fromInt(mapRouteLineColor(hue = 250.0))
 
         // The re-tone clamps to each hue's own sRGB gamut limit, so a hue can shift a degree or two.
         const val HUE_TOLERANCE_DEGREES = 3.0

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -18,7 +18,6 @@ package org.onebusaway.android.map
 import kotlin.math.cos
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.api.adapters.ObaStopElement
@@ -105,9 +104,10 @@ class RouteSegmentHighlightTest {
         assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, overlay.widthProfile)
         assertEquals(0xFF00FF00.toInt(), overlay.color)
         assertFalse(overlay.directional)
-        // Both halves of the selected route carry a case, so the approach and the ride read as one line
-        // rather than as two things that happen to meet.
-        assertEquals(RouteLineCase.SELECTION, approach.case)
+        // Both halves of the selected route carry a case in the selection colour, so the approach and the
+        // ride read as one line rather than as two things that happen to meet. The approach's is the lighter
+        // weight, because at 3.5dp it is thinner than a full selection case is wide.
+        assertEquals(RouteLineCase.APPROACH, approach.case)
         assertEquals(RouteLineCase.SELECTION, overlay.case)
     }
 
@@ -132,8 +132,8 @@ class RouteSegmentHighlightTest {
         assertEquals(RouteLineDash.TRAIL, result[1].dash)
         assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, result[2].widthProfile)
         // Only the selected route is cased: the rest of the rider's journey is context, not selection.
-        assertNotEquals(RouteLineCase.SELECTION, result[1].case)
-        assertEquals(RouteLineCase.SELECTION, result[0].case)
+        assertEquals(RouteLineCase.NONE, result[1].case)
+        assertEquals(RouteLineCase.APPROACH, result[0].case)
         assertEquals(RouteLineCase.SELECTION, result[2].case)
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -75,12 +75,40 @@ class RouteLineWidthProfileTest {
     fun `a case reads as an outline at every zoom, so it stays off the width ramp`() {
         // The case is a fixed dp inset on each side, deliberately not scaled by the line's zoom multiplier: a
         // halo that thinned with its line would stop separating it from the basemap exactly when zoomed out.
-        assertEquals(1.5f, RouteLineCase.SELECTION.widthDp, 0f)
-        // The lighter edge every directions ride wears; selection stays legible against it by being the
-        // heavier of the two, which is what lets it still mean "selected".
+        assertEquals(2.25f, RouteLineCase.SELECTION.widthDp, 0f)
+        // The lighter edge every directions ride wears; selection stays legible against it by being three
+        // times the weight, which is what lets it still mean "selected".
         assertEquals(0.75f, RouteLineCase.OUTLINE.widthDp, 0f)
-        // And both stay finer than the thinnest line they can wrap, so a case reads as that line's edge
-        // rather than as a second line under it.
-        assertTrue(RouteLineCase.SELECTION.extraWidthDp < ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
+        // An outline stays finer than the thinnest line it can wrap, so it reads as that line's edge rather
+        // than as a second line under it.
+        assertTrue(RouteLineCase.OUTLINE.extraWidthDp < ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
+    }
+
+    @Test
+    fun `a selection case outgrows the approach line, which is the one line it is allowed to`() {
+        // Selection deliberately broke the rule the outline still keeps: at 2.25dp per side it adds 4.5dp to
+        // a line the approach profile draws at 3.5dp, so on *that* line the case is wider than the line and
+        // reads as a band with a coloured core rather than as an edge.
+        //
+        // Accepted, and only there. The approach — where the vehicle is coming from, upstream of the boarding
+        // point — is the one line drawn deliberately too thin to identify itself, and its own profile says so:
+        // "its case, not its width, is what connects it to the ride". A heavier case makes that connection
+        // more legible, not less. Every other line carrying a selection is at least the ride's 15dp, where
+        // 4.5dp is an edge by any reading.
+        //
+        // Pinned as a test because it is the kind of thing a later width tune would trip over unknowingly: if
+        // some *other* profile ever drops under the selection case's own width, that is a real regression and
+        // this is where it should surface.
+        assertTrue(RouteLineCase.SELECTION.extraWidthDp > ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
+        listOf(
+            ITINERARY_RIDE_WIDTH_PROFILE,
+            ITINERARY_STREET_WIDTH_PROFILE,
+            ITINERARY_CONTEXT_WIDTH_PROFILE
+        ).forEach {
+            assertTrue(
+                "a ${it.thicknessDp}dp line is thinner than the ${RouteLineCase.SELECTION.extraWidthDp}dp its case adds",
+                RouteLineCase.SELECTION.extraWidthDp < it.thicknessDp
+            )
+        }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -77,7 +77,7 @@ class RouteLineWidthProfileTest {
         // halo that thinned with its line would stop separating it from the basemap exactly when zoomed out.
         assertEquals(2.25f, RouteLineCase.SELECTION.widthDp, 0f)
         // The approach's own weight: the selection colour on a line too thin to carry the selection width.
-        assertEquals(1.5f, RouteLineCase.APPROACH.widthDp, 0f)
+        assertEquals(1f, RouteLineCase.APPROACH.widthDp, 0f)
         // The lighter edge every directions ride wears; selection stays legible against it by being three
         // times the weight, which is what lets it still mean "selected".
         assertEquals(0.75f, RouteLineCase.OUTLINE.widthDp, 0f)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -76,39 +76,43 @@ class RouteLineWidthProfileTest {
         // The case is a fixed dp inset on each side, deliberately not scaled by the line's zoom multiplier: a
         // halo that thinned with its line would stop separating it from the basemap exactly when zoomed out.
         assertEquals(2.25f, RouteLineCase.SELECTION.widthDp, 0f)
+        // The approach's own weight: the selection colour on a line too thin to carry the selection width.
+        assertEquals(1.5f, RouteLineCase.APPROACH.widthDp, 0f)
         // The lighter edge every directions ride wears; selection stays legible against it by being three
         // times the weight, which is what lets it still mean "selected".
         assertEquals(0.75f, RouteLineCase.OUTLINE.widthDp, 0f)
-        // An outline stays finer than the thinnest line it can wrap, so it reads as that line's edge rather
-        // than as a second line under it.
-        assertTrue(RouteLineCase.OUTLINE.extraWidthDp < ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
+        // Ascending, so that a heavier case always means a stronger claim on the rider's attention.
+        assertEquals(
+            RouteLineCase.entries.map { it.widthDp }.sorted(),
+            RouteLineCase.entries.map { it.widthDp }
+        )
     }
 
     @Test
-    fun `a selection case outgrows the approach line, which is the one line it is allowed to`() {
-        // Selection deliberately broke the rule the outline still keeps: at 2.25dp per side it adds 4.5dp to
-        // a line the approach profile draws at 3.5dp, so on *that* line the case is wider than the line and
-        // reads as a band with a coloured core rather than as an edge.
+    fun `every case is finer than the thinnest line that asks for it`() {
+        // The rule that makes a case read as its line's *edge* rather than as a second line under it — and
+        // the reason APPROACH exists at all. A selection case adds 4.5dp, which is more width than the
+        // approach line (3.5dp) has; taking the full selection weight there drew the thinnest line on the map
+        // as a band with a coloured core. So the approach asks for a lighter case in the same colour, and the
+        // rule holds everywhere again.
         //
-        // Accepted, and only there. The approach — where the vehicle is coming from, upstream of the boarding
-        // point — is the one line drawn deliberately too thin to identify itself, and its own profile says so:
-        // "its case, not its width, is what connects it to the ride". A heavier case makes that connection
-        // more legible, not less. Every other line carrying a selection is at least the ride's 15dp, where
-        // 4.5dp is an edge by any reading.
-        //
-        // Pinned as a test because it is the kind of thing a later width tune would trip over unknowingly: if
-        // some *other* profile ever drops under the selection case's own width, that is a real regression and
-        // this is where it should surface.
-        assertTrue(RouteLineCase.SELECTION.extraWidthDp > ITINERARY_APPROACH_WIDTH_PROFILE.thicknessDp)
-        listOf(
-            ITINERARY_RIDE_WIDTH_PROFILE,
-            ITINERARY_STREET_WIDTH_PROFILE,
-            ITINERARY_CONTEXT_WIDTH_PROFILE
-        ).forEach {
-            assertTrue(
-                "a ${it.thicknessDp}dp line is thinner than the ${RouteLineCase.SELECTION.extraWidthDp}dp its case adds",
-                RouteLineCase.SELECTION.extraWidthDp < it.thicknessDp
-            )
+        // Checked per case against what can actually ask for it, rather than against the thinnest profile on
+        // the map, since that is what the claim means. A later width tune that drops one of these lines under
+        // its own case surfaces here.
+        mapOf(
+            // Every directions ride wears an outline, and a focused on-street leg keeps it too.
+            RouteLineCase.OUTLINE to listOf(ITINERARY_RIDE_WIDTH_PROFILE, ITINERARY_STREET_WIDTH_PROFILE),
+            // Only the approach.
+            RouteLineCase.APPROACH to listOf(ITINERARY_APPROACH_WIDTH_PROFILE),
+            // The ridden span, and a focused itinerary leg of either kind.
+            RouteLineCase.SELECTION to listOf(ITINERARY_RIDE_WIDTH_PROFILE, ITINERARY_STREET_WIDTH_PROFILE)
+        ).forEach { (case, profiles) ->
+            profiles.forEach {
+                assertTrue(
+                    "$case adds ${case.extraWidthDp}dp to a line only ${it.thicknessDp}dp wide",
+                    case.extraWidthDp < it.thicknessDp
+                )
+            }
         }
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RouteLineWidthProfileTest.kt
@@ -99,20 +99,20 @@ class RouteLineWidthProfileTest {
         // Checked per case against what can actually ask for it, rather than against the thinnest profile on
         // the map, since that is what the claim means. A later width tune that drops one of these lines under
         // its own case surfaces here.
-        mapOf(
+        listOf(
             // Every directions ride wears an outline, and a focused on-street leg keeps it too.
-            RouteLineCase.OUTLINE to listOf(ITINERARY_RIDE_WIDTH_PROFILE, ITINERARY_STREET_WIDTH_PROFILE),
+            RouteLineCase.OUTLINE to ITINERARY_RIDE_WIDTH_PROFILE,
+            RouteLineCase.OUTLINE to ITINERARY_STREET_WIDTH_PROFILE,
             // Only the approach.
-            RouteLineCase.APPROACH to listOf(ITINERARY_APPROACH_WIDTH_PROFILE),
+            RouteLineCase.APPROACH to ITINERARY_APPROACH_WIDTH_PROFILE,
             // The ridden span, and a focused itinerary leg of either kind.
-            RouteLineCase.SELECTION to listOf(ITINERARY_RIDE_WIDTH_PROFILE, ITINERARY_STREET_WIDTH_PROFILE)
-        ).forEach { (case, profiles) ->
-            profiles.forEach {
-                assertTrue(
-                    "$case adds ${case.extraWidthDp}dp to a line only ${it.thicknessDp}dp wide",
-                    case.extraWidthDp < it.thicknessDp
-                )
-            }
+            RouteLineCase.SELECTION to ITINERARY_RIDE_WIDTH_PROFILE,
+            RouteLineCase.SELECTION to ITINERARY_STREET_WIDTH_PROFILE
+        ).forEach { (case, profile) ->
+            assertTrue(
+                "$case adds ${case.extraWidthDp}dp to a line only ${profile.thicknessDp}dp wide",
+                case.extraWidthDp < profile.thicknessDp
+            )
         }
     }
 }


### PR DESCRIPTION
Closes #2226.

Selection on the map is said with case **thickness** (#2082), which a rider can only read when the case is visibly not the line it wraps. In dark mode it wasn't: the case kept its line's hue *and* its chroma, so a green ride got a green edge and the thickness step had nothing to be read against. This fixes the colour, then leans harder on the weight.

## 1. The case colour now depends on the weight

| | `OUTLINE` (every ride) | `APPROACH` / `SELECTION` |
|---|---|---|
| dark basemap | 90 *(unchanged)* | **100** |
| light basemap | 10 *(unchanged)* | **5** |

An outline is not the highlight — it holds a faded ride off the basemap and has never said anything about selection — so it stays exactly where it was, hue and all. The selected line goes to the literal end.

### Why that reads, when 1.29:1 doesn't

The tone step between the two cases is small: **1.29:1** on the dark basemap, 1.10:1 on the light one. Neither is a difference on its own, and the separation does not come from there.

It comes from the gamut. At tone 100 there is no chroma left to give, so on the dark map the selected case comes back **white**, while every outline around it stays tinted with the route it wraps. Being the only colourless edge on screen is a categorical difference, not a 1.29:1 one:

| line | its outline @90 | its selection @100 |
|---|---|---|
| route 62 gold `#AD7B00` | `#FFDEA9` — chroma 23, a lighter gold | `#FFFFFF` — chroma 2.9 |
| a green ride | chroma **68**, a lighter green | `#FFFFFF` |

On the light basemap tone 5 still carries a hue, so there the selected case reads as *depth* rather than colourlessness. Each theme's signal is whatever its end of the scale can offer.

The pixel values above are real: route 62 draws as `#AD7B00` over a `#242F3E` dark basemap on device, both sampled from a screenshot.

## 2. Case weights: a fourth rung

`RouteLineCase` gains `APPROACH`, and the ladder is now:

| | per side | wraps |
|---|---|---|
| `OUTLINE` | 0.75dp | every directions ride |
| `APPROACH` | 1dp | the selected line's approach (3.5dp) |
| `SELECTION` | **2.25dp** | the ridden segment / focused leg (9–15dp) |

The ridden segment's case is 1.5× what it was, so selection is three times the outline's weight rather than twice it. Two weights read as one edge and a thicker one; three read as an edge and a band, which is what this wants — a selection case competes for attention with the line it wraps, not with the basemap.

The approach gets its own rung because it is the thinnest line on the map. A 2.25dp case adds 4.5dp, more width than the 3.5dp approach line has, so it drew as a band with a coloured core — worse zoomed out, where the ramp halves the line while a case (by design) doesn't thin at all. `APPROACH` adds 2dp instead, which stays an edge even at the far end of the zoom ramp, where the line halves to 1.75dp and a case (by design) doesn't thin at all.

**Its colour is unchanged — `APPROACH` resolves to the selection tone, not one of its own.** That is why it is a separate weight and not a separate colour: the approach and the ride it leads into have to read as one route line stepping down at the boarding point, which they only do if their cases are the same colour. What differs is width, which is a statement about the lines and not about what they mean.

So the rule that a case reads as its line's *edge* and never as a second line under it holds everywhere. The test asserts it per case against the profiles that can actually ask for it.

## Plumbing

The case weight is threaded through to the interline cutover slash too, which is drawn in its line's case colour and so has to ask the same question. `NONE` answers alongside `OUTLINE` rather than being rejected: an uncased line can still carry a cut, and a hairline joint's casing is what that mark is.

## Testing

- `ItineraryLegStyleTest` — the hue-circle sweep now runs on the selection case (the old tone 90 fails both its bars: tone step 35 against 40, chroma 75 against 10), the outline keeps its both-themes hue assertion, plus cases for the selection tones and for `NONE` resolving to the outline's.
- `RouteLineWidthProfileTest` — the four weights, their ascending order, and the finer-than-its-line rule per case.
- `RouteSegmentHighlightTest` — the approach now takes `APPROACH`, the ridden span `SELECTION`.
- `testObaGoogleDebugUnitTest` + `testObaMaplibreDebugUnitTest` green; `compileObaGoogleDebugKotlin`/`compileObaMaplibreDebugKotlin -PwarningsAsErrors=true` and `spotlessCheck` clean.
- Installed on device; the colour work was checked against real sampled pixels. **A cased line itself has not been verified on device** — a case only appears once a vehicle or an itinerary leg is selected, and the map's vehicle markers have no semantic test handle to select one through.

The commits are the working history; squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
