### PR TITLE
Draw no leg-end bulbs on a drilled-into ride (#2241)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -88,12 +88,25 @@ internal fun List<RoutePolyline>.asSelectedRouteApproach(): List<RoutePolyline> 
  * question about a ride the rider is choosing; a context leg is here to say where the leg being read sits
  * in the journey, and is drawn at half the width the stripes were cut against — so the same rhythm arrives
  * as a fleck of noise beside the leg that is actually being read.
+ *
+ * And it drops both end marks (#2241), for the same reason and with the same force as
+ * [asPinnedTripGhost]: a bulb pair means "alight here, board there" and a cut means "the route changes
+ * under you", which are readings of a trip being *followed*, not of the faint trace saying where one leg
+ * of it sits. The leg they could still be read on is the ride the rider drilled into — and this view
+ * redraws that ride at full weight over its context copy, deliberately marking where the rider boards
+ * with the boarding *stop* rather than a bulb (see [routePolylinesWithSegment]). A mark surviving into
+ * the context is therefore one this view has already decided not to draw, held under the redraw only by
+ * the redraw happening to cover it: a mark is drawn about the line's endpoint, not inside its stroke, so
+ * whether it showed came down to what else landed on top of that point — and on an interchangeable ride
+ * it showed.
  */
 internal fun List<RoutePolyline>.asItineraryContext(): List<RoutePolyline> = map { line ->
     line.copy(
         widthProfile = ITINERARY_CONTEXT_WIDTH_PROFILE,
         directional = false,
-        stripeColors = emptyList()
+        stripeColors = emptyList(),
+        startMark = RouteLineMark.NONE,
+        endMark = RouteLineMark.NONE
     )
 }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -138,6 +138,35 @@ class RouteSegmentHighlightTest {
     }
 
     @Test
+    fun routePolylinesWithSegment_drawsNoLegEndBulbs_whateverTheRideIsSharedWith() {
+        // #2241: the drilled-into ride is marked with the stop the rider boards at, not with a bulb, and
+        // nothing else in this view draws one either. The rider's own journey arrives as context around
+        // it, and an itinerary leg carries the bulbs the overview drew — including the leg being drilled
+        // into, whose context copy this view redraws over. Asserted over the whole drawn set, because
+        // "no bulbs here" is a property of the view and not of the one line that happens to be selected:
+        // a mark left on a context leg is held out of sight only by the redraw landing on top of it,
+        // which is what an interchangeable ride's did not do.
+        val interchangeableRide = RoutePolyline(
+            color = 2,
+            points = segment,
+            stripeColors = listOf(3),
+            widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
+            case = RouteLineCase.OUTLINE,
+            startMark = RouteLineMark.BULB,
+            endMark = RouteLineMark.BULB
+        )
+
+        val result = routePolylinesWithSegment(
+            base = listOf(RoutePolyline(color = 1, points = segment)),
+            spans = ride(segment),
+            colorOf = { 4 },
+            itineraryContext = listOf(interchangeableRide).asItineraryContext()
+        )
+
+        assertTrue(result.none { it.startMark == RouteLineMark.BULB || it.endMark == RouteLineMark.BULB })
+    }
+
+    @Test
     fun routePolylinesWithSegment_drawsAnInterlinedRideAsOneSpanPerRoute_cutAtEachCutover() {
         // #2127: one ride, two routes. Drawn as a single line it had to pick one route's colour for the
         // whole thing and had no interior to mark, so the cutover the itinerary map shows disappeared the

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -14,6 +14,7 @@ import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.map.render.haversineMeters
@@ -42,6 +43,26 @@ class RouteViewGeometryTest {
         assertEquals(line.dash, context.dash)
         assertEquals(line.transforms, context.transforms)
         assertEquals(false, context.directional)
+    }
+
+    @Test
+    fun `itinerary context carries no end marks`() {
+        // #2241: a bulb pair ("alight here, board there") and an interline cut are readings of a trip
+        // being followed at full weight. The leg they could still be read on is the one the rider
+        // drilled into, which this view redraws over its context copy and marks with the boarding stop
+        // instead — so a mark surviving here is one the view already decided not to draw, and it showed.
+        val ride = RoutePolyline(
+            color = 0xFF123456.toInt(),
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
+            widthProfile = FOCUSED_ROUTE_LINE_WIDTH_PROFILE,
+            startMark = RouteLineMark.INTERLINE_CUT,
+            endMark = RouteLineMark.BULB
+        )
+
+        val context = listOf(ride).asItineraryContext().single()
+
+        assertEquals(RouteLineMark.NONE, context.startMark)
+        assertEquals(RouteLineMark.NONE, context.endMark)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2241.

A directions transit leg is bulbed at each end of the ride, so consecutive rides stay segmented and a bulb pair reads as "alight here, board there" (#2084). Drilling into one leaves that vocabulary behind: the route view draws the ridden span with no marks at all and names the boarding with the stop the rider gets on at, and the cutover slash is the only end mark it keeps (#2127).

The rider's journey is retained around that ride as context (#2048), and each context leg is the itinerary's own line reduced — half weight, no chevrons, no stripes — but it kept its end marks. Including the leg being drilled into, whose context copy the ride is redrawn over: a mark the view had already decided not to draw, held out of sight only by what happened to land on top of the point it is drawn about. On an interchangeable ride it was not covered, and the bulbs showed.

Bulbs have one producer in the app (`DirectionsMapController`), and the route view's whole drawn set is the approach lines, that context, and the ridden span — so the context was the only thing that could still be carrying one.

Reduce the marks with everything else the context reduces. Same rule `asPinnedTripGhost` already applies for the same reason — the marks belong to a trip being followed at full weight, not to the faint trace saying where one leg of it sits — so the drilled-into ride now draws no bulbs whichever routes it may be boarded on, and the journey around it none either.

## Testing

Two new JVM tests:

- `RouteViewGeometryTest.itinerary context carries no end marks`
- `RouteSegmentHighlightTest.routePolylinesWithSegment_drawsNoLegEndBulbs_whateverTheRideIsSharedWith` — asserted over the whole drawn set, since "no bulbs here" is a property of the view and not of the one line that happens to be selected.

`testObaGoogleDebugUnitTest` for both classes passes with `-PwarningsAsErrors=true` (30 tests, 0 failures); `spotlessCheck` clean.

Not device-verified: the precise reason an interchangeable ride's bulbs were uncovered while an ordinary ride's were not is a rendering-order/geometry detail, so a look at a 1 Line/2 Line leg before merge is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route map itinerary lines displaying endpoint markers intended only for actively followed trips.
  * Ensured all rendered itinerary polylines consistently remove start and end bulb markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->