### PR TITLE
Render the drawer's beta marker as a pill, not a string (#2253)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/BetaPill.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/BetaPill.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+
+/** Fully rounded, so the pill reads as a tag pinned to the label rather than as a second button. */
+private val PILL_SHAPE = RoundedCornerShape(percent = 50)
+private val PILL_H_PADDING = 6.dp
+private val PILL_V_PADDING = 1.dp
+
+/** Wide tracking is what makes four capitals at this size read as a badge rather than as a shouted word. */
+private val PILL_LETTER_SPACING = 0.5.sp
+
+/**
+ * The "BETA" tag that marks a feature as still in beta — a small capitalized pill on a secondary
+ * container, sat beside the feature's own name.
+ *
+ * It exists so that name can stay a plain, translatable noun phrase ("Plan a trip") instead of carrying
+ * "(beta)" baked into every locale's string (#2253): the qualifier is a piece of *presentation*, and
+ * gluing it into the string means every translation has to repeat it, no caller can show the name
+ * without it, and it can never be styled apart from the label it qualifies. Rendered as its own
+ * composable it is one word in one place, and dropping it when a feature graduates is a one-line change
+ * at each call site rather than a string edit in every locale.
+ *
+ * TalkBack reads it as part of the surrounding row's label — "Plan a trip, beta" — which is the whole
+ * point of the qualifier, so it is deliberately not marked as decorative.
+ */
+@Composable
+fun BetaPill(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = PILL_SHAPE,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = stringResource(R.string.beta_pill),
+            modifier = Modifier.padding(horizontal = PILL_H_PADDING, vertical = PILL_V_PADDING),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = PILL_LETTER_SPACING
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "BetaPill — beside a label")
+@Composable
+private fun BetaPillPreview() {
+    ObaTheme {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            Column(Modifier.padding(12.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Plan a trip", style = MaterialTheme.typography.labelLarge)
+                    Spacer(Modifier.width(8.dp))
+                    BetaPill()
+                }
+                Spacer(Modifier.height(12.dp))
+                BetaPill()
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/BetaPill.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/BetaPill.kt
@@ -15,10 +15,8 @@
  */
 package org.onebusaway.android.ui.compose.components
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -81,13 +79,11 @@ fun BetaPill(modifier: Modifier = Modifier) {
 private fun BetaPillPreview() {
     ObaTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
-            Column(Modifier.padding(12.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("Plan a trip", style = MaterialTheme.typography.labelLarge)
-                    Spacer(Modifier.width(8.dp))
-                    BetaPill()
-                }
-                Spacer(Modifier.height(12.dp))
+            // In context, which is the only way the pill is used — its whole job is to sit next to a
+            // feature's name, and it takes no parameters, so a bare instance would show nothing more.
+            Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                Text("Plan a trip", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.width(8.dp))
                 BetaPill()
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/HomeNavDrawer.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/HomeNavDrawer.kt
@@ -90,7 +90,7 @@ fun HomeNavDrawerSheet(
                     R.string.navdrawer_item_plan_trip,
                     R.drawable.ic_maps_directions,
                     onPlanTrip,
-                    beta = true
+                    tag = { BetaPill() }
                 )
             }
             if (payFareAvailable) {
@@ -106,29 +106,35 @@ fun HomeNavDrawerSheet(
     }
 }
 
-/** The gap between a row's name and its [BetaPill] — a word's worth, so the pill reads as a tag on the
- *  name rather than as part of it. */
-private val BETA_PILL_GAP = 8.dp
+/** The gap between a row's name and its [tag][DrawerRow] — a word's worth, so the tag reads as pinned
+ *  to the name rather than as part of it. */
+private val DRAWER_ROW_TAG_GAP = 8.dp
 
+/**
+ * One drawer row. [tag] optionally puts a small marker right after the name — a [BetaPill] today — as a
+ * slot rather than a per-marker flag, so a second kind of tag is another caller passing a composable
+ * instead of another boolean here.
+ *
+ * The tag sits against the name rather than in `NavigationDrawerItem`'s own `badge` slot, which would
+ * push it to the row's trailing edge: it qualifies the name ("Plan a trip, in beta"), so it belongs
+ * where the name ends, not across the drawer from it. The name yields the room the tag needs and wraps
+ * into what is left, so a longer translation can't shoulder the tag out of the row.
+ */
 @Composable
 private fun DrawerRow(
     @StringRes title: Int,
     @DrawableRes icon: Int?,
     onClick: () -> Unit,
-    beta: Boolean = false
+    tag: (@Composable () -> Unit)? = null
 ) {
     NavigationDrawerItem(
         label = {
-            if (beta) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(BETA_PILL_GAP),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(stringResource(title))
-                    BetaPill()
-                }
-            } else {
-                Text(stringResource(title))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(DRAWER_ROW_TAG_GAP),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(stringResource(title), modifier = Modifier.weight(1f, fill = false))
+                tag?.invoke()
             }
         },
         selected = false,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/HomeNavDrawer.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/HomeNavDrawer.kt
@@ -17,7 +17,9 @@ package org.onebusaway.android.ui.home.drawer
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -32,12 +34,14 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
+import org.onebusaway.android.ui.compose.components.BetaPill
 import org.onebusaway.android.ui.tutorial.LocalTutorialState
 import org.onebusaway.android.ui.tutorial.ScriptedTutorial
 import org.onebusaway.android.ui.tutorial.tutorialAnchor
@@ -80,7 +84,14 @@ fun HomeNavDrawerSheet(
                 DrawerRow(R.string.navdrawer_item_my_reminders, R.drawable.ic_drawer_alarm, onReminders)
             }
             if (planTripAvailable) {
-                DrawerRow(R.string.navdrawer_item_plan_trip, R.drawable.ic_maps_directions, onPlanTrip)
+                // The trip planner is still in beta, and says so with a pill beside its name rather
+                // than "(beta)" glued into the string every locale has to repeat (#2253).
+                DrawerRow(
+                    R.string.navdrawer_item_plan_trip,
+                    R.drawable.ic_maps_directions,
+                    onPlanTrip,
+                    beta = true
+                )
             }
             if (payFareAvailable) {
                 DrawerRow(R.string.navdrawer_item_pay_fare, R.drawable.credit_card, onPayFare)
@@ -95,14 +106,31 @@ fun HomeNavDrawerSheet(
     }
 }
 
+/** The gap between a row's name and its [BetaPill] — a word's worth, so the pill reads as a tag on the
+ *  name rather than as part of it. */
+private val BETA_PILL_GAP = 8.dp
+
 @Composable
 private fun DrawerRow(
     @StringRes title: Int,
     @DrawableRes icon: Int?,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    beta: Boolean = false
 ) {
     NavigationDrawerItem(
-        label = { Text(stringResource(title)) },
+        label = {
+            if (beta) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(BETA_PILL_GAP),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(stringResource(title))
+                    BetaPill()
+                }
+            } else {
+                Text(stringResource(title))
+            }
+        },
         selected = false,
         icon = icon?.let { res ->
             // Pin to the standard 24dp; some drawer drawables are hi-res PNGs whose intrinsic size

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -29,7 +29,7 @@
     <string name="navdrawer_item_help">Ayuda</string>
     <string name="navdrawer_item_send_feedback">Enviar comentarios</string>
     <string name="navdrawer_item_open_source">Visitanos en GitHub</string>
-    <string name="navdrawer_item_plan_trip">Planea un Viaje (beta)</string>
+    <string name="navdrawer_item_plan_trip">Planea un Viaje</string>
     <string name="navdrawer_item_pay_fare">Pagar mi pasaje</string>
 
     <!-- Permissions -->

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -26,7 +26,7 @@
     <string name="navdrawer_item_help">Ohjeet</string>
     <string name="navdrawer_item_send_feedback">Lähetä palautetta</string>
     <string name="navdrawer_item_open_source">Vieraile GitHubissa</string>
-    <string name="navdrawer_item_plan_trip">Suunnittele matka (beta)</string>
+    <string name="navdrawer_item_plan_trip">Suunnittele matka</string>
     <string name="navdrawer_item_pay_fare">Maksa matkalippu</string>
     <string name="navdrawer_item_starred_routes">Tähdellä merkityt linjat</string>
 

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -27,7 +27,7 @@
     <string name="navdrawer_item_help">Aiuto</string>
     <string name="navdrawer_item_send_feedback">Invia feedback</string>
     <string name="navdrawer_item_open_source">Scoprici su GitHub!</string>
-    <string name="navdrawer_item_plan_trip">Pianifica un viaggio (beta)</string>
+    <string name="navdrawer_item_plan_trip">Pianifica un viaggio</string>
     <string name="navdrawer_item_pay_fare">Compra biglietto</string>
 
     <!-- Permissions -->

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -10,7 +10,7 @@
     <string name="navdrawer_item_send_feedback">Wyślij opinię</string>
     <string name="navdrawer_item_starred_routes">Ulubione linie</string>
     <string name="navdrawer_item_open_source">Odwiedź nas na GitHubie</string>
-    <string name="navdrawer_item_plan_trip">Zaplanuj podróż (beta)</string>
+    <string name="navdrawer_item_plan_trip">Zaplanuj podróż</string>
     <string name="navdrawer_item_pay_fare">Zapłać za bilet</string>
 
     <!-- Permissions -->

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="navdrawer_item_help">Help</string>
     <string name="navdrawer_item_send_feedback">Send feedback</string>
     <string name="navdrawer_item_open_source">Visit us on GitHub</string>
-    <string name="navdrawer_item_plan_trip">Plan a trip (beta)</string>
+    <string name="navdrawer_item_plan_trip">Plan a trip</string>
     <string name="navdrawer_item_pay_fare">Pay my fare</string>
 
     <!-- Permissions -->
@@ -38,6 +38,8 @@
     </string>
 
     <!-- Generic -->
+    <!-- Pill shown beside the name of a feature that is still in beta. -->
+    <string name="beta_pill">BETA</string>
     <string name="generic_comm_error">Sorry, there was a communication error and we can’t show this
         information. Try again and it might work.
     </string>


### PR DESCRIPTION
Closes #2253.

## What

The drawer's trip-planner row named itself **"Plan a trip (beta)"** — one string carrying both the feature's name and a note about its maturity. Now the string is just **"Plan a trip"**, and a new `BetaPill` composable renders `BETA` as a small capitalized pill beside it.

## Why it's worth splitting

Gluing the qualifier into the string means every locale has to repeat it (all four that translate this row did), no caller can show the name without it, and it can never be styled apart from the label it qualifies. As its own composable it's one word in one place, and graduating the feature out of beta becomes a one-line change at the call site rather than a string edit in every locale.

## Notes

- **The pill sits against the name, not at the row's trailing edge.** `NavigationDrawerItem` has its own `badge` slot, which would push the marker across the drawer; this marker qualifies the *name*, so it belongs where the name ends. That choice is written down at `DrawerRow` rather than left implicit in the layout.
- **`DrawerRow` takes a `tag: (@Composable () -> Unit)?` slot**, not a `beta: Boolean` — a second kind of marker is another caller passing a composable, not another flag on the shared row.
- The name takes `weight(1f, fill = false)`, so a longer translation wraps into the room it has instead of shouldering the pill out of the 260dp drawer.
- **TalkBack** reads the row as "Plan a trip, beta" — the pill is a plain `Text`, deliberately not marked decorative, because the qualifier is information.
- `beta_pill` is **translatable**: all four locales already wrote "beta" lowercase in their own strings, so a translator may reasonably want to case it differently.
- The stale `(beta)` was dropped from `values-es`, `-fi`, `-it`, `-pl`, which would otherwise have rendered "Pianifica un viaggio (beta) BETA".

## Scope

Other `(beta)` strings elsewhere in the app (`destination_reminder_dialog_title`, `preferences_trip_plan_notifications_title`, `NotificationChannels.kt`) are left alone — #2253 is about the drawer. `BetaPill` is now available if we want to convert them.

## Testing

`spotlessApply` + `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` clean; built and installed on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prominent “BETA” badge beside the “Plan a trip” option in the navigation drawer.
  * Improved label layout to keep the badge visible alongside wrapped text.

* **Localization**
  * Updated English, Spanish, Finnish, Italian, and Polish trip-planning labels to remove the “(beta)” suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->