### PR TITLE
Walk to the first stop when the plan says, not when the rider looks (#2248)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -542,11 +542,14 @@ private fun DirectionStopEtaStripContent(
  * The strip's "you get here at …" rule for [reachStop].
  *
  * The rule is handed to [EtaStrip] as a *resolver* against the strip's own live clock rather than as
- * an instant: a [ReachStop.OnFoot] is now plus the walk (#2227), so it has to move with the clock, and
- * the strip is the one place already ticking one (#1781) — its pills and this rule then read the same
- * now. That reads as the rule holding still at the rider's walking distance while the pills flow past
- * it, which is exactly what it means: everything left of the rule is a departure they can no longer
- * walk to in time. A [ReachStop.OnArrival] is an absolute moment and ignores the clock it is handed.
+ * an instant: a [ReachStop.OnFoot] is the walk added to when the rider sets off (#2227), so it has to
+ * move with the clock, and the strip is the one place already ticking one (#1781) — its pills and this
+ * rule then read the same now. That reads as the rule holding still at the rider's walking distance
+ * while the pills flow past it, which is exactly what it means: everything left of the rule is a
+ * departure they can no longer walk to in time. A walk a depart-at plan hasn't started yet holds at the
+ * planned departure plus the walk instead, until the clock reaches it (#2248) — a plan hours out rules
+ * where the plan put it, not where the rider happened to open it. A [ReachStop.OnArrival] is an absolute
+ * moment and ignores the clock it is handed.
  *
  * Remembered so the marker is one stable object per plan: the strip keys its per-minute spoken text on
  * it, and the strip's own callers are already stable between polls.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripLogBuilder.kt
@@ -144,11 +144,21 @@ object TripLogBuilder {
      * that absence is carried as null rather than substituted for with the ride's own departure — see
      * [TripLogEntry.Transit.reachStop] for what that would tell the rider. The empty-run guard is what
      * says so: an empty run would otherwise pass the all-street test and fabricate a zero-length walk.
+     *
+     * [plannedStart] rules the walk too, as the floor on when that run begins ([ReachStop.OnFoot.notBefore],
+     * #2248) — the same fact, spent on both shapes of the itinerary's first entry, so the two agree about
+     * whether a plan hours out has started. The walk keeps the duration shape rather than being resolved
+     * here into `OnArrival(plannedStart + walk)`, because the floor has to be re-taken against the live
+     * clock: past the planned departure the rider is setting out *now*, and an instant fixed at build time
+     * would sit in the past and rule nothing.
      */
     private fun List<TripLeg>.reachStopFor(legIndex: Int, plannedStart: ServerTime?): ReachStop? {
         val precedingLegs = take(legIndex).ifEmpty { return plannedStart?.let(ReachStop::OnArrival) }
         return if (precedingLegs.all { it.isStreet }) {
-            ReachStop.OnFoot(precedingLegs.last().endTime - precedingLegs.first().startTime)
+            ReachStop.OnFoot(
+                duration = precedingLegs.last().endTime - precedingLegs.first().startTime,
+                notBefore = plannedStart
+            )
         } else {
             ReachStop.OnArrival(precedingLegs.last().endTime)
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsScreen.kt
@@ -2367,7 +2367,7 @@ private fun previewTransitLeg(
     mode = mode,
     routeColorHex = routeColorHex,
     headsign = headsign,
-    reachStop = ReachStop.OnFoot(3.minutes),
+    reachStop = ReachStop.OnFoot(3.minutes, notBefore = null),
     boardTime = ServerTime(4 * 60_000L),
     exitTime = ServerTime(20 * 60_000L),
     durationMinutes = 16,
@@ -2396,7 +2396,7 @@ private fun previewFerryLeg(alerts: List<TripAlertItem> = emptyList()) = preview
     rideEvents = emptyList(),
     alerts = alerts
 ).copy(
-    reachStop = ReachStop.OnFoot(20.minutes),
+    reachStop = ReachStop.OnFoot(20.minutes, notBefore = null),
     boardTime = ServerTime(24 * 60_000L),
     exitTime = ServerTime(84 * 60_000L),
     durationMinutes = 60,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripresults/TripResultsUiState.kt
@@ -200,13 +200,15 @@ sealed interface TripLogEntry {
      * [reachStop] and [boardTime] are different things and both matter: the rider gets to the stop by
      * the first and the vehicle leaves at the second. The gap between them is the planned wait, and it's
      * what the Board node's live ETA strip marks (#2125) — without it the strip reads as if the rider
-     * were standing at the stop already. When nothing precedes the ride, the plan's own start stands in
-     * (#2228): a "leave at 5pm" plan puts the rider at the stop at 5pm, so read at 3pm every departure
-     * before then is genuinely out of reach — the strip says so instead of offering them. [reachStop] is
-     * **null** only when the plan doesn't say when the rider sets out (an arrive-by plan that opens on
-     * transit). Substituting [boardTime] there would dim every departure earlier than the one the plan
-     * happened to pick — including the ones a rider already at the stop could catch — which is the
-     * opposite of the truth.
+     * were standing at the stop already. A depart-at plan's own start is spent on the itinerary's first
+     * ride either way it can be reached: it stands in whole when nothing precedes the ride (#2228), and
+     * is when the leading walk sets off when one does (#2248). So a "leave at 5pm" plan read at 3pm puts
+     * the rider at that stop at 5pm (plus the walk, if any) and every departure before then is genuinely
+     * out of reach — the strip says so instead of offering them, as the later rides' own strips already
+     * did. [reachStop] is **null** only when the plan doesn't say when the rider sets out (an arrive-by
+     * plan that opens on transit). Substituting [boardTime] there would dim every departure earlier than
+     * the one the plan happened to pick — including the ones a rider already at the stop could catch —
+     * which is the opposite of the truth.
      */
     data class Transit(
         val routeShortName: String?,
@@ -243,13 +245,17 @@ sealed interface TripLogEntry {
  *    walk they make across that transfer. When the ride opens the itinerary nothing delivers them and
  *    the plan's own start is that moment instead (#2228) — a "leave at 5pm" plan has them at the stop
  *    at 5pm.
- *  - [OnFoot] — the rider makes their own way here from the itinerary's origin, and all the plan really
- *    knows is [OnFoot.duration]: how long that takes, not when they set off. Resolved against the live
- *    clock at the point of use (the ETA strip's own), so the rule means "if you set off now".
+ *  - [OnFoot] — the rider makes their own way here from the itinerary's origin, and the plan commits to
+ *    no moment they arrive: [OnFoot.duration] is how long the way there takes, and [OnFoot.notBefore]
+ *    the soonest they set off along it. So the rule is *re-taken* at the point of use against the live
+ *    clock (the ETA strip's own) and means "if you set off now" — or at the plan's own departure while
+ *    that is still ahead of the clock (#2248), which is the same sentence with a later "now".
  *
- * The distinction is a type rather than a nullable "…or use the duration" flag so the two can't be
- * confused at a call site: an absolute instant and an amount of time are not interchangeable, and the
- * bug this replaces was precisely one being read as the other.
+ * The distinction is a type rather than one shape with a nullable "…and this is a duration" flag so the
+ * two can't be confused at a call site — the bug this replaces was precisely one being read as the
+ * other. What separates them is not instant-vs-duration (an [OnFoot] names an instant too) but whether
+ * the clock moves the answer: an [OnArrival] is a moment the plan has committed to and stands wherever
+ * it is read from, and an [OnFoot] is a rule resolved afresh every time it is asked.
  */
 sealed interface ReachStop {
 
@@ -257,7 +263,8 @@ sealed interface ReachStop {
     data class OnArrival(val at: ServerTime) : ReachStop
 
     /**
-     * The rider walks (or bikes) here from the trip's origin, and it takes [duration].
+     * The rider walks (or bikes) here from the trip's origin, it takes [duration], and they set off no
+     * earlier than [notBefore].
      *
      * Deliberately a duration and not the access leg's own end time. OTP time-shifts the *leading*
      * street run of an itinerary as late as it can — it ends on the departure it was planned for, so
@@ -280,18 +287,37 @@ sealed interface ReachStop {
      * "now plus the walk" is the right rule regardless of where the plan put the walk — so the shape
      * degrades benignly; the only thing lost would be the option of trusting that server's end time,
      * which nothing depends on.
+     *
+     * [notBefore] is when the rider sets off, when the plan says: the requested departure of a depart-at
+     * plan ([TripPlanParams.plannedStart][org.onebusaway.android.ui.tripplan.TripPlanParams.plannedStart],
+     * #2248), and null for an arrive-by one, which fixes when the trip ends and says nothing about when
+     * the rider sets out. It is a *floor* on the walk's start rather than its start outright — [resolvedAt]
+     * takes the later of it and now — because the rider who opens a "leave at 8:45pm" plan at 8:50pm is
+     * setting out now, exactly like a leave-now rider, and the two are one case. (A leave-now plan does
+     * name a start, the instant it was submitted; the floor is already behind the clock there, so the max
+     * leaves it behind and the case falls out rather than being special-cased.) Without it the walk would
+     * resolve at the live clock unconditionally, so a plan hours out would rule its first ride at "if you
+     * left this second" while every ride after it ruled at the plan's own times — the two ends of one
+     * itinerary disagreeing about whether it has started yet. Stated at every construction, with no
+     * default: a site that forgot to say would take "no floor" silently, which is #2248 itself back
+     * again — and null is a real answer here (an arrive-by plan), not an unset one.
      */
-    data class OnFoot(val duration: Duration) : ReachStop
+    data class OnFoot(val duration: Duration, val notBefore: ServerTime?) : ReachStop
 }
 
 /**
- * The moment the rider reaches the stop, as of [now] — an [ReachStop.OnArrival]'s own instant, or
- * [now] plus the walk for a [ReachStop.OnFoot]. The one place the two shapes collapse to a comparable
- * instant, so the ETA strip's rule and anything else that wants one can't disagree about how.
+ * The moment the rider reaches the stop, as of [now] — an [ReachStop.OnArrival]'s own instant, or the
+ * walk added to when the rider sets off for a [ReachStop.OnFoot]. The one place the two shapes collapse
+ * to a comparable instant, so the ETA strip's rule and anything else that wants one can't disagree
+ * about how.
+ *
+ * Setting off is the later of [now] and [ReachStop.OnFoot.notBefore], for the reason given there. Taking
+ * the later of the two also keeps the walk rule monotonic in [now] — it only ever moves later as the
+ * clock runs — which is what lets the strip re-resolve it every poll and never see it retreat.
  */
 fun ReachStop.resolvedAt(now: ServerTime): ServerTime = when (this) {
     is ReachStop.OnArrival -> at
-    is ReachStop.OnFoot -> now + duration
+    is ReachStop.OnFoot -> maxOf(now, notBefore ?: now) + duration
 }
 
 /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ReachStopTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/ReachStopTest.kt
@@ -28,12 +28,35 @@ class ReachStopTest {
 
     @Test
     fun aWalkKeepsItsDistanceAsTheClockRuns() {
-        // Measured *from now*, so the rule holds still at the rider's walking distance while the strip's
-        // pills flow past it — which is what "if you set off now" means (#2227).
-        val onFoot = ReachStop.OnFoot(4.minutes)
+        // Measured *from now* when the plan names no departure to wait for, so the rule holds still at the
+        // rider's walking distance while the strip's pills flow past it — "if you set off now" (#2227).
+        val onFoot = ReachStop.OnFoot(4.minutes, notBefore = null)
 
         assertEquals(ServerTime(14 * 60_000L), onFoot.resolvedAt(ServerTime(10 * 60_000L)))
         assertEquals(ServerTime(24 * 60_000L), onFoot.resolvedAt(ServerTime(20 * 60_000L)))
+    }
+
+    @Test
+    fun aWalkAPlanHasNotStartedYet_waitsForThePlansOwnDeparture() {
+        // A depart-at plan read hours early: the rider sets off at the departure they asked for, not the
+        // moment they opened the itinerary, so the rule stands at that departure plus the walk however
+        // early the strip polls (#2248). Otherwise this leg would offer live departures while every later
+        // leg of the same plan reported nothing boardable.
+        val onFoot = ReachStop.OnFoot(4.minutes, notBefore = ServerTime(60 * 60_000L))
+
+        assertEquals(ServerTime(64 * 60_000L), onFoot.resolvedAt(ServerTime(10 * 60_000L)))
+        assertEquals(ServerTime(64 * 60_000L), onFoot.resolvedAt(ServerTime(59 * 60_000L)))
+    }
+
+    @Test
+    fun aWalkPastThePlansDeparture_setsOffNow() {
+        // Once the planned departure is behind us the floor stops binding and the rule resumes trailing
+        // the clock — the rider is setting out now, like any other. The boundary is the first assertion:
+        // the two cases meet at the planned departure rather than jumping at it.
+        val onFoot = ReachStop.OnFoot(4.minutes, notBefore = ServerTime(60 * 60_000L))
+
+        assertEquals(ServerTime(64 * 60_000L), onFoot.resolvedAt(ServerTime(60 * 60_000L)))
+        assertEquals(ServerTime(74 * 60_000L), onFoot.resolvedAt(ServerTime(70 * 60_000L)))
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripresults/TripLogBuilderTest.kt
@@ -290,7 +290,9 @@ class TripLogBuilderTest {
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(ReachStop.OnFoot(4.minutes), transit.reachStop)
+        // No plannedStart — an arrive-by plan says nothing about when the rider sets out — so the walk
+        // carries no floor and goes on resolving at the live clock (#2248).
+        assertEquals(ReachStop.OnFoot(4.minutes, notBefore = null), transit.reachStop)
         assertEquals(ServerTime(9 * 60_000L), transit.boardTime)
     }
 
@@ -317,7 +319,7 @@ class TripLogBuilderTest {
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(ReachStop.OnFoot(10.minutes), transit.reachStop)
+        assertEquals(ReachStop.OnFoot(10.minutes, notBefore = null), transit.reachStop)
     }
 
     @Test
@@ -368,20 +370,23 @@ class TripLogBuilderTest {
     }
 
     @Test
-    fun thePlansStart_standsInOnlyForARideNothingPrecedes() {
-        // With a walk ahead of the ride, the walk is how the rider gets to the stop; the plan's start is
-        // when they left home, and must not displace it.
+    fun thePlansStart_doesNotDisplaceTheWalkButSaysWhenItBegins() {
+        // With a walk ahead of the ride, the walk is still how the rider gets to the stop — the plan's
+        // start is when they leave home, not when they arrive, so it must not stand in for the walk. It
+        // does say when they set off, which the walk carries as its floor (#2248): a plan hours out is
+        // read as starting then, the same way the ride-first shape above is.
+        val start = ServerTime(2 * 60_000L)
         val transit = TripLogBuilder
             .build(
                 legs = listOf(walkLeg, transitLeg),
                 flatDirections = listOf(walkDir, boardDir, alightDir),
                 routeLegRefs = listOf(null, transitRef),
-                plannedStart = ServerTime(0L)
+                plannedStart = start
             )
             .filterIsInstance<TripLogEntry.Transit>()
             .single()
 
-        assertEquals(ReachStop.OnFoot(walkLeg.duration), transit.reachStop)
+        assertEquals(ReachStop.OnFoot(walkLeg.duration, notBefore = start), transit.reachStop)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2248.

## What was wrong

An itinerary planned to depart at 8:45pm and opened at 3:48pm disagreed with itself about whether it had started. Its later rides collapsed to "No live departures yet" — nothing in the arrivals feed reaches that far — while the first ride's ETA strip offered the departures leaving right now.

The two ends take different shapes of the same rule. A ride something *delivers* the rider to gets `ReachStop.OnArrival`, an absolute instant the plan commits to, and hours out nothing in the poll clears it. A ride the rider *walks* to from the origin gets `ReachStop.OnFoot`, a duration — deliberately, since OTP time-shifts the access leg to end on the departure it picked, so that leg's own end time is `boardTime` restated — and `resolvedAt` resolved it as `now + duration`: "if you set off this second". For a leave-now plan that is exactly right. For a depart-at plan it read the rider as having set out the moment they opened the itinerary.

## The fix

`plannedStart` — the plan's requested departure — was already threaded to `TripLogBuilder.reachStopFor` for the neighbouring branch (#2228, the ride that *opens* an itinerary). The leading walk now carries it too, as `ReachStop.OnFoot.notBefore`: the earliest the rider sets off. `resolvedAt` takes the later of it and now:

```kotlin
is ReachStop.OnFoot -> maxOf(now, notBefore ?: now) + duration
```

That leaves today's live-clock behaviour untouched for a leave-now plan and for a depart-at plan opened *after* its time has come — the rider setting out at 8:50pm on an 8:45pm plan is setting out now, the same case, not a second branch. It stays a floor on a duration rather than becoming `OnArrival(plannedStart + walk)`, because that instant would sit in the past once the departure passed and rule nothing; the floor also keeps the walk rule monotonic in `now`, which is what lets the strip re-resolve it per poll and never see it retreat.

So one fact — the plan's own start — is now spent on both shapes an itinerary's first entry can take, and both ends of a plan hours out agree that it hasn't started yet.

`notBefore` takes no default, following `LegBadge.join` next door: a construction site that forgot to say would silently mean "no floor", which is this bug back again — and null is a real answer here (an arrive-by plan), not an unset one.

## Not in scope

An arrive-by plan is unchanged: it names no start, `notBefore` is null there. Whether a plan whose *whole* window is far in the future should carry a live strip at all — for either plan kind — is the separate question the issue leaves open, and this change is a prerequisite for it either way.

## Testing

JVM unit tests, all passing:

- `ReachStopTest` gains the waiting case (the rule stands at the planned departure plus the walk however early the strip polls) and the release case (past the planned departure the floor stops binding and the rule resumes trailing the clock, meeting at the boundary rather than jumping).
- `TripLogBuilderTest` asserts the leading walk carries the plan's start as its floor, and the existing access-walk / multi-leg-access cases now state `notBefore = null` explicitly.

`./gradlew spotlessApply`, the affected unit tests, and `compileObaGoogleDebugKotlin -PwarningsAsErrors=true` are green. Not yet exercised on a device — the visible check is planning a trip with a walk to the first boarding stop, departing several hours out, and confirming the first ride's Board row now collapses like the later ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved walking ETA calculations for depart-at trip plans.
  * Walking segments now wait until the planned departure when appropriate.
  * Plans opened after their departure time correctly calculate walking time from the current moment.
  * Arrive-by plans continue to use their fixed arrival time behavior.

* **Tests**
  * Added coverage for planned-departure and late-opening walking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->