### PR TITLE
Fix: DirectionsAdvancedSettingsDialog ui alignment

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -956,12 +956,14 @@ private fun DirectionsAdvancedSettingsDialog(
                 SwitchRow(
                     label = stringResource(R.string.minimize_transfers),
                     checked = minimizeTransfers,
-                    onCheckedChange = { minimizeTransfers = it }
+                    onCheckedChange = { minimizeTransfers = it },
+                    modifier = Modifier.padding(top = 12.dp)
                 )
                 SwitchRow(
                     label = stringResource(R.string.wheelchair_accessible),
                     checked = wheelchair,
-                    onCheckedChange = { wheelchair = it }
+                    onCheckedChange = { wheelchair = it },
+                    modifier = Modifier.padding(top = 8.dp)
                 )
             }
         },


### PR DESCRIPTION
Fixes #2237
<img width="720" height="1600" alt="WhatsApp Image 2026-08-18 at 1 39 32 PM" src="https://github.com/user-attachments/assets/1c0861eb-bf30-48e2-aaa1-dd27fab98a9e" />

Input field gave proper spacing and be clearly separated from the others.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Format your changes with `./gradlew spotlessApply`.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout in the advanced settings dialog.
  * Reduced the maximum-walk-distance field width for a more compact appearance.
  * Added consistent top padding to the minimize-transfers and wheelchair options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->