### PR TITLE
Prominently warn about spotty OSM/OTP walking data (#2218)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
@@ -71,6 +71,10 @@ fun alertAccentColor(severity: AlertSeverity): Color = when (severity) {
  * to the full description), and what they must agree on is the *colour* — which is exactly the part a
  * second copy of the table below would eventually get wrong.
  *
+ * For the same reason it also carries the one caution that isn't a feed alert: the directions safety
+ * banner (`DirectionsCautionBanner`, #2218), which warns that the walking data may be wrong. It is a
+ * genuine [AlertSeverity.WARNING] and the alternative was a duplicate palette.
+ *
  * [onClick] makes the whole card the tap target; a card with nothing to open passes null and takes no
  * clickable at all rather than an empty one. The card also exposes [severity] as a localized state
  * description, because its container colour is otherwise invisible to a screen reader.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/AlertSurface.kt
@@ -31,9 +31,10 @@ import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 
 /**
- * How loudly a service alert is drawn — the app's single alert-severity vocabulary, shared by every
- * surface that shows one (the arrivals banner, the trip planner's directions, #2143). Each feed's own
- * severity scale is mapped onto these three at its own wire boundary: the OBA `situation` scale by
+ * How loudly a warning is drawn — the app's single alert-severity vocabulary, shared by every surface
+ * that shows one (the arrivals banner, the trip planner's directions, #2143, and the one caution that
+ * isn't a feed alert at all, #2218). Each feed's own severity scale is mapped onto these three at its
+ * own wire boundary: the OBA `situation` scale by
  * `severityOf` (`ArrivalsRepository`), OTP2's `AlertSeverityLevelType` by `TripAlertSeverity.tone`
  * (`TripAlerts`). Presentation lives here so a severe alert can't read as urgent on one screen and
  * merely advisory on another.
@@ -66,14 +67,11 @@ fun alertAccentColor(severity: AlertSeverity): Color = when (severity) {
 }
 
 /**
- * The severity-tinted rounded card a service alert is drawn on. Only the container is shared: each
- * surface lays out its own contents (the arrivals banner is one line, the directions banner expands
- * to the full description), and what they must agree on is the *colour* — which is exactly the part a
- * second copy of the table below would eventually get wrong.
- *
- * For the same reason it also carries the one caution that isn't a feed alert: the directions safety
- * banner (`DirectionsCautionBanner`, #2218), which warns that the walking data may be wrong. It is a
- * genuine [AlertSeverity.WARNING] and the alternative was a duplicate palette.
+ * The severity-tinted rounded card a warning is drawn on. Only the container is shared: each surface
+ * lays out its own contents (the arrivals banner is one line, the directions banner expands to the
+ * full description, and `DirectionsCautionBanner` (#2218) is the one caution that isn't a feed alert
+ * at all), and what they must agree on is the *colour* — which is exactly the part a second copy of
+ * the table below would eventually get wrong.
  *
  * [onClick] makes the whole card the tap target; a card with nothing to open passes null and takes no
  * clickable at all rather than an empty one. The card also exposes [severity] as a localized state

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -99,6 +99,7 @@ import org.onebusaway.android.ui.home.directions.DirectionsFormCard
 import org.onebusaway.android.ui.home.directions.DirectionsLongPressMenu
 import org.onebusaway.android.ui.home.directions.DirectionsPickOverlay
 import org.onebusaway.android.ui.home.directions.DirectionsResultsSheet
+import org.onebusaway.android.ui.home.directions.DirectionsSafetyNotice
 import org.onebusaway.android.ui.home.directions.itineraryPins
 import org.onebusaway.android.ui.home.directions.pinPoint
 import org.onebusaway.android.ui.home.donation.DonationFeature
@@ -1139,6 +1140,13 @@ fun HomeScreen(
                                         onDismiss = homeViewModel::dismissDirectionsExit
                                     )
                                 }
+                                // The one-time "these directions may be wrong" acknowledgement (#2218).
+                                // Gated on the focus alone, not on pickTarget, so every way into
+                                // directions passes through it; declining leaves the way Back does.
+                                DirectionsSafetyNotice(
+                                    active = directionsActive,
+                                    onDecline = homeViewModel::navigateBackInDirections
+                                )
                             }
                         }
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -1142,11 +1142,12 @@ fun HomeScreen(
                                 }
                                 // The one-time "these directions may be wrong" acknowledgement (#2218).
                                 // Gated on the focus alone, not on pickTarget, so every way into
-                                // directions passes through it; declining leaves the way Back does.
-                                DirectionsSafetyNotice(
-                                    active = directionsActive,
-                                    onDecline = homeViewModel::navigateBackInDirections
-                                )
+                                // directions passes through it.
+                                if (directionsActive) {
+                                    DirectionsSafetyNotice(
+                                        onDecline = homeViewModel::leaveDirections
+                                    )
+                                }
                             }
                         }
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -1168,6 +1168,20 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
+     * Leave directions outright, asking nothing — the answer to a modal the rider declined rather than
+     * to a gesture (today, backing out of the safety notice, #2218).
+     *
+     * Deliberately *not* [navigateBackInDirections]: that is a three-rung ladder (pop a sub-focus, else
+     * stage the #2140 confirmation, else exit), and only its last rung is what declining means. Borrowed
+     * for a modal it misbehaves the moment there is anything to pop or to confirm — a pinned-trip resume
+     * puts a drawn plan behind the notice on the rider's very first visit, and the ladder would answer
+     * Back by raising a confirm dialog *underneath* the full-screen notice still covering the screen.
+     * Unlike [confirmExitDirections] this needs no staged-exit guard: it isn't a control on the trip
+     * surface (#2075) but the dismissal of a modal that is itself the only thing on screen.
+     */
+    fun leaveDirections() = exitDirections()
+
+    /**
      * The system Back gesture while in directions. A leg the user drilled into — its route, or an
      * on-street leg framed on its own — steps back out of that leg first, so Back reverses the drill-in
      * (restoring the camera it moved) instead of leaving the trip behind (#2075); only from the plain

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNotice.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNotice.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -73,8 +72,8 @@ internal fun markSafetyNoticeAcknowledged(prefs: PreferencesRepository) {
  * arrive expecting parity with commercial map apps. Tuning OTP is the real fix; this is the honest
  * disclosure that has to hold in the meantime, and it is shown once rather than on every plan because
  * the per-itinerary
- * [DirectionsCautionBanner][org.onebusaway.android.ui.tripresults.DirectionsCautionBanner] is the
- * standing reminder.
+ * [DirectionsCautionBanner][org.onebusaway.android.ui.tripresults.DirectionsCautionBanner] is what
+ * repeats it.
  *
  * The caller composes it only while directions has the focus, which covers *every* way in (the
  * drawer, the map long-press menu, a pinned-trip resume, a monitor notification): they all land on the

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNotice.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNotice.kt
@@ -76,10 +76,10 @@ internal fun markSafetyNoticeAcknowledged(prefs: PreferencesRepository) {
  * [DirectionsCautionBanner][org.onebusaway.android.ui.tripresults.DirectionsCautionBanner] is the
  * standing reminder.
  *
- * Shown whenever [active] and the acknowledgement is still owed, which covers *every* way into
- * directions (the drawer, the map long-press menu, a pinned-trip resume, a monitor notification):
- * they all land on the same [CurrentFocus.Directions][org.onebusaway.android.ui.home.CurrentFocus]
- * that [active] is read from, so none of them can slip past it.
+ * The caller composes it only while directions has the focus, which covers *every* way in (the
+ * drawer, the map long-press menu, a pinned-trip resume, a monitor notification): they all land on the
+ * same [CurrentFocus.Directions][org.onebusaway.android.ui.home.CurrentFocus], so none of them can
+ * slip past it.
  *
  * It is a full-screen [Dialog] rather than a sibling in the host's `Box` because it needs its own
  * window: that is what puts it unconditionally over the map, the form card *and* the results sheet,
@@ -91,22 +91,23 @@ internal fun markSafetyNoticeAcknowledged(prefs: PreferencesRepository) {
  * but the rider is never trapped behind it either.
  */
 @Composable
-internal fun DirectionsSafetyNotice(active: Boolean, onDecline: () -> Unit) {
+internal fun DirectionsSafetyNotice(onDecline: () -> Unit) {
     val context = LocalContext.current
     // Resolved once rather than per recomposition, matching the remember { …EntryPoint.get(…) }
-    // pattern elsewhere. The repository reads its own writes synchronously, so the initial read
-    // already reflects an acknowledgement made earlier in this process.
+    // pattern elsewhere.
     val prefs = remember { PreferencesEntryPoint.get(context) }
-    // Seeded from prefs and flipped locally on acknowledgement: the write is async-persisted, and
-    // this is what closes the notice on the very next frame rather than on the next process.
-    var pending by rememberSaveable { mutableStateOf(isSafetyNoticePending(prefs)) }
-    if (!active || !pending) return
+    // State rather than a bare read, because a preference isn't snapshot-observed and the button tap
+    // needs something to recompose on. `remember`, not `rememberSaveable`: the preference is already
+    // the durable record of this exact bit, and it reads its own writes synchronously, so re-seeding
+    // from it — on a config change, or on the next entry into directions — is always right.
+    var pending by remember { mutableStateOf(isSafetyNoticePending(prefs)) }
+    if (!pending) return
 
     Dialog(
         onDismissRequest = onDecline,
         properties = DialogProperties(
-            // A tap outside can't reach it (it fills the window), but saying so keeps the intent
-            // explicit: the only two answers are the button and Back.
+            // The content fills the window, so there is no outside to tap; pinned false anyway, so
+            // the two answers stay the two the KDoc names even if the layout ever changes.
             dismissOnClickOutside = false,
             usePlatformDefaultWidth = false,
             decorFitsSystemWindows = false
@@ -142,11 +143,6 @@ internal fun DirectionsSafetyNotice(active: Boolean, onDecline: () -> Unit) {
                         R.string.directions_safety_body,
                         stringResource(R.string.app_name)
                     ),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                Spacer(Modifier.height(16.dp))
-                Text(
-                    text = stringResource(R.string.directions_safety_body_secondary),
                     style = MaterialTheme.typography.bodyLarge
                 )
                 Spacer(Modifier.height(32.dp))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNotice.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNotice.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import org.onebusaway.android.R
+import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.ui.compose.components.AlertSeverity
+import org.onebusaway.android.ui.compose.components.alertAccentColor
+
+/**
+ * Whether the rider has yet to acknowledge the directions safety notice (#2218) — true on a fresh
+ * install, false forever after the acknowledgement. Pure (it only reads [prefs]) so the gate is
+ * JVM-unit-testable, the same shape
+ * [ArrivalTutorial.pendingSteps][org.onebusaway.android.ui.tutorial.ArrivalTutorial.pendingSteps] uses.
+ */
+internal fun isSafetyNoticePending(prefs: PreferencesRepository): Boolean = !prefs.getBoolean(R.string.preference_key_directions_safety_acknowledged, false)
+
+/** Records the acknowledgement, so the notice is never shown again on this install. */
+internal fun markSafetyNoticeAcknowledged(prefs: PreferencesRepository) {
+    prefs.setBoolean(R.string.preference_key_directions_safety_acknowledged, true)
+}
+
+/**
+ * The one-time notice that stands between a rider and their first set of directions (#2218).
+ *
+ * OTP plans walking legs from open map data whose crosswalk, signal and sidewalk coverage is patchy —
+ * a route really can send someone across a busy street where there is no safe crossing — while riders
+ * arrive expecting parity with commercial map apps. Tuning OTP is the real fix; this is the honest
+ * disclosure that has to hold in the meantime, and it is shown once rather than on every plan because
+ * the per-itinerary
+ * [DirectionsCautionBanner][org.onebusaway.android.ui.tripresults.DirectionsCautionBanner] is the
+ * standing reminder.
+ *
+ * Shown whenever [active] and the acknowledgement is still owed, which covers *every* way into
+ * directions (the drawer, the map long-press menu, a pinned-trip resume, a monitor notification):
+ * they all land on the same [CurrentFocus.Directions][org.onebusaway.android.ui.home.CurrentFocus]
+ * that [active] is read from, so none of them can slip past it.
+ *
+ * It is a full-screen [Dialog] rather than a sibling in the host's `Box` because it needs its own
+ * window: that is what puts it unconditionally over the map, the form card *and* the results sheet,
+ * and what lets it take Back ahead of the host's directions `BackHandler` without either having to
+ * know about the other.
+ *
+ * **Back is not an acknowledgement.** It leaves directions instead ([onDecline]) and writes nothing,
+ * so the notice returns on the next entry. There is no way through to the planner except the button,
+ * but the rider is never trapped behind it either.
+ */
+@Composable
+internal fun DirectionsSafetyNotice(active: Boolean, onDecline: () -> Unit) {
+    val context = LocalContext.current
+    // Resolved once rather than per recomposition, matching the remember { …EntryPoint.get(…) }
+    // pattern elsewhere. The repository reads its own writes synchronously, so the initial read
+    // already reflects an acknowledgement made earlier in this process.
+    val prefs = remember { PreferencesEntryPoint.get(context) }
+    // Seeded from prefs and flipped locally on acknowledgement: the write is async-persisted, and
+    // this is what closes the notice on the very next frame rather than on the next process.
+    var pending by rememberSaveable { mutableStateOf(isSafetyNoticePending(prefs)) }
+    if (!active || !pending) return
+
+    Dialog(
+        onDismissRequest = onDecline,
+        properties = DialogProperties(
+            // A tap outside can't reach it (it fills the window), but saying so keeps the intent
+            // explicit: the only two answers are the button and Back.
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding()
+                    .navigationBarsPadding()
+                    // Scrolls rather than clips: at the largest accessibility font scale, or in
+                    // landscape, the body plus the button is taller than the window.
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.baseline_warning_24),
+                    contentDescription = null,
+                    tint = alertAccentColor(AlertSeverity.WARNING),
+                    modifier = Modifier.size(64.dp)
+                )
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = stringResource(R.string.directions_safety_title),
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(
+                        R.string.directions_safety_body,
+                        stringResource(R.string.app_name)
+                    ),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.directions_safety_body_secondary),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Spacer(Modifier.height(32.dp))
+                Button(
+                    onClick = {
+                        markSafetyNoticeAcknowledged(prefs)
+                        pending = false
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.directions_safety_acknowledge))
+                }
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionsCautionBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionsCautionBanner.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.AlertSeverity
+import org.onebusaway.android.ui.compose.components.AlertSurface
+import org.onebusaway.android.ui.icons.AppIcons
+
+/**
+ * The standing caution at the head of every itinerary's step-by-step detail (#2218): the walking legs
+ * below it are planned from open map data that is often missing crosswalks, signals and sidewalks, so
+ * a drawn route is not a promise that it can be safely walked.
+ *
+ * It sits under the option picker rather than on the option cards because it is true of every option,
+ * not a property of the one being compared — and above the timeline because the steps are what it
+ * qualifies.
+ *
+ * Collapsed it is the one line; tapping expands the same explanation the one-time
+ * [DirectionsSafetyNotice][org.onebusaway.android.ui.home.directions.DirectionsSafetyNotice] gave,
+ * which is the only way back to that text once acknowledged. The expansion is local state, so this
+ * needs nothing from the host.
+ *
+ * Drawn on the shared [AlertSurface] so it carries the app's one warning tint rather than a second
+ * copy of that colour table.
+ */
+@Composable
+internal fun DirectionsCautionBanner(modifier: Modifier = Modifier) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    AlertSurface(
+        severity = AlertSeverity.WARNING,
+        modifier = modifier,
+        onClick = { expanded = !expanded }
+    ) {
+        // Top-aligned for the same reason the service-alert banner is: the glyph and the chevron mark
+        // the caution, so on an expanded one they belong beside its first line.
+        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_warning_24),
+                contentDescription = null
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.directions_caution_banner),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                if (expanded) {
+                    Text(
+                        text = stringResource(
+                            R.string.directions_safety_body,
+                            stringResource(R.string.app_name)
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                    Text(
+                        text = stringResource(R.string.directions_safety_body_secondary),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
+            }
+            Icon(
+                imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
+                contentDescription = stringResource(
+                    if (expanded) {
+                        R.string.directions_caution_hide_details
+                    } else {
+                        R.string.directions_caution_show_details
+                    }
+                ),
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionsCautionBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/DirectionsCautionBanner.kt
@@ -15,13 +15,7 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,81 +23,47 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.compose.components.AlertSeverity
-import org.onebusaway.android.ui.compose.components.AlertSurface
-import org.onebusaway.android.ui.icons.AppIcons
 
 /**
- * The standing caution at the head of every itinerary's step-by-step detail (#2218): the walking legs
- * below it are planned from open map data that is often missing crosswalks, signals and sidewalks, so
- * a drawn route is not a promise that it can be safely walked.
+ * The caution at the head of every itinerary's step-by-step detail (#2218): the walking legs below it
+ * are planned from open map data that is often missing crosswalks, signals and sidewalks, so a drawn
+ * route is not a promise that it can be safely walked.
  *
  * It sits under the option picker rather than on the option cards because it is true of every option,
  * not a property of the one being compared — and above the timeline because the steps are what it
- * qualifies.
+ * qualifies. It scrolls away with the rest of the header, as the picker does: a bar pinned over a
+ * bottom sheet would cost real estate the sheet hasn't got.
  *
  * Collapsed it is the one line; tapping expands the same explanation the one-time
  * [DirectionsSafetyNotice][org.onebusaway.android.ui.home.directions.DirectionsSafetyNotice] gave,
- * which is the only way back to that text once acknowledged. The expansion is local state, so this
- * needs nothing from the host.
- *
- * Drawn on the shared [AlertSurface] so it carries the app's one warning tint rather than a second
- * copy of that colour table.
+ * which is the only way back to that text once acknowledged. Both read the one
+ * `directions_safety_body` string, so the two can't come to say different things. The expansion is
+ * local state, so this needs nothing from the host.
  */
 @Composable
 internal fun DirectionsCautionBanner(modifier: Modifier = Modifier) {
     var expanded by rememberSaveable { mutableStateOf(false) }
-    AlertSurface(
+    ExpandableAlertBanner(
         severity = AlertSeverity.WARNING,
-        modifier = modifier,
-        onClick = { expanded = !expanded }
+        summary = stringResource(R.string.directions_caution_banner),
+        expanded = expanded,
+        onToggle = { expanded = !expanded },
+        showDetailsRes = R.string.directions_caution_show_details,
+        hideDetailsRes = R.string.directions_caution_hide_details,
+        modifier = modifier
     ) {
-        // Top-aligned for the same reason the service-alert banner is: the glyph and the chevron mark
-        // the caution, so on an expanded one they belong beside its first line.
-        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
-            Icon(
-                painter = painterResource(R.drawable.baseline_warning_24),
-                contentDescription = null
-            )
-            Spacer(Modifier.width(12.dp))
-            Column(Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.directions_caution_banner),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                if (expanded) {
-                    Text(
-                        text = stringResource(
-                            R.string.directions_safety_body,
-                            stringResource(R.string.app_name)
-                        ),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-                    Text(
-                        text = stringResource(R.string.directions_safety_body_secondary),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-                }
-            }
-            Icon(
-                imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
-                contentDescription = stringResource(
-                    if (expanded) {
-                        R.string.directions_caution_hide_details
-                    } else {
-                        R.string.directions_caution_show_details
-                    }
-                ),
-                modifier = Modifier.size(20.dp)
-            )
-        }
+        Text(
+            text = stringResource(
+                R.string.directions_safety_body,
+                stringResource(R.string.app_name)
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 8.dp)
+        )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ExpandableAlertBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/ExpandableAlertBanner.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripresults
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.AlertSeverity
+import org.onebusaway.android.ui.compose.components.AlertSurface
+import org.onebusaway.android.ui.icons.AppIcons
+
+/**
+ * The warning banner shape the trip planner draws over its directions: a glyph, a one-line [summary],
+ * and — when there is more behind it — a chevron that expands [detail] in place, all on the app's
+ * shared severity-tinted [AlertSurface].
+ *
+ * Two things wear it, and they must not drift apart: a leg's service alert ([TripAlertBanner]) and the
+ * standing "these directions may be wrong" caution ([DirectionsCautionBanner], #2218). What they share
+ * is not just the colour but the whole row — the metrics, the top alignment, the whole-card tap target,
+ * and the accessibility contract that the chevron is what announces expand/collapse. That last one is
+ * the reason this is a composable rather than a convention: an a11y fix applied to one copy of the row
+ * and not the other regresses silently, on a screen nobody thought to re-check.
+ *
+ * Top-aligned, because the glyph and the chevron mark the banner — on an expanded one they belong
+ * beside its first line rather than floating down beside the middle of the body.
+ *
+ * [expanded] and [onToggle] are hoisted: each caller keys its own expansion the way its content
+ * demands (a service alert on the alert's identity, so a re-plan returning the same alert keeps it
+ * open). A banner with nothing to expand passes a null [onToggle] and gets neither chevron nor tap
+ * target, rather than an affordance that reveals nothing.
+ */
+@Composable
+internal fun ExpandableAlertBanner(
+    severity: AlertSeverity,
+    summary: String,
+    expanded: Boolean,
+    onToggle: (() -> Unit)?,
+    @StringRes showDetailsRes: Int,
+    @StringRes hideDetailsRes: Int,
+    modifier: Modifier = Modifier,
+    detail: @Composable ColumnScope.() -> Unit
+) {
+    AlertSurface(severity = severity, modifier = modifier, onClick = onToggle) {
+        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_warning_24),
+                contentDescription = null
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(text = summary, style = MaterialTheme.typography.bodyMedium)
+                if (expanded) {
+                    detail()
+                }
+            }
+            if (onToggle != null) {
+                Icon(
+                    imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
+                    contentDescription = stringResource(
+                        if (expanded) hideDetailsRes else showDetailsRes
+                    ),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
@@ -15,14 +15,8 @@
  */
 package org.onebusaway.android.ui.tripresults
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,9 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -43,9 +35,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
-import org.onebusaway.android.ui.compose.components.AlertSurface
 import org.onebusaway.android.ui.compose.components.linkifyUrls
-import org.onebusaway.android.ui.icons.AppIcons
 
 /**
  * One service alert over the trip planner's directions (#2143), drawn on the shared

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripAlertBanner.kt
@@ -48,9 +48,9 @@ import org.onebusaway.android.ui.compose.components.linkifyUrls
 import org.onebusaway.android.ui.icons.AppIcons
 
 /**
- * One service alert over the trip planner's directions (#2143), drawn on the app's shared
- * severity-tinted [AlertSurface] so a suspension reads the same here as it does on the arrivals
- * screen.
+ * One service alert over the trip planner's directions (#2143), drawn on the shared
+ * [ExpandableAlertBanner] so a suspension reads the same here as it does on the arrivals screen — and
+ * the same as the safety caution it may sit beside.
  *
  * Collapsed it is the feed's headline alone — enough, under the leg's own header, to know that ride is
  * in doubt. Tapping expands the full description in place, plus the agency's own
@@ -67,39 +67,16 @@ internal fun TripAlertBanner(alert: TripAlertItem, modifier: Modifier = Modifier
     // Keyed on the alert's content identity, so a re-plan that returns the same alert keeps it open and
     // one that returns a different alert doesn't inherit the old one's expansion.
     var expanded by rememberSaveable(alert.contentId) { mutableStateOf(false) }
-    AlertSurface(
+    ExpandableAlertBanner(
         severity = alert.severity,
-        modifier = modifier,
-        onClick = if (alert.hasDetail) ({ expanded = !expanded }) else null
+        summary = alert.summary,
+        expanded = expanded,
+        onToggle = if (alert.hasDetail) ({ expanded = !expanded }) else null,
+        showDetailsRes = R.string.directions_alert_show_details,
+        hideDetailsRes = R.string.directions_alert_hide_details,
+        modifier = modifier
     ) {
-        // Top-aligned: the glyph and the chevron mark the alert, and on an expanded one they belong
-        // beside its first line rather than floating down beside the middle of the description.
-        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
-            Icon(
-                painter = painterResource(R.drawable.baseline_warning_24),
-                contentDescription = null
-            )
-            Spacer(Modifier.width(12.dp))
-            Column(Modifier.weight(1f)) {
-                Text(text = alert.summary, style = MaterialTheme.typography.bodyMedium)
-                if (expanded) {
-                    AlertDetail(alert)
-                }
-            }
-            if (alert.hasDetail) {
-                Icon(
-                    imageVector = if (expanded) AppIcons.KeyboardArrowUp else AppIcons.KeyboardArrowDown,
-                    contentDescription = stringResource(
-                        if (expanded) {
-                            R.string.directions_alert_hide_details
-                        } else {
-                            R.string.directions_alert_show_details
-                        }
-                    ),
-                    modifier = Modifier.size(20.dp)
-                )
-            }
-        }
+        AlertDetail(alert)
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -1249,6 +1249,10 @@ private fun TripLogList(
             reminderControl()
             HorizontalDivider()
             Spacer(Modifier.height(LOG_EDGE_GAP))
+            // Below the picker, above the steps: the walking legs are what it qualifies, and it is
+            // true of every option rather than of the one being compared (#2218).
+            DirectionsCautionBanner()
+            Spacer(Modifier.height(LOG_EDGE_GAP))
         }
         // Keyed by row identity, not position, so opening a leg doesn't discard the subcompositions of
         // every row below it — a board row's live ETA session survives the insert.

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -66,6 +66,11 @@
     <string name="preference_key_never_show_change_location_mode_dialog">preference_never_show_change_location_mode_dialog</string>
     <string name="preference_key_never_show_payment_warning_dialog">never_show_payment_warning_dialog</string>
     <string name="preference_key_never_show_destination_reminder_beta_dialog">preference_never_show_destination_reminder_beta_dialog</string>
+    <!-- Set once the rider acknowledges the directions safety notice (#2218). Deliberately NOT cleared
+         by "show tutorials again" (TutorialPrefs.resetAllTutorials): this is a safety acknowledgement,
+         not onboarding, and re-running the tutorials does not un-acknowledge it. The caution banner at
+         the head of every itinerary is the standing reminder. -->
+    <string name="preference_key_directions_safety_acknowledged">directions_safety_acknowledged</string>
     <string name="preferences_key_user_denied_location_permissions">preferences_key_user_denied_location_permissions</string>
     <string name="preferences_display_test_alerts">preferences_display_test_alerts</string>
     <string name="preference_key_push_test_device">preference_push_test_device</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1025,6 +1025,22 @@
          %1$s is the localized severity label, announced in place so it reads e.g.
          "1 Line, Severe service alert". -->
     <string name="directions_leg_service_alert">%1$s service alert</string>
+    <!-- The one-time full-screen safety notice, shown the first time a rider opens directions (#2218).
+         OTP plans walking legs from open map data whose crosswalk / signal / sidewalk coverage is
+         patchy, and riders arrive expecting parity with commercial map apps.
+         Note: %1$s is replaced with app_name for white-label support. -->
+    <string name="directions_safety_title">Directions may be wrong</string>
+    <string name="directions_safety_body">%1$s builds walking directions from open map data that is often missing crosswalks, traffic signals and sidewalks. A route may send you across a busy street where there is no safe place to cross.</string>
+    <string name="directions_safety_body_secondary">Always look for a marked crossing and use your own judgment. Do not rely on these directions to keep you safe.</string>
+    <!-- The button that acknowledges the notice; nothing else dismisses it into the planner. -->
+    <string name="directions_safety_acknowledge">I understand</string>
+    <!-- The standing caution at the head of every itinerary detail. Tapping it expands the same
+         explanation the one-time notice gave, which is the only way back to that text once
+         acknowledged. -->
+    <string name="directions_caution_banner">Directions can be wrong. Always use caution.</string>
+    <!-- Content descriptions for that caution banner&#8217;s chevron. -->
+    <string name="directions_caution_show_details">Show safety details</string>
+    <string name="directions_caution_hide_details">Hide safety details</string>
     <!-- Confirmation shown when a gesture (Back, or a tap on the map background) would close directions
          while a planned trip is drawn on the map, since that discards the whole plan. -->
     <string name="directions_exit_confirm_title">Leave these directions?</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1030,13 +1030,13 @@
          patchy, and riders arrive expecting parity with commercial map apps.
          Note: %1$s is replaced with app_name for white-label support. -->
     <string name="directions_safety_title">Directions may be wrong</string>
-    <string name="directions_safety_body">%1$s builds walking directions from open map data that is often missing crosswalks, traffic signals and sidewalks. A route may send you across a busy street where there is no safe place to cross.</string>
-    <string name="directions_safety_body_secondary">Always look for a marked crossing and use your own judgment. Do not rely on these directions to keep you safe.</string>
+    <!-- One string rather than a paragraph each: the two are never shown apart, and the caution banner
+         below expands to exactly this text, so splitting them would be an invariant with no owner. -->
+    <string name="directions_safety_body">%1$s builds walking directions from open map data that is often missing crosswalks, traffic signals and sidewalks. A route may send you across a busy street where there is no safe place to cross.\n\nAlways look for a marked crossing and use your own judgment. Do not rely on these directions to keep you safe.</string>
     <!-- The button that acknowledges the notice; nothing else dismisses it into the planner. -->
     <string name="directions_safety_acknowledge">I understand</string>
-    <!-- The standing caution at the head of every itinerary detail. Tapping it expands the same
-         explanation the one-time notice gave, which is the only way back to that text once
-         acknowledged. -->
+    <!-- The caution at the head of every itinerary detail. Tapping it expands the same explanation the
+         one-time notice gave, which is the only way back to that text once acknowledged. -->
     <string name="directions_caution_banner">Directions can be wrong. Always use caution.</string>
     <!-- Content descriptions for that caution banner&#8217;s chevron. -->
     <string name="directions_caution_show_details">Show safety details</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNoticeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNoticeTest.kt
@@ -44,16 +44,6 @@ class DirectionsSafetyNoticeTest {
     }
 
     @Test
-    fun acknowledging_isIdempotent() {
-        val prefs = FakePreferencesRepository()
-
-        markSafetyNoticeAcknowledged(prefs)
-        markSafetyNoticeAcknowledged(prefs)
-
-        assertFalse(isSafetyNoticePending(prefs))
-    }
-
-    @Test
     fun pending_whenTheFlagIsExplicitlyCleared() {
         val prefs = FakePreferencesRepository()
         prefs.setBoolean(R.string.preference_key_directions_safety_acknowledged, false)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNoticeTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/directions/DirectionsSafetyNoticeTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home.directions
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.testing.FakePreferencesRepository
+
+/**
+ * Unit tests for the pure half of the directions safety notice (#2218): whether the acknowledgement
+ * is still owed, and that recording it sticks.
+ */
+class DirectionsSafetyNoticeTest {
+
+    @Test
+    fun pending_onFreshInstall() {
+        // FakePreferencesRepository seeds *observed* booleans to true; the synchronous getters this
+        // gate uses fall through to the caller's default, so an unset key reads as unacknowledged.
+        assertTrue(isSafetyNoticePending(FakePreferencesRepository()))
+    }
+
+    @Test
+    fun notPending_onceAcknowledged() {
+        val prefs = FakePreferencesRepository()
+
+        markSafetyNoticeAcknowledged(prefs)
+
+        assertFalse(isSafetyNoticePending(prefs))
+    }
+
+    @Test
+    fun acknowledging_isIdempotent() {
+        val prefs = FakePreferencesRepository()
+
+        markSafetyNoticeAcknowledged(prefs)
+        markSafetyNoticeAcknowledged(prefs)
+
+        assertFalse(isSafetyNoticePending(prefs))
+    }
+
+    @Test
+    fun pending_whenTheFlagIsExplicitlyCleared() {
+        val prefs = FakePreferencesRepository()
+        prefs.setBoolean(R.string.preference_key_directions_safety_acknowledged, false)
+
+        assertTrue(isSafetyNoticePending(prefs))
+    }
+}


### PR DESCRIPTION
Closes #2218.

OTP plans walking legs from OSM, whose crosswalk, signal and sidewalk coverage is patchy. In the reported case it routes a walker straight across Lake City Way at a high-speed turn with no crossing, where Google Maps sends them a few blocks to a signal. Tuning OTP is the real fix, but holes will always exist and riders arrive assuming parity — so until the data catches up, the app says plainly that it might be wrong.

The issue asks for two things, and this is exactly those two.

### 1. Once, up front

A full-screen notice stands in front of a rider's first set of directions, with an "I understand" they have to tap.

It is gated on the directions **focus**, so every way in passes through it — the drawer's "Plan a trip", the map long-press menu, a pinned-trip resume, and a monitor-notification re-entry all land on `CurrentFocus.Directions`.

**Back is not an acknowledgement.** It leaves directions and writes nothing, so the notice returns next time. Nothing reaches the planner except the button, but nobody is trapped behind it either.

It is a full-screen `Dialog` rather than a sibling in `HomeScreen`'s `Box` because it needs its own window: that is what puts it over the map, the form card *and* the results sheet at once, and what lets it take Back ahead of the host's directions `BackHandler` without either having to know about the other.

### 2. Every time

A caution at the head of each itinerary's step-by-step detail — below the option picker, since it is true of every option rather than of the one being compared, and above the timeline, since the walking steps are what it qualifies. Tapping it expands the same explanation the notice gave, which is the only way back to that text once acknowledged. Both read the one `directions_safety_body` string, so the two cannot come to say different things.

### Notes for review

- **`leaveDirections()` on `HomeViewModel` is new.** Declining the notice must not borrow `navigateBackInDirections()`: that is a three-rung ladder (pop a sub-focus, else stage the #2140 confirmation, else exit) and only its last rung is what declining means. This is not hypothetical — a pinned-trip resume puts a drawn plan behind the notice on a rider's first visit, where the ladder would answer Back by raising the confirm dialog *underneath* the full-screen notice still covering the screen.
- **`ExpandableAlertBanner` is extracted, not added.** The new caution and the existing `TripAlertBanner` were the same row twice over — metrics, top alignment, whole-card tap target, and the chevron that carries the expand/collapse announcement. They now share one composable, so an a11y fix to that chevron cannot land on one screen and silently miss the other.
- **`AlertSurface` / `AlertSeverity` KDoc widened**, since a non-feed caution now wears them. No structural change: the severity ordering invariant is untouched, and the `stateDescription` values were already generic ("Warning", not "service alert").
- **The acknowledgement is deliberately not cleared by "show tutorials again"** — it is a safety acknowledgement, not onboarding, and `resetAllTutorials` would un-acknowledge a safety disclosure. Recorded at the preference key. Joining `ArrivalTutorial` would also have gated it behind `preference_key_show_tutorial_screens`, hiding it from riders with tutorials off.
- Strings are English-only; `MissingTranslation` is disabled in this project's lint config.

### Verification

`./gradlew test check -PwarningsAsErrors=true` green (both flavors, Spotless included); new JVM tests cover the preference gate. Lint left to CI per the repo's "don't run lint locally" rule.

Installed on a Pixel 7 Pro with app storage cleared. **On-device UX has not been signed off yet** — worth exercising the pinned-trip-resume path in particular, since that is where the decline bug above lived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-time safety notice when entering directions, with localized guidance and acknowledgement.
  * Added a caution banner explaining walking directions, with expandable details.
  * Added expand/collapse controls and accessibility labels for trip alerts and safety information.
  * Dismissing the safety notice now exits directions immediately.
* **Improvements**
  * Standardized the appearance and behavior of trip alert and directions warning banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->