### PR TITLE
Trim the arrivals tutorial to the one lesson the tour can't teach

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -193,11 +193,7 @@ fun HomeNavHost(
                     },
                     onSettings = { menuNav(NavRoutes.SETTINGS, R.string.analytics_label_button_press_settings) },
                     onSearch = { query -> navController.navigateFromHome(NavRoutes.search(query)) },
-                    onRecentStopsRoutes = {
-                        // The user found the drawer item on their own — don't later spotlight it in onboarding.
-                        PreferencesEntryPoint.get(context).setBoolean(ArrivalTutorial.KEY_MORE_MENU, true)
-                        navController.navigateFromHome(NavRoutes.myRecent())
-                    },
+                    onRecentStopsRoutes = { navController.navigateFromHome(NavRoutes.myRecent()) },
                     // Recents dropdown taps reveal the stop / route on the map (the same stop-focus the
                     // search results and map markers use).
                     onRecentStop = { id, lat, lon -> navController.revealStopOnMap(id, lat, lon) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -676,10 +676,7 @@ fun HomeScreen(
                             // than sitting on a separate default-colored strip.
                             sheetContainerColor = MaterialTheme.colorScheme.surface,
                             sheetDragHandle = {
-                                ArrivalsDragHandle(
-                                    onToggle = toggleSheet,
-                                    modifier = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_PANEL)
-                                )
+                                ArrivalsDragHandle(onToggle = toggleSheet)
                             },
                             sheetContent = {
                                 // Bounded so a long list can't grow the sheet past maxSheetContentDp — that
@@ -1000,9 +997,6 @@ fun HomeScreen(
                                             recents = recents,
                                             onRecentStop = onRecentStop,
                                             onRecentRoute = onRecentRoute,
-                                            // Recent stops/routes lives in the drawer, so the onboarding spotlight points at
-                                            // the menu FAB that opens it (was the retired overflow ⋮).
-                                            menuModifier = Modifier.tutorialAnchor(tutorialState, ArrivalTutorial.KEY_MORE_MENU),
                                             modifier = Modifier.statusBarsPadding()
                                         )
                                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/ArrivalTutorial.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/ArrivalTutorial.kt
@@ -25,51 +25,37 @@ import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.preferences.PreferencesRepository
 
 /**
- * The arrivals-panel onboarding sequence — the Compose successor to the legacy ShowcaseView
- * "arrival header" tutorial chain (which spotlighted XML views removed in the Compose migration).
- * Spotlights, in order, the ETA pill, the slide-up chevron, and the hamburger menu — which now holds
- * "Recent stops/routes" (see the [Modifier.tutorialAnchor] call sites in `ArrivalsPanel` / the sheet
- * host). Shown once the first
- * time a stop's arrivals load, gated by [pendingSteps]; "show tutorials again" re-arms it by clearing
- * the [resetKeys] (see `TutorialPrefs.resetAllTutorials`).
+ * The arrivals-panel onboarding spotlight — what a rider is told about the panel the first time a
+ * stop's arrivals load, gated by [pendingSteps]; "show tutorials again" re-arms it by clearing the
+ * [resetKeys] (see `TutorialPrefs.resetAllTutorials`).
  *
- * Each step's [TutorialStep.id] is both its spotlight anchor key and its persisted "already shown"
- * preference key. These are fresh `.tutorial_compose_arrival_*` keys (not the legacy ShowcaseView
- * chain's): the old chain was removed in the Compose migration, so the restored series should show in
- * full for everyone rather than be silently truncated by a user's stale legacy shown-flags.
+ * **One step, deliberately.** This began as the Compose successor to the legacy ShowcaseView "arrival
+ * header" chain and carried that chain's three: the ETA pill, the slide-up chevron, and the drawer's
+ * Recent stops/routes. The scripted tour (#2164) then took over onboarding and made the last two
+ * redundant — it drives the arrivals sheet for half its length and opens the drawer outright, so a
+ * rider who had just finished it was met with two spotlights re-explaining what they had been shown
+ * minutes before. Those steps are gone rather than merely suppressed after a tour: the tour is the
+ * app's onboarding now, and a second sequence teaching the same controls has nobody left to serve.
+ *
+ * What survives is the one lesson the tour cannot leave behind, because it is about *reading a value*
+ * rather than finding a control: what the ETA pill's colours mean.
+ *
+ * The step's [TutorialStep.id] is both its spotlight anchor key and its persisted "already shown"
+ * preference key. It is a fresh `.tutorial_compose_arrival_*` key (not the legacy ShowcaseView
+ * chain's): the old chain was removed in the Compose migration, so this should show for everyone
+ * rather than be silently skipped by a user's stale legacy shown-flag.
  */
 object ArrivalTutorial {
 
     /** ETA pill — "how long until your bus arrives" + the deviation-color legend. */
     const val KEY_ETA = ".tutorial_compose_arrival_eta"
 
-    /** Slide-up chevron — pull the panel up for the full arrivals list. */
-    const val KEY_PANEL = ".tutorial_compose_arrival_panel"
-
-    /**
-     * Hamburger menu (☰) — "Recent stops/routes" moved out of the retired overflow into the drawer, so
-     * this now spotlights the nav icon that opens it. The persisted pref value stays the legacy
-     * `.tutorial_compose_more_menu` so users who already saw the step aren't re-shown it.
-     */
-    const val KEY_MORE_MENU = ".tutorial_compose_more_menu"
-
-    /** The sequence, in display order. */
+    /** The sequence — see the note on this object about why it is one step. */
     val steps: List<TutorialStep> = listOf(
         TutorialStep(
             id = KEY_ETA,
             title = R.string.tutorial_arrival_header_arrival_info_title,
             body = R.string.tutorial_arrival_header_arrival_info_text
-        ),
-        TutorialStep(
-            id = KEY_PANEL,
-            title = R.string.tutorial_arrival_header_sliding_panel_title,
-            body = R.string.tutorial_arrival_header_sliding_panel_text
-        ),
-        TutorialStep(
-            id = KEY_MORE_MENU,
-            title = R.string.tutorial_recent_stops_routes_title,
-            body = R.string.tutorial_recent_stops_routes_text,
-            bodyIcon = R.drawable.history_24
         )
     )
 
@@ -102,11 +88,11 @@ object ArrivalTutorial {
  * Records each arrivals spotlight as shown the moment it is actually on screen, for whichever tutorial
  * is running. Renders nothing; host it once, alongside the [TutorialState] it watches.
  *
- * A step is recorded *as it is displayed* rather than the whole sequence being marked when one starts,
- * because either tutorial can end early — the corner "X", or system Back, which the overlay treats the
- * same way. Marking up front meant a rider who pressed Back meaning to collapse the arrivals sheet
- * silently retired all three spotlights before seeing two of them, with no scrim to hint that anything
- * had been dismissed; what is left unmarked simply stays owed, and comes back at the next stop.
+ * A step is recorded *as it is displayed* rather than when a sequence starts, because either tutorial
+ * can end early — the corner "X", or system Back, which the overlay treats the same way, or now a
+ * stray tap outside the caption. Marking up front retired spotlights the rider never saw, with no
+ * scrim to hint that anything had been dismissed; what is left unmarked simply stays owed, and comes
+ * back at the next stop.
  *
  * Keyed on [TutorialStep.anchorId], so the scripted tour (#2164) counts too: its ETA-pill steps ring
  * [ArrivalTutorial.KEY_ETA] to teach the same control, and re-ambushing the rider with the opportunistic

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/SpotlightTutorial.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/SpotlightTutorial.kt
@@ -374,12 +374,16 @@ fun TutorialOverlay(state: TutorialState) {
         Modifier
             .fillMaxSize()
             .onGloballyPositioned { overlayOrigin = it.positionInRoot() }
-            // The overlay swallows every touch that isn't one of the caption's own buttons, so the app
-            // underneath can't be operated out from under the script — but it no longer *advances* on
-            // one. Tap-anywhere-to-continue was inherited from the legacy ShowcaseView, and it stopped
-            // being safe the moment there was a Back button to miss: a tap a few pixels off it moved
-            // the tour the other way, which is precisely the mistake Back exists to undo.
-            .pointerInput(step.id) { detectTapGestures { } }
+            // A tap anywhere out here advances the tour, and the app underneath never sees it — the
+            // overlay swallows every touch so the script can't be operated out from under itself.
+            //
+            // "Out here" is the point. The legacy ShowcaseView advanced on a tap *anywhere*, including
+            // on the caption, which stopped being safe once the caption grew a Back button: a press a
+            // few pixels wide of it moved the tour the other way, which is the exact mistake Back
+            // exists to undo. The caption now consumes its own taps (see [TutorialCaption]), so the
+            // two gestures can't be confused — the card is for going back and closing, everywhere else
+            // is for going on.
+            .pointerInput(step.id) { detectTapGestures { state.advance() } }
     ) {
         // The ring: a crisp brand-color outline hugging the target, backed by a softer, wider halo so it
         // reads against a busy map as well as against a flat panel. Both pulse together.
@@ -485,7 +489,12 @@ private fun TutorialCaption(
             .statusBarsPadding()
             .navigationBarsPadding()
             .padding(24.dp)
-            .widthIn(max = 360.dp),
+            .widthIn(max = 360.dp)
+            // Swallow taps that land on the card. The overlay behind it advances on a tap, and this is
+            // the one region where that would be wrong: the card holds Back and the close "X", so a
+            // near-miss on either must do nothing rather than move the tour forward. Children (the
+            // buttons) are hit first, so this only catches the gaps between them.
+            .pointerInput(Unit) { detectTapGestures { } },
         shape = RoundedCornerShape(16.dp),
         // The brand green, not the theme surface. With the scrim gone (see [TutorialOverlay]) a card
         // painted the ordinary surface colour is the same near-black as the dark-mode map behind it, so

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/TutorialPrefs.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/TutorialPrefs.kt
@@ -21,9 +21,15 @@ import org.onebusaway.android.app.di.PreferencesEntryPoint
 
 /**
  * Tutorial preference-flag constants and reset, kept after the ShowcaseView-based tutorials were
- * replaced by Compose onboarding. The constants are still referenced by the launch flow
- * ([TUTORIAL_WELCOME]) and the help dialog ([TUTORIAL_OPT_OUT_DIALOG]); [resetAllTutorials] re-arms
- * onboarding from Settings.
+ * replaced by Compose onboarding: [TUTORIAL_WELCOME] gates the launch flow's "show the tutorial?"
+ * prompt and [TUTORIAL_OPT_OUT_DIALOG] the help dialog. [resetAllTutorials] re-arms onboarding from
+ * Settings.
+ *
+ * Five further flags used to live here — the arrival sort, Recent stops/routes, the two starred-stops
+ * hints and the Open311 categories. Each was declared and dutifully reset, and none had been *read*
+ * since the ShowcaseView tutorials they belonged to were deleted, so resetting them re-armed nothing.
+ * A flag nobody asks about is not a feature that is off; it is a line that makes the reset below look
+ * more thorough than it is.
  */
 object TutorialPrefs {
 
@@ -31,27 +37,12 @@ object TutorialPrefs {
 
     const val TUTORIAL_OPT_OUT_DIALOG = ".tutorial_opt_out_dialog"
 
-    const val TUTORIAL_ARRIVAL_SORT = ".tutorial_arrival_sort"
-
-    const val TUTORIAL_RECENT_STOPS_ROUTES = ".tutorial_recent_stops_routes"
-
-    const val TUTORIAL_STARRED_STOPS_SORT = ".tutorial_starred_stops_sort"
-
-    const val TUTORIAL_STARRED_STOPS_SHORTCUT = ".tutorial_starred stops_shortcut"
-
-    const val TUTORIAL_SEND_FEEDBACK_OPEN311_CATEGORIES = ".tutorial_send_feedback_open311_categories"
-
     /** Resets all tutorials so they are shown to the user again. */
     fun resetAllTutorials(context: Context) {
         val prefs = PreferencesEntryPoint.get(context)
         prefs.setBoolean(R.string.preference_key_show_tutorial_screens, true)
 
         prefs.setBoolean(TUTORIAL_WELCOME, false)
-        prefs.setBoolean(TUTORIAL_ARRIVAL_SORT, false)
-        prefs.setBoolean(TUTORIAL_RECENT_STOPS_ROUTES, false)
-        prefs.setBoolean(TUTORIAL_STARRED_STOPS_SORT, false)
-        prefs.setBoolean(TUTORIAL_STARRED_STOPS_SHORTCUT, false)
-        prefs.setBoolean(TUTORIAL_SEND_FEEDBACK_OPEN311_CATEGORIES, false)
 
         // Re-arm the Compose arrivals-panel onboarding spotlight (its keys live with the sequence).
         for (key in ArrivalTutorial.resetKeys()) {

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -764,15 +764,6 @@
         si el bus esta adelantado (rojo) o va atrasado (azul). Si es verde se encuentra a tiempo. Si nosotros no sabemos
         donde se encuentra el bus, se muestra el tiempo planificado (gris).
     </string>
-    <string name="tutorial_arrival_header_sliding_panel_title">Desliza hacia arriba para ver más llegadas
-    </string>
-    <string name="tutorial_arrival_header_sliding_panel_text">Toca sobre la flecha o desliza el panel hacia arriba
-        para ver mas llegadas de buses en esta parada.
-    </string>
-    <string name="tutorial_recent_stops_routes_title">Paradas y rutas recientes</string>
-    <string name="tutorial_recent_stops_routes_text">Encuentra las paradas y rutas que recientemente has mirado
-        en el menú.
-    </string>
 
     <!-- Permissions -->
     <string name="location_permissions_title">La ubicación en tiempo real necesita permisos</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -604,15 +604,6 @@
         bussi etuajassa (punainen) vai myöhässä (sininen). Ajallaan = vihreä taustaväri. Jos bussin 
         sijaintia ei tiedetä, näytetään aikataulun mukainen saapumisaika (harmaa taustaväri).
     </string>
-    <string name="tutorial_arrival_header_sliding_panel_title">Liu’uta nähdäksesi lisää saapuvia
-    </string>
-    <string name="tutorial_arrival_header_sliding_panel_text">Napsauta nuolta tai liikuta paneelia ylöspäin
-        nähdäksesi lisää tälle pysäkille saapuvia vuoroja.
-    </string>
-    <string name="tutorial_recent_stops_routes_title">Viimeisimmät pysäkit ja reitit</string>
-    <string name="tutorial_recent_stops_routes_text">Valikon avulla löydät pysäkit ja reitit
-        joita olet viimeksi katsellut.
-    </string>
     <string name="tutorial_opt_out_dialog_title">Näytetäänkö opas?</string>
     <string name="tutorial_opt_out_dialog_text">Haluatko nähdä ponnahdusikkunoiden kuvaukset %1$sn käytöstä? Voit aina ottaa ponnahdusikkunat käyttöön tai poistaa ne käytöstä asetuksista, tai näyttää oppaan myöhemmin Ohje-valikon kautta.</string>
 

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -617,10 +617,6 @@
     <string name="tutorial_opt_out_dialog_text">Desideri che vengano mostrati popup informativi per l’utilizzo di %1$s? Puoi sempre attivare e disattivare i popup nelle impostazioni, o mostrare il tutorial in seguito premendo su Aiuto.</string>
     <string name="tutorial_arrival_header_arrival_info_title">Quanto manca all’arrivo dell’autobus?</string>
     <string name="tutorial_arrival_header_arrival_info_text">Tanto così! Lo sfondo colorato ti dice se l’autobus è in anticipo (rosso) o in ritardo (blu). In orario = sfondo verde. Se non sappiamo dove sia l’autobus, ti mostriamo l’orario previsto (sfondo grigio). Grigio con testo barrato significa che il tragitto è stato cancellato.</string>
-    <string name="tutorial_arrival_header_sliding_panel_title">Scorri in su per mostrare più arrivi</string>
-    <string name="tutorial_arrival_header_sliding_panel_text">Tocca la freccia o trascina il pannello in su per vedere altri arrivi a questa fermata.</string>
-    <string name="tutorial_recent_stops_routes_title">Fermate e linee recenti</string>
-    <string name="tutorial_recent_stops_routes_text">Per ritrovare le fermate e le linee cercate di recente, apri il menu.</string>
 
     <!-- Permissions -->
     <string name="location_permissions_title">Autorizzazioni per la posizione</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -680,15 +680,6 @@
     <string name="tutorial_arrival_header_arrival_info_text">Kolor tła powie Ci
         czy autobus będzie wcześniej (czerwony) lub spóźniony (niebieskie). Na czas = zielone tłó. Jeśli nie wiemy gdzie jest autobus, to czas według rozkładu (szare tło).
     </string>
-    <string name="tutorial_arrival_header_sliding_panel_title">Przesuń w górę by zobaczyć więcej przyjazdów
-    </string>
-    <string name="tutorial_arrival_header_sliding_panel_text">Dotknij strzałki i przesuń panel do góry
-        by zobaczyć więcej przyjazdów na tym przystanku.
-    </string>
-    <string name="tutorial_recent_stops_routes_title">Ostatnie przystanki i trasy</string>
-    <string name="tutorial_recent_stops_routes_text">Znajdź przystanki i trasy które ostatnio
-        przeglądałeś w menu.
-    </string>
     <string name="tutorial_opt_out_dialog_title">Pokazać samouczek?</string>
     <string name="tutorial_opt_out_dialog_text">Czy chcesz zobaczyć wyskakujące opisy jak korzystać z %1$s? Zawsze możesz włączyć lub wyłączyć wyskakujące okienka w Ustawieniach, lub wyświetlić samouczek później przez Pomoc.</string>
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -900,15 +900,6 @@
         where the bus is, the scheduled time is shown (gray background). Gray with strikethrough text
         (a line through it) means the trip is canceled.
     </string>
-    <string name="tutorial_arrival_header_sliding_panel_title">Slide up to show more arrivals
-    </string>
-    <string name="tutorial_arrival_header_sliding_panel_text">Drag the panel up
-        to see more arrivals for this stop.
-    </string>
-    <string name="tutorial_recent_stops_routes_title">Recent stops and routes</string>
-    <string name="tutorial_recent_stops_routes_text">Find the stops and routes that you’ve recently
-        looked at in the menu.
-    </string>
     <!-- Onboarding spotlight card: the corner close button's accessibility label + the final-step action -->
     <string name="tutorial_button_close">End tutorial</string>
     <string name="tutorial_button_finish">Finish</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tutorial/ArrivalTutorialTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tutorial/ArrivalTutorialTest.kt
@@ -34,14 +34,18 @@ class ArrivalTutorialTest {
 
         val pending = ArrivalTutorial.pendingSteps(prefs)
 
-        assertEquals(
-            listOf(
-                ArrivalTutorial.KEY_ETA,
-                ArrivalTutorial.KEY_PANEL,
-                ArrivalTutorial.KEY_MORE_MENU
-            ),
-            pending.map { it.id }
-        )
+        assertEquals(listOf(ArrivalTutorial.KEY_ETA), pending.map { it.id })
+    }
+
+    /**
+     * The panel and Recent-stops spotlights were dropped once the scripted tour took over onboarding:
+     * it drives the arrivals sheet and opens the drawer itself, so those two fired straight after a
+     * finished tour to re-explain what it had just shown. Pinned as a count rather than left implicit,
+     * because re-adding a step here is re-adding a popup a tour-taker sees for the second time.
+     */
+    @Test
+    fun theSequenceIsJustTheEtaSpotlight() {
+        assertEquals(listOf(ArrivalTutorial.KEY_ETA), ArrivalTutorial.steps.map { it.id })
     }
 
     @Test
@@ -57,10 +61,7 @@ class ArrivalTutorialTest {
         val prefs = FakePreferencesRepository()
         prefs.setBoolean(ArrivalTutorial.KEY_ETA, true)
 
-        assertEquals(
-            listOf(ArrivalTutorial.KEY_PANEL, ArrivalTutorial.KEY_MORE_MENU),
-            ArrivalTutorial.pendingSteps(prefs).map { it.id }
-        )
+        assertTrue(ArrivalTutorial.pendingSteps(prefs).isEmpty())
     }
 
     @Test
@@ -85,18 +86,16 @@ class ArrivalTutorialTest {
     }
 
     /**
-     * The scripted tour teaches the ETA pill and nothing else of this sequence, so exactly one of these
-     * spotlights is retired by taking the tour — the recorder keys on the shared anchor. If a tour step
-     * ever picks up the panel or menu anchor, this is the assertion that says so: the two sequences
-     * would then be teaching the same control, and the tour would be silently retiring more of the
-     * opportunistic one than it appears to.
+     * The tour covers this sequence completely — it rings [ArrivalTutorial.KEY_ETA] itself — so taking
+     * the tour retires the whole thing via the shared anchor, and nothing is left to pop up afterwards.
+     * That is the property that broke when the tour only covered part of the sequence.
      */
     @Test
-    fun theScriptedTourReusesOnlyTheEtaSpotlight() {
+    fun theScriptedTourReusesEverySpotlightInTheSequence() {
         val reused = ArrivalTutorial.steps
             .map { it.id }
             .filter { anchor -> ScriptedTutorial.steps.any { it.anchorId == anchor } }
 
-        assertEquals(listOf(ArrivalTutorial.KEY_ETA), reused)
+        assertEquals(ArrivalTutorial.steps.map { it.id }, reused)
     }
 }


### PR DESCRIPTION
Follow-up to #2236, from walking the finished tour on a device.

## Two spotlights fired after the tour, re-teaching it

Finishing the guided tour was followed by two more popups at the next real stop: **"Slide up to show more arrivals"** and **"Recent stops and routes"**. Both had already been demonstrated minutes earlier — the tour drives the arrivals sheet for half its length and opens the drawer outright — so they read as the app forgetting what it had just done.

They fired because the tour only retires the arrivals spotlights it actually *displays* (matched by shared `anchorId`), and the one it displays is the ETA pill.

Rather than suppress them after a tour, they are **removed**. The tour is the app's onboarding now, and a second sequence teaching the same controls has nobody left to serve. What survives is the one lesson the tour cannot leave behind, because it is about *reading a value* rather than finding a control: what the ETA pill's colours mean.

Gone with them: their two spotlight anchors, the pre-retire write on the drawer's Recent item, and four strings across five locales.

> [!NOTE]
> **Behaviour change worth a second opinion:** a rider who *declines* the tour at first launch no longer gets either lesson. That was a deliberate call — the alternative was keeping the steps and marking them shown on tour completion — but it is the one part of this that is a product decision rather than a cleanup.

`ArrivalTutorialTest` now pins the sequence to its single step, and the tour-coverage test asserts the tour rings **every** anchor in the sequence, so a step added here without matching tour coverage fails the build rather than turning back into a post-tour popup.

## Tap outside the caption to advance

Tap-to-advance was inherited from the legacy ShowcaseView and dropped when the caption grew a Back button: a press a few pixels wide of it moved the tour the wrong way, which is the exact mistake Back exists to undo.

It is back, scoped so that can't happen. The overlay advances on a tap; the caption `Surface` consumes its own, so the card is inert — a near-miss on Back or the "X" now does nothing instead of advancing. Its buttons are hit first and are unaffected; only the gaps between them swallow. On the last step a tap finishes the tour, same as "Done".

## Five dead tutorial flags

`TutorialPrefs` carried five constants — the arrival sort, Recent stops/routes, two starred-stops hints, the Open311 categories — each declared and dutifully reset by `resetAllTutorials`, and none *read* since the ShowcaseView tutorials they belonged to were deleted. Resetting them re-armed nothing. `TUTORIAL_WELCOME` and `TUTORIAL_OPT_OUT_DIALOG` are live and stay.

## Testing

`./gradlew test check -x lint -PwarningsAsErrors=true` and `spotlessCheck` green; lint left to CI. Installed on a Pixel 7 Pro — **not yet walked end-to-end on device**, so the tap-to-advance feel near the caption edges and the absence of post-tour popups are worth confirming before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated onboarding so the arrivals tutorial focuses only on estimated arrival times.
  - Tapping outside tutorial captions now advances the spotlight, while caption interactions remain protected.
- **Bug Fixes**
  - Visiting recent stops and routes no longer incorrectly marks the “More” menu onboarding item as complete.
- **Documentation**
  - Clarified tutorial behavior when steps remain undisplayed or users exit early.
- **Localization**
  - Removed outdated tutorial text for sliding arrivals panels and recent stops/routes across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->