### PR TITLE
Size the directions handle like the arrivals one (#2240)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DragHandle.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/DragHandle.kt
@@ -34,13 +34,6 @@ val DRAG_HANDLE_BAR_HEIGHT = 4.dp
 val DRAG_HANDLE_VERTICAL_PADDING = 9.dp
 val DRAG_HANDLE_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_VERTICAL_PADDING * 2
 
-// The same bar in a full 48dp band — Android's minimum touch-target size, which is also the geometry
-// Material 3 gives `BottomSheetDefaults.DragHandle`. Used by [SheetDragHandle] for a sheet that collapses
-// to a handle-only peek, where the band is all that separates a tap from the system gesture area; the
-// tighter band above is for handles sitting atop content that is already on screen.
-val DRAG_HANDLE_TOUCH_TARGET_PADDING = 22.dp
-val DRAG_HANDLE_TOUCH_TARGET_HEIGHT = DRAG_HANDLE_BAR_HEIGHT + DRAG_HANDLE_TOUCH_TARGET_PADDING * 2
-
 /**
  * The short tinted grab-bar pill drawn inside a bottom-sheet drag handle — a muted grey matching the
  * panel chrome, so it reads as part of the sheet. Callers wrap it in their own padded, gesture-bearing
@@ -58,16 +51,18 @@ fun DragHandleBar(modifier: Modifier = Modifier) {
 }
 
 /**
- * [DragHandleBar] centred in a full 48dp touch-target band ([DRAG_HANDLE_TOUCH_TARGET_HEIGHT]) — the
- * handle to hand a Material `BottomSheetScaffold` as its `sheetDragHandle`. The scaffold wraps whatever
- * it's given with the sheet's tap-to-toggle and expand/collapse accessibility actions, so this only has
- * to supply the geometry; sizing the band here (rather than using `BottomSheetDefaults.DragHandle`) keeps
- * a handle-only peek height computable from an app-owned constant instead of one of M3's private ones.
+ * [DragHandleBar] centred in the shared [DRAG_HANDLE_HEIGHT] band — the handle to hand a Material
+ * `BottomSheetScaffold` as its `sheetDragHandle`. The scaffold wraps whatever it's given with the sheet's
+ * tap-to-toggle and expand/collapse accessibility actions, so this only has to supply the geometry;
+ * sizing the band here (rather than using `BottomSheetDefaults.DragHandle`, whose 48dp band read as an
+ * oversized grab strip next to the arrivals sheet — #2240) keeps a handle-only peek height computable
+ * from an app-owned constant instead of one of M3's private ones, and keeps the two sheets' handles the
+ * same size.
  */
 @Composable
 fun SheetDragHandle(modifier: Modifier = Modifier) {
     Box(
-        modifier = modifier.padding(vertical = DRAG_HANDLE_TOUCH_TARGET_PADDING),
+        modifier = modifier.padding(vertical = DRAG_HANDLE_VERTICAL_PADDING),
         contentAlignment = Alignment.Center
     ) {
         DragHandleBar()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -97,7 +97,7 @@ import org.onebusaway.android.ui.arrivals.components.EtaStripMarker
 import org.onebusaway.android.ui.arrivals.components.countBefore
 import org.onebusaway.android.ui.arrivals.rememberArrivalRowCallbacks
 import org.onebusaway.android.ui.compose.components.CenteredLongPressMenu
-import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_TOUCH_TARGET_HEIGHT
+import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.MenuRow
 import org.onebusaway.android.ui.compose.components.RouteBadge
 import org.onebusaway.android.ui.compose.components.SheetDragHandle
@@ -304,7 +304,7 @@ fun DirectionsResultsSheet(
     // content is padded above the nav chrome so the collapsed handle (and the last list row) aren't
     // stranded under the gesture pill / 3-button bar. The peek includes it so the handle clears it.
     val navBottom = navigationBarBottomPadding()
-    val peekHeight = DRAG_HANDLE_TOUCH_TARGET_HEIGHT + navBottom
+    val peekHeight = DRAG_HANDLE_HEIGHT + navBottom
     // containerSize (px), not Configuration.screenHeightDp (lint-flagged as unreliable across insets).
     //
     // Floored at the peek, because a sheet shorter than its own peek inverts the two states: M3 anchors
@@ -359,8 +359,8 @@ fun DirectionsResultsSheet(
         sheetTonalElevation = 2.dp,
         sheetShadowElevation = 8.dp,
         // The scaffold supplies the drag gesture and the tap/accessibility actions around whatever handle
-        // it's given, so this is the app's own bar — the same one the arrivals sheet shows — in the 48dp
-        // band [DRAG_HANDLE_TOUCH_TARGET_HEIGHT] measures for the peek above.
+        // it's given, so this is the app's own bar — the same one the arrivals sheet shows, in the same
+        // [DRAG_HANDLE_HEIGHT] band the peek above measures for (#2240).
         sheetDragHandle = { SheetDragHandle() },
         sheetContent = {
             // Sized so handle + content == fullHeight, which is what sets the sheet's expanded anchor.
@@ -383,7 +383,7 @@ fun DirectionsResultsSheet(
                 onOptionsSeeded = onOptionsSeeded,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(fullHeight - DRAG_HANDLE_TOUCH_TARGET_HEIGHT)
+                    .height(fullHeight - DRAG_HANDLE_HEIGHT)
                     .navigationBarsPadding()
             )
         },


### PR DESCRIPTION
Fixes #2240.

The two bottom sheets drew the same 32×4dp grab bar but in different bands: the arrivals handle centres it in the shared 22dp band (`DRAG_HANDLE_HEIGHT`), while the directions handle used a separate 48dp touch-target band, so the collapsed directions strip read as an oversized grab bar next to it.

`SheetDragHandle` now centres the bar in the same `DRAG_HANDLE_HEIGHT` band, and the directions sheet's peek and expanded-content math follow the one constant. The `DRAG_HANDLE_TOUCH_TARGET_*` constants had no other caller and are gone, so there's a single handle geometry left to drift.

Worth knowing: that 48dp band was Android's minimum touch-target size, and the handle is what a tap toggles on a sheet that collapses to handle-only. The tap band is now 22dp tall (full sheet width), with the nav-bar inset still padding the peek below it, and the scaffold's drag gesture unchanged across the whole sheet.

Compiles clean under `-PwarningsAsErrors=true`; `spotlessCheck` passes. Not device-verified — the visual check is worth a look on the directions results sheet, collapsed and expanded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the sheet drag handle spacing for a more consistent layout.
  * Adjusted directions sheet sizing to align with the updated drag handle dimensions.
  * Improved collapsed and expanded sheet height behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->