### PR TITLE
Accept place/route intents from other apps (#1936)

### DIFF
--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -257,7 +257,8 @@ its place to whoever follows the redirect, and expanding somebody else's URL ove
 not something this app does, so the name Maps shared alongside it is used instead.
 
 Readable links are those on an enumerated short list of maps hosts — `maps.google.com`, `www.google.com`,
-`google.com`, `maps.apple.com`, `openstreetmap.org` — read for the parameters those hosts document
+`google.com`, `maps.apple.com`, `openstreetmap.org`, `www.openstreetmap.org` — matched exactly, so a
+host and its `www.` form are separate entries. They are read for the parameters those hosts document
 (`q`, `query`, `destination`, `daddr`, `address`, `ll`, OSM's `mlat`/`mlon`), plus Google's
 `…/maps/place/<Name>/@<lat>,<lng>,<zoom>z` place-page path. Where a link names both ends of a journey, only
 the destination is read. Where it names a place both as text and as a coordinate, the coordinate wins and

--- a/docs/DEEP_LINKING.md
+++ b/docs/DEEP_LINKING.md
@@ -12,6 +12,10 @@ Two families of link, both handled by `HomeActivity` (the app's single Activity)
 | `onebusaway://add-region?name=…&oba-url=…` | Adds that named region and switches to it, after the rider confirms — see below |
 | `https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913&service_date=1698307200.0&stop_sequence=5` | Opens that trip's details, scrolled to the stop in the path |
 
+Those name a **stop, trip or region** — OneBusAway's own vocabulary, which only these two apps speak.
+Separately, the app accepts a **place** named by any other app on the device (a `geo:` URI, a shared maps
+link or address) and plans a trip to it — see [Place intents from other apps](#place-intents-from-other-apps).
+
 ## Custom-scheme links
 
 Every brand answers to the cross-platform `onebusaway://` scheme **and** to its own scheme
@@ -211,6 +215,85 @@ adb shell am start -a android.intent.action.VIEW \
   com.joulespersecond.seattlebusbot
 ```
 
+## Place intents from other apps
+
+Separate from OneBusAway's own link vocabulary above: the app also accepts a **place** named by any other
+app on the device ([#1936](https://github.com/OneBusAway/onebusaway-android/issues/1936)), and opens the
+home map's directions focus with it as the trip's **destination**. The other end defaults to the device's
+current location, so a place that arrives with coordinates plans on the spot; the form's reverse button is
+the way to say "from there" instead.
+
+This is what replaced the trip planner's in-app address-book picker. Rather than asking for the rider's
+contacts and building a picker, the app accepts the place their address book already knows how to hand
+out — via Contacts' own "open this address" action, or the share sheet.
+
+| Intent | Example | What it does |
+| --- | --- | --- |
+| `ACTION_VIEW` `geo:` | `geo:47.6097,-122.3422` | Plans to that point |
+| `ACTION_VIEW` `geo:` | `geo:0,0?q=400+Broad+St%2C+Seattle` | Geocodes the address, then plans to it |
+| `ACTION_VIEW` `geo:` | `geo:0,0?q=47.6097,-122.3422(Space+Needle)` | Plans to that point, labelled |
+| `ACTION_SEND` `text/plain` | `https://maps.apple.com/?ll=47.6,-122.3` | Plans to the place the link names |
+| `ACTION_SEND` `text/plain` | `400 Broad St, Seattle, WA` | Geocodes the text, then plans to it |
+
+### `geo:`
+
+The forms Android
+[documents](https://developer.android.com/guide/components/intents-common#Maps), plus RFC 5870's
+`;`-separated parameters. `?z=` (zoom), `;u=` (uncertainty) and a third `,`-separated altitude component
+are accepted and ignored — this app frames a trip, not a map viewport.
+
+`geo:0,0` is read as the platform's **placeholder** for "the place is in `q`, not in my coordinate", which
+is how Android's documentation spells every `?q=` form and what Contacts emits for a postal address. Where
+a URI carries both a real coordinate and a `q`, the coordinate wins and `q` becomes its label — a sender
+that supplies both means "this position, called that", and geocoding the label would throw away the exact
+answer it already gave us.
+
+### Shared text
+
+`ACTION_SEND` of `text/plain`. Any URI in the text that the app can read wins; otherwise the prose around
+the links is geocoded, with the links themselves stripped out (they are not place names). That is how a
+Google Maps share — `"Pike Place Market\nhttps://maps.app.goo.gl/…"` — resolves: the short link only names
+its place to whoever follows the redirect, and expanding somebody else's URL over the network on a share is
+not something this app does, so the name Maps shared alongside it is used instead.
+
+Readable links are those on an enumerated short list of maps hosts — `maps.google.com`, `www.google.com`,
+`google.com`, `maps.apple.com`, `openstreetmap.org` — read for the parameters those hosts document
+(`q`, `query`, `destination`, `daddr`, `address`, `ll`, OSM's `mlat`/`mlon`), plus Google's
+`…/maps/place/<Name>/@<lat>,<lng>,<zoom>z` place-page path. Where a link names both ends of a journey, only
+the destination is read. Where it names a place both as text and as a coordinate, the coordinate wins and
+the text becomes its label. An unrecognized host costs the rider nothing — its prose is geocoded instead —
+whereas guessing at an unfamiliar host's parameters would send them somewhere wrong.
+
+`https` maps links are deliberately **not** claimed as `ACTION_VIEW`. Doing so would put OneBusAway in the
+chooser for every Google Maps URL on the device, which is not an offer a transit app should be making;
+sharing to us is the rider saying they meant us. `geo:` *is* claimed, because that intent means "open this
+location" and nothing more specific — being in that chooser alongside the map apps is the point.
+
+### Geocoding a place named only as text
+
+Resolved through the same geocoder the trip-plan form's own autocomplete uses, taking its top-ranked
+match. Geocoding is a ranked search with no exact source to consult instead, and this is the answer that
+list already puts first; what keeps it honest is that the result lands as an ordinary **cancellable pill
+showing the name it resolved to**, so a wrong match is visible and one tap from being corrected. Text that
+resolves to nothing is left in the field with its suggestion list live, for the rider to pick from, rather
+than being silently dropped.
+
+### Testing
+
+```bash
+# A point
+adb shell am start -a android.intent.action.VIEW -d 'geo:47.6097,-122.3422' \
+  com.joulespersecond.seattlebusbot
+
+# An address, as Contacts emits it (single-quoted so the shell keeps the +/%)
+adb shell am start -a android.intent.action.VIEW \
+  -d 'geo:0,0?q=400+Broad+St%2C+Seattle%2C+WA' com.joulespersecond.seattlebusbot
+
+# Shared text
+adb shell am start -a android.intent.action.SEND -t text/plain \
+  -e android.intent.extra.TEXT '400 Broad St, Seattle, WA' com.joulespersecond.seattlebusbot
+```
+
 ## Implementation
 
 - `ui/nav/ExternalDeepLinks.kt` — owns this whole vocabulary (schemes, hosts, path shape, parameter
@@ -229,5 +312,10 @@ adb shell am start -a android.intent.action.VIEW \
 - `ui/home/RegionPickerHost.kt` — the picker, including long-press-to-remove for custom regions.
 - `util/ExternalIntents.kt` — `openInBrowser`, the explicit-package browser handoff (and the `<queries>`
   element in `src/main/AndroidManifest.xml` that makes browsers visible to it on API 30+).
+- `ui/nav/PlaceIntents.kt` — separate concern: the *other* apps' vocabulary — `geo:` URIs, maps links and
+  shared text (`parse` is pure and unit-tested in `PlaceIntentsTest`). Consumed by
+  `HomeActivity.maybePlanToPlaceFromIntent`, which opens the directions focus and fills the destination via
+  `TripPlanViewModel.setEndpointPaired` / `setEndpointFromQuery`. Its intent-filters (`geo:` VIEW,
+  `text/plain` SEND) are in `src/main/AndroidManifest.xml`.
 - `ui/nav/DeepLinkUris.kt` — separate concern: the app's *internal* `content://` stop/route
   vocabulary, used by pinned launcher shortcuts and in-app launches.

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -152,15 +152,13 @@
                 <data android:host="add-region" />
                 <data android:host="view-stop" />
             </intent-filter>
-            <!-- Place intents from other apps (#1936) — the vocabulary lives in
-                 org.onebusaway.android.ui.nav.PlaceIntents, and HomeActivity.maybePlanToPlaceFromIntent
-                 opens the directions focus with the place as the destination. This is what replaced the
-                 trip planner's in-app address-book picker: instead of reading the rider's contacts, we
-                 accept the place their address book already knows how to hand out.
-
-                 `geo:` is the platform's standard "open this location" — what Contacts emits for a postal
-                 address — so claiming it puts OneBusAway in the same chooser as the map apps, which is
-                 where a rider wanting transit directions to an address is looking. -->
+            <!-- Place intents from other apps (#1936): `geo:` (the platform's "open this location", what
+                 the address book emits for a postal address) and shared `text/plain` (a maps link or a
+                 bare address). Both are read by org.onebusaway.android.ui.nav.PlaceIntents — which owns
+                 this vocabulary and the reasoning behind these two filters, including why https maps
+                 links are deliberately not claimed here — and consumed by
+                 HomeActivity.maybePlanToPlaceFromIntent, which opens the directions focus with the place
+                 as the trip's destination. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -168,10 +166,6 @@
 
                 <data android:scheme="geo" />
             </intent-filter>
-            <!-- The share sheet: shared text may be a maps link (PlaceIntents.MAPS_HOSTS) or just an
-                 address. Maps links are read *here* and deliberately not claimed as https ACTION_VIEW,
-                 which would put this app in the chooser for every Google Maps URL on the device — not an
-                 offer a transit app should be making. Sharing to us is the rider saying they meant us. -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
 

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -159,10 +159,16 @@
                  links are deliberately not claimed here — and consumed by
                  HomeActivity.maybePlanToPlaceFromIntent, which opens the directions focus with the place
                  as the trip's destination. -->
+            <!-- BROWSABLE as well as DEFAULT, matching what Google Maps declares for `geo:`: without it a
+                 `<a href="geo:…">` on a web page can't reach us, which would make this app the one map
+                 app on the device a geo link can't open. Unlike the BROWSABLE `add-region` filter above,
+                 a hostile page gains nothing worth having here — the worst it can do is open the trip
+                 planner with a destination filled in. Nothing is written and nothing is sent. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="geo" />
             </intent-filter>

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -152,6 +152,33 @@
                 <data android:host="add-region" />
                 <data android:host="view-stop" />
             </intent-filter>
+            <!-- Place intents from other apps (#1936) — the vocabulary lives in
+                 org.onebusaway.android.ui.nav.PlaceIntents, and HomeActivity.maybePlanToPlaceFromIntent
+                 opens the directions focus with the place as the destination. This is what replaced the
+                 trip planner's in-app address-book picker: instead of reading the rider's contacts, we
+                 accept the place their address book already knows how to hand out.
+
+                 `geo:` is the platform's standard "open this location" — what Contacts emits for a postal
+                 address — so claiming it puts OneBusAway in the same chooser as the map apps, which is
+                 where a rider wanting transit directions to an address is looking. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="geo" />
+            </intent-filter>
+            <!-- The share sheet: shared text may be a maps link (PlaceIntents.MAPS_HOSTS) or just an
+                 address. Maps links are read *here* and deliberately not claimed as https ACTION_VIEW,
+                 which would put this app in the chooser for every Google Maps URL on the device — not an
+                 offer a transit app should be making. Sharing to us is the rider saying they meant us. -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+            </intent-filter>
             <meta-data
                 android:name="android.app.searchable"
                 android:resource="@xml/searchable"/>

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -66,9 +66,12 @@ import org.onebusaway.android.ui.nav.ExternalDeepLinks
 import org.onebusaway.android.ui.nav.IntentRouteMapper
 import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.nav.PlaceIntents
 import org.onebusaway.android.ui.nav.readRouteReveal
 import org.onebusaway.android.ui.report.ReportLauncher
 import org.onebusaway.android.ui.survey.SurveyViewModel
+import org.onebusaway.android.ui.tripplan.TripEndpoint
+import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.pinned.PinnedTripViewModel
 import org.onebusaway.android.ui.tripplan.toGeocoded
@@ -238,6 +241,7 @@ class HomeActivity : AppCompatActivity() {
     private fun applyLaunchIntentSideEffects(intent: Intent) {
         applyIntentSideEffects(intent)
         maybeRestoreDirectionsFromIntent(intent)
+        maybePlanToPlaceFromIntent(intent)
         maybeRevealTrackedRouteFromIntent(intent)
         if (intent.extras?.getBoolean(TutorialPrefs.TUTORIAL_WELCOME) == true) {
             viewModel.requestWelcomeTutorial()
@@ -301,6 +305,42 @@ class HomeActivity : AppCompatActivity() {
             itineraries = itineraries
         )
     }
+
+    /**
+     * A place another app handed us (#1936): a `geo:` URI — what the address book emits for a postal
+     * address, and what every maps app understands — or a maps link / address shared to us as text. See
+     * [PlaceIntents], which owns that vocabulary.
+     *
+     * Opens the directions focus with the place as the trip's **destination**, its other end paired with
+     * the device's fix by [TripPlanViewModel.setEndpointPaired], so a place that arrives with coordinates
+     * plans on the spot. The sender named one place, not a journey; "take me there" is what a rider who
+     * opens a transit app from an address means, and the form's own reverse button is the way to say the
+     * other thing.
+     *
+     * Runs here, with the other launch-intent focus changes, because this is where the ViewModels are:
+     * the directions focus is home-map state rather than a NavHost destination, so [IntentRouteMapper]
+     * correctly resolves these intents to no route at all.
+     */
+    private fun maybePlanToPlaceFromIntent(intent: Intent) {
+        val place = PlaceIntents.placeForIntent(intent) ?: return
+        viewModel.enterDirections()
+        when (place) {
+            is PlaceIntents.Place.Point ->
+                tripPlanViewModel.setEndpointPaired(TripEndpointSlot.TO, place.toEndpoint())
+            is PlaceIntents.Place.Query ->
+                tripPlanViewModel.setEndpointFromQuery(TripEndpointSlot.TO, place.text)
+        }
+    }
+
+    /**
+     * A place that arrived with coordinates, as a plan endpoint: [TripEndpoint.Geocoded] when the sender
+     * named it, and otherwise [TripEndpoint.MapPoint] — whose fixed "Selected location" label is the
+     * honest one for a bare coordinate, and whose terminals the plan reverse-geocodes for the itinerary
+     * anyway ([TripPlanViewModel] `placeNameOf`).
+     */
+    private fun PlaceIntents.Place.Point.toEndpoint(): TripEndpoint = label
+        ?.let { TripEndpoint.Geocoded(displayName = it, lat = lat, lon = lon) }
+        ?: TripEndpoint.MapPoint(lat = lat, lon = lon)
 
     /**
      * Runs the domain mutations implied by certain incoming intents, kept out of [IntentRouteMapper]'s

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -68,9 +68,9 @@ import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.PlaceIntents
 import org.onebusaway.android.ui.nav.readRouteReveal
+import org.onebusaway.android.ui.nav.toEndpoint
 import org.onebusaway.android.ui.report.ReportLauncher
 import org.onebusaway.android.ui.survey.SurveyViewModel
-import org.onebusaway.android.ui.tripplan.TripEndpoint
 import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.pinned.PinnedTripViewModel
@@ -331,16 +331,6 @@ class HomeActivity : AppCompatActivity() {
                 tripPlanViewModel.setEndpointFromQuery(TripEndpointSlot.TO, place.text)
         }
     }
-
-    /**
-     * A place that arrived with coordinates, as a plan endpoint: [TripEndpoint.Geocoded] when the sender
-     * named it, and otherwise [TripEndpoint.MapPoint] — whose fixed "Selected location" label is the
-     * honest one for a bare coordinate, and whose terminals the plan reverse-geocodes for the itinerary
-     * anyway ([TripPlanViewModel] `placeNameOf`).
-     */
-    private fun PlaceIntents.Place.Point.toEndpoint(): TripEndpoint = label
-        ?.let { TripEndpoint.Geocoded(displayName = it, lat = lat, lon = lon) }
-        ?: TripEndpoint.MapPoint(lat = lat, lon = lon)
 
     /**
      * Runs the domain mutations implied by certain incoming intents, kept out of [IntentRouteMapper]'s

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -1104,13 +1104,13 @@ fun HomeScreen(
                                     )
                                 }
                                 // Long-press → "directions from/to here": enters directions and fills the
-                                // chosen endpoint with the pressed point (see setEndpointFromLongPress).
+                                // chosen endpoint with the pressed point (see setEndpointPaired).
                                 longPressPoint?.let { point ->
                                     val mapPoint = TripEndpoint.MapPoint(point.latitude, point.longitude)
                                     DirectionsLongPressMenu(
                                         onChooseSlot = { slot ->
                                             homeViewModel.enterDirections(mapViewModel.viewport)
-                                            tripPlanViewModel.setEndpointFromLongPress(slot, mapPoint)
+                                            tripPlanViewModel.setEndpointPaired(slot, mapPoint)
                                             longPressPoint = null
                                         },
                                         onDismiss = { longPressPoint = null }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -148,9 +148,11 @@ import org.onebusaway.android.util.PreferenceUtils
  * point directly on the home map). The itinerary itself renders on the shared home map via the
  * [MapViewModel] directions controller — driven by [TripResultsSheet]'s selection.
  *
- * The address-book (contacts) picker was removed (#1936 tracks accepting place intents from other apps
- * instead). Map-pick is hoisted to the caller ([DirectionsFormCard]'s `onPickEndpoint`);
- * current-location, date/time, and advanced settings are wired here.
+ * The address-book (contacts) picker was removed; the app instead accepts place intents from other apps
+ * (#1936), so the address book hands OneBusAway an address rather than OneBusAway reading the contacts —
+ * see [org.onebusaway.android.ui.nav.PlaceIntents]. Map-pick is hoisted to the caller
+ * ([DirectionsFormCard]'s `onPickEndpoint`); current-location, date/time, and advanced settings are
+ * wired here.
  */
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import android.content.Intent
+import java.net.URI
+import java.net.URLDecoder
+
+/**
+ * The one place that knows how *another app* names a place to this one (#1936) — the vocabulary behind
+ * the `geo:` and `ACTION_SEND` intent-filters on `HomeActivity`. It is what replaced the trip planner's
+ * in-app address-book picker: rather than reading the rider's contacts ourselves, we accept the place
+ * their address book (or maps app, or browser) already knows how to hand out.
+ *
+ * Two ways in, and the difference between them is deliberate:
+ *
+ *  1. **`ACTION_VIEW` on a `geo:` URI** — the platform's standard "open this location", which Contacts
+ *     emits for a postal address and every maps app understands. Claiming this scheme puts OneBusAway in
+ *     the same chooser as the map apps, which is exactly where a rider looking for transit directions
+ *     wants to find it.
+ *  2. **`ACTION_SEND` of `text/plain`** — the share sheet. Shared text may be a maps link ([MAPS_HOSTS])
+ *     or just an address.
+ *
+ * `https` maps links are deliberately *not* claimed as `ACTION_VIEW`: doing so would put this app in the
+ * chooser for every Google Maps URL on the device, which is not an offer a transit app should be making.
+ * Through the share sheet the rider has already said they meant us, so the same URLs are read there.
+ *
+ * [parse] is pure — [PlaceRequest] is an already-projected intent with no Android dependency — so the
+ * whole vocabulary is JVM-unit-testable ([org.onebusaway.android.ui.nav.PlaceIntentsTest]); [read] is the
+ * thin Android-facing projection, and `HomeActivity.maybePlanToPlaceFromIntent` is the one consumer.
+ *
+ * Routing-wise these intents resolve to nothing: the directions focus is home-map state rather than a
+ * NavHost destination, so [IntentRouteMapper] correctly leaves them on the home/map path and the work
+ * happens in the Activity's launch-intent side effects, next to the other focus changes.
+ *
+ * Distinct from [ExternalDeepLinks], which owns the links that name a *stop, trip or region* — OneBusAway's
+ * own vocabulary, which only this app (and OneBusAway for iOS) speaks. This file speaks everyone else's.
+ * `docs/DEEP_LINKING.md` documents both.
+ */
+object PlaceIntents {
+
+    /** A place another app named for us. */
+    sealed interface Place {
+        /** An exact position, plus whatever the sender called it (null when it named it nothing). */
+        data class Point(val lat: Double, val lon: Double, val label: String? = null) : Place
+
+        /** Text naming a place — a postal address, or a place name — for the geocoder to resolve. */
+        data class Query(val text: String) : Place
+    }
+
+    /** The Android-free projection of an incoming intent that [parse] consumes; produced by [read]. */
+    data class PlaceRequest(
+        /** The intent's data URI as written (still percent-encoded), or null if it carries none. */
+        val dataUri: String? = null,
+        /** `Intent.EXTRA_TEXT` — what a `text/plain` share carries. */
+        val sharedText: String? = null
+    )
+
+    /** Reads [intent] as a place another app is handing us, or null if it isn't one. */
+    fun placeForIntent(intent: Intent): Place? = parse(read(intent))
+
+    /**
+     * The place [request] names, or null if it names none.
+     *
+     * The data URI is consulted first and the shared text second, so a share that carries both is read
+     * from the machine-readable half. Either may be present without the other.
+     */
+    fun parse(request: PlaceRequest): Place? = request.dataUri?.let { parseUriString(it) } ?: request.sharedText?.let { parseSharedText(it) }
+
+    /** Projects the Android [intent] into the plain [PlaceRequest] that [parse] consumes. */
+    private fun read(intent: Intent): PlaceRequest = PlaceRequest(
+        dataUri = intent.data?.toString(),
+        // Read as a CharSequence, which is what EXTRA_TEXT is declared as: a sender that shares styled
+        // text puts a Spanned here, and getStringExtra would hand back null for it.
+        sharedText = intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
+    )
+
+    /** A URI in either family — the `geo:` scheme, or a link on one of [MAPS_HOSTS]. */
+    private fun parseUriString(uri: String): Place? = if (uri.startsWith(GEO_SCHEME, ignoreCase = true)) parseGeoUri(uri) else parseMapsUrl(uri)
+
+    // --- geo: ---------------------------------------------------------------------------------------
+
+    /**
+     * `geo:` — the platform's "open this location" URI, in the forms Android documents
+     * ([common intents](https://developer.android.com/guide/components/intents-common#Maps)) plus
+     * RFC 5870's `;`-separated parameters:
+     *
+     * ```text
+     * geo:47.6097,-122.3422            an exact point
+     * geo:47.6097,-122.3422;u=35       …with RFC 5870 uncertainty (ignored)
+     * geo:47.6097,-122.3422?z=17       …with a zoom (ignored — we frame the trip, not the map)
+     * geo:0,0?q=1600+Amphitheatre+Pkwy an address to geocode
+     * geo:0,0?q=47.6,-122.3(Pike+Place+Market)   a labelled point
+     * ```
+     *
+     * `q` wins over the URI's own coordinate when it *is* one, and otherwise labels it — see
+     * [GEO_PLACEHOLDER] for the one case where a coordinate is present and still not a position.
+     */
+    private fun parseGeoUri(uri: String): Place? {
+        val schemeSpecificPart = uri.substring(GEO_SCHEME.length)
+        val uriPoint = parseCoordinates(schemeSpecificPart.substringBefore('?'))
+        val query = formParams(schemeSpecificPart.substringAfter('?', "")).nonBlank(PARAM_Q)
+            // No `q` to fall back on, so a URI that is nothing but the placeholder names nothing at all.
+            ?: return uriPoint?.takeIf { it != GEO_PLACEHOLDER }
+        // `q` may itself be a coordinate, optionally labelled.
+        labelledCoordinates(query)?.let { return it }
+        // Otherwise it is text, and it only *labels* the URI when the URI carries a real position.
+        return if (uriPoint == null || uriPoint == GEO_PLACEHOLDER) Place.Query(query) else uriPoint.copy(label = query)
+    }
+
+    // --- maps links ---------------------------------------------------------------------------------
+
+    /**
+     * A shared link on one of [MAPS_HOSTS], read for the place it points at. An unrecognized host, or one
+     * whose link says nothing we can read, returns null and the shared text falls back to its prose (see
+     * [parseSharedText]) — which is how a Maps **short link** (`maps.app.goo.gl`, `goo.gl/maps`) is
+     * handled. Those name their place only to whoever resolves the redirect, and a network round trip to
+     * expand somebody else's URL is not a thing this app should be doing on a share; the place name Maps
+     * shares alongside the link is the better source anyway.
+     */
+    private fun parseMapsUrl(url: String): Place? {
+        val link = parseUrl(url) ?: return null
+        if (link.host !in MAPS_HOSTS) return null
+        osmMarker(link.params)?.let { return it }
+        googlePlacePath(link.pathSegments)?.let { return it }
+        val values = PLACE_PARAMS.mapNotNull { link.params.nonBlank(it) }
+        // An exact coordinate beats text wherever it is spelled, because it needs no geocoder and can't
+        // resolve to the wrong place: `maps.apple.com/?q=Home&ll=47.6,-122.3` means that position, named
+        // Home. Text is the answer only when no parameter carries a position.
+        val text = values.firstOrNull { labelledCoordinates(it) == null }
+        values.firstNotNullOfOrNull { labelledCoordinates(it) }?.let { return it.copy(label = it.label ?: text) }
+        return text?.let { Place.Query(it) }
+    }
+
+    /** `…/maps/place/<Name>/@<lat>,<lng>,<zoom>z/…` — how a Google Maps place page is copied out. */
+    private fun googlePlacePath(pathSegments: List<String>): Place.Point? {
+        val at = pathSegments.firstOrNull { it.startsWith(GOOGLE_AT_PREFIX) } ?: return null
+        val point = parseCoordinates(at.removePrefix(GOOGLE_AT_PREFIX)) ?: return null
+        val placeIndex = pathSegments.indexOf(GOOGLE_PLACE_SEGMENT)
+        val name = if (placeIndex < 0) {
+            null
+        } else {
+            pathSegments.getOrNull(placeIndex + 1)?.takeIf { it.isNotBlank() && !it.startsWith(GOOGLE_AT_PREFIX) }
+        }
+        return point.copy(label = name)
+    }
+
+    /** `openstreetmap.org/?mlat=…&mlon=…` — OSM spells its marker as a coordinate pair, not one value. */
+    private fun osmMarker(params: Map<String, String>): Place.Point? {
+        val lat = params.nonBlank(PARAM_OSM_LAT) ?: return null
+        val lon = params.nonBlank(PARAM_OSM_LON) ?: return null
+        return parseCoordinates("$lat,$lon")
+    }
+
+    // --- shared text --------------------------------------------------------------------------------
+
+    /**
+     * Text shared to the app: any URI in it that we can read wins, and otherwise the prose around them is
+     * the query.
+     *
+     * Dropping the URIs from that query rather than geocoding the raw text matters — Google Maps shares a
+     * place as `"Pike Place Market\nhttps://maps.app.goo.gl/…"`, and the link half is not a place name.
+     */
+    private fun parseSharedText(text: String): Place? {
+        URI_TOKEN.findAll(text).firstNotNullOfOrNull { parseUriString(it.value) }?.let { return it }
+        val prose = URI_TOKEN.replace(text, " ").split(WHITESPACE).filter { it.isNotBlank() }
+        return prose.takeIf { it.isNotEmpty() }?.let { Place.Query(it.joinToString(" ")) }
+    }
+
+    // --- shared parsing -----------------------------------------------------------------------------
+
+    /**
+     * `<lat>,<lng>` — the one coordinate spelling all of the above share. A trailing third component
+     * (RFC 5870's altitude, Google's `17z` zoom) and RFC 5870's `;`-separated parameters are accepted and
+     * dropped; anything that isn't two numbers inside the coordinate ranges is not a coordinate.
+     */
+    private fun parseCoordinates(text: String): Place.Point? {
+        val parts = text.substringBefore(';').split(',')
+        if (parts.size !in 2..3) return null
+        val lat = parts[0].trim().toDoubleOrNull() ?: return null
+        val lon = parts[1].trim().toDoubleOrNull() ?: return null
+        if (lat !in -90.0..90.0 || lon !in -180.0..180.0) return null
+        return Place.Point(lat, lon)
+    }
+
+    /** `<lat>,<lng>(<label>)` — [parseCoordinates] plus `geo:`'s optional parenthesised label. */
+    private fun labelledCoordinates(value: String): Place.Point? {
+        val open = value.indexOf('(')
+        if (open < 0) return parseCoordinates(value)
+        val label = value.substring(open + 1).substringBeforeLast(')').trim()
+        return parseCoordinates(value.substring(0, open))?.copy(label = label.takeIf { it.isNotBlank() })
+    }
+
+    /** An `http`/`https` URL decomposed into the parts [parseMapsUrl] reads, or null if it isn't one. */
+    private fun parseUrl(url: String): Link? {
+        val uri = runCatching { URI(url) }.getOrNull() ?: return null
+        if (uri.scheme?.lowercase() !in WEB_SCHEMES) return null
+        return Link(
+            host = uri.host?.lowercase(),
+            pathSegments = uri.rawPath.orEmpty().split('/').filter { it.isNotEmpty() }.map(::formDecode),
+            params = formParams(uri.rawQuery.orEmpty())
+        )
+    }
+
+    /** An already-decomposed maps link. */
+    private data class Link(
+        val host: String?,
+        val pathSegments: List<String>,
+        val params: Map<String, String>
+    )
+
+    /** `a=1&b=2` → the decoded pairs. A repeated name keeps its last value, as a server would read it. */
+    private fun formParams(query: String): Map<String, String> = query
+        .split('&')
+        .filter { it.isNotEmpty() }
+        .associate { formDecode(it.substringBefore('=')) to formDecode(it.substringAfter('=', "")) }
+
+    /**
+     * Decodes an `application/x-www-form-urlencoded` value — the encoding these URIs are documented to
+     * use, `+`-for-space included (Android's own example is
+     * `geo:0,0?q=1600+Amphitheatre+Parkway%2C+Mountain+View%2C+CA`).
+     *
+     * A malformed escape decodes to itself rather than throwing: the value is a place name on its way to
+     * a geocoder, and a stray `%` in one is no reason to drop the whole intent.
+     */
+    private fun formDecode(value: String): String = runCatching { URLDecoder.decode(value, Charsets.UTF_8.name()) }.getOrDefault(value)
+
+    /** A parameter present with no value reads as `""` — treat it as absent, as [ExternalDeepLinks] does. */
+    private fun Map<String, String>.nonBlank(name: String): String? = this[name]?.takeIf { it.isNotBlank() }
+
+    // --- vocabulary ---------------------------------------------------------------------------------
+
+    private const val GEO_SCHEME = "geo:"
+
+    private val WEB_SCHEMES = setOf("http", "https")
+
+    /**
+     * `geo:0,0` — the platform's documented spelling of "this URI names its place in `q`, not in its own
+     * coordinate": every `?q=` form in Android's common-intents documentation is written `geo:0,0?q=…`,
+     * and Contacts emits exactly that for a postal address.
+     *
+     * Read as the sentinel it is, rather than as a position off West Africa. The alternative — letting the
+     * coordinate always win — would geocode nothing but would also send every address-book address to the
+     * middle of the Atlantic; letting `q` always win would instead discard a real coordinate whenever a
+     * sender supplies both, which the labelled forms above do.
+     */
+    private val GEO_PLACEHOLDER = Place.Point(0.0, 0.0)
+
+    /**
+     * The maps hosts whose shared links are read. Deliberately a short, exact list rather than a pattern:
+     * a link this app can't read costs the rider nothing (its prose is geocoded instead), while guessing
+     * at an unfamiliar host's parameters would send them somewhere wrong.
+     *
+     * Google's country domains (`maps.google.co.uk`, …) are not enumerated for the same reason the
+     * short-link hosts aren't handled — see [parseMapsUrl].
+     */
+    private val MAPS_HOSTS = setOf(
+        "maps.google.com",
+        "www.google.com",
+        "google.com",
+        "maps.apple.com",
+        "www.openstreetmap.org",
+        "openstreetmap.org"
+    )
+
+    /**
+     * Every query parameter across [MAPS_HOSTS] that names a place, in the order a tie between two text
+     * values is broken: Google's classic `q`/`daddr` and its `api=1` `query`/`destination`, and Apple's
+     * `q`/`daddr`/`address`/`ll`. A trip needs the *destination*, so where a link names both ends (the
+     * directions forms) only the far end is listed — `origin`/`saddr`/`sll` are read by nobody here.
+     */
+    private val PLACE_PARAMS = listOf("destination", "daddr", "q", "query", "address", "ll")
+
+    private const val PARAM_Q = "q"
+    private const val PARAM_OSM_LAT = "mlat"
+    private const val PARAM_OSM_LON = "mlon"
+
+    private const val GOOGLE_PLACE_SEGMENT = "place"
+    private const val GOOGLE_AT_PREFIX = "@"
+
+    /** A URI as it appears inside shared prose: a scheme we read, then everything up to whitespace. */
+    private val URI_TOKEN = Regex("""(?:https?://|geo:)\S+""", RegexOption.IGNORE_CASE)
+
+    private val WHITESPACE = Regex("""\s+""")
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.nav
 import android.content.Intent
 import java.net.URI
 import java.net.URLDecoder
+import org.onebusaway.android.ui.tripplan.TripEndpoint
 
 /**
  * The one place that knows how *another app* names a place to this one (#1936) — the vocabulary behind
@@ -112,13 +113,13 @@ object PlaceIntents {
     private fun parseGeoUri(uri: String): Place? {
         val schemeSpecificPart = uri.substring(GEO_SCHEME.length)
         val uriPoint = parseCoordinates(schemeSpecificPart.substringBefore('?'))
-        val query = formParams(schemeSpecificPart.substringAfter('?', "")).nonBlank(PARAM_Q)
+        val q = formParams(schemeSpecificPart.substringAfter('?', "")).nonBlank(PARAM_Q)
             // No `q` to fall back on, so a URI that is nothing but the placeholder names nothing at all.
-            ?: return uriPoint?.takeIf { it != GEO_PLACEHOLDER }
+            ?: return uriPoint?.takeUnless { it.isGeoPlaceholder }
         // `q` may itself be a coordinate, optionally labelled.
-        labelledCoordinates(query)?.let { return it }
+        labelledCoordinates(q)?.let { return it }
         // Otherwise it is text, and it only *labels* the URI when the URI carries a real position.
-        return if (uriPoint == null || uriPoint == GEO_PLACEHOLDER) query(query) else uriPoint.copy(label = normalized(query))
+        return if (uriPoint == null || uriPoint.isGeoPlaceholder) query(q) else uriPoint.copy(label = normalized(q))
     }
 
     // --- maps links ---------------------------------------------------------------------------------
@@ -132,30 +133,28 @@ object PlaceIntents {
      * shares alongside the link is the better source anyway.
      */
     private fun parseMapsUrl(url: String): Place? {
-        val link = parseUrl(url) ?: return null
-        if (link.host !in MAPS_HOSTS) return null
+        val link = parseMapsLink(url) ?: return null
         osmMarker(link.params)?.let { return it }
         googlePlacePath(link.pathSegments)?.let { return it }
-        val values = PLACE_PARAMS.mapNotNull { link.params.nonBlank(it) }
+        // Each candidate classified once, as either a position or text.
+        val candidates = PLACE_PARAMS.mapNotNull { link.params.nonBlank(it) }.map { it to labelledCoordinates(it) }
         // An exact coordinate beats text wherever it is spelled, because it needs no geocoder and can't
         // resolve to the wrong place: `maps.apple.com/?q=Home&ll=47.6,-122.3` means that position, named
         // Home. Text is the answer only when no parameter carries a position.
-        val text = values.firstOrNull { labelledCoordinates(it) == null }
-        values.firstNotNullOfOrNull { labelledCoordinates(it) }
-            ?.let { return it.copy(label = it.label ?: text?.let(::normalized)) }
-        return text?.let { query(it) }
+        val text = candidates.firstOrNull { (_, point) -> point == null }?.first
+        val point = candidates.firstNotNullOfOrNull { (_, point) -> point }
+        return point?.copy(label = point.label ?: text?.let(::normalized)) ?: text?.let(::query)
     }
 
     /** `…/maps/place/<Name>/@<lat>,<lng>,<zoom>z/…` — how a Google Maps place page is copied out. */
     private fun googlePlacePath(pathSegments: List<String>): Place.Point? {
         val at = pathSegments.firstOrNull { it.startsWith(GOOGLE_AT_PREFIX) } ?: return null
         val point = parseCoordinates(at.removePrefix(GOOGLE_AT_PREFIX)) ?: return null
-        val placeIndex = pathSegments.indexOf(GOOGLE_PLACE_SEGMENT)
-        val name = if (placeIndex < 0) {
-            null
-        } else {
-            pathSegments.getOrNull(placeIndex + 1)?.takeIf { !it.startsWith(GOOGLE_AT_PREFIX) }?.let(::normalized)
-        }
+        // dropWhile rather than indexOf: a URL with no `place` segment leaves nothing to take, where
+        // `indexOf` + 1 would wrap -1 around to the first segment and name the place "maps".
+        val name = pathSegments.dropWhile { it != GOOGLE_PLACE_SEGMENT }.drop(1).firstOrNull()
+            ?.takeUnless { it.startsWith(GOOGLE_AT_PREFIX) }
+            ?.let(::normalized)
         return point.copy(label = name)
     }
 
@@ -213,6 +212,18 @@ object PlaceIntents {
         return Place.Point(lat, lon)
     }
 
+    /**
+     * `geo:0,0` — the platform's documented spelling of "this URI names its place in `q`, not in its own
+     * coordinate": every `?q=` form in Android's common-intents documentation is written `geo:0,0?q=…`,
+     * and Contacts emits exactly that for a postal address.
+     *
+     * Read as the sentinel it is, rather than as a position off West Africa. The alternative — letting the
+     * coordinate always win — would geocode nothing but would also send every address-book address to the
+     * middle of the Atlantic; letting `q` always win would instead discard a real coordinate whenever a
+     * sender supplies both, which the labelled forms do.
+     */
+    private val Place.Point.isGeoPlaceholder: Boolean get() = lat == 0.0 && lon == 0.0
+
     /** `<lat>,<lng>(<label>)` — [parseCoordinates] plus `geo:`'s optional parenthesised label. */
     private fun labelledCoordinates(value: String): Place.Point? {
         val open = value.indexOf('(')
@@ -221,20 +232,29 @@ object PlaceIntents {
         return parseCoordinates(value.substring(0, open))?.copy(label = normalized(label))
     }
 
-    /** An `http`/`https` URL decomposed into the parts [parseMapsUrl] reads, or null if it isn't one. */
-    private fun parseUrl(url: String): Link? {
+    /**
+     * Decomposes [url] into the parts [parseMapsUrl] reads, or null if it isn't a link on one of
+     * [MAPS_HOSTS]. Scheme and host are checked before anything is decoded, so an `https` URL we have no
+     * table for — the app's own `onebusaway.co` deep links land here on every launch — costs one `URI`
+     * parse rather than a decode of every path segment and query parameter.
+     */
+    private fun parseMapsLink(url: String): MapsLink? {
         val uri = runCatching { URI(url) }.getOrNull() ?: return null
         if (uri.scheme?.lowercase() !in WEB_SCHEMES) return null
-        return Link(
-            host = uri.host?.lowercase(),
+        if (uri.host?.lowercase() !in MAPS_HOSTS) return null
+        return MapsLink(
             pathSegments = uri.rawPath.orEmpty().split('/').filter { it.isNotEmpty() }.map(::formDecode),
             params = formParams(uri.rawQuery.orEmpty())
         )
     }
 
-    /** An already-decomposed maps link. */
-    private data class Link(
-        val host: String?,
+    /**
+     * An already-decomposed maps link. Named for what it is rather than reusing [ExternalDeepLinks.Link]:
+     * the two carry the same shape of fact but not the same decoding — that one's parameters come from
+     * `Uri.getQueryParameter`, which leaves `+` as a literal plus, where these are form-decoded (see
+     * [formDecode]) — and one `Link` per vocabulary is clearer than one type with two meanings.
+     */
+    private data class MapsLink(
         val pathSegments: List<String>,
         val params: Map<String, String>
     )
@@ -263,18 +283,6 @@ object PlaceIntents {
     private const val GEO_SCHEME = "geo:"
 
     private val WEB_SCHEMES = setOf("http", "https")
-
-    /**
-     * `geo:0,0` — the platform's documented spelling of "this URI names its place in `q`, not in its own
-     * coordinate": every `?q=` form in Android's common-intents documentation is written `geo:0,0?q=…`,
-     * and Contacts emits exactly that for a postal address.
-     *
-     * Read as the sentinel it is, rather than as a position off West Africa. The alternative — letting the
-     * coordinate always win — would geocode nothing but would also send every address-book address to the
-     * middle of the Atlantic; letting `q` always win would instead discard a real coordinate whenever a
-     * sender supplies both, which the labelled forms above do.
-     */
-    private val GEO_PLACEHOLDER = Place.Point(0.0, 0.0)
 
     /**
      * The maps hosts whose shared links are read. Deliberately a short, exact list rather than a pattern:
@@ -313,3 +321,17 @@ object PlaceIntents {
 
     private val WHITESPACE = Regex("""\s+""")
 }
+
+/**
+ * An incoming place that arrived with coordinates, as a trip-plan endpoint: [TripEndpoint.Geocoded] when
+ * the sender named it, and otherwise [TripEndpoint.MapPoint] — whose fixed "Selected location" label is
+ * the honest one for a bare coordinate, and whose terminals a plan reverse-geocodes for the itinerary
+ * anyway (`TripPlanViewModel.placeNameOf`).
+ *
+ * Top-level and `internal` — like [org.onebusaway.android.ui.tripplan.toGeocoded], the sibling adapter
+ * that turns a geocoder result into the same type — so this stays JVM-unit-testable rather than being
+ * buried in the Activity that consumes it.
+ */
+internal fun PlaceIntents.Place.Point.toEndpoint(): TripEndpoint = label
+    ?.let { TripEndpoint.Geocoded(displayName = it, lat = lat, lon = lon) }
+    ?: TripEndpoint.MapPoint(lat = lat, lon = lon)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
@@ -118,7 +118,7 @@ object PlaceIntents {
         // `q` may itself be a coordinate, optionally labelled.
         labelledCoordinates(query)?.let { return it }
         // Otherwise it is text, and it only *labels* the URI when the URI carries a real position.
-        return if (uriPoint == null || uriPoint == GEO_PLACEHOLDER) Place.Query(query) else uriPoint.copy(label = query)
+        return if (uriPoint == null || uriPoint == GEO_PLACEHOLDER) query(query) else uriPoint.copy(label = normalized(query))
     }
 
     // --- maps links ---------------------------------------------------------------------------------
@@ -141,8 +141,9 @@ object PlaceIntents {
         // resolve to the wrong place: `maps.apple.com/?q=Home&ll=47.6,-122.3` means that position, named
         // Home. Text is the answer only when no parameter carries a position.
         val text = values.firstOrNull { labelledCoordinates(it) == null }
-        values.firstNotNullOfOrNull { labelledCoordinates(it) }?.let { return it.copy(label = it.label ?: text) }
-        return text?.let { Place.Query(it) }
+        values.firstNotNullOfOrNull { labelledCoordinates(it) }
+            ?.let { return it.copy(label = it.label ?: text?.let(::normalized)) }
+        return text?.let { query(it) }
     }
 
     /** `…/maps/place/<Name>/@<lat>,<lng>,<zoom>z/…` — how a Google Maps place page is copied out. */
@@ -153,7 +154,7 @@ object PlaceIntents {
         val name = if (placeIndex < 0) {
             null
         } else {
-            pathSegments.getOrNull(placeIndex + 1)?.takeIf { it.isNotBlank() && !it.startsWith(GOOGLE_AT_PREFIX) }
+            pathSegments.getOrNull(placeIndex + 1)?.takeIf { !it.startsWith(GOOGLE_AT_PREFIX) }?.let(::normalized)
         }
         return point.copy(label = name)
     }
@@ -176,11 +177,27 @@ object PlaceIntents {
      */
     private fun parseSharedText(text: String): Place? {
         URI_TOKEN.findAll(text).firstNotNullOfOrNull { parseUriString(it.value) }?.let { return it }
-        val prose = URI_TOKEN.replace(text, " ").split(WHITESPACE).filter { it.isNotBlank() }
-        return prose.takeIf { it.isNotEmpty() }?.let { Place.Query(it.joinToString(" ")) }
+        return query(URI_TOKEN.replace(text, " "))
     }
 
     // --- shared parsing -----------------------------------------------------------------------------
+
+    /** A [Place.Query] over [text], or null when [normalized] leaves nothing of it. */
+    private fun query(text: String): Place.Query? = normalized(text)?.let { Place.Query(it) }
+
+    /**
+     * Collapses a value's whitespace to single spaces, or null if nothing is left of it.
+     *
+     * Every place name here is headed for a geocoder or a single-line form field, and senders put real
+     * line breaks in them: Google Contacts spells a street address `daddr=14420+75th+Ave+NE%0ABothell…`,
+     * whose `%0A` decodes to a newline that a text field truncates at and a geocoder does nothing useful
+     * with. So it is applied wherever a name is *produced*, not just on the shared-text path.
+     */
+    private fun normalized(text: String): String? = text
+        .split(WHITESPACE)
+        .filter { it.isNotBlank() }
+        .joinToString(" ")
+        .takeIf { it.isNotEmpty() }
 
     /**
      * `<lat>,<lng>` — the one coordinate spelling all of the above share. A trailing third component
@@ -200,8 +217,8 @@ object PlaceIntents {
     private fun labelledCoordinates(value: String): Place.Point? {
         val open = value.indexOf('(')
         if (open < 0) return parseCoordinates(value)
-        val label = value.substring(open + 1).substringBeforeLast(')').trim()
-        return parseCoordinates(value.substring(0, open))?.copy(label = label.takeIf { it.isNotBlank() })
+        val label = value.substring(open + 1).substringBeforeLast(')')
+        return parseCoordinates(value.substring(0, open))?.copy(label = normalized(label))
     }
 
     /** An `http`/`https` URL decomposed into the parts [parseMapsUrl] reads, or null if it isn't one. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -248,19 +248,23 @@ class TripPlanViewModel @Inject constructor(
      * opened for; a rider who types over it in the meantime wins.
      */
     fun setEndpointFromQuery(slot: TripEndpointSlot, query: String) {
+        if (query.isBlank()) return
         val typed = TripEndpoint.FreeText(query)
-        _formState.update { it.withEndpoint(slot, typed) }
-        replanOrClearResult()
+        setEndpoint(slot, typed)
         viewModelScope.launch {
-            val match = geocode.suggest(query).getOrNull()?.firstOrNull()
+            // Called instead of [suggestionsFor] because that folds a failed lookup into an empty one,
+            // and the two want different things below.
+            val suggestions = geocode.suggest(query)
             // The rider may have typed over the field while the lookup was out — theirs wins.
             if (_formState.value.endpointAt(slot) != typed) return@launch
-            if (match == null) {
-                // Hand the text to the field's own debounced lookup, so the rider has a list to pick from.
-                queries.getValue(slot).value = query
-                return@launch
+            val match = suggestions.getOrNull()?.firstOrNull()
+            when {
+                match != null -> setEndpointPaired(slot, match)
+                // A lookup that *failed* is worth asking again, so arm the field's own debounced pipeline.
+                // One that succeeded with nothing is not — re-asking would only repeat the same answer,
+                // and [setEndpoint] has already left the field showing the text with no suggestions.
+                suggestions.isFailure -> queries.getValue(slot).value = query
             }
-            setEndpointPaired(slot, match)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.location.LocationRepository
@@ -198,7 +199,7 @@ class TripPlanViewModel @Inject constructor(
         replanOrClearResult()
     }
 
-    /** Sets one endpoint (from a suggestion, current location, contacts, or map) and re-plans if ready. */
+    /** Sets one endpoint (from a suggestion, the current location, or the map) and re-plans if ready. */
     fun setEndpoint(slot: TripEndpointSlot, endpoint: TripEndpoint) {
         _formState.update { it.withEndpoint(slot, endpoint) }
         replanOrClearResult()
@@ -207,7 +208,7 @@ class TripPlanViewModel @Inject constructor(
     /**
      * Sets [slot] to the device's current location, returning false when there's no fix to set it to.
      * Saying *why* there's none is left to the caller, whose business it is: the field's own button
-     * explains itself with a toast, while the long-press path below pairs silently.
+     * explains itself with a toast, while the trip-end paths below pair silently.
      */
     fun setEndpointToCurrentLocation(slot: TripEndpointSlot): Boolean {
         val here = currentLocation() ?: return false
@@ -216,17 +217,51 @@ class TripPlanViewModel @Inject constructor(
     }
 
     /**
-     * Sets the endpoint a map long-press named ("directions from/to here"), pairing the trip's other
-     * end with the device's current location — [TripPlanFormState.withEndpointPaired] owns the rule
-     * (#2092). Both ends land in one form update, so the pair submits as a single plan.
+     * Sets an endpoint that arrived as *one end of a trip* rather than as an edit to a form — a map
+     * long-press ("directions from/to here"), or a place another app handed us (#1936) — pairing the
+     * trip's other end with the device's current location. [TripPlanFormState.withEndpointPaired] owns
+     * the rule (#2092); both ends land in one form update, so the pair submits as a single plan.
      *
      * Distinct from [setEndpoint], which the crosshair pick-on-map path uses: that one is an edit
      * within a form the rider is already filling, so it pairs nothing.
      */
-    fun setEndpointFromLongPress(slot: TripEndpointSlot, endpoint: TripEndpoint) {
+    fun setEndpointPaired(slot: TripEndpointSlot, endpoint: TripEndpoint) {
         val here = currentLocation()
         _formState.update { it.withEndpointPaired(slot, endpoint, here) }
         replanOrClearResult()
+    }
+
+    /**
+     * Fills [slot] from a place another app named only as *text* — a shared postal address, or the place
+     * name that came alongside a maps link it gave us (#1936) — by resolving it through the same geocoder
+     * the form's own autocomplete uses, and pairing it as [setEndpointPaired] does so the trip plans on
+     * the spot.
+     *
+     * The top-ranked match is taken. Geocoding is a ranked search with no exact source to consult
+     * instead, and this is the same answer the field's suggestion list puts first; what keeps it honest is
+     * that the result lands as an ordinary cancellable pill *showing the name it resolved to*, so a wrong
+     * match is visible and one tap from being corrected.
+     *
+     * A query that resolves to nothing is left in the field as typed text with its suggestion list live,
+     * rather than being silently dropped — the rider picks. The text is shown immediately either way,
+     * since the resolve is a network round trip and an empty form would say nothing about what the app was
+     * opened for; a rider who types over it in the meantime wins.
+     */
+    fun setEndpointFromQuery(slot: TripEndpointSlot, query: String) {
+        val typed = TripEndpoint.FreeText(query)
+        _formState.update { it.withEndpoint(slot, typed) }
+        replanOrClearResult()
+        viewModelScope.launch {
+            val match = geocode.suggest(query).getOrNull()?.firstOrNull()
+            // The rider may have typed over the field while the lookup was out — theirs wins.
+            if (_formState.value.endpointAt(slot) != typed) return@launch
+            if (match == null) {
+                // Hand the text to the field's own debounced lookup, so the rider has a list to pick from.
+                queries.getValue(slot).value = query
+                return@launch
+            }
+            setEndpointPaired(slot, match)
+        }
     }
 
     /** The device's last known fix as a plan endpoint, or null when there is none (or no permission). */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/PlaceIntentsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/PlaceIntentsTest.kt
@@ -156,6 +156,27 @@ class PlaceIntentsTest {
         )
     }
 
+    /**
+     * The URL Google Contacts builds for a postal address, captured off a Pixel 7 Pro. The `%0A` between
+     * street and city decodes to a real newline — which a single-line form field truncates at and a
+     * geocoder can do nothing with — so the whole address has to survive as one line.
+     */
+    @Test
+    fun `a contacts address URL keeps its whole address on one line`() {
+        assertEquals(
+            Place.Query("14420 75th Ave NE Bothell, WA 98011"),
+            viewed("https://www.google.com/maps?daddr=14420+75th+Ave+NE%0ABothell,+WA+98011&entry=ml&utm_campaign=ml-ardl-mgrc")
+        )
+    }
+
+    @Test
+    fun `a labelled coordinate keeps its label on one line`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422, "Pike Place Market"),
+            viewed("geo:0,0?q=47.6097,-122.3422(Pike%0APlace%0AMarket)")
+        )
+    }
+
     @Test
     fun `an unknown maps host is not read`() {
         assertNull(viewed("https://maps.example.com/?q=Pike+Place+Market"))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/PlaceIntentsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/PlaceIntentsTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import org.onebusaway.android.ui.nav.PlaceIntents.Place
 import org.onebusaway.android.ui.nav.PlaceIntents.PlaceRequest
 import org.onebusaway.android.ui.nav.PlaceIntents.parse
+import org.onebusaway.android.ui.tripplan.TripEndpoint
 
 /**
  * Unit tests for the place-intent vocabulary (#1936) — the `geo:` URIs, maps links and shared text
@@ -228,6 +229,25 @@ class PlaceIntentsTest {
     fun `an empty share names nothing`() {
         assertNull(shared("   "))
         assertNull(parse(PlaceRequest()))
+    }
+
+    // --- as a plan endpoint -------------------------------------------------------------------------
+
+    @Test
+    fun `a named point becomes a geocoded endpoint carrying its name`() {
+        assertEquals(
+            TripEndpoint.Geocoded("Space Needle", lat = 47.6205, lon = -122.3493),
+            Place.Point(47.6205, -122.3493, "Space Needle").toEndpoint()
+        )
+    }
+
+    /** Nothing to call it, so it becomes the same kind of endpoint a map pick makes. */
+    @Test
+    fun `an unnamed point becomes a map-point endpoint`() {
+        assertEquals(
+            TripEndpoint.MapPoint(lat = 47.6205, lon = -122.3493),
+            Place.Point(47.6205, -122.3493).toEndpoint()
+        )
     }
 
     // --- precedence ---------------------------------------------------------------------------------

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/PlaceIntentsTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/PlaceIntentsTest.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.onebusaway.android.ui.nav.PlaceIntents.Place
+import org.onebusaway.android.ui.nav.PlaceIntents.PlaceRequest
+import org.onebusaway.android.ui.nav.PlaceIntents.parse
+
+/**
+ * Unit tests for the place-intent vocabulary (#1936) — the `geo:` URIs, maps links and shared text
+ * another app can name a place with. [parse] is pure over an already-projected intent, so the whole
+ * vocabulary is covered here; only the `Intent` reads it sits behind need Android.
+ */
+class PlaceIntentsTest {
+
+    private fun viewed(uri: String) = parse(PlaceRequest(dataUri = uri))
+
+    private fun shared(text: String) = parse(PlaceRequest(sharedText = text))
+
+    // --- geo: ---------------------------------------------------------------------------------------
+
+    @Test
+    fun `bare geo URI is the point itself`() {
+        assertEquals(Place.Point(47.6097, -122.3422), viewed("geo:47.6097,-122.3422"))
+    }
+
+    @Test
+    fun `geo zoom and RFC 5870 uncertainty are dropped`() {
+        assertEquals(Place.Point(47.6097, -122.3422), viewed("geo:47.6097,-122.3422?z=17"))
+        assertEquals(Place.Point(47.6097, -122.3422), viewed("geo:47.6097,-122.3422;u=35"))
+    }
+
+    /** RFC 5870 allows an altitude as a third component; it is accepted and ignored. */
+    @Test
+    fun `geo altitude is dropped`() {
+        assertEquals(Place.Point(48.2, 16.3), viewed("geo:48.2,16.3,183"))
+    }
+
+    /** What Contacts emits for a postal address: the `geo:0,0` placeholder plus a form-encoded `q`. */
+    @Test
+    fun `geo placeholder with an address is a query`() {
+        assertEquals(
+            Place.Query("1600 Amphitheatre Parkway, Mountain View, CA"),
+            viewed("geo:0,0?q=1600+Amphitheatre+Parkway%2C+Mountain+View%2C+CA")
+        )
+    }
+
+    @Test
+    fun `geo q may be a labelled coordinate`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422, "Pike Place Market"),
+            viewed("geo:0,0?q=47.6097,-122.3422(Pike+Place+Market)")
+        )
+    }
+
+    @Test
+    fun `geo q may be a bare coordinate`() {
+        assertEquals(Place.Point(47.6097, -122.3422), viewed("geo:0,0?q=47.6097,-122.3422"))
+    }
+
+    /** A sender that supplies both means "this position, called that" — the coordinate is not discarded. */
+    @Test
+    fun `geo q labels a real coordinate rather than replacing it`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422, "Pike Place Market"),
+            viewed("geo:47.6097,-122.3422?q=Pike+Place+Market")
+        )
+    }
+
+    @Test
+    fun `geo scheme is case-insensitive`() {
+        assertEquals(Place.Point(47.6097, -122.3422), viewed("GEO:47.6097,-122.3422"))
+    }
+
+    @Test
+    fun `geo placeholder alone names nothing`() {
+        assertNull(viewed("geo:0,0"))
+    }
+
+    @Test
+    fun `out-of-range and non-numeric coordinates are not coordinates`() {
+        assertNull(viewed("geo:91.0,-122.3"))
+        assertNull(viewed("geo:47.6,-181.0"))
+        assertNull(viewed("geo:north,west"))
+    }
+
+    // --- other schemes ------------------------------------------------------------------------------
+
+    @Test
+    fun `the app's own deep links and internal URIs are not places`() {
+        assertNull(viewed("onebusaway://view-stop?stopID=1_75403"))
+        assertNull(viewed("https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_18196913"))
+        assertNull(viewed("content://com.joulespersecond.oba/stops/1_75403"))
+    }
+
+    // --- maps links ---------------------------------------------------------------------------------
+
+    @Test
+    fun `google maps classic q may be an address or a coordinate`() {
+        assertEquals(
+            Place.Query("Pike Place Market, Seattle"),
+            viewed("https://maps.google.com/maps?q=Pike+Place+Market%2C+Seattle")
+        )
+        assertEquals(Place.Point(47.6097, -122.3422), viewed("https://maps.google.com/maps?q=47.6097,-122.3422"))
+    }
+
+    @Test
+    fun `google maps api=1 search and directions name the destination`() {
+        assertEquals(
+            Place.Query("Space Needle"),
+            viewed("https://www.google.com/maps/search/?api=1&query=Space+Needle")
+        )
+        assertEquals(
+            Place.Query("Space Needle"),
+            viewed("https://www.google.com/maps/dir/?api=1&origin=Pike+Place&destination=Space+Needle")
+        )
+    }
+
+    @Test
+    fun `google maps place page carries its name and its coordinate`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422, "Pike Place Market"),
+            viewed("https://www.google.com/maps/place/Pike+Place+Market/@47.6097,-122.3422,17z/data=!3m1")
+        )
+    }
+
+    @Test
+    fun `apple maps coordinate beats its own place name, which becomes the label`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422, "Home"),
+            viewed("https://maps.apple.com/?q=Home&ll=47.6097,-122.3422")
+        )
+    }
+
+    @Test
+    fun `openstreetmap marker is a coordinate pair`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422),
+            viewed("https://www.openstreetmap.org/?mlat=47.6097&mlon=-122.3422")
+        )
+    }
+
+    @Test
+    fun `an unknown maps host is not read`() {
+        assertNull(viewed("https://maps.example.com/?q=Pike+Place+Market"))
+    }
+
+    @Test
+    fun `a maps host with nothing readable on it names nothing`() {
+        assertNull(viewed("https://www.google.com/maps"))
+    }
+
+    // --- shared text --------------------------------------------------------------------------------
+
+    @Test
+    fun `plain shared text is a query`() {
+        assertEquals(Place.Query("400 Broad St, Seattle, WA 98109"), shared("400 Broad St, Seattle, WA 98109"))
+    }
+
+    @Test
+    fun `a readable maps link inside shared text wins over its prose`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422),
+            shared("Look at this\nhttps://www.openstreetmap.org/?mlat=47.6097&mlon=-122.3422")
+        )
+    }
+
+    /**
+     * How a Google Maps share arrives: a place name and a short link only the network can expand. The
+     * link is dropped from the query rather than geocoded along with the name.
+     */
+    @Test
+    fun `an unreadable link leaves its prose as the query`() {
+        assertEquals(
+            Place.Query("Pike Place Market"),
+            shared("Pike Place Market\nhttps://maps.app.goo.gl/AbCdEf123")
+        )
+    }
+
+    @Test
+    fun `a geo URI shared as text is read as one`() {
+        assertEquals(Place.Point(47.6097, -122.3422), shared("geo:47.6097,-122.3422"))
+    }
+
+    @Test
+    fun `a share with nothing but an unreadable link names nothing`() {
+        assertNull(shared("https://maps.app.goo.gl/AbCdEf123"))
+    }
+
+    @Test
+    fun `an empty share names nothing`() {
+        assertNull(shared("   "))
+        assertNull(parse(PlaceRequest()))
+    }
+
+    // --- precedence ---------------------------------------------------------------------------------
+
+    @Test
+    fun `the data URI is read before the shared text`() {
+        assertEquals(
+            Place.Point(47.6097, -122.3422),
+            parse(PlaceRequest(dataUri = "geo:47.6097,-122.3422", sharedText = "somewhere else"))
+        )
+    }
+
+    @Test
+    fun `an unreadable data URI falls through to the shared text`() {
+        assertEquals(
+            Place.Query("Pike Place Market"),
+            parse(PlaceRequest(dataUri = "content://whatever/1", sharedText = "Pike Place Market"))
+        )
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -82,6 +82,15 @@ class TripPlanViewModelTest {
         }
     }
 
+    /** A geocoder whose forward lookup answers only when the test completes [pending]. */
+    private class DeferredGeocodeRepository(
+        private val pending: CompletableDeferred<Result<List<TripEndpoint.Geocoded>>>
+    ) : GeocodeRepository {
+        override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> = pending.await()
+
+        override suspend fun reverse(lat: Double, lon: Double): Result<String?> = Result.success(null)
+    }
+
     /** A geocoder whose reverse lookup never answers, to exercise the plan's naming timeout. */
     private class StalledGeocodeRepository : GeocodeRepository {
         override suspend fun suggest(query: String) = Result.success(emptyList<TripEndpoint.Geocoded>())
@@ -315,7 +324,7 @@ class TripPlanViewModelTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
         val vm = viewModel(plan = plan)
 
-        vm.setEndpointFromLongPress(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        vm.setEndpointPaired(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
         advanceUntilIdle()
 
         val state = vm.formState.value
@@ -334,11 +343,82 @@ class TripPlanViewModelTest {
         vm.setEndpoint(TripEndpointSlot.FROM, origin)
         advanceUntilIdle()
 
-        vm.setEndpointFromLongPress(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
+        vm.setEndpointPaired(TripEndpointSlot.TO, TripEndpoint.MapPoint(lat = 47.7, lon = -122.2))
         advanceUntilIdle()
 
         assertTrue(vm.formState.value.canSubmit)
         assertEquals(1, plan.calls)
+    }
+
+    // --- a place another app named as text (#1936) ---------------------------------------------------
+
+    @Test
+    fun `a place named as text resolves to the geocoder's top match and plans`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val geocode = FakeGeocodeRepository(Result.success(listOf(destination, origin)))
+        val vm = viewModel(geocode = geocode, plan = plan)
+        vm.setEndpoint(TripEndpointSlot.FROM, origin)
+        advanceUntilIdle()
+
+        vm.setEndpointFromQuery(TripEndpointSlot.TO, "400 Broad St")
+        advanceUntilIdle()
+
+        assertEquals("400 Broad St", geocode.lastQuery)
+        assertEquals(destination, vm.formState.value.to)
+        assertEquals(1, plan.calls)
+    }
+
+    /** The text is on screen before the geocoder answers, so the form says what the app was opened for. */
+    @Test
+    fun `a place named as text shows its text while the lookup is out`() = runTest {
+        val pending = CompletableDeferred<Result<List<TripEndpoint.Geocoded>>>()
+        val vm = viewModel(geocode = DeferredGeocodeRepository(pending))
+
+        vm.setEndpointFromQuery(TripEndpointSlot.TO, "400 Broad St")
+        runCurrent()
+
+        assertEquals(TripEndpoint.FreeText("400 Broad St"), vm.formState.value.to)
+
+        pending.complete(Result.success(listOf(destination)))
+        advanceUntilIdle()
+        assertEquals(destination, vm.formState.value.to)
+    }
+
+    /** A rider who types over the field while the lookup is out keeps what they typed. */
+    @Test
+    fun `an edit during the lookup is not overwritten by its result`() = runTest {
+        val pending = CompletableDeferred<Result<List<TripEndpoint.Geocoded>>>()
+        val vm = viewModel(geocode = DeferredGeocodeRepository(pending))
+
+        vm.setEndpointFromQuery(TripEndpointSlot.TO, "400 Broad St")
+        runCurrent()
+        vm.onQueryChange(TripEndpointSlot.TO, "Space Needle")
+        pending.complete(Result.success(listOf(destination)))
+        advanceUntilIdle()
+
+        assertEquals(TripEndpoint.FreeText("Space Needle"), vm.formState.value.to)
+    }
+
+    @Test
+    fun `a place named as text that resolves to nothing is left in the field for the rider`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
+        val vm = viewModel(geocode = FakeGeocodeRepository(Result.success(emptyList())), plan = plan)
+
+        vm.setEndpointFromQuery(TripEndpointSlot.TO, "nowhere at all")
+        advanceUntilIdle()
+
+        assertEquals(TripEndpoint.FreeText("nowhere at all"), vm.formState.value.to)
+        assertEquals(0, plan.calls)
+    }
+
+    @Test
+    fun `a failed lookup leaves the text in the field rather than dropping it`() = runTest {
+        val vm = viewModel(geocode = FakeGeocodeRepository(Result.failure(IOException("offline"))))
+
+        vm.setEndpointFromQuery(TripEndpointSlot.TO, "400 Broad St")
+        advanceUntilIdle()
+
+        assertEquals(TripEndpoint.FreeText("400 Broad St"), vm.formState.value.to)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -69,10 +69,12 @@ class TripPlanViewModelTest {
         var reverseResult: Result<String?> = Result.success(null)
     ) : GeocodeRepository {
         var lastQuery: String? = null
+        var suggestCalls = 0
         val reverseCalls = mutableListOf<Pair<Double, Double>>()
 
         override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> {
             lastQuery = query
+            suggestCalls++
             return result
         }
 
@@ -399,26 +401,46 @@ class TripPlanViewModelTest {
         assertEquals(TripEndpoint.FreeText("Space Needle"), vm.formState.value.to)
     }
 
+    /**
+     * A lookup that succeeded with nothing has already given its answer, so the question isn't repeated
+     * through the field's debounced pipeline — the geocoder is asked exactly once.
+     */
     @Test
     fun `a place named as text that resolves to nothing is left in the field for the rider`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(TripItinerary())))
-        val vm = viewModel(geocode = FakeGeocodeRepository(Result.success(emptyList())), plan = plan)
+        val geocode = FakeGeocodeRepository(Result.success(emptyList()))
+        val vm = viewModel(geocode = geocode, plan = plan)
 
         vm.setEndpointFromQuery(TripEndpointSlot.TO, "nowhere at all")
         advanceUntilIdle()
 
         assertEquals(TripEndpoint.FreeText("nowhere at all"), vm.formState.value.to)
+        assertEquals(1, geocode.suggestCalls)
         assertEquals(0, plan.calls)
     }
 
+    /** A lookup that *failed*, by contrast, is worth retrying — the field's own pipeline is armed. */
     @Test
-    fun `a failed lookup leaves the text in the field rather than dropping it`() = runTest {
-        val vm = viewModel(geocode = FakeGeocodeRepository(Result.failure(IOException("offline"))))
+    fun `a failed lookup leaves the text in the field and retries`() = runTest {
+        val geocode = FakeGeocodeRepository(Result.failure(IOException("offline")))
+        val vm = viewModel(geocode = geocode)
 
         vm.setEndpointFromQuery(TripEndpointSlot.TO, "400 Broad St")
         advanceUntilIdle()
 
         assertEquals(TripEndpoint.FreeText("400 Broad St"), vm.formState.value.to)
+        assertEquals(2, geocode.suggestCalls)
+    }
+
+    @Test
+    fun `a blank place name asks the geocoder nothing`() = runTest {
+        val geocode = FakeGeocodeRepository(Result.success(emptyList()))
+        val vm = viewModel(geocode = geocode)
+
+        vm.setEndpointFromQuery(TripEndpointSlot.TO, "   ")
+        advanceUntilIdle()
+
+        assertEquals(0, geocode.suggestCalls)
     }
 
     @Test


### PR DESCRIPTION
Closes #1936.

The trip planner's in-app address-book picker is already gone; this is the other half. Rather than reading the rider's contacts ourselves, accept the place their address book — or maps app, or browser — already knows how to hand out, and open the home map's directions focus with it as the trip's destination.

## Two filters, and the difference between them is the point

- **`ACTION_VIEW` on `geo:`** — the platform's standard "open this location". Claiming the scheme puts OneBusAway in the same chooser as the map apps, which is where a rider wanting transit directions to an address is looking.
- **`ACTION_SEND` of `text/plain`** — the share sheet, where a maps link or a bare address arrives.

`https` maps links are deliberately **not** claimed as `ACTION_VIEW`. That would put this app in the chooser for every Google Maps URL on the device, which is not an offer a transit app should be making; sharing to us is the rider saying they meant us. (It would also be inert — see the Google Contacts finding below.)

`PlaceIntents` owns that vocabulary the way `ExternalDeepLinks` owns OneBusAway's own: `geo:` in the forms Android documents plus RFC 5870's `;`-parameters, and an enumerated table of maps hosts/parameters (Google, Apple, OSM) read out of shared text. `parse` is pure over a projected intent, so all of it is JVM-unit-tested.

Routing-wise these resolve to nothing: the directions focus is home-map state rather than a NavHost destination, so `IntentRouteMapper` stays a pure translator and the work runs in `HomeActivity`'s launch-intent side effects, next to the notification restore and the tracked-route reveal.

The destination is filled through `setEndpointFromLongPress`, renamed `setEndpointPaired` now that it has a second caller with the same shape — one end of a trip arriving whole, pairing the other with the device's fix — so a place with coordinates plans on the spot.

## ⚠️ Needs sign-off: `geo:0,0` is read as a sentinel

Per CLAUDE.md's "No unsanctioned heuristics" rule, calling this out explicitly for a human decision before merge.

`geo:0,0` is decoded as the platform's spelling of *"this URI names its place in `q`, not in its own coordinate"* rather than as a position off West Africa. Every `?q=` form in [Android's common-intents documentation](https://developer.android.com/guide/components/intents-common#Maps) is written `geo:0,0?q=…`, so this is decoding a documented sentinel rather than guessing from magnitude — the same category as the `-1` "no region" sentinel the codebase already reads. The alternative readings are both worse: letting the coordinate always win sends every address-book address to the middle of the Atlantic, and letting `q` always win discards a real coordinate whenever a sender supplies both (which the labelled `q=lat,lng(Label)` form does). Documented at the site as `isGeoPlaceholder`.

Two related judgment calls, neither a heuristic but both worth a look:

- **A place named only as text takes the geocoder's top-ranked match.** Geocoding is a ranked search with no exact source to consult instead, and this is the answer the field's own suggestion list already puts first. What keeps it honest is that the result lands as an ordinary **cancellable pill showing the name it resolved to**, so a wrong match is visible and one tap from being corrected. Text that resolves to nothing stays in the field with its suggestion list live rather than being dropped.
- **Maps short links (`maps.app.goo.gl`) are not resolved.** They name their place only to whoever follows the redirect, and expanding somebody else's URL over the network on a share isn't something this app should do. They fall to the prose rule instead — links are stripped from the shared text and the rest is geocoded — which is exactly how a Google Maps share (`"Pike Place Market\nhttps://maps.app.goo.gl/…"`) resolves.

## Finding: Google Contacts is out of reach, and not because of the design choice above

Measured on a Pixel 7 Pro (Android 17). Tapping an address in Google Contacts never creates a `geo:` intent:

```
Contacts → VIEW https://maps.google.com/…            → resolves to Chrome
Chrome   → VIEW https://www.google.com/maps?daddr=…  → pkg=com.google.android.apps.maps
```

It builds an **https maps URL**, hands it to the default browser, and Chrome bounces it to Maps. Claiming those hosts wouldn't help: since API 31 an unverified domain isn't offered to the app at all (the same rule this repo's `DEEP_LINKING.md` already documents for `onebusaway.co`), and App Links verification matches the domain's `assetlinks.json` against our signing certificate — so OneBusAway can never be approved for `google.com`. **That path is closed by the platform, not by the filter choice.**

So the issue's headline use case is served for address books that emit `geo:` — the device lists 12 such handlers (Transit, Citymapper, OsmAnd, Uber, Lyft…) — and via the share sheet, but not for Google Contacts' address tap specifically. Worth deciding separately whether to chase that with a `text/x-vcard` filter on Contacts' *Share* action, which would stay permission-free (the content arrives in the intent, no `READ_CONTACTS`). Not attempted here.

## Verified

- Full unit suite, `spotlessCheck`, and `-PwarningsAsErrors=true` all clean.
- On device (Pixel 7 Pro): `geo:` point, `geo:0,0?q=<address>`, and the real Contacts maps URL delivered via share — each opened the directions focus, filled From with the current location, and planned. Both new filters confirmed registered via `dumpsys package`.
- One caveat: the final quality-pass commit (`e0466ae`) is verified by build and unit tests only — the device came unplugged before it could be re-run. It touches the parsing paths all three device checks exercise, so those are worth repeating before merge.

## Commits

1. **Accept place intents from other apps** — the filters, `PlaceIntents`, the `HomeActivity` wiring, `setEndpointPaired`/`setEndpointFromQuery`, and `docs/DEEP_LINKING.md`.
2. **Keep a place name on one line** — Google Contacts spells an address `daddr=14420+75th+Ave+NE%0ABothell,+WA+98011`; the `%0A` decodes to a real newline, which the single-line To field truncated at and the geocoder could do nothing with. Found by testing on the device.
3. **Simplify the place-intent parsing and its endpoint fill** — a `/simplify` pass. Chiefly: a query resolving to nothing had cost two geocoder round trips (the second guaranteed to repeat the first's empty answer); the maps-URL parser classified each candidate twice; and the pure `Place.Point → TripEndpoint` adapter moved out of the Activity, where no JVM test could reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Open directions directly from shared map links, `geo:` links, addresses, and location text from other apps.
  - Support Google Maps, Apple Maps, and OpenStreetMap links, including coordinates and place labels.
  - Resolve shared address text into trip destinations with geocoding and preserve unresolved searches for retry.

- **Bug Fixes**
  - Improved handling of malformed, unsupported, empty, and ambiguous location links.

- **Documentation**
  - Added guidance and testing examples for supported deep-linking formats and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->