### PR TITLE
Keep every boardable route's lead-in when an ETA pill is tapped (#2239)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -266,7 +266,7 @@ class RouteMapController(
 
     // The single-route presentation is retained even while a focused stop temporarily owns the
     // geometry/stop layer, so closing the stop or changing directions restores it without a reload.
-    private var basePolylines: List<RoutePolyline> = emptyList()
+    private var base: RouteBase = RouteBase.None
     private var baseStopPresentation: RouteStopPresentation? = null
 
     // Which live vehicles belong to the focused ride (#2124): the boarding stop's arrivals select
@@ -278,6 +278,27 @@ class RouteMapController(
         scope = scope,
         onSelectionChanged = ::publishVehicleSet
     )
+
+    /**
+     * The route geometry drawn beneath everything else, carried together with **what it is**.
+     *
+     * The same field holds two different things: a route's own corridor in an ordinary session, and a
+     * focused ride's approach set — one upstream lead-in per boardable route (#2010) — when a trip-plan
+     * leg is drilled into. The difference decides whether a drilled-into vehicle may replace it, which is
+     * the whole of #2239, so it travels with the lines rather than being asked of the ride again at the
+     * publish: [showDirectionPolylines] and [refreshApproachLines] are the only two places that build a
+     * base, each already knows which kind it built, and a third derivation would be free to disagree the
+     * moment either of their own rules moved.
+     */
+    private data class RouteBase(
+        val polylines: List<RoutePolyline>,
+        val isRideApproach: Boolean
+    ) {
+        companion object {
+            /** No route drawn — the state [stop] returns to. */
+            val None = RouteBase(emptyList(), isRideApproach = false)
+        }
+    }
 
     private data class FocusedRouteLines(
         val routeId: String,
@@ -856,9 +877,10 @@ class RouteMapController(
         val leaderRouteId = routeId ?: return
         // Only a focused ride has an approach; a plain route draws its whole shape and never re-derives.
         if (!riddenSpans.isDrawableRide()) return
-        val next = approachLines(focusedRouteLines(leaderRouteId), riddenPath)
-        if (next != basePolylines) {
-            basePolylines = next
+        // Guarded above on the ride being drawn, so what this builds is by construction an approach set.
+        val next = RouteBase(approachLines(focusedRouteLines(leaderRouteId), riddenPath), isRideApproach = true)
+        if (next != base) {
+            base = next
             publishMapPresentation()
         }
     }
@@ -890,7 +912,7 @@ class RouteMapController(
         routeStopRoutes = emptyList()
         directions = emptyList()
         routeShape = null
-        basePolylines = emptyList()
+        base = RouteBase.None
         baseStopPresentation = null
         directionState = DirectionState.Resolved(null)
         pendingFocus = null
@@ -937,7 +959,8 @@ class RouteMapController(
         val plan = assembleRouteMapPresentation(
             isActive = isActive,
             emphasizedRoute = routeId?.let { RouteDirectionKey(it, presentationDirectionId) },
-            basePolylines = basePolylines,
+            basePolylines = base.polylines,
+            baseIsRideApproach = base.isRideApproach,
             baseStopPresentation = baseStopPresentation,
             focusTrips = focus.trips,
             focusedGeometry = focus.geometry,
@@ -1019,7 +1042,7 @@ class RouteMapController(
 
     /**
      * The selected trip's own direction shape, thinned to sit beneath its exact trip line. In
-     * whole-route mode [basePolylines] is the merged both-directions geometry, so drawing that as
+     * whole-route mode the [base] geometry is the merged both-directions shape, so drawing that as
      * the underlay would surface the opposite direction; resolve the direction shape instead.
      */
     private fun selectedDirectionUnderlay(directionId: Int?): List<RoutePolyline> = directionPolylines(directionId).asDeemphasizedRouteUnderlay()
@@ -1278,7 +1301,7 @@ class RouteMapController(
         val approaches = approachLines(focusedRouteLines, ridePath)
         // In leg focus, only the approaches to the boarding point remain as route context. Stay-aboard
         // continuations happen after boarding and are already represented by the selected leg overlay.
-        basePolylines = approaches
+        base = RouteBase(approaches, isRideApproach = isLegFocus)
         publishMapPresentation()
         publishVehicleSet()
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapPresentationPlan.kt
@@ -78,7 +78,8 @@ internal data class SelectedTripRenderInput(
  *    otherwise, but the thinned direction underlay is gated on stop-focus being active at all, not on
  *    whether an adjacency colour happened to be found for this exact direction. (The #1899 regression
  *    was exactly that: the underlay decision proxied off the colour lookup instead of the real
- *    stop-focus state, see #1902.)
+ *    stop-focus state, see #1902.) What it replaces is a *route's* geometry — see [baseIsRideApproach]
+ *    for the ride focus, whose base is not that and stays (#2239).
  * 2. **No stop-focus session** ([focusTrips] null): the plain base route (or ordinary nearby stops).
  * 3. **Stop-focus session**: adjacency geometry for the focused stop's trips, drawn over the emphasized
  *    base route only when that route isn't itself one of the focused trips ([showBaseRoute]).
@@ -87,11 +88,19 @@ internal data class SelectedTripRenderInput(
  * work enters lazily so the merge policy itself stays plain data, JVM-testable across every branch: the
  * focused-stop projection as the [projectedFocusStops] thunk, the selected-trip underlay/stop projection
  * as thunks on [SelectedTripRenderInput]. That projection geometry is covered by instrumented tests.
+ *
+ * @param baseIsRideApproach what [basePolylines] *is*, which decides what a drilled-into vehicle does to
+ * it (#2239). False for an ordinary route session, where it is the shown route's own corridor — one
+ * route's geometry, which the exact trip line is a better answer for, and which the trip's own thinned
+ * underlay stands in for. True in a directions ride focus, where it is the ride's approach set: the
+ * upstream lead-in of every route the rider may board (#2010), only one of which the selected vehicle
+ * runs — so it stays drawn, and brings its own route context, leaving the corridor underlay off.
  */
 internal fun assembleRouteMapPresentation(
     isActive: Boolean,
     emphasizedRoute: RouteDirectionKey?,
     basePolylines: List<RoutePolyline>,
+    baseIsRideApproach: Boolean,
     baseStopPresentation: RouteStopPresentation?,
     focusTrips: Set<FocusedTrip>?,
     focusedGeometry: FocusedTripGeometry,
@@ -109,26 +118,31 @@ internal fun assembleRouteMapPresentation(
     }
 
     // 1. Selected vehicle: draw its exact trip in place of the direction geometry. Stop focus alone
-    // gates the underlay, not whether an adjacency color happened to be found for this exact
-    // direction — see selectedTripStyle (#1902).
+    // gates the underlay's stop-focus case, not whether an adjacency color happened to be found for
+    // this exact direction — see selectedTripStyle (#1902).
     if (selected != null) {
         val style = selectedTripStyle(
-            focusTrips != null,
-            selected.presentation.routeDirection,
-            routeColors,
-            selected.routeColorFallback
+            stopFocusActive = focusTrips != null,
+            rideApproachActive = baseIsRideApproach,
+            selectedRouteDirection = selected.presentation.routeDirection,
+            routeColors = routeColors,
+            routeColorFallback = selected.routeColorFallback
         )
         val selectedTrip = selected.presentation.points
             .takeIf { it.size >= 2 }
             ?.let { points -> focusedRoutePolyline(style.color, points, directional = true) }
         if (selectedTrip != null) {
+            // A ride's approach set survives the vehicle drawn over it (see [baseIsRideApproach]); a
+            // route's own corridor is what the exact trip replaces. Kept first, so the trip reads over it.
+            val keptBase = if (baseIsRideApproach) basePolylines else emptyList()
             return RouteMapPresentation(
-                polylines = focusedGeometry.toTripFocusedRoutePolylines(
-                    selected.presentation.routeDirection,
-                    routeColors,
-                    if (style.includeUnderlay) selected.directionUnderlay() else emptyList(),
-                    selectedTrip
-                ),
+                polylines = keptBase +
+                    focusedGeometry.toTripFocusedRoutePolylines(
+                        selected.presentation.routeDirection,
+                        routeColors,
+                        if (style.includeUnderlay) selected.directionUnderlay() else emptyList(),
+                        selectedTrip
+                    ),
                 framingPolylines = listOf(selectedTrip),
                 routeModeScalesStopsWithZoom = isActive,
                 badges = badges,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -219,7 +219,10 @@ private data class RouteBadgeSpec(
 internal data class SelectedTripStyle(val color: Int, val includeUnderlay: Boolean)
 
 /**
- * [stopFocusActive] alone gates the underlay: inside stop focus the focused-stop's own siblings
+ * The underlay is the route context a selected trip is read against, so it is dropped wherever the view
+ * already draws one of its own — and each such view is asked about directly, never proxied.
+ *
+ * [stopFocusActive] alone gates the stop-focus case: inside stop focus the focused-stop's own siblings
  * already carry the route's other geometry, so the underlay is dropped even when [selectedRouteDirection]
  * isn't among the focused stop's own trips and [routeColors] carries no adjacency entry for it — that
  * combination used to fall back to a whole-route-style underlay (the #1899 regression fixed by #1902),
@@ -227,15 +230,20 @@ internal data class SelectedTripStyle(val color: Int, val includeUnderlay: Boole
  * A color miss still falls back to [routeColorFallback]; only the underlay must not follow it. Both
  * inputs are already in the map's route-line colour policy ([mapRouteLineColor]) — this picks between
  * them, it doesn't render either.
+ *
+ * [rideApproachActive] is the directions-ride case (#2239): a focused ride draws each boardable route's
+ * upstream lead-in as its route context and deliberately nothing else, so putting the whole corridor
+ * back under a tapped vehicle would undo the very restriction the ride focus is drawn with.
  */
 internal fun selectedTripStyle(
     stopFocusActive: Boolean,
+    rideApproachActive: Boolean,
     selectedRouteDirection: RouteDirectionKey,
     routeColors: Map<RouteDirectionKey, Int>,
     routeColorFallback: Int
 ): SelectedTripStyle = SelectedTripStyle(
     color = routeColors[selectedRouteDirection] ?: routeColorFallback,
-    includeUnderlay = !stopFocusActive
+    includeUnderlay = !stopFocusActive && !rideApproachActive
 )
 
 /** Presented route-direction identities at each scheduled stop, optionally narrowed to [route]. */

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteMapPresentationPlanTest.kt
@@ -170,7 +170,9 @@ class RouteMapPresentationPlanTest {
             )
         )
 
-        // Underlay + exact trip, in that order; the trip carries the GTFS fallback colour.
+        // Underlay + exact trip, in that order; the trip carries the GTFS fallback colour. Two lines and
+        // no more is also what says the base is gone: outside a ride focus the base is one route's own
+        // corridor, which the exact trip replaces and the thinned underlay stands in for (#2239).
         assertEquals(2, plan.polylines.size)
         assertSame(underlay.single(), plan.polylines.first())
         val trip = plan.polylines.last()
@@ -231,6 +233,36 @@ class RouteMapPresentationPlanTest {
         assertEquals(0xFF00FF00.toInt(), plan.polylines.single().color)
     }
 
+    // --- Mode 1 in a directions ride focus: the base is the ride's lead-ins, not a corridor (#2239) ---
+
+    @Test
+    fun `a drilled-into vehicle in a ride focus keeps every boardable route's lead-in beneath it`() {
+        // The ride's approach set: the planned route's lead-in and an interchangeable route's (#2010).
+        val leadIns = listOf(
+            line(GeoPoint(1.0, 0.0), GeoPoint(1.0, 1.0)),
+            line(GeoPoint(2.0, 0.0), GeoPoint(2.0, 1.0))
+        )
+        val plan = assemble(
+            base = leadIns,
+            baseIsRideApproach = true,
+            focusTrips = null,
+            selected = SelectedTripRenderInput(
+                presentation = selectedTrip("45", 0),
+                routeColorFallback = 0xFF00FF00.toInt(),
+                // The ride draws its own route context, so the corridor underlay must not be built.
+                directionUnderlay = { fail("a ride focus must not put the route's corridor back") },
+                stopPresentation = { RouteStopPresentation(emptyList(), emptyList(), emptyMap(), emptyMap()) }
+            )
+        )
+
+        // Both lead-ins still drawn — tapping one route's pill must not erase the other's — with the
+        // tapped vehicle's own trip over them.
+        assertEquals(leadIns, plan.polylines.dropLast(1))
+        assertEquals(selectedTrip("45", 0).points, plan.polylines.last().points)
+        // The trip alone is still what the selection frames.
+        assertEquals(listOf(plan.polylines.last()), plan.framingPolylines)
+    }
+
     @Test
     fun `a degenerate selected trip falls through to the base route`() {
         val plan = assemble(
@@ -280,6 +312,8 @@ class RouteMapPresentationPlanTest {
     private fun assemble(
         isActive: Boolean = true,
         emphasizedRoute: RouteDirectionKey? = RouteDirectionKey("45", 0),
+        base: List<RoutePolyline> = basePolylines,
+        baseIsRideApproach: Boolean = false,
         focusTrips: Set<FocusedTrip>?,
         focusedGeometry: FocusedTripGeometry = FocusedTripGeometry(emptyList()),
         focusedStops: FocusedTripStops = FocusedTripStops(emptyMap(), emptyMap()),
@@ -290,7 +324,8 @@ class RouteMapPresentationPlanTest {
     ) = assembleRouteMapPresentation(
         isActive = isActive,
         emphasizedRoute = emphasizedRoute,
-        basePolylines = basePolylines,
+        basePolylines = base,
+        baseIsRideApproach = baseIsRideApproach,
         baseStopPresentation = baseStops,
         focusTrips = focusTrips,
         focusedGeometry = focusedGeometry,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -193,26 +193,43 @@ class RouteViewGeometryTest {
         // adjacency map to begin with.
         assertEquals(
             SelectedTripStyle(color = 99, includeUnderlay = true),
-            selectedTripStyle(stopFocusActive = false, direction, routeColors = emptyMap(), routeColorFallback = 99)
+            style(stopFocusActive = false, direction = direction, routeColors = emptyMap())
         )
         // Stop focus, no adjacency entry for this exact direction (e.g. an opposite-direction vehicle
         // whose direction isn't among the focused stop's own trips, #1902): underlay still drops, but
         // the color falls back to GTFS since there's no adjacency color to carry instead.
         assertEquals(
             SelectedTripStyle(color = 99, includeUnderlay = false),
-            selectedTripStyle(stopFocusActive = true, direction, routeColors = emptyMap(), routeColorFallback = 99)
+            style(stopFocusActive = true, direction = direction, routeColors = emptyMap())
         )
         // Whole-route mode with a stray adjacency entry (shouldn't occur in practice, since routeColors
         // is only ever populated during stop focus) still keeps the underlay — it is not proxied off
         // the color lookup.
         assertEquals(
             SelectedTripStyle(color = 10, includeUnderlay = true),
-            selectedTripStyle(stopFocusActive = false, direction, routeColors = withColor, routeColorFallback = 99)
+            style(stopFocusActive = false, direction = direction, routeColors = withColor)
         )
         // Stop focus with a matching adjacency entry: the ordinary case — adjacency color, no underlay.
         assertEquals(
             SelectedTripStyle(color = 10, includeUnderlay = false),
-            selectedTripStyle(stopFocusActive = true, direction, routeColors = withColor, routeColorFallback = 99)
+            style(stopFocusActive = true, direction = direction, routeColors = withColor)
+        )
+    }
+
+    @Test
+    fun `a ride focus drops the corridor underlay, whatever colour the trip takes`() {
+        val direction = RouteDirectionKey("45", 0)
+
+        // A directions ride already draws its own route context — each boardable route's lead-in — so
+        // the corridor underlay would put the whole route back over it (#2239). The colour is untouched
+        // by the gate: it still falls back to the GTFS one with no adjacency entry to carry.
+        assertEquals(
+            SelectedTripStyle(color = 99, includeUnderlay = false),
+            style(rideApproachActive = true, direction = direction, routeColors = emptyMap())
+        )
+        assertEquals(
+            SelectedTripStyle(color = 10, includeUnderlay = false),
+            style(rideApproachActive = true, direction = direction, routeColors = mapOf(direction to 10))
         )
     }
 
@@ -336,4 +353,17 @@ class RouteViewGeometryTest {
         override val textColor: Int? = null
         override val agencyId = "agency"
     }
+
+    private fun style(
+        stopFocusActive: Boolean = false,
+        rideApproachActive: Boolean = false,
+        direction: RouteDirectionKey,
+        routeColors: Map<RouteDirectionKey, Int>
+    ) = selectedTripStyle(
+        stopFocusActive = stopFocusActive,
+        rideApproachActive = rideApproachActive,
+        selectedRouteDirection = direction,
+        routeColors = routeColors,
+        routeColorFallback = 99
+    )
 }


### PR DESCRIPTION
Fixes #2239.

## What was wrong

In a directions ride focus the map's base geometry is the **ride's approach set** — the upstream lead-in of every route the rider may board (#2010), one per route — and deliberately nothing else: leg focus draws where each option is coming from, the committed journey, and the ridden leg.

Tapping an ETA pill drills into that vehicle's trip (#2224). The presentation assembler's selected-vehicle branch is written for an ordinary route session, where the base is the shown route's own corridor and the exact trip line is a better answer for it, so it did two things that are wrong in a ride:

- **replaced the base wholesale**, erasing the other boardable route's lead-in — the rider's other option vanished from the map the moment they tapped a pill;
- **put the whole-route corridor back** beneath the trip as the selected-trip underlay (kept whenever stop focus is inactive), which is the very geometry leg focus restricts itself away from.

## The fix

Tell the assembler what the base *is*, with a new `baseIsRideApproach`:

- the approach set stays drawn, with the drilled-into trip over it — the vehicle runs one of those routes, it does not speak for the others;
- `selectedTripStyle` drops the corridor underlay for the same reason it drops it inside stop focus: that view already draws a route context of its own. Both gates ask about the real state directly rather than proxying off another lookup, which is what #1902 fixed for the stop-focus one.

The nature travels with the lines rather than being re-derived where they are read: the controller's base is one `RouteBase` value, stamped by the only two places that build one (`showDirectionPolylines`, which already has the leg-focus flag in hand, and `refreshApproachLines`, which runs only for a drawn ride). A later change to what counts as leg focus therefore can't leave the flag lying.

Ordinary route selections and selections inside stop focus are unchanged.

## Testing

- `RouteMapPresentationPlanTest`: a drilled-into vehicle in a ride focus keeps every boardable route's lead-in beneath it, and never builds the corridor underlay. The existing whole-route selection test already pins the opposite case (base replaced, thinned underlay only).
- `RouteViewGeometryTest`: the ride gate drops the underlay whatever colour the trip takes.
- Both new tests were confirmed to fail against the previous behaviour.
- `./gradlew spotlessCheck :onebusaway-android:testObaGoogleDebugUnitTest -PwarningsAsErrors=true` green. Not exercised on a device — reproducing it needs a live plan with an interchangeable-routes leg.

Not touched, and worth a separate look if it bothers you: a drilled-into vehicle in a ride focus still swaps the ride's stops for that trip's own whole-trip stop list, its exact line still runs past the alighting stop, and `routePolylinesWithSegment` restyles that line as an approach along with the lead-ins it is drawn over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map rendering during ride-focus sessions.
  * Ride approach paths now remain visible beneath the selected trip.
  * Prevented unnecessary corridor underlays from obscuring or duplicating ride approach geometry.
  * Preserved existing route replacement behavior and trip color selection for non-ride selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->