### PR TITLE
Draw a drilled-into ride as the leg it is (#2241, #2246)

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -25,6 +25,7 @@ import androidx.core.graphics.createBitmap
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.ButtCap
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
 import com.google.android.gms.maps.model.CustomCap
@@ -158,7 +159,15 @@ class GoogleMapRenderer(
         widthOf = ::routeWidthPx,
         createLine = ::addRoutePolyline,
         removeLines = { lines -> lines.forEach { it.remove() } },
-        setWidth = { line, width -> line.width = width },
+        // A width patch re-stamps the end caps with it. Maps scales a custom cap by the stroke it was
+        // stamped against, so a mark drawn inset by a constant weight (a case's bulb halo) would have that
+        // weight scale with the line and stop matching the case beside it; re-stamping is what holds it.
+        // A line whose marks are simply proportional restates the same cap, which costs nothing.
+        setWidth = { line, polyline, width, markInset ->
+            line.width = width
+            line.startCap = endCapFor(polyline, polyline.startMark, width, markInset) ?: DEFAULT_LINE_CAP
+            line.endCap = endCapFor(polyline, polyline.endMark, width, markInset) ?: DEFAULT_LINE_CAP
+        },
         caseColorOf = caseColorOf,
         caseExtraWidth = { it.case.extraWidthDp * density }
     )
@@ -356,13 +365,13 @@ class GoogleMapRenderer(
         routePolylineReconciler.reconcile(next, map.cameraPosition.zoom)
     }
 
-    private fun addRoutePolyline(polyline: RoutePolyline, widthPx: Float): Polyline {
+    private fun addRoutePolyline(polyline: RoutePolyline, widthPx: Float, markInsetPx: Float): Polyline {
         val options = PolylineOptions()
             .width(widthPx)
             .addPoints(polyline.points)
             .applyDashPattern(polyline)
-        endCapFor(polyline, polyline.startMark)?.let { options.startCap(it) }
-        endCapFor(polyline, polyline.endMark)?.let { options.endCap(it) }
+        endCapFor(polyline, polyline.startMark, widthPx, markInsetPx)?.let { options.startCap(it) }
+        endCapFor(polyline, polyline.endMark, widthPx, markInsetPx)?.let { options.endCap(it) }
         if (polyline.directional) {
             // Advanced spans are substantially more expensive for Maps to retessellate while
             // zooming. Reserve that path for the lines that actually need repeated chevrons.
@@ -379,19 +388,36 @@ class GoogleMapRenderer(
     }
 
     /**
-     * The cap [mark] asks for on [polyline], or null for a flat end. Both marks are [CustomCap]s, which is
-     * what lets them be requested per end and stay right at every zoom: Maps scales a custom cap with the
-     * line's stroke and orients it along the line itself, so neither needs the camera-settle re-stamp a
-     * marker-based mark (the route labels) does.
+     * The cap [mark] asks for on [polyline], drawn against a stroke of [widthPx] and inset by [markInsetPx],
+     * or null for a flat end. Both marks are [CustomCap]s, which is what lets them be requested per end and
+     * orients them along the line itself.
+     *
+     * [markInsetPx] is the one thing a cap cannot express on its own: Maps sizes a custom cap *from the
+     * stroke*, so anything drawn at a constant weight rather than a fraction of the line has to be restated
+     * whenever that stroke changes, which is why a width patch re-stamps these.
      */
-    private fun endCapFor(polyline: RoutePolyline, mark: RouteLineMark): CustomCap? = when (mark) {
+    private fun endCapFor(
+        polyline: RoutePolyline,
+        mark: RouteLineMark,
+        widthPx: Float,
+        markInsetPx: Float
+    ): CustomCap? = when (mark) {
         RouteLineMark.NONE -> null
-        RouteLineMark.BULB -> endpointBulbCap(polyline.resolvedColor)
+        RouteLineMark.BULB -> endpointBulbCap(polyline.resolvedColor, widthPx, markInsetPx)
         RouteLineMark.INTERLINE_CUT -> interlineSeamCap(polyline)
     }
 
-    /** A circle 2x the stroke width, scaled by Maps together with the line at every zoom. */
-    private fun endpointBulbCap(color: Int): CustomCap {
+    /**
+     * A circle 2x the stroke width, less [markInsetPx] of radius.
+     *
+     * The inset is spent on the reference width rather than on the bitmap, so every bulb of one colour
+     * shares one descriptor however it is sized: Maps draws the disc at `bitmapRadius / referenceWidth` of
+     * the stroke, so naming a wider reference than the line really is draws the same disc smaller by
+     * exactly that much. A line's own bulb asks for no inset and comes out at the stroke width, as it
+     * always has; a case's bulb asks for the weight the case shows along the line, so its halo is that
+     * weight too instead of the doubled one a full-width copy of the bulb gave it (#2241).
+     */
+    private fun endpointBulbCap(color: Int, widthPx: Float, markInsetPx: Float): CustomCap {
         val descriptor = descriptorCache.get("route-endpoint-bulb:$color") {
             val bitmap = createBitmap(ENDPOINT_BULB_BITMAP_PX, ENDPOINT_BULB_BITMAP_PX)
             Canvas(bitmap).drawCircle(
@@ -402,7 +428,7 @@ class GoogleMapRenderer(
             )
             bitmap
         }
-        return CustomCap(descriptor, ENDPOINT_BULB_REFERENCE_WIDTH_PX)
+        return CustomCap(descriptor, ENDPOINT_BULB_REFERENCE_WIDTH_PX * bulbReferenceScale(widthPx, markInsetPx))
     }
 
     /**
@@ -893,6 +919,9 @@ class GoogleMapRenderer(
         private const val ENDPOINT_BULB_BITMAP_PX = 40
         private const val ENDPOINT_BULB_REFERENCE_WIDTH_PX = 20f
 
+        /** What an un-marked end draws as, and so what re-stamping a mark that has gone away restores. */
+        private val DEFAULT_LINE_CAP = ButtCap()
+
         // gms polyline/marker dimensions are in screen pixels.
         private const val DEFAULT_ROUTE_WIDTH_PX = 10f
         private const val TRIP_BAND_WIDTH_PX = 44f
@@ -965,3 +994,23 @@ class GoogleMapRenderer(
 // Internal (not private) so the inner marker/overlay classes call it without a synthetic accessor
 // (lint SyntheticAccessor); it's a trivial converter used only within this file.
 internal fun GeoPoint.toLatLng() = LatLng(latitude, longitude)
+
+/**
+ * The factor a bulb's [CustomCap] reference width is stretched by to inset the drawn disc by [markInsetPx]
+ * of radius on a stroke of [widthPx].
+ *
+ * Maps draws a custom cap at `bitmapRadius / referenceWidth` of the stroke, so a disc that fills its bitmap
+ * comes out at exactly the stroke width — which is what a bulb is. Naming a reference *wider* than the line
+ * really is shrinks that disc by the same proportion, so the radius wanted, `widthPx - markInsetPx`, is
+ * asked for as the ratio between the two. Pure, and separated from the drawing so
+ * `GoogleEndpointBulbCapTest` can pin the geometry on the JVM.
+ *
+ * The inset is a constant weight while the stroke follows the zoom ramp, so this is not a fixed factor: it
+ * has to be recomputed whenever the width is patched, which is what the reconciler's width callback does.
+ * Degenerate insets (a line thinner than the inset it asks for) fall back to the full-width disc rather
+ * than inverting the cap.
+ */
+internal fun bulbReferenceScale(widthPx: Float, markInsetPx: Float): Float {
+    val radius = widthPx - markInsetPx
+    return if (radius <= 0f || widthPx <= 0f) 1f else widthPx / radius
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/DirectionsMapController.kt
@@ -17,14 +17,9 @@ package org.onebusaway.android.map
 
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
-import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripVertexType
-import org.onebusaway.android.directions.model.decodedPoints
-import org.onebusaway.android.directions.model.substitutableRoutes
-import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
-import org.onebusaway.android.models.ObaShape
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.parseObaHexColor
 
@@ -102,65 +97,11 @@ class DirectionsMapController(private val host: MapHost) {
         val endLat = endPlace.lat
         val endLon = endPlace.lon
 
-        // The routes the *drawer* offers for each leg, not the raw interchangeable set: `substitutableRoutes`
-        // is already narrowed by what the rest of the plan needs of this leg (a leg of a stay-aboard
-        // interline admits no substitute at all, #2000 × #2010), so the label on a line and the badge in the
-        // drawer beside it name one ride the same way.
-        //
-        // Its alignment to the legs is stated rather than defended against, in the same terms
-        // [ModeSymbols.forLegs] states it for the same list: a short list read defensively would quietly
-        // label a ride with fewer routes than it can be taken on — the rider is told to wait for the 1 Line
-        // when the 2 Line would also do — and nothing downstream could tell that from a leg that genuinely
-        // has no alternatives. Misalignment is a bug in the analysis, so say so where it is read.
-        val substitutes = itinerary.substitutableRoutes()
-        require(substitutes.size == legs.size) {
-            "substitutable routes must be index-aligned to legs (${substitutes.size} vs ${legs.size})"
-        }
-
-        // Every leg that has geometry to draw, decoded and styled once: the polylines below stroke it and
-        // the route labels are anchored on it, so a label cannot end up a different colour from its own
-        // line (a leg without geometry draws neither).
-        val drawableLegs = legs.mapIndexedNotNull { legIndex, leg ->
-            val geometry = leg.legGeometry ?: return@mapIndexedNotNull null
-            val shape = LegShape(geometry)
-            if (shape.length <= 0) return@mapIndexedNotNull null
-            val style = itineraryLegStyle(leg.legKind(), parseObaHexColor(leg.routeColor), palette)
-            // The wire hex is parsed here, on the leg and on every route offered in its place, so the
-            // styling itself stays free of `android.graphics` (see the [ItineraryLegStyle] file header).
-            val interchangeable = substitutes[legIndex].map { route ->
-                ItinerarySubstitute(route, parseObaHexColor(route.routeColor))
-            }
-            ItineraryDrawableLeg(legIndex, leg, shape.points, style, interchangeable)
-        }
-        // Every leg's points run in travel order, but no itinerary leg stamps chevrons any more — see
-        // [itineraryLegStyle], which also decides the hairline case a ride wears.
-        val caps = itineraryLegCaps(legs)
-        legLines = drawableLegs.map { drawable ->
-            val (legIndex, _, points, style) = drawable
-            val legCaps = caps[legIndex]
-            ItineraryLegLine(
-                legIndex,
-                RoutePolyline(
-                    style.color,
-                    points,
-                    // The other routes this ride may be taken on, striped through it (#2100) so the line
-                    // says what its badge does; empty for every ride offering no alternative.
-                    stripeColors = drawable.stripeColors(palette),
-                    widthProfile = style.widthProfile,
-                    dash = style.dash,
-                    case = style.case,
-                    // A cutover (#2127) and a bulb are alternatives, not additions — the cut goes precisely
-                    // where the ride runs on and the bulb is therefore withheld, which is what this `when`
-                    // says and what a pair of booleans left each renderer to decide for itself.
-                    startMark = when {
-                        legCaps.startSeam -> RouteLineMark.INTERLINE_CUT
-                        style.roundCaps && legCaps.start -> RouteLineMark.BULB
-                        else -> RouteLineMark.NONE
-                    },
-                    endMark = if (style.roundCaps && legCaps.end) RouteLineMark.BULB else RouteLineMark.NONE
-                )
-            )
-        }
+        // How this trip is drawn, from the one builder that answers that (#2246): the lines at full
+        // fidelity — stripes and end marks included — and the legs the route labels are anchored on.
+        val drawn = drawnItinerary(itinerary, palette, ::parseObaHexColor)
+        val drawableLegs = drawn.legs
+        legLines = drawn.lines
         // A freshly drawn itinerary is the overview: every leg at full weight until one is focused.
         focusedLegIndices = emptySet()
         publishLegs()
@@ -249,13 +190,6 @@ class DirectionsMapController(private val host: MapHost) {
         if (current?.point == point) return current
         current?.let { host.removeMarker(it.id) }
         return point?.let { EndpointMarker(it, host.addMarker(it.latitude, it.longitude, hue)) }
-    }
-
-    /** An [ObaShape] over a [TripLegGeometry] (ported from the legacy DirectionsMapController). */
-    private class LegShape(private val geometry: TripLegGeometry) : ObaShape {
-        override val length: Int get() = geometry.length
-        override val points: List<GeoPoint> get() = geometry.decodedPoints()
-        override val rawPoints: String get() = geometry.points.orEmpty()
     }
 
     companion object {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -22,6 +22,7 @@ import org.onebusaway.android.directions.model.TripLeg
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.decodedPoints
 import org.onebusaway.android.directions.model.routeDisplayLabel
+import org.onebusaway.android.directions.model.substitutableRoutes
 import org.onebusaway.android.map.layout.RouteBadgePath
 import org.onebusaway.android.map.layout.RouteBadgeRequest
 import org.onebusaway.android.map.layout.placeRouteBadges
@@ -138,33 +139,98 @@ internal fun itineraryLegStyle(
 }
 
 /**
- * Every leg of [itinerary] that has geometry, as plain styled lines — the shared half of what
- * [org.onebusaway.android.map.DirectionsMapController] does when it draws a trip, without the labels,
- * pins, caps or focus the drawn view adds around them.
+ * How one itinerary is drawn: every leg that has geometry, decoded and styled once, and the line that
+ * strokes each of them.
  *
- * Exists because a *pinned* trip has to be drawn by something that is not a directions session (#2053):
- * the ghost outlives every mode the rider explores through, so it cannot be owned by the controller
- * whose whole lifetime is one directions view.
+ * The legs come back beside the lines because the route labels are anchored on them
+ * ([itineraryRouteBadges]), so a label cannot end up a different colour from the line it names.
  */
-internal fun itineraryLegLines(
+internal data class DrawnItinerary(
+    val legs: List<ItineraryDrawableLeg>,
+    val lines: List<ItineraryLegLine>
+)
+
+/**
+ * Draw [itinerary] — **at full fidelity**: every leg's colour, weight, dash and case, a shared ride's
+ * stripes (#2100), and the mark each end is finished with (#2084, #2127).
+ *
+ * The single answer to "how is this trip drawn", and deliberately the only one. Every view of a trip is
+ * a *reduction* of what this returns — the parked trip's ghost ([asPinnedTripGhost], #2053), the journey
+ * kept around a leg a rider drilled into ([asItineraryContext], #2048) — so each of them states what it
+ * takes away from a line the rider has already seen. There used to be two builders instead: this one,
+ * which left out marks and stripes, and the same walk again inside
+ * [org.onebusaway.android.map.DirectionsMapController], which put them in. A builder that merely leaves
+ * a feature out cannot be reduced *from* — it can only quietly differ, which is what let the ghost draw
+ * a trip that could never carry what the drawn one did, and made "does this view drop stripes?" a
+ * question with two answers.
+ *
+ * [parseRouteColor] turns a wire hex into an ARGB int. It is injected because that is the one part that
+ * needs `android.graphics`, which keeps everything here JVM-pure (see the file header) — and it is
+ * spent on the leg's own route and on every route offered in its place alike.
+ */
+internal fun drawnItinerary(
     itinerary: TripItinerary,
     palette: RouteLinePalette,
-    routeColorOf: (TripLeg) -> Int?
-): List<RoutePolyline> = itinerary.legs.mapNotNull { leg ->
-    val geometry = leg.legGeometry ?: return@mapNotNull null
-    val points = geometry.decodedPoints()
-    if (points.size < 2) return@mapNotNull null
-    val style = itineraryLegStyle(leg.legKind(), routeColorOf(leg), palette)
-    // No caps, cuts or focus: those are readings of a trip being *followed*, and this builds the shape
-    // of one merely being remembered. The caller restyles what it gets (see `asPinnedTripGhost`).
-    RoutePolyline(
-        style.color,
-        points,
-        widthProfile = style.widthProfile,
-        dash = style.dash,
-        case = style.case
+    parseRouteColor: (String?) -> Int?
+): DrawnItinerary {
+    val legs = itinerary.legs
+    // The routes the *drawer* offers for each leg, not the raw interchangeable set: `substitutableRoutes`
+    // is already narrowed by what the rest of the plan needs of this leg (a leg of a stay-aboard
+    // interline admits no substitute at all, #2000 x #2010), so the label on a line and the badge in the
+    // drawer beside it name one ride the same way.
+    //
+    // Its alignment to the legs is stated rather than defended against, in the same terms
+    // [org.onebusaway.android.ui.tripresults.ModeSymbols.forLegs] states it for the same list: a short
+    // list read defensively would quietly label a ride with fewer routes than it can be taken on — the
+    // rider is told to wait for the 1 Line when the 2 Line would also do — and nothing downstream could
+    // tell that from a leg that genuinely has no alternatives. Misalignment is a bug in the analysis, so
+    // say so where it is read.
+    val substitutes = itinerary.substitutableRoutes()
+    require(substitutes.size == legs.size) {
+        "substitutable routes must be index-aligned to legs (${substitutes.size} vs ${legs.size})"
+    }
+    // A leg with fewer than two points draws nothing, which is the whole of what "has geometry" means
+    // here — `decodedPoints` already answers empty for a geometry the wire declared no length for.
+    val drawable = legs.mapIndexedNotNull { legIndex, leg ->
+        val points = leg.legGeometry?.decodedPoints().orEmpty()
+        if (points.size < 2) return@mapIndexedNotNull null
+        ItineraryDrawableLeg(
+            legIndex,
+            leg,
+            points,
+            itineraryLegStyle(leg.legKind(), parseRouteColor(leg.routeColor), palette),
+            substitutes[legIndex].map { route -> ItinerarySubstitute(route, parseRouteColor(route.routeColor)) }
+        )
+    }
+    // Every leg's points run in travel order, but no itinerary leg stamps chevrons any more — see
+    // [itineraryLegStyle], which also decides the hairline case a ride wears.
+    val caps = itineraryLegCaps(legs)
+    return DrawnItinerary(
+        legs = drawable,
+        lines = drawable.map { ItineraryLegLine(it.index, it.line(caps[it.index], palette)) }
     )
 }
+
+/** The line one drawable leg is stroked with, finished at each end by its own [caps]. */
+private fun ItineraryDrawableLeg.line(caps: ItineraryLegCaps, palette: RouteLinePalette) = RoutePolyline(
+    style.color,
+    points,
+    // The other routes this ride may be taken on, striped through it (#2100) so the line says what its
+    // badge does; empty for every ride offering no alternative.
+    stripeColors = stripeColors(palette),
+    widthProfile = style.widthProfile,
+    dash = style.dash,
+    case = style.case,
+    // A cutover (#2127) and a bulb are alternatives, not additions — the cut goes precisely where the
+    // ride runs on and the bulb is therefore withheld, which is what this `when` says and what a pair of
+    // booleans left each renderer to decide for itself.
+    startMark = when {
+        caps.startSeam -> RouteLineMark.INTERLINE_CUT
+        style.roundCaps && caps.start -> RouteLineMark.BULB
+        else -> RouteLineMark.NONE
+    },
+    endMark = if (style.roundCaps && caps.end) RouteLineMark.BULB else RouteLineMark.NONE
+)
 
 /**
  * One drawn itinerary leg, paired with its index in the itinerary. The pairing is what lets a focus be
@@ -325,14 +391,33 @@ internal fun itineraryRouteBadges(
  * rather than two the rider can't tell apart. That is also why a substitute matching the planned route's
  * colour drops out entirely: it would stripe the line with the colour it already is.
  */
-internal fun ItineraryDrawableLeg.stripeColors(palette: RouteLinePalette): List<Int> = interchangeable
-    .inInterchangeableOrder { it.route.displayName }
-    .map { it.lineColor(palette) }
-    .distinct()
-    .filterNot { it == style.color }
+internal fun ItineraryDrawableLeg.stripeColors(palette: RouteLinePalette): List<Int> = rideStripeColors(
+    interchangeable.inInterchangeableOrder { it.route.displayName }.map { it.routeColor },
+    lineColor = style.color,
+    palette = palette
+)
 
-/** The colour this map draws [ItinerarySubstitute]'s own line in, were the rider to drill into it (#2063). */
-private fun ItinerarySubstitute.lineColor(palette: RouteLinePalette): Int = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor, palette).color
+/**
+ * The stripe rule itself, over already-ordered [alternatives] — each an agency's raw published colour, or
+ * null where it publishes none — and the [lineColor] the ride is already stroked in.
+ *
+ * Split out from [stripeColors] so the *drilled-into* ride can stripe by the same rule (#2241). That ride
+ * is drawn by a route session, from [org.onebusaway.android.map.RiddenSpan]s rather than from the drawable
+ * legs here, and it used to be drawn as a plain line: tapping a shared ride to look at it closer was
+ * exactly when the map stopped saying it was two routes. One rule, spent from both places, is what makes
+ * the line the rider taps and the line they get back the same line.
+ */
+internal fun rideStripeColors(
+    alternatives: List<Int?>,
+    lineColor: Int?,
+    palette: RouteLinePalette
+): List<Int> = alternatives
+    .map { riddenLineColor(it, palette) }
+    .distinct()
+    .filterNot { it == lineColor }
+
+/** The colour this map draws a ride on [routeColor]'s route in, were the rider to drill into it (#2063). */
+internal fun riddenLineColor(routeColor: Int?, palette: RouteLinePalette): Int = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor, palette).color
 
 private data class RideIdentity(val route: String, val interchangeableRouteIds: Set<String>)
 
@@ -346,7 +431,7 @@ private data class Ride(val identity: RideIdentity, val name: String, val drawab
     fun badgedRoutes(palette: RouteLinePalette): List<BadgedRoute> = (
         listOf(BadgedRoute(name, drawable.style.color)) +
             drawable.interchangeable.map { substitute ->
-                BadgedRoute(substitute.route.displayName, substitute.lineColor(palette))
+                BadgedRoute(substitute.route.displayName, riddenLineColor(substitute.routeColor, palette))
             }
         ).inInterchangeableOrder(BadgedRoute::routeShortName)
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/ItineraryLegStyle.kt
@@ -394,7 +394,9 @@ internal fun itineraryRouteBadges(
 internal fun ItineraryDrawableLeg.stripeColors(palette: RouteLinePalette): List<Int> = rideStripeColors(
     interchangeable.inInterchangeableOrder { it.route.displayName }.map { it.routeColor },
     lineColor = style.color,
-    palette = palette
+    // This view draws a ride through the ridden substitution, so it reads an alternative the same way —
+    // including a colourless one, which lands on the shared anchor here exactly as the ride itself would.
+    colorOf = { riddenLineColor(it, palette) }
 )
 
 /**
@@ -406,13 +408,20 @@ internal fun ItineraryDrawableLeg.stripeColors(palette: RouteLinePalette): List<
  * legs here, and it used to be drawn as a plain line: tapping a shared ride to look at it closer was
  * exactly when the map stopped saying it was two routes. One rule, spent from both places, is what makes
  * the line the rider taps and the line they get back the same line.
+ *
+ * [colorOf] renders one alternative, and is the caller's because the two views resolve a route's colour
+ * differently: this one puts a ride through the ridden substitution, while a route session draws it as the
+ * corridor beneath it is drawn, reaching the renderer's own default where nothing is published (#2186,
+ * #2041's remaining work). Both must answer in the space [lineColor] is stated in, or the comparison below
+ * is between two spellings of one colour rather than between two colours: a route publishing nothing would
+ * then stripe a line it is already the colour of.
  */
 internal fun rideStripeColors(
     alternatives: List<Int?>,
     lineColor: Int?,
-    palette: RouteLinePalette
+    colorOf: (Int?) -> Int
 ): List<Int> = alternatives
-    .map { riddenLineColor(it, palette) }
+    .map(colorOf)
     .distinct()
     .filterNot { it == lineColor }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -605,7 +605,12 @@ class MapViewModel @Inject constructor(
     fun setPinnedTripTrace(itinerary: TripItinerary?) {
         renderState.setPinnedTripPolylines(
             itinerary?.let {
-                itineraryLegLines(it, directionsPalette()) { leg -> parseObaHexColor(leg.routeColor) }
+                // The same lines the drawn trip is stroked with (#2246), reduced to a trace: the ghost is
+                // a *view* of a trip, so it starts from how that trip is drawn rather than from a second,
+                // quieter idea of it.
+                drawnItinerary(it, directionsPalette(), ::parseObaHexColor)
+                    .lines
+                    .map(ItineraryLegLine::line)
                     .asPinnedTripGhost()
             }.orEmpty()
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -988,7 +988,7 @@ class RouteMapController(
                 // The ride keeps the stripes it had as a leg (#2100/#2241), rendered by this session's own
                 // palette — the directions one when the rider drilled in from a trip plan, so the stripes
                 // are the colours the badge on that leg named.
-                stripeColorsOf = { span -> rideStripeColors(span.interchangeableColors, spanColor(span), palette) }
+                stripeColorsOf = { span, color -> rideStripeColors(span.interchangeableColors, color, palette) }
             ),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -984,7 +984,11 @@ class RouteMapController(
                 plan.polylines,
                 riddenSpans,
                 colorOf = ::spanColor,
-                itineraryContext = itineraryContext
+                itineraryContext = itineraryContext,
+                // The ride keeps the stripes it had as a leg (#2100/#2241), rendered by this session's own
+                // palette — the directions one when the rider drilled in from a trip plan, so the stripes
+                // are the colours the badge on that leg named.
+                stripeColorsOf = { span -> rideStripeColors(span.interchangeableColors, spanColor(span), palette) }
             ),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteMapController.kt
@@ -988,7 +988,18 @@ class RouteMapController(
                 // The ride keeps the stripes it had as a leg (#2100/#2241), rendered by this session's own
                 // palette — the directions one when the rider drilled in from a trip plan, so the stripes
                 // are the colours the badge on that leg named.
-                stripeColorsOf = { span, color -> rideStripeColors(span.interchangeableColors, color, palette) }
+                //
+                // An alternative is resolved exactly as this view resolves the ride itself ([spanColor]),
+                // the renderer's own fallback included, so the two are compared in one space: a route that
+                // publishes no colour is drawn in the default here, which is the colour the ride is already
+                // stroked in, so it drops out instead of striping the line with itself.
+                stripeColorsOf = { span, color ->
+                    rideStripeColors(
+                        span.interchangeableColors,
+                        lineColor = color ?: DEFAULT_ROUTE_LINE_COLOR,
+                        colorOf = { palette.lineColor(it) ?: DEFAULT_ROUTE_LINE_COLOR }
+                    )
+                }
             ),
             framingPolylines = plan.framingPolylines,
             routeModeScalesStopsWithZoom = plan.routeModeScalesStopsWithZoom

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -142,7 +142,9 @@ internal fun List<RiddenSpan>.isDrawableRide(): Boolean = sumOf { it.points.size
  *
  * The end marks follow the same rule the itinerary map's own caps do ([itineraryLegCaps]): a bulb where the
  * rider gets on and off, an [RouteLineMark.INTERLINE_CUT] where the vehicle changed route under them
- * ([RiddenSpan.startsCutover]), and nothing at a seam they sit through. The bulbs are why the ride reads as
+ * ([RiddenSpan.startsCutover]), and nothing at a seam they sit through. The ride's own ends win over a cut,
+ * which the itinerary map gets for free (a seam leg is never a leg the rider boards) and this has to say,
+ * since a leader with no geometry to draw can leave a cutover span first. The bulbs are why the ride reads as
  * a ride here rather than as a piece of corridor, and the cut is why drilling into an interlined ride shows
  * the rider *more* about it rather than losing the one thing that said the route changes mid-ride.
  *
@@ -181,8 +183,12 @@ internal fun routePolylinesWithSegment(
             widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
             case = RouteLineCase.SELECTION,
             startMark = when {
-                span.startsCutover -> RouteLineMark.INTERLINE_CUT
+                // The ride's own start wins over the cut. A leader with no drawable geometry drops out
+                // above, which can leave a *cutover* span first: the rider still gets on where the drawn
+                // ride begins, and a cut there would announce a change of route with nothing before it to
+                // change from.
                 index == 0 -> RouteLineMark.BULB
+                span.startsCutover -> RouteLineMark.INTERLINE_CUT
                 else -> RouteLineMark.NONE
             },
             endMark = if (index == ridden.lastIndex) RouteLineMark.BULB else RouteLineMark.NONE

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -64,12 +64,19 @@ internal fun List<GeoPoint>.isDrawableSegment() = size >= 2
  * [plannedColor] is the GTFS colour the *plan* published for that route, already parsed — the same source
  * the itinerary's own line for this leg was styled from — carried along so the span can be drawn before
  * [routeId]'s route has loaded (see [riddenSpanColorSource]). Null when the plan published none.
+ *
+ * [interchangeableColors] are the parsed GTFS colours of the routes the rider may board *in place of* this
+ * one (#2010), in the order the ride's badge names them, and they are what keeps the ride striped once the
+ * rider drills into it (#2100/#2241). Carried on the span for the same reason [plannedColor] is: the fact
+ * belongs to the plan, and the route session the ride is drawn in has no other way to learn it. Empty for a
+ * ride with no alternative — and so for every leg of a stay-aboard interline, which admits none.
  */
 data class RiddenSpan(
     val points: List<GeoPoint>,
     val routeId: String? = null,
     val plannedColor: Int? = null,
-    val startsCutover: Boolean = false
+    val startsCutover: Boolean = false,
+    val interchangeableColors: List<Int?> = emptyList()
 )
 
 /**
@@ -119,34 +126,51 @@ internal fun List<RiddenSpan>.isDrawableRide(): Boolean = sumOf { it.points.size
 /**
  * Compose the route's polylines when [spans] are highlighted: the route [base] upstream of the boarding
  * point drawn as the selected line's approach, then the rider's [itineraryContext], then the ridden span(s),
- * each in the colour [colorOf] gives it. This order makes the visual hierarchy match the semantics: where
- * the vehicle comes from, the committed journey, the current leg. Without a drawable span, retains the
- * ordinary plain-route ordering: itinerary context beneath [base], with no approach restyle or selected
- * overlay.
+ * each in the colour [colorOf] gives it and striped with the colours [stripeColorsOf] gives it. This order
+ * makes the visual hierarchy match the semantics: where the vehicle comes from, the committed journey, the
+ * current leg. Without a drawable span, retains the ordinary plain-route ordering: itinerary context beneath
+ * [base], with no approach restyle or selected overlay.
  *
- * The ride keeps [ITINERARY_RIDE_WIDTH_PROFILE] — the very weight it had as a leg of the itinerary it was
- * tapped from — and says it is the selected one with a case rather than by out-widening its surroundings
+ * **The ride is the leg the rider tapped, drawn again — not a route line that happens to share its shape.**
+ * It keeps [ITINERARY_RIDE_WIDTH_PROFILE], the very weight it had as a leg of the itinerary; it keeps the
+ * stripes of a ride the rider may board either route for (#2100), which drilling in used to erase, so that
+ * looking closer at a shared ride stopped saying it was shared (#2241); and it keeps the marks its ends
+ * carried there. It says it is the *selected* one with a case rather than by out-widening its surroundings
  * (#2082). Its approach carries the same case, so the two read as one route line stepping down where the
  * rider boards. Neither carries direction chevrons (#2129): like every other itinerary line, the ride is
  * marked selected by its case and weight alone.
  *
- * A span the vehicle changed route onto is cut at its start ([RiddenSpan.startsCutover]), the same mark the
- * itinerary map rules across that join — so drilling into an interlined ride shows the rider *more* about it,
- * rather than losing the one thing that said the route changes mid-ride.
+ * The end marks follow the same rule the itinerary map's own caps do ([itineraryLegCaps]), stated here over
+ * span position because a ride's spans *are* its legs: a bulb where the rider gets on and off, an
+ * [RouteLineMark.INTERLINE_CUT] where the vehicle changed route under them ([RiddenSpan.startsCutover]), and
+ * nothing at a seam they sit through. The bulbs are why the ride reads as a ride here rather than as a piece
+ * of corridor, and the cut is why drilling into an interlined ride shows the rider *more* about it rather
+ * than losing the one thing that said the route changes mid-ride.
+ *
+ * [stripeColorsOf] is a lambda for the same reason [colorOf] is: this file picks which colours a ride is
+ * drawn *from*, and the rendering of them stays with the caller's palette (see the file header).
  */
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,
     spans: List<RiddenSpan>,
     colorOf: (RiddenSpan) -> Int?,
-    itineraryContext: List<RoutePolyline> = emptyList()
+    itineraryContext: List<RoutePolyline> = emptyList(),
+    stripeColorsOf: (RiddenSpan) -> List<Int> = { emptyList() }
 ): List<RoutePolyline> {
-    val overlay = spans.filter { it.points.isDrawableSegment() }.map { span ->
+    val ridden = spans.filter { it.points.isDrawableSegment() }
+    val overlay = ridden.mapIndexed { index, span ->
         RoutePolyline(
             color = colorOf(span),
             points = span.points,
+            stripeColors = stripeColorsOf(span),
             widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
             case = RouteLineCase.SELECTION,
-            startMark = if (span.startsCutover) RouteLineMark.INTERLINE_CUT else RouteLineMark.NONE
+            startMark = when {
+                span.startsCutover -> RouteLineMark.INTERLINE_CUT
+                index == 0 -> RouteLineMark.BULB
+                else -> RouteLineMark.NONE
+            },
+            endMark = if (index == ridden.lastIndex) RouteLineMark.BULB else RouteLineMark.NONE
         )
     }
     if (overlay.isEmpty()) return itineraryContext + base

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -148,21 +148,24 @@ internal fun List<RiddenSpan>.isDrawableRide(): Boolean = sumOf { it.points.size
  * than losing the one thing that said the route changes mid-ride.
  *
  * [stripeColorsOf] is a lambda for the same reason [colorOf] is: this file picks which colours a ride is
- * drawn *from*, and the rendering of them stays with the caller's palette (see the file header).
+ * drawn *from*, and the rendering of them stays with the caller's palette (see the file header). It is
+ * handed the colour the span was *already* resolved to, so the stripes are deduplicated against the colour
+ * the line is actually stroked in rather than against a second, independently resolved answer.
  */
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,
     spans: List<RiddenSpan>,
     colorOf: (RiddenSpan) -> Int?,
     itineraryContext: List<RoutePolyline> = emptyList(),
-    stripeColorsOf: (RiddenSpan) -> List<Int> = { emptyList() }
+    stripeColorsOf: (RiddenSpan, Int?) -> List<Int> = { _, _ -> emptyList() }
 ): List<RoutePolyline> {
     val ridden = spans.filter { it.points.isDrawableSegment() }
     val overlay = ridden.mapIndexed { index, span ->
+        val color = colorOf(span)
         RoutePolyline(
-            color = colorOf(span),
+            color = color,
             points = span.points,
-            stripeColors = stripeColorsOf(span),
+            stripeColors = stripeColorsOf(span, color),
             widthProfile = ITINERARY_RIDE_WIDTH_PROFILE,
             case = RouteLineCase.SELECTION,
             startMark = when {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteSegmentHighlight.kt
@@ -140,17 +140,29 @@ internal fun List<RiddenSpan>.isDrawableRide(): Boolean = sumOf { it.points.size
  * rider boards. Neither carries direction chevrons (#2129): like every other itinerary line, the ride is
  * marked selected by its case and weight alone.
  *
- * The end marks follow the same rule the itinerary map's own caps do ([itineraryLegCaps]), stated here over
- * span position because a ride's spans *are* its legs: a bulb where the rider gets on and off, an
- * [RouteLineMark.INTERLINE_CUT] where the vehicle changed route under them ([RiddenSpan.startsCutover]), and
- * nothing at a seam they sit through. The bulbs are why the ride reads as a ride here rather than as a piece
- * of corridor, and the cut is why drilling into an interlined ride shows the rider *more* about it rather
- * than losing the one thing that said the route changes mid-ride.
+ * The end marks follow the same rule the itinerary map's own caps do ([itineraryLegCaps]): a bulb where the
+ * rider gets on and off, an [RouteLineMark.INTERLINE_CUT] where the vehicle changed route under them
+ * ([RiddenSpan.startsCutover]), and nothing at a seam they sit through. The bulbs are why the ride reads as
+ * a ride here rather than as a piece of corridor, and the cut is why drilling into an interlined ride shows
+ * the rider *more* about it rather than losing the one thing that said the route changes mid-ride.
+ *
+ * The two halves of that rule reach here differently, deliberately. The **cut** is carried as data: it is a
+ * fact about the ride ("the vehicle changed route onto this span"), read off the same `Interlines.chains`
+ * transitions [itineraryLegCaps] folds into its seams, so both maps cut in the same places by construction.
+ * The **bulbs** are decided here, from position in the *drawn* list — because which end is an end is a fact
+ * about what this view is actually drawing, not about the plan: a span whose geometry is undrawable is
+ * dropped above, and the boarding bulb has to land on the first point the rider can actually see rather
+ * than disappear with it. Carrying `start`/`end` across instead would need that same "first one drawn"
+ * reasoning anyway, one layer further from where the dropping happens.
  *
  * [stripeColorsOf] is a lambda for the same reason [colorOf] is: this file picks which colours a ride is
  * drawn *from*, and the rendering of them stays with the caller's palette (see the file header). It is
  * handed the colour the span was *already* resolved to, so the stripes are deduplicated against the colour
- * the line is actually stroked in rather than against a second, independently resolved answer.
+ * the line is actually stroked in rather than against a second, independently resolved answer — and that
+ * colour moves: it upgrades from the plan's to the route's own once that route loads (#2186), through
+ * whichever palette this session draws with. Which is why the ride's stripes are re-derived here from the
+ * colours the plan carried rather than handed over as a finished line: a line baked by the itinerary would
+ * freeze its stripes against the colour and palette it had *there*.
  */
 internal fun routePolylinesWithSegment(
     base: List<RoutePolyline>,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/RouteViewGeometry.kt
@@ -20,7 +20,6 @@ import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
 import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
-import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.models.FocusedTrip
@@ -47,11 +46,22 @@ internal fun focusedRoutePolyline(
     transforms = ROUTE_VIEW_TRANSFORMS
 )
 
+// The reductions: a line built for one view, restated for another that says less. Every one of them
+// **constructs** its line rather than `copy()`-ing the original minus a few fields, for the reason
+// `RoutePolyline.asCase` gives for doing the same — a feature added to [RoutePolyline] is then absent
+// from a reduced line unless someone puts it here, which is the safe default. Copy-minus is the opposite
+// default, and it is what let a drilled-into leg keep bulbs this view had decided not to draw (#2241):
+// every new feature rode along until someone noticed, one incident per feature. A reduction that needs a
+// new field will fail to compile into existence; one that quietly gains a feature will not.
+
 /** The active route's broader geometry retained beneath an exact selected-trip line. */
 internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyline> = map { line ->
-    line.copy(
+    RoutePolyline(
+        color = line.color,
+        points = line.points,
         widthProfile = DEEMPHASIZED_ROUTE_LINE_WIDTH_PROFILE,
-        directional = false
+        dash = line.dash,
+        transforms = line.transforms
     )
 }
 
@@ -71,29 +81,38 @@ internal fun List<RoutePolyline>.asDeemphasizedRouteUnderlay(): List<RoutePolyli
  * stay off: the approach is where the vehicle comes from, not a span the rider travels.
  */
 internal fun List<RoutePolyline>.asSelectedRouteApproach(): List<RoutePolyline> = map { line ->
-    line.copy(
+    RoutePolyline(
+        color = line.color,
+        points = line.points,
         widthProfile = ITINERARY_APPROACH_WIDTH_PROFILE,
-        directional = false,
         dash = RouteLineDash.NONE,
-        case = RouteLineCase.APPROACH
+        case = RouteLineCase.APPROACH,
+        transforms = line.transforms
     )
 }
 
 /**
  * The rider's committed journey retained around a focused transit leg. It keeps each leg's mode/route
- * colour and dash, but drops chevrons and takes a middle weight: stronger than unused route geometry,
- * weaker than the selected ridden segment.
+ * colour, dash and case, and takes a middle weight: stronger than unused route geometry, weaker than the
+ * selected ridden segment.
  *
- * It also drops a shared ride's stripes (#2100). Striping answers "which of these routes may I board?", a
+ * It drops a shared ride's stripes (#2100). Striping answers "which of these routes may I board?", a
  * question about a ride the rider is choosing; a context leg is here to say where the leg being read sits
  * in the journey, and is drawn at half the width the stripes were cut against — so the same rhythm arrives
- * as a fleck of noise beside the leg that is actually being read.
+ * as a fleck of noise beside the leg that is actually being read. It drops the end marks with them: a bulb
+ * pair means "alight here, board there" and a cut means "the route changes under you", which are readings
+ * of a trip being *followed* at full weight, not of the trace saying where one leg of it sits — the same
+ * call [asPinnedTripGhost] makes. The ride the rider is actually reading keeps both, drawn over this at
+ * full weight by [routePolylinesWithSegment].
  */
 internal fun List<RoutePolyline>.asItineraryContext(): List<RoutePolyline> = map { line ->
-    line.copy(
+    RoutePolyline(
+        color = line.color,
+        points = line.points,
         widthProfile = ITINERARY_CONTEXT_WIDTH_PROFILE,
-        directional = false,
-        stripeColors = emptyList()
+        dash = line.dash,
+        case = line.case,
+        transforms = line.transforms
     )
 }
 
@@ -102,16 +121,16 @@ internal fun List<RoutePolyline>.asItineraryContext(): List<RoutePolyline> = map
  *
  * Keeps each leg's colour — the one thing the ghost is *for* is saying which trip is waiting — and drops
  * everything that competes for attention: the case that would halo it above the basemap, the terminus
- * bulbs and interline cuts that are details of a trip being read, and any chevrons. What is left is a
- * thin coloured trace of the journey.
+ * bulbs and interline cuts that are details of a trip being read, a shared ride's stripes, and any
+ * chevrons. What is left is a thin coloured trace of the journey.
  */
 internal fun List<RoutePolyline>.asPinnedTripGhost(): List<RoutePolyline> = map { line ->
-    line.copy(
+    RoutePolyline(
+        color = line.color,
+        points = line.points,
         widthProfile = PINNED_TRIP_GHOST_WIDTH_PROFILE,
-        directional = false,
-        case = RouteLineCase.NONE,
-        startMark = RouteLineMark.NONE,
-        endMark = RouteLineMark.NONE
+        dash = line.dash,
+        transforms = line.transforms
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/RoutePolylineReconciler.kt
@@ -35,24 +35,38 @@ package org.onebusaway.android.map.render
  * case weights differ, in whatever width unit that flavor's [widthOf] returns). Everything else — the
  * bookkeeping the fixes were about — is shared.
  *
+ * [createLine] and [setWidth] are both handed the stroke *and* the mark inset that goes with it (see
+ * [markInset]), and [setWidth] the line's model besides: a mark whose size is not simply proportional to
+ * the stroke has to be restated when the stroke changes, so a width patch is a mark patch too. A renderer
+ * whose marks all scale with the line can ignore both and just set the width.
+ *
  * Not thread-safe: every method mutates native map state and must run on the map's main thread, which
  * is where both renderers already call it.
  */
 class RoutePolylineReconciler<NativeLine>(
     private val widthOf: (RoutePolyline, Float) -> Float,
-    private val createLine: (RoutePolyline, Float) -> NativeLine,
+    private val createLine: (RoutePolyline, Float, Float) -> NativeLine,
     private val removeLines: (List<NativeLine>) -> Unit,
-    private val setWidth: (NativeLine, Float) -> Unit,
+    private val setWidth: (NativeLine, RoutePolyline, Float, Float) -> Unit,
     private val caseColorOf: (RoutePolyline) -> Int,
     private val caseExtraWidth: (RoutePolyline) -> Float
 ) {
+    /** One drawn case: the native stroke and the model it was drawn from, paired so a width patch can
+     *  restate the marks on it (see [markInset]) rather than only its width. */
+    private class DrawnCase<NativeLine>(val native: NativeLine, val polyline: RoutePolyline)
+
     /**
      * One drawn line: its stroke, plus the wider case (halo) stroke beneath it when the line asked for one.
      * Held as a pair so a case cannot outlive its line or drift out of sync with its width.
      */
-    private class Drawn<NativeLine>(val case: NativeLine?, val line: NativeLine, val caseExtraWidth: Float) {
+    private class Drawn<NativeLine>(
+        val case: DrawnCase<NativeLine>?,
+        val line: NativeLine,
+        val polyline: RoutePolyline,
+        val caseExtraWidth: Float
+    ) {
         /** Both strokes, case first — the order they were added, and so the order they draw. */
-        val natives: List<NativeLine> get() = listOfNotNull(case, line)
+        val natives: List<NativeLine> get() = listOfNotNull(case?.native, line)
     }
 
     // The lines currently drawn, positionally aligned with [renderedPolylines]/[renderedWidths].
@@ -122,9 +136,11 @@ class RoutePolylineReconciler<NativeLine>(
      */
     private fun create(polyline: RoutePolyline, width: Float): Drawn<NativeLine> {
         val extra = caseExtraWidth(polyline)
+        val casePolyline = polyline.takeIf { it.case != RouteLineCase.NONE }?.asCase(caseColorOf(polyline))
         return Drawn(
-            case = if (polyline.case != RouteLineCase.NONE) createLine(polyline.asCase(caseColorOf(polyline)), width + extra) else null,
-            line = createLine(polyline, width),
+            case = casePolyline?.let { DrawnCase(createLine(it, width + extra, markInset(extra)), it) },
+            line = createLine(polyline, width, NO_MARK_INSET),
+            polyline = polyline,
             // Retained with the pair: a width resync patches the case from the line's new width, and the
             // amount to add is a property of the case that was drawn, not of the reconcile doing the patching.
             caseExtraWidth = extra
@@ -132,8 +148,25 @@ class RoutePolylineReconciler<NativeLine>(
     }
 
     private fun Drawn<NativeLine>.applyWidth(width: Float) {
-        setWidth(line, width)
-        case?.let { setWidth(it, width + caseExtraWidth) }
+        setWidth(line, polyline, width, NO_MARK_INSET)
+        case?.let { setWidth(it.native, it.polyline, width + caseExtraWidth, markInset(caseExtraWidth)) }
+    }
+
+    private companion object {
+        /** A line's own marks are drawn at its full stroke — only a case insets them. */
+        const val NO_MARK_INSET = 0f
+
+        /**
+         * How far a case's end marks are drawn *inside* its own stroke: half its extra width, which is the
+         * weight the case shows along the line.
+         *
+         * Without it a bulb's halo comes out at twice the weight of the case beside it. A bulb is a circle
+         * of the line's own stroke width, so the case's copy of it is a circle of the *case's* stroke width
+         * — wider by the whole extra, while the case shows only half of that on each side of the line it
+         * wraps. The halo is the one place a case's weight is set by the mark's size rather than by the
+         * line's, so it is the one place that has to be told (#2241).
+         */
+        fun markInset(caseExtraWidth: Float) = caseExtraWidth / 2f
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsRepository.kt
@@ -35,6 +35,7 @@ import org.onebusaway.android.map.RiddenSpan
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.geoPointOrNull
+import org.onebusaway.android.util.inInterchangeableOrder
 import org.onebusaway.android.util.parseObaHexColor
 import org.onebusaway.android.util.runCatchingCancellable
 
@@ -156,12 +157,20 @@ class DefaultTripResultsRepository @Inject constructor(
             // *published* colour until that route can state it, and the map's own route lines have never had
             // that substitution either (#2041's remaining work), so a colourless ride resolves the same way
             // before and after the load instead of changing colour on landing.
+            // The routes the rider may board in this one's place, in the order the ride's badge names them
+            // (#2010) — so the ride keeps its stripes when the rider drills into it (#2100/#2241), and keeps
+            // them in the badge's own order. Read off the chain leader, which is where `substitutableRoutes`
+            // puts them, and empty for an interlined chain by construction.
+            val interchangeableColors = substitutable[chain.leaderIndex]
+                .inInterchangeableOrder { it.displayName }
+                .map { parseObaHexColor(it.routeColor) }
             val riddenSpans = (chain.leaderIndex..chain.alightIndex).map { j ->
                 RiddenSpan(
                     points = legs[j].legGeometry?.decodedPoints().orEmpty(),
                     routeId = ids[j].routeId,
                     plannedColor = parseObaHexColor(legs[j].routeColor),
-                    startsCutover = j in chain.transitionLegIndices
+                    startsCutover = j in chain.transitionLegIndices,
+                    interchangeableColors = interchangeableColors
                 )
             }
             refs[chain.leaderIndex] = RouteLegRef(

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -168,7 +168,11 @@ class MapLibreRenderer(
     // operations below are supplied here.
     private val routePolylineReconciler = RoutePolylineReconciler<Polyline>(
         widthOf = ::routeWidth,
-        createLine = { polyline, width ->
+        // The mark inset the reconciler offers is ignored here: the classic annotation draws no caps, and
+        // the bulbs are their own circle layer drawn from the canonical lines rather than from these
+        // strokes (see [MapLibreRouteEndpointBulbLayer]) — so nothing on a maplibre line is sized from a
+        // stroke it would have to be restated against.
+        createLine = { polyline, width, _ ->
             map.addPolyline(
                 PolylineOptions()
                     .color(polyline.resolvedColor)
@@ -177,7 +181,7 @@ class MapLibreRenderer(
             )
         },
         removeLines = { lines -> map.removeAnnotations(lines) },
-        setWidth = { line, width -> line.width = width },
+        setWidth = { line, _, width, _ -> line.width = width },
         caseColorOf = caseColorOf,
         // maplibre annotation widths are already in dp, so no density conversion is involved.
         caseExtraWidth = { it.case.extraWidthDp }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -2,8 +2,8 @@
 package org.onebusaway.android.map
 
 import android.annotation.SuppressLint
-import kotlin.time.Duration.Companion.minutes
 import com.google.android.material.color.utilities.Hct
+import kotlin.time.Duration.Companion.minutes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -18,6 +18,7 @@ import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVehicleRental
 import org.onebusaway.android.directions.model.TripVertexType
+import org.onebusaway.android.map.render.DEFAULT_ROUTE_LINE_COLOR
 import org.onebusaway.android.map.render.ITINERARY_RIDE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.ITINERARY_STREET_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteLineCase
@@ -499,6 +500,27 @@ class ItineraryLegStyleTest {
         assertEquals(
             badge.routes.map { it.color }.toSet(),
             (listOf(ride.style.color) + ride.stripeColors(DIRECTIONS)).toSet()
+        )
+    }
+
+    @Test
+    fun `a colourless route stripes in whatever colour the view draws a colourless route in`() {
+        // The rule compares an alternative against the colour its line already is, so both have to be
+        // stated in the same space or the comparison is between two spellings of one colour. The two views
+        // spell it differently: the itinerary puts a colourless ride on the shared anchor, while a route
+        // session draws it the way the corridor beneath it is drawn — the renderer's own default. Each
+        // resolves its own, and in both a colourless alternative drops out of a colourless ride's stripes
+        // rather than striping it with itself.
+        val itineraryColour = riddenLineColor(null, DIRECTIONS)
+        assertEquals(
+            emptyList<Int>(),
+            rideStripeColors(listOf(null), lineColor = itineraryColour, colorOf = { riddenLineColor(it, DIRECTIONS) })
+        )
+
+        val routeViewColour = DEFAULT_ROUTE_LINE_COLOR
+        assertEquals(
+            emptyList<Int>(),
+            rideStripeColors(listOf(null), lineColor = routeViewColour, colorOf = { DIRECTIONS.lineColor(it) ?: DEFAULT_ROUTE_LINE_COLOR })
         )
     }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/ItineraryLegStyleTest.kt
@@ -2,6 +2,7 @@
 package org.onebusaway.android.map
 
 import android.annotation.SuppressLint
+import kotlin.time.Duration.Companion.minutes
 import com.google.android.material.color.utilities.Hct
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -9,7 +10,10 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.directions.model.InterchangeableRoute
+import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripLeg
+import org.onebusaway.android.directions.model.TripLegAlternative
+import org.onebusaway.android.directions.model.TripLegGeometry
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.model.TripPlace
 import org.onebusaway.android.directions.model.TripVehicleRental
@@ -20,8 +24,10 @@ import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
 import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
+import org.onebusaway.android.time.ServerTime
 import org.onebusaway.android.util.ACHROMATIC_ROUTE_CHROMA
 import org.onebusaway.android.util.GeoPoint
+import org.onebusaway.android.util.encodePolyline
 import org.onebusaway.android.util.riddenRouteHue
 import org.onebusaway.android.util.routeBadgeChipColor
 
@@ -518,6 +524,87 @@ class ItineraryLegStyleTest {
         assertEquals(listOf(rideColor(0xFF0000FF.toInt())), ride.stripeColors(DIRECTIONS))
     }
 
+    @Test
+    fun `one builder draws the trip, and the views of it are reductions of what it draws`() {
+        // #2246: there were two builders — this one without marks or stripes, and the directions
+        // controller's own walk with both — so the parked trip could never draw what the read trip did,
+        // and "does this view drop stripes?" had two answers. One builder now draws at full fidelity and
+        // every view states what it takes away, which is the only shape in which they can be compared.
+        val drawn = drawnItinerary(interchangeableRideItinerary(), DIRECTIONS, parseRouteColor = ::testHexColor)
+
+        val ride = drawn.lines.single().line
+        // Full fidelity: the ride the rider may board either route for is striped, and bulbed at the ends
+        // where they get on and off.
+        assertEquals(listOf(rideColor(testHexColor(ALTERNATIVE_ROUTE_COLOR)!!)), ride.stripeColors)
+        assertEquals(RouteLineMark.BULB, ride.startMark)
+        assertEquals(RouteLineMark.BULB, ride.endMark)
+        // The legs come back beside the lines because the route labels are anchored on them.
+        assertEquals(listOf(ride.color), drawn.legs.map { it.style.color })
+
+        // And the ghost is that same line, reduced — not a second, quieter idea of the trip.
+        val ghost = drawn.lines.map { it.line }.asPinnedTripGhost().single()
+        assertEquals(ride.color, ghost.color)
+        assertEquals(ride.points, ghost.points)
+        assertEquals(emptyList<Int>(), ghost.stripeColors)
+        assertEquals(RouteLineMark.NONE, ghost.startMark)
+        assertEquals(RouteLineMark.NONE, ghost.endMark)
+    }
+
+    @Test
+    fun `a leg with nothing drawable is left out, and does not shift the ones that are`() {
+        // A leg that carried no shape draws no line, so a position in the drawn list is not a leg index —
+        // which is the whole reason a line is paired with the index it came from.
+        val itinerary = TripItinerary(
+            legs = listOf(
+                TripLeg(mode = TripMode.WALK),
+                transitLeg(PLANNED_ROUTE_COLOR, listOf(GeoPoint(47.6, -122.3), GeoPoint(47.7, -122.4)))
+            )
+        )
+
+        val drawn = drawnItinerary(itinerary, DIRECTIONS, parseRouteColor = ::testHexColor)
+
+        assertEquals(listOf(1), drawn.lines.map { it.legIndex })
+    }
+
+    /** An itinerary of one ride, offered on a second route the rider may board in its place (#2010). */
+    private fun interchangeableRideItinerary() = TripItinerary(
+        startTime = ServerTime(0L),
+        legs = listOf(
+            transitLeg(
+                routeColor = PLANNED_ROUTE_COLOR,
+                points = listOf(GeoPoint(47.6, -122.3), GeoPoint(47.7, -122.4)),
+                alternatives = listOf(
+                    TripLegAlternative(
+                        routeId = "route-2",
+                        routeShortName = "2 Line",
+                        routeColor = ALTERNATIVE_ROUTE_COLOR,
+                        duration = 20.minutes,
+                        fromStopId = "1_500",
+                        toStopId = "1_501"
+                    )
+                )
+            )
+        )
+    )
+
+    private fun transitLeg(
+        routeColor: String?,
+        points: List<GeoPoint>,
+        alternatives: List<TripLegAlternative> = emptyList()
+    ) = TripLeg(
+        mode = TripMode.RAIL,
+        routeId = "route-1",
+        routeShortName = "1 Line",
+        routeColor = routeColor,
+        duration = 20.minutes,
+        startTime = ServerTime(0L),
+        endTime = ServerTime(0L) + 20.minutes,
+        from = TripPlace(name = "Board", stopId = "1_500"),
+        to = TripPlace(name = "Alight", stopId = "1_501"),
+        legGeometry = TripLegGeometry(encodePolyline(points), points.size),
+        alternatives = alternatives
+    )
+
     /** The colour this map draws a ride whose agency publishes [routeColor] in. */
     private fun rideColor(routeColor: Int) = itineraryLegStyle(ItineraryLegKind.TRANSIT, routeColor, DIRECTIONS).color
 
@@ -559,7 +646,15 @@ class ItineraryLegStyleTest {
         )
     }
 
+    /** Stands in for `parseObaHexColor`, which needs `android.graphics`: the builder takes it as a lambda. */
+    private fun testHexColor(hex: String?): Int? = hex?.removePrefix("#")?.toLongOrNull(16)?.toInt()?.let { 0xFF000000.toInt() or it }
+
     private companion object {
+        // Two published GTFS colours, as they arrive on the wire.
+        const val PLANNED_ROUTE_COLOR = "0072BC"
+
+        const val ALTERNATIVE_ROUTE_COLOR = "00A94F"
+
         // The palette the directions view actually draws with, and the one every other view does. Most cases
         // here are about a leg's *shape* rather than its colour, and take the directions palette because that
         // is the only palette an itinerary leg is ever stroked with.

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/PinnedTripGhostTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/PinnedTripGhostTest.kt
@@ -42,6 +42,8 @@ class PinnedTripGhostTest {
         val cased = RoutePolyline(
             0xFF0A5B3E.toInt(),
             points,
+            // A ride the rider may board either route for (#2100): striped on the trip they were reading.
+            stripeColors = listOf(0xFF0072BC.toInt()),
             directional = true,
             case = RouteLineCase.OUTLINE,
             startMark = RouteLineMark.BULB,
@@ -54,6 +56,9 @@ class PinnedTripGhostTest {
         assertEquals(RouteLineMark.NONE, ghost.startMark)
         assertEquals(RouteLineMark.NONE, ghost.endMark)
         assertEquals(false, ghost.directional)
+        // The stripes go too. A parked trip is a reminder of where the rider is going, and the rhythm of a
+        // shared ride at a trace's weight reads as noise rather than as a choice of routes.
+        assertEquals(emptyList<Int>(), ghost.stripeColors)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -180,7 +180,7 @@ class RouteSegmentHighlightTest {
             base = emptyList(),
             spans = listOf(span),
             colorOf = { 0xFF0072BC.toInt() },
-            stripeColorsOf = { it.interchangeableColors.filterNotNull() }
+            stripeColorsOf = { span, _ -> span.interchangeableColors.filterNotNull() }
         )
 
         assertEquals(listOf(0xFF00A94F.toInt()), result.single().stripeColors)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -156,16 +156,44 @@ class RouteSegmentHighlightTest {
         )
 
         assertEquals(listOf(45, 75), result.map { it.color })
-        // The cut goes on the span the vehicle *changed route onto*, and only there: the ride's own start
-        // is a boarding, which this view marks with the stop the rider gets on at.
-        assertEquals(listOf(RouteLineMark.NONE, RouteLineMark.INTERLINE_CUT), result.map { it.startMark })
-        // Both spans are still the selected ride: same weight, same case, no bulb between them — the
-        // rider does not get off here.
+        // The cut goes on the span the vehicle *changed route onto*, and only there. The ride's own ends
+        // are a boarding and an alighting, and take the bulbs the itinerary map gives them ([itineraryLegCaps]);
+        // the seam between the spans takes neither, because the rider sits through it.
+        assertEquals(listOf(RouteLineMark.BULB, RouteLineMark.INTERLINE_CUT), result.map { it.startMark })
+        assertEquals(listOf(RouteLineMark.NONE, RouteLineMark.BULB), result.map { it.endMark })
+        // Both spans are still the selected ride: same weight, same case.
         result.forEach {
             assertEquals(ITINERARY_RIDE_WIDTH_PROFILE, it.widthProfile)
             assertEquals(RouteLineCase.SELECTION, it.case)
-            assertEquals(RouteLineMark.NONE, it.endMark)
         }
+    }
+
+    @Test
+    fun routePolylinesWithSegment_drawsTheRideWithTheStripesItHadAsALeg() {
+        // #2241: a ride the rider may board either route for is striped on the itinerary map (#2100), and
+        // drilling in used to draw it as a plain line — so tapping a shared ride to look at it closer was
+        // exactly when the map stopped saying it was shared. The stripes are the ride's, not the route
+        // session's, so they travel on the span and are rendered by the caller's palette.
+        val span = RiddenSpan(segment, routeId = "1_100479", interchangeableColors = listOf(0xFF00A94F.toInt()))
+
+        val result = routePolylinesWithSegment(
+            base = emptyList(),
+            spans = listOf(span),
+            colorOf = { 0xFF0072BC.toInt() },
+            stripeColorsOf = { it.interchangeableColors.filterNotNull() }
+        )
+
+        assertEquals(listOf(0xFF00A94F.toInt()), result.single().stripeColors)
+    }
+
+    @Test
+    fun routePolylinesWithSegment_marksTheRidesOwnEndsWhereverItStartsAndStops() {
+        // A plain single-route ride: the rider gets on at one end and off at the other, which is what a
+        // bulb pair says (#2084) — the same thing it said on the itinerary map they tapped it from.
+        val result = routePolylinesWithSegment(emptyList(), ride(segment), colorOf = { 1 })
+
+        assertEquals(RouteLineMark.BULB, result.single().startMark)
+        assertEquals(RouteLineMark.BULB, result.single().endMark)
     }
 
     @Test
@@ -179,7 +207,11 @@ class RouteSegmentHighlightTest {
 
         val result = routePolylinesWithSegment(emptyList(), spans, colorOf = { 12 })
 
-        assertTrue(result.all { it.startMark == RouteLineMark.NONE })
+        assertTrue(result.none { it.startMark == RouteLineMark.INTERLINE_CUT })
+        // The seam itself is unmarked at both of its sides — it is interior to one ride, so neither a cut
+        // nor the bulb pair that would read as getting off and back on.
+        assertEquals(RouteLineMark.NONE, result.first().endMark)
+        assertEquals(RouteLineMark.NONE, result.last().startMark)
     }
 
     @Test
@@ -190,6 +222,10 @@ class RouteSegmentHighlightTest {
         val result = routePolylinesWithSegment(emptyList(), spans, colorOf = { 7 })
 
         assertEquals(listOf(segment), result.map { it.points })
+        // And the ride's ends are the ends of what is actually drawn: the dropped span must not take the
+        // boarding bulb down with it, leaving the drawn remainder looking like the middle of a ride.
+        assertEquals(RouteLineMark.BULB, result.single().startMark)
+        assertEquals(RouteLineMark.BULB, result.single().endMark)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteSegmentHighlightTest.kt
@@ -174,16 +174,46 @@ class RouteSegmentHighlightTest {
         // drilling in used to draw it as a plain line — so tapping a shared ride to look at it closer was
         // exactly when the map stopped saying it was shared. The stripes are the ride's, not the route
         // session's, so they travel on the span and are rendered by the caller's palette.
-        val span = RiddenSpan(segment, routeId = "1_100479", interchangeableColors = listOf(0xFF00A94F.toInt()))
+        val rideColor = 0xFF0072BC.toInt()
+        val otherColor = 0xFF00A94F.toInt()
+        // One alternative drawn in the ride's own colour, and one that is not.
+        val span = RiddenSpan(segment, routeId = "1_100479", interchangeableColors = listOf(rideColor, otherColor))
+        var stripedAgainst: Int? = null
 
         val result = routePolylinesWithSegment(
             base = emptyList(),
             spans = listOf(span),
-            colorOf = { 0xFF0072BC.toInt() },
-            stripeColorsOf = { span, _ -> span.interchangeableColors.filterNotNull() }
+            colorOf = { rideColor },
+            // The ride's resolved colour is handed to the stripe rule rather than resolved a second time,
+            // which is what lets an alternative drawn in that same colour drop out instead of striping the
+            // line with itself. Asserted through the callback, since this is the function's half of that —
+            // the filtering itself is [rideStripeColors], covered in ItineraryLegStyleTest.
+            stripeColorsOf = { striped, color ->
+                stripedAgainst = color
+                striped.interchangeableColors.filterNotNull().distinct().filterNot { it == color }
+            }
         )
 
-        assertEquals(listOf(0xFF00A94F.toInt()), result.single().stripeColors)
+        assertEquals(rideColor, stripedAgainst)
+        assertEquals(listOf(otherColor), result.single().stripeColors)
+    }
+
+    @Test
+    fun routePolylinesWithSegment_marksTheDrawnRidesStartAsABoarding_evenWhenThatSpanIsACutover() {
+        // A leader with no geometry to draw drops out, which can leave a *cutover* span first. The rider
+        // still gets on where the drawn ride begins, so that end is a boarding: a cut there would announce
+        // a change of route with nothing before it to have changed from. The itinerary map never has to
+        // decide this — a seam leg is never one the rider boards — so it is decided here.
+        val north = listOf(GeoPoint(47.60, -122.33), GeoPoint(47.62, -122.33))
+        val spans = listOf(
+            RiddenSpan(emptyList(), routeId = "45"),
+            RiddenSpan(north, routeId = "75", startsCutover = true)
+        )
+
+        val result = routePolylinesWithSegment(emptyList(), spans, colorOf = { 75 })
+
+        assertEquals(RouteLineMark.BULB, result.single().startMark)
+        assertEquals(RouteLineMark.BULB, result.single().endMark)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/RouteViewGeometryTest.kt
@@ -2,6 +2,7 @@
 package org.onebusaway.android.map
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -13,7 +14,9 @@ import org.onebusaway.android.map.render.ROUTE_BADGE_SCALE_PROFILE
 import org.onebusaway.android.map.render.ROUTE_LINE_WIDTH_PROFILE
 import org.onebusaway.android.map.render.RouteBadge
 import org.onebusaway.android.map.render.RouteBadgeTap
+import org.onebusaway.android.map.render.RouteLineCase
 import org.onebusaway.android.map.render.RouteLineDash
+import org.onebusaway.android.map.render.RouteLineMark
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.RoutePolylineTransform
 import org.onebusaway.android.map.render.haversineMeters
@@ -42,6 +45,65 @@ class RouteViewGeometryTest {
         assertEquals(line.dash, context.dash)
         assertEquals(line.transforms, context.transforms)
         assertEquals(false, context.directional)
+    }
+
+    @Test
+    fun `every reduction states its whole line, so a new feature reaches none of them`() {
+        // #2241/#2246: these used to be `copy()`-minus-a-few-fields, which made "keep it" the default for
+        // every field RoutePolyline gained — stripes (#2100) and end marks (#2084) both rode into views
+        // that had decided against them, and were noticed one incident at a time. Constructed lines make
+        // "drop it" the default instead. Asserted over a line carrying *everything*, so a field added to
+        // RoutePolyline and quietly passed through shows up here rather than on a rider's map.
+        val loaded = RoutePolyline(
+            color = 0xFF123456.toInt(),
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
+            stripeColors = listOf(0xFF654321.toInt()),
+            widthProfile = FOCUSED_ROUTE_LINE_WIDTH_PROFILE,
+            directional = true,
+            dash = RouteLineDash.TRAIL,
+            case = RouteLineCase.SELECTION,
+            startMark = RouteLineMark.INTERLINE_CUT,
+            endMark = RouteLineMark.BULB,
+            transforms = setOf(RoutePolylineTransform.ZOOM_SIMPLIFY)
+        )
+        val lines = listOf(loaded)
+
+        for ((name, reduced) in listOf(
+            "itinerary context" to lines.asItineraryContext().single(),
+            "pinned trip ghost" to lines.asPinnedTripGhost().single(),
+            "selected route approach" to lines.asSelectedRouteApproach().single(),
+            "deemphasized underlay" to lines.asDeemphasizedRouteUnderlay().single()
+        )) {
+            // Chevrons, stripes and end marks belong to the line being read at full weight. Every one of
+            // these says less than that, and none of them says any of the three.
+            assertEquals("$name kept its chevrons", false, reduced.directional)
+            assertEquals("$name kept its stripes", emptyList<Int>(), reduced.stripeColors)
+            assertEquals("$name kept a start mark", RouteLineMark.NONE, reduced.startMark)
+            assertEquals("$name kept an end mark", RouteLineMark.NONE, reduced.endMark)
+            // What every reduction is *for* is saying which line this is, so all of them keep the colour
+            // and the geometry, and none may keep the weight — that is the thing each one restates.
+            assertEquals("$name lost its colour", loaded.color, reduced.color)
+            assertEquals("$name lost its geometry", loaded.points, reduced.points)
+            assertNotEquals("$name kept its weight", loaded.widthProfile, reduced.widthProfile)
+        }
+    }
+
+    @Test
+    fun `only the itinerary context keeps the case that says what kind of line it is`() {
+        // The context is the rider's own journey, so a ride there still wears the hairline case every ride
+        // wears (#2041). The ghost drops it (a halo is exactly what a parked trip must not have, #2053),
+        // and the two route-view reductions state their own.
+        val ride = RoutePolyline(
+            color = 1,
+            points = listOf(GeoPoint(0.0, 0.0), GeoPoint(0.0, 1.0)),
+            case = RouteLineCase.OUTLINE
+        )
+        val lines = listOf(ride)
+
+        assertEquals(RouteLineCase.OUTLINE, lines.asItineraryContext().single().case)
+        assertEquals(RouteLineCase.NONE, lines.asPinnedTripGhost().single().case)
+        assertEquals(RouteLineCase.APPROACH, lines.asSelectedRouteApproach().single().case)
+        assertEquals(RouteLineCase.NONE, lines.asDeemphasizedRouteUnderlay().single().case)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineReconcilerTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/RoutePolylineReconcilerTest.kt
@@ -17,7 +17,7 @@ import org.onebusaway.android.util.GeoPoint
 class RoutePolylineReconcilerTest {
 
     /** Stand-in for a native gms/maplibre Polyline: tracks its width and removal. */
-    private class FakeLine(val polyline: RoutePolyline, var width: Float) {
+    private class FakeLine(val polyline: RoutePolyline, var width: Float, var markInset: Float) {
         var removed = false
     }
 
@@ -34,17 +34,20 @@ class RoutePolylineReconcilerTest {
 
         val reconciler = RoutePolylineReconciler<FakeLine>(
             widthOf = widthOf,
-            createLine = { polyline, width ->
+            createLine = { polyline, width, markInset ->
                 createCount++
-                FakeLine(polyline, width).also(created::add)
+                FakeLine(polyline, width, markInset).also(created::add)
             },
             removeLines = { lines ->
                 removeCount++
                 lines.forEach { it.removed = true }
             },
-            setWidth = { line, width ->
+            // The mark inset arrives with every width, create or patch: a mark sized against the stroke has
+            // to be restated when the stroke moves, so the two travel together (see the renderer's caps).
+            setWidth = { line, _, width, markInset ->
                 setWidthCount++
                 line.width = width
+                line.markInset = markInset
             },
             caseColorOf = { CASE_COLOR },
             caseExtraWidth = { it.case.extraWidthDp }
@@ -249,6 +252,26 @@ class RoutePolylineReconcilerTest {
 
         assertEquals(10f + SELECTION_CASE_EXTRA, h.cases().single().width, 0f)
         assertEquals(10f, h.strokes().single().width, 0f)
+    }
+
+    @Test
+    fun `a case insets its end marks by the weight it shows, and keeps that inset when re-widened`() {
+        // #2241: a bulb is a circle of its line's stroke width, so the case's copy of it came out wider by
+        // the case's *whole* extra while the case shows only half of that on each side of the line — a halo
+        // at twice the weight of the case beside it. The inset is what closes that, and because it is a
+        // constant weight against a stroke that follows the zoom ramp, it has to survive the re-widening
+        // rather than being a factor stamped once.
+        val h = Harness()
+        h.reconciler.reconcile(listOf(line(1, 0.0).copy(case = RouteLineCase.SELECTION)), zoom = 4f)
+
+        assertEquals(SELECTION_CASE_EXTRA / 2f, h.cases().single().markInset, 0f)
+        // The line's own marks are drawn at its full stroke: a bulb is sized from the ride it caps.
+        assertEquals(0f, h.strokes().single().markInset, 0f)
+
+        h.reconciler.resyncWidths(zoom = 10f)
+
+        assertEquals(SELECTION_CASE_EXTRA / 2f, h.cases().single().markInset, 0f)
+        assertEquals(0f, h.strokes().single().markInset, 0f)
     }
 
     @Test

--- a/onebusaway-android/src/testGoogle/java/org/onebusaway/android/map/googlemapsv2/GoogleEndpointBulbCapTest.kt
+++ b/onebusaway-android/src/testGoogle/java/org/onebusaway/android/map/googlemapsv2/GoogleEndpointBulbCapTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.googlemapsv2
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * How a bulb's halo is sized (#2241). Maps draws a custom cap at `bitmapRadius / referenceWidth` of the
+ * stroke, so the disc a bulb is drawn from comes out at exactly the stroke width — and the case's copy of
+ * it, drawn on a wider stroke, came out wider by the case's *whole* extra while the case shows only half
+ * of that on each side of the line. These pin the inset that closes the gap, stated as the drawn radius
+ * rather than as the factor, since the radius is the thing a rider sees.
+ */
+class GoogleEndpointBulbCapTest {
+
+    /** The radius the cap draws at on a stroke of [widthPx], given the reference-width factor. */
+    private fun drawnRadius(widthPx: Float, markInsetPx: Float) = widthPx / bulbReferenceScale(widthPx, markInsetPx)
+
+    @Test
+    fun `a line's own bulb is a circle of its stroke width`() {
+        // Unchanged behaviour, and the reason the inset is expressed as a factor of 1 for an ordinary line:
+        // the bulb is what says the rider gets on or off here, and it is sized from the ride it caps.
+        assertEquals(15f, drawnRadius(widthPx = 15f, markInsetPx = 0f), 0.001f)
+    }
+
+    @Test
+    fun `a case's bulb is inset, so its halo is the weight the case shows along the line`() {
+        // A selected ride: 15px stroke, cased 2.25px per side, so the case is drawn at 19.5px and its bulb
+        // must land 2.25px outside the 15px one — the same weight the rider reads beside the line, and half
+        // the 4.5px halo an un-inset copy of the bulb gave it.
+        val lineRadius = 15f
+        val band = 2.25f
+        val caseStroke = lineRadius + 2 * band
+
+        assertEquals(lineRadius + band, drawnRadius(caseStroke, markInsetPx = band), 0.001f)
+    }
+
+    @Test
+    fun `the halo keeps its weight at every stroke the zoom ramp reaches`() {
+        // The inset is a constant weight while the stroke follows the ramp, so the factor is not fixed —
+        // which is exactly why the width patch re-stamps the cap. Same band at both ends of the ramp.
+        val band = 2.25f
+        for (lineRadius in listOf(7.5f, 11.25f, 15f)) {
+            val caseStroke = lineRadius + 2 * band
+            assertEquals(
+                "halo drifted at a $lineRadius px stroke",
+                band,
+                drawnRadius(caseStroke, markInsetPx = band) - lineRadius,
+                0.001f
+            )
+        }
+    }
+
+    @Test
+    fun `a stroke thinner than the inset it asks for draws the plain disc`() {
+        // Nothing produces this today — a case is always wider than the band it shows — but inverting the
+        // cap is a far worse answer than declining to inset, so it degrades rather than going negative.
+        assertEquals(1f, bulbReferenceScale(widthPx = 2f, markInsetPx = 2f), 0.001f)
+        assertEquals(1f, bulbReferenceScale(widthPx = 1f, markInsetPx = 4f), 0.001f)
+    }
+}


### PR DESCRIPTION
Fixes #2241. Closes #2246. Replaces #2245, which took the wrong direction.

## The regression

Tapping a transit leg redraws its ride over the route it runs on, and that ride was built fresh from the route session's own vocabulary — a plain line. The stripes that say a rider may board either of two routes (#2100) were gone, and so were the end marks saying where they get on and off. **Drilling into a shared ride to look at it closer was exactly when the map stopped saying it was shared.**

The bulbs were the visible half of the same thing. They survived on the itinerary *context* drawn beneath the ride, and a mark is drawn about the line's endpoint rather than inside its stroke — so whether one showed came down to what happened to land on top of that point. On an interchangeable ride nothing did, which is why the bulbs appeared there and nowhere else. #2245 made that consistent by deleting them; it left the striping regression standing, and the bulbs were never the problem.

## The fix

The ride is the leg the rider tapped, drawn again — not a route line that happens to share its shape.

- **Stripes** travel on `RiddenSpan`, for the same reason its planned colour already does (#2186): the fact belongs to the plan, and the route session has no other way to learn it. They are rendered by that session's palette through `rideStripeColors`, the rule the itinerary's own line now also spends — one rule, so the line the rider taps and the line they get back are the same line.
- **End marks** follow the caps rule the itinerary map already computes, stated over span position because a ride's spans *are* its legs: a bulb where the rider boards and alights, an interline cut where the vehicle changed route under them, nothing at a seam they sit through.

## The drift underneath (#2246)

Two builders answered one question: `itineraryLegLines`, which left marks and stripes out, and `DirectionsMapController`'s own walk, which put them in — so the parked trip could never draw what the read trip did. `drawnItinerary` now draws at full fidelity and every view is a reduction of it.

The reductions **construct** their lines instead of `copy()`-ing minus a few fields — what `RoutePolyline.asCase` already does, for the reason it gives: a feature added to `RoutePolyline` is absent from a reduced line unless someone puts it there. Copy-minus made "keep it" the default, which is how stripes and marks rode into views that had decided against them, noticed one incident at a time. Two were still riding, harmless only because of what their producers happened not to set:

- `asPinnedTripGhost` kept `stripeColors` — safe only because its producer never set them, which unifying the builders would have ended.
- `asSelectedRouteApproach` kept both marks and stripes.

`asDeemphasizedRouteUnderlay` gets the same treatment, so no reduction is left in the old shape.

## Testing

- `one builder draws the trip, and the views of it are reductions of what it draws` — full-fidelity line, ghost derived from it.
- `every reduction states its whole line, so a new feature reaches none of them` — asserted over a line carrying every field, so a future `RoutePolyline` feature passed through quietly fails here rather than on a rider's map.
- `routePolylinesWithSegment_drawsTheRideWithTheStripesItHadAsALeg`, `…marksTheRidesOwnEndsWhereverItStartsAndStops`, plus updated interline/self-interline/skipped-span expectations.

`testObaGoogleDebugUnitTest` (map, tripresults, HomeViewModel) passes with `-PwarningsAsErrors=true`; `spotlessCheck` clean.

## Worth a look on device

- A 1 Line/2 Line leg tapped from the drawer: the ride should stay striped, in the same colours the badge names.
- The bulbs now sit at the ride's ends in route focus, where the board/alight stop circles also are. Consistent with the overview, but it is a redundancy worth eyeballing.
- A colourless alternative stripes through the ridden-route substitution while the ride's own colour does not (the drill-in has never applied it — #2041's remaining work), so the two can disagree for an agency that publishes no colour. Unchanged by this PR, but newly visible next to a stripe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved map itinerary rendering with clearer route stripes, endpoint markers, and interline transitions.
  * Preserved interchangeable-route colors across rides, route segments, and trip views.
  * Improved consistency between directions, route views, and pinned-trip map overlays.
  * Improved endpoint marker sizing across zoom levels.
* **Bug Fixes**
  * Corrected handling of itinerary legs without drawable geometry.
  * Pinned-trip overlays now remove visual emphasis while retaining route geometry and colors.
  * Improved preservation of line styling across map presentation modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->