### PR TITLE
Call the itinerary cards columns in the tutorial (#2252)

### DIFF
--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -948,10 +948,10 @@
         far you’ll walk, and when you want to leave or arrive.
     </string>
     <string name="tutorial_scripted_itineraries_title">Several ways to go</string>
-    <string name="tutorial_scripted_itineraries_text">Each row is a different way to make the trip.</string>
+    <string name="tutorial_scripted_itineraries_text">Each column is a different way to make the trip.</string>
     <string name="tutorial_scripted_itinerary_detail_title">See it on the map</string>
-    <string name="tutorial_scripted_itinerary_detail_text">Tap a row to open it up — the map draws that
-        trip, and you can step through each leg of it.
+    <string name="tutorial_scripted_itinerary_detail_text">Tap a column to show trip details on the
+        map and in the directions drawer.
     </string>
     <string name="tutorial_scripted_leg_title">Focus route stage</string>
     <string name="tutorial_scripted_leg_text">Tap on a route stage to show it on the map, along with


### PR DESCRIPTION
Fixes #2252.

The scripted tutorial's trip-planning steps described the itinerary list as rows, but it renders as a horizontal strip of columns.

- **Several ways to go** — "Each **column** is a different way to make the trip."
- **See it on the map** — "Tap a **column** to show trip details on the map and in the directions drawer."

String-resource only; neither string has translations to update (they exist in `values/strings.xml` alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the in-app tutorial to describe itinerary options as columns.
  * Clarified that tapping a column displays trip details on the map and in the directions drawer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->