### PR TITLE
Ship releases from CI, closed track first, and cut 27.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+name: Release to Google Play
+
+# Builds a signed obaGoogle release App Bundle and uploads it to Google Play via
+# gradle-play-publisher (the `play {}` block in onebusaway-android/build.gradle.kts).
+#
+# Manual dispatch only. Publishing is an outward-facing, hard-to-undo action — a push- or
+# tag-triggered release would let a mistyped tag or a stray merge ship to real users — so a human
+# presses the button and picks the track. The default track is `beta` (Play's open testing), which
+# is where this app's releases land before promotion.
+#
+# What this job does NOT do: re-run the test suite. The instrumented suite needs an emulator and
+# takes ~20 minutes (see android.yml); this workflow assumes the commit you're releasing is already
+# green on main. It is still a real compile gate — the release build runs R8/resource shrinking,
+# which the debug CI path does not.
+#
+# Required repository secrets — see docs/RELEASING.md for how each one is produced:
+#   RELEASE_KEYSTORE_BASE64    base64 of the upload keystore
+#   RELEASE_KEY_ALIAS          key alias within that keystore
+#   RELEASE_KEYSTORE_PASSWORD  keystore password
+#   RELEASE_KEY_PASSWORD       key password
+#   PELIAS_API_KEY_OBA         Pelias geocoding key for the oba brand (trip planner search)
+#   ANDROID_PUBLISHER_CREDENTIALS  Google Play service-account JSON (read by GPP from the env)
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play track to publish to'
+        required: true
+        default: 'beta'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      release_status:
+        description: 'Release status on that track'
+        required: true
+        default: 'completed'
+        type: choice
+        options:
+          # `draft` uploads the bundle but leaves the release unpublished in the Play Console, so a
+          # human can review and roll it out by hand. Useful for a first run against a new
+          # service-account setup.
+          - completed
+          - draft
+
+# Never let two publishes race: gradle-play-publisher opens a Play "edit" per run, and concurrent
+# edits on the same app conflict. Don't cancel a run in progress — an interrupted upload is worse
+# than a queued one.
+concurrency:
+  group: play-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          # This job never pushes, so don't leave the token in git config.
+          persist-credentials: false
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v6.3.0
+
+      # The build script reads signing config from a properties file named by the `secure.properties`
+      # Gradle property (see the signingConfigs block in onebusaway-android/build.gradle.kts), and
+      # resolves `key.store` relative to the module directory. Reproduce that layout from secrets.
+      - name: Restore signing key
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KEYSTORE_BASE64}" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 is not set. See docs/RELEASING.md."
+            exit 1
+          fi
+          printf '%s' "${KEYSTORE_BASE64}" | base64 --decode > onebusaway-android/release.keystore
+          # Written with a restrictive umask; the runner is ephemeral but the file is a signing key.
+          chmod 600 onebusaway-android/release.keystore
+          umask 077
+          cat > onebusaway-android/secure.properties <<EOF
+          key.store=release.keystore
+          key.alias=${KEY_ALIAS}
+          key.storepassword=${KEYSTORE_PASSWORD}
+          key.keypassword=${KEY_PASSWORD}
+          EOF
+
+      - name: Verify signing config
+        run: >-
+          ./gradlew :onebusaway-android:signingReport
+          -Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties
+          --no-configuration-cache --stacktrace
+
+      # `--no-configuration-cache`: the configuration cache buys nothing on a cold runner (each run
+      # is a fresh checkout, so the cache is always a miss) and gradle-play-publisher's Play API
+      # interaction at configuration time has historically not been cache-friendly. Cheap insurance
+      # on a job that runs a few times a year.
+      - name: Build and publish App Bundle
+        env:
+          # gradle-play-publisher reads the service-account JSON from this variable when
+          # PLAY_STORE_JSON_KEY names no file — see the play {} block in build.gradle.kts.
+          ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.ANDROID_PUBLISHER_CREDENTIALS }}
+        run: >-
+          ./gradlew publishObaGoogleReleaseBundle
+          --track ${{ inputs.track }}
+          --release-status ${{ inputs.release_status }}
+          -Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties
+          -PPelias_oba=${{ secrets.PELIAS_API_KEY_OBA }}
+          --no-configuration-cache --stacktrace
+
+      # Keep the exact artifact that was uploaded, plus the R8 mapping needed to read any crash
+      # report from this build that Crashlytics didn't already ingest.
+      - name: Upload bundle and mapping
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: obaGoogleRelease-bundle
+          path: |
+            onebusaway-android/build/outputs/bundle/obaGoogleRelease/*.aab
+            onebusaway-android/build/outputs/mapping/obaGoogleRelease/mapping.txt
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Remove signing material
+        if: always()
+        run: rm -f onebusaway-android/release.keystore onebusaway-android/secure.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,27 +94,30 @@ jobs:
           # This job never pushes, so don't leave the token in git config.
           persist-credentials: false
 
-      # Fail before the build rather than after the upload. `beta` is Play's OPEN testing track and
-      # `production` is everyone: enrolment in open testing is sticky and per-programme, not
-      # per-release, so both reach their users as silent automatic updates. A full rollout there is
-      # not something to reach by leaving a dropdown at its default, so require a staged one and
-      # make widening it a deliberate Play Console action. `user_fraction: '1.0'` is the escape
-      # hatch if a full rollout really is wanted — it still lands as a haltable release.
-      - name: Refuse an unstaged rollout to an open track
+      # Fail before the build: a bad combination caught here costs seconds, caught after the upload
+      # costs a version code. `beta` is OPEN testing and `production` is everyone — both update
+      # their users silently — so a release to either must be staged, and finishing the rollout is a
+      # deliberate Play Console action. Full-rollout-from-CI isn't offered, and can't be faked: Play
+      # requires 0 < userFraction < 1, so 1.0 is rejected rather than meaning "everyone".
+      - name: Validate the rollout for this track
         env:
           TRACK: ${{ inputs.track }}
           RELEASE_STATUS: ${{ inputs.release_status }}
+          USER_FRACTION: ${{ inputs.user_fraction }}
         run: |
           set -euo pipefail
-          if [ "$RELEASE_STATUS" = "completed" ]; then
-            case "$TRACK" in
-              beta|production)
-                echo "::error::Refusing release_status=completed on the '$TRACK' track, which"
-                echo "::error::updates its users silently. Use inProgress with a user_fraction"
-                echo "::error::(1.0 for everyone), or widen an existing rollout in the Console."
-                exit 1
-                ;;
-            esac
+          case "$RELEASE_STATUS:$TRACK" in
+            completed:beta | completed:production)
+              echo "::error::'$TRACK' updates its users silently, so a release there must be staged."
+              echo "::error::Use inProgress with a user_fraction, then widen to 100% in the Console."
+              exit 1
+              ;;
+          esac
+          if [ "$RELEASE_STATUS" = inProgress ]; then
+            # awk reads a non-number as 0, so a typo like "10" (meaning 10%) is caught here too.
+            awk -v f="$USER_FRACTION" 'BEGIN { exit !(f > 0 && f < 1) }' ||
+              { echo "::error::user_fraction must be between 0 and 1 (0.1 == 10%), got '$USER_FRACTION'."; exit 1; }
+            echo "Staged rollout: $USER_FRACTION of '$TRACK'."
           fi
 
       - name: Setup Java
@@ -177,14 +180,8 @@ jobs:
         run: |
           set -euo pipefail
           args=(publishObaGoogleReleaseBundle --track "$TRACK" --release-status "$RELEASE_STATUS")
-          if [ "$RELEASE_STATUS" = "inProgress" ]; then
-            if [ -z "$USER_FRACTION" ]; then
-              echo "::error::release_status=inProgress needs a user_fraction (e.g. 0.1 for 10%)."
-              exit 1
-            fi
-            args+=(--user-fraction "$USER_FRACTION")
-            echo "Staged rollout: $USER_FRACTION of the $TRACK track."
-          fi
+          # Already validated by the guard step above; Play rejects a fraction on any other status.
+          if [ "$RELEASE_STATUS" = inProgress ]; then args+=(--user-fraction "$USER_FRACTION"); fi
           ./gradlew "${args[@]}" \
             "-Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties" \
             "-PPelias_oba=$PELIAS_KEY" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,15 @@ name: Release to Google Play
 #
 # Manual dispatch only. Publishing is an outward-facing, hard-to-undo action — a push- or
 # tag-triggered release would let a mistyped tag or a stray merge ship to real users — so a human
-# presses the button and picks the track. The default track is `beta` (Play's open testing), which
-# is where this app's releases land before promotion.
+# presses the button and picks the track.
+#
+# Releases go to a CLOSED track first and are graduated to open testing by hand. The default is
+# `alpha`, the closed track that already has an audience attached
+# (onebusaway-developers@googlegroups.com). This matters because `beta` is Play's *open* testing
+# track, and enrolment there is per-programme and sticky rather than per-release: everyone who ever
+# joined — including people who did so years ago and forgot — receives beta builds as ordinary
+# silent automatic updates. A release reaching them should be a decision, not a default, so a full
+# rollout to `beta` or `production` is refused outright by a guard step below.
 #
 # What this job does NOT do: re-run the test suite. The instrumented suite needs an emulator and
 # takes ~20 minutes (see android.yml); this workflow assumes the commit you're releasing is already
@@ -27,11 +34,18 @@ on:
       track:
         description: 'Play track to publish to'
         required: true
-        default: 'beta'
+        default: 'alpha'
         type: choice
         options:
-          - internal
+          # `alpha` is closed testing, and the only track with an audience already attached
+          # (onebusaway-developers@googlegroups.com). It is the default because a release should
+          # reach a closed group first and be graduated to open testing by hand.
           - alpha
+          # `Closed beta` and `internal` exist but have no testers attached, so publishing to
+          # either reaches nobody until a group or email list is added in the Play Console.
+          - Closed beta
+          - internal
+          # `beta` is OPEN testing: every enrolled user gets it as a silent automatic update.
           - beta
           - production
       release_status:
@@ -40,11 +54,21 @@ on:
         default: 'completed'
         type: choice
         options:
-          # `draft` uploads the bundle but leaves the release unpublished in the Play Console, so a
-          # human can review and roll it out by hand. Useful for a first run against a new
-          # service-account setup.
+          # `completed` goes to the whole track at once. Fine on a closed track — the closed
+          # audience is itself the staging mechanism — which is why it is the default alongside
+          # `alpha`. On `beta` or `production` it is refused; see the guard step below.
+          # `inProgress` is a staged rollout: only `user_fraction` of the track is offered the
+          # update, and it can be halted or resumed from the Play Console.
+          # `draft` uploads the bundle but leaves the release unpublished, so a human rolls it out
+          # by hand — useful for a first run against a new service-account setup.
           - completed
+          - inProgress
           - draft
+      user_fraction:
+        description: 'Fraction of the track to roll out to, for inProgress (0.1 == 10%)'
+        required: false
+        default: '0.1'
+        type: string
 
 # Never let two publishes race: gradle-play-publisher opens a Play "edit" per run, and concurrent
 # edits on the same app conflict. Don't cancel a run in progress — an interrupted upload is worse
@@ -57,12 +81,41 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # This job reads the repository and nothing else; everything it writes goes to Play, authorized
+    # by the service account rather than by GITHUB_TOKEN. Narrow the token explicitly so the job
+    # doesn't inherit a broader repository or organization default — it holds the signing key, so
+    # it's the last place to want ambient write access.
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v7
         with:
           # This job never pushes, so don't leave the token in git config.
           persist-credentials: false
+
+      # Fail before the build rather than after the upload. `beta` is Play's OPEN testing track and
+      # `production` is everyone: enrolment in open testing is sticky and per-programme, not
+      # per-release, so both reach their users as silent automatic updates. A full rollout there is
+      # not something to reach by leaving a dropdown at its default, so require a staged one and
+      # make widening it a deliberate Play Console action. `user_fraction: '1.0'` is the escape
+      # hatch if a full rollout really is wanted — it still lands as a haltable release.
+      - name: Refuse an unstaged rollout to an open track
+        env:
+          TRACK: ${{ inputs.track }}
+          RELEASE_STATUS: ${{ inputs.release_status }}
+        run: |
+          set -euo pipefail
+          if [ "$RELEASE_STATUS" = "completed" ]; then
+            case "$TRACK" in
+              beta|production)
+                echo "::error::Refusing release_status=completed on the '$TRACK' track, which"
+                echo "::error::updates its users silently. Use inProgress with a user_fraction"
+                echo "::error::(1.0 for everyone), or widen an existing rollout in the Console."
+                exit 1
+                ;;
+            esac
+          fi
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -102,25 +155,40 @@ jobs:
       - name: Verify signing config
         run: >-
           ./gradlew :onebusaway-android:signingReport
-          -Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties
+          "-Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties"
           --no-configuration-cache --stacktrace
 
       # `--no-configuration-cache`: the configuration cache buys nothing on a cold runner (each run
       # is a fresh checkout, so the cache is always a miss) and gradle-play-publisher's Play API
       # interaction at configuration time has historically not been cache-friendly. Cheap insurance
       # on a job that runs a few times a year.
+      #
+      # `--user-fraction` is passed only for an `inProgress` release: gradle-play-publisher rejects
+      # it on a `completed` or `draft` one, since a fraction is meaningless there.
       - name: Build and publish App Bundle
         env:
           # gradle-play-publisher reads the service-account JSON from this variable when
           # PLAY_STORE_JSON_KEY names no file — see the play {} block in build.gradle.kts.
           ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.ANDROID_PUBLISHER_CREDENTIALS }}
-        run: >-
-          ./gradlew publishObaGoogleReleaseBundle
-          --track ${{ inputs.track }}
-          --release-status ${{ inputs.release_status }}
-          -Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties
-          -PPelias_oba=${{ secrets.PELIAS_API_KEY_OBA }}
-          --no-configuration-cache --stacktrace
+          TRACK: ${{ inputs.track }}
+          RELEASE_STATUS: ${{ inputs.release_status }}
+          USER_FRACTION: ${{ inputs.user_fraction }}
+          PELIAS_KEY: ${{ secrets.PELIAS_API_KEY_OBA }}
+        run: |
+          set -euo pipefail
+          args=(publishObaGoogleReleaseBundle --track "$TRACK" --release-status "$RELEASE_STATUS")
+          if [ "$RELEASE_STATUS" = "inProgress" ]; then
+            if [ -z "$USER_FRACTION" ]; then
+              echo "::error::release_status=inProgress needs a user_fraction (e.g. 0.1 for 10%)."
+              exit 1
+            fi
+            args+=(--user-fraction "$USER_FRACTION")
+            echo "Staged rollout: $USER_FRACTION of the $TRACK track."
+          fi
+          ./gradlew "${args[@]}" \
+            "-Psecure.properties=$GITHUB_WORKSPACE/onebusaway-android/secure.properties" \
+            "-PPelias_oba=$PELIAS_KEY" \
+            --no-configuration-cache --stacktrace
 
       # Keep the exact artifact that was uploaded, plus the R8 mapping needed to read any crash
       # report from this build that Crashlytics didn't already ingest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,17 +93,19 @@ service account and how to rotate its key — is in **`docs/RELEASING.md`**; loc
 
 Two things that bite:
 
-- **`versionCode` is not yours to edit.** `resolutionStrategy = AUTO` in the `play {}` block
-  auto-increments it from the highest code on Play. Only `versionName` is bumped by hand. AUTO is
+- **`versionCode` is not yours to edit, and git tags don't tell you what shipped.** The tags stop
+  at `v2.4.19` (2025) while `26.1.0`/code 154 is live on Play — ask Play, not git, before choosing
+  a `versionName`. `resolutionStrategy = AUTO` in the `play {}` block
+  auto-increments `versionCode` from the highest code on Play. Only `versionName` is bumped by hand. AUTO is
   consulted on every release *assemble*, not just `publish*` tasks — without credentials the block
   falls back to `IGNORE` and the checked-in `versionCode` is used, so the build works but its
   output must not be uploaded.
 - **Release notes live in two places and must agree**: `main_help_whatsnew` in
   `src/main/res/values/strings.xml` (the in-app what's-new dialog, translated) and
   `src/oba/play/release-notes/en-US/default.txt` (the Play listing, 500-char cap). The Play tree is
-  under `src/oba/` so the sample and third-party brands don't inherit OneBusAway's listing; only
-  `en-US` is checked in, because Play rejects release notes for a locale its listing doesn't
-  declare — see the README there.
+  under `src/oba/` so the sample and third-party brands don't inherit OneBusAway's listing, and
+  `en-US` is the only locale because it is the only one the live store listing declares — Play
+  rejects release notes for any other, failing the publish. See the README there.
 
 ## Build Variants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,17 @@ only prints them. The codebase is kept at **zero** compiler warnings (#1692); do
 
 Releases ship from the **Release to Google Play** workflow (`.github/workflows/release.yml`):
 manual dispatch only, builds a signed `obaGoogle` release App Bundle, and uploads it with
-[gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) to the **beta** (open
-testing) track by default. Full procedure — cutting a release, the six repository secrets, the Play
-service account and how to rotate its key — is in **`docs/RELEASING.md`**; local publishing is in
-`docs/BUILD.md`.
+[gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher). Full procedure — cutting
+a release, the six repository secrets, the Play service account and how to rotate its key — is in
+**`docs/RELEASING.md`**; local publishing is in `docs/BUILD.md`.
+
+A release climbs the tracks one rung at a time, each rung a human decision: `alpha` (closed testing,
+the default, and the only track with testers attached) → `beta` → `production`. **`beta` is Play's
+*open* testing track**, and enrolment there is per-programme and sticky, not per-release — everyone
+who ever joined gets beta builds as silent automatic updates. So a full (`completed`) rollout to
+`beta` or `production` is refused by a guard step; those tracks take a staged (`inProgress`) release
+that can be halted from the Console. Production promotion isn't possible from CI at all: the service
+account has testing-track permission only.
 
 Two things that bite:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,32 +82,28 @@ only prints them. The codebase is kept at **zero** compiler warnings (#1692); do
     **fix them, or opt that check out** in the `lint {}` block with a one-line rationale — don't
     reintroduce a whole-project baseline.
 
-## Automated Publishing (gradle-play-publisher)
+## Releasing (gradle-play-publisher, via CI)
 
-Uses [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) to auto-increment `versionCode`, build, and upload to Google Play.
+Releases ship from the **Release to Google Play** workflow (`.github/workflows/release.yml`):
+manual dispatch only, builds a signed `obaGoogle` release App Bundle, and uploads it with
+[gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) to the **beta** (open
+testing) track by default. Full procedure — cutting a release, the six repository secrets, the Play
+service account and how to rotate its key — is in **`docs/RELEASING.md`**; local publishing is in
+`docs/BUILD.md`.
 
-### Setup
-1. In [Google Cloud Console](https://console.cloud.google.com/), create a service account (IAM & Admin → Service Accounts) and download the JSON key
-2. Enable the Google Play Android Developer API in Google Cloud Console
-3. In [Google Play Console](https://play.google.com/console), invite the service account email under Users & permissions and grant "Release manager" permissions
-4. Add to `gradle.properties`: `PLAY_STORE_JSON_KEY=/path/to/service-account-key.json`
+Two things that bite:
 
-### Commands
-```bash
-# Build AAB, auto-increment versionCode, upload to open testing (beta) track
-./gradlew publishObaGoogleReleaseBundle
-
-# Same as above + upload all Play Store metadata
-./gradlew publishObaGoogleReleaseApps
-
-# Promote beta release to production
-./gradlew promoteObaGoogleReleaseArtifact
-
-# Download existing Play Store listing metadata into repo
-./gradlew bootstrapObaGoogleReleaseListing
-```
-
-Configuration is in the `play {}` block of `onebusaway-android/build.gradle.kts`. Default: App Bundles to the **beta** (open testing) track with auto-incrementing `versionCode`.
+- **`versionCode` is not yours to edit.** `resolutionStrategy = AUTO` in the `play {}` block
+  auto-increments it from the highest code on Play. Only `versionName` is bumped by hand. AUTO is
+  consulted on every release *assemble*, not just `publish*` tasks — without credentials the block
+  falls back to `IGNORE` and the checked-in `versionCode` is used, so the build works but its
+  output must not be uploaded.
+- **Release notes live in two places and must agree**: `main_help_whatsnew` in
+  `src/main/res/values/strings.xml` (the in-app what's-new dialog, translated) and
+  `src/oba/play/release-notes/en-US/default.txt` (the Play listing, 500-char cap). The Play tree is
+  under `src/oba/` so the sample and third-party brands don't inherit OneBusAway's listing; only
+  `en-US` is checked in, because Play rejects release notes for a locale its listing doesn't
+  declare — see the README there.
 
 ## Build Variants
 
@@ -123,12 +119,6 @@ Default variant: `obaGoogleDebug`
 Add to `onebusaway-android/gradle.properties`:
 ```
 Pelias_oba=YOUR_API_KEY
-```
-
-### Required for Push Notifications (OneSignal)
-Add to `onebusaway-android/gradle.properties`:
-```
-ONESIGNAL_APP_ID=YOUR_APP_ID
 ```
 
 ### Release Builds

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -72,6 +72,7 @@ Note that the paths in these files always use the Unix path separator `/`, even 
 Before doing each release build, you'll need to:
 1. Set `versionName` in `onebusaway-android/build.gradle.kts` to the appropriate next semantic version name. If you are using the automated publishing workflow (see below), `versionCode` is auto-incremented. Otherwise, bump `versionCode` by 1 manually.
 2. Check `onebusaway-android/src/main/res/values/strings.xml` element `main_help_whatsnew` to make sure that the latest changes we want to highlight for the user are entered there. After update, users see this in a dialog.
+3. Update the Play Store "What's new" text in `onebusaway-android/src/oba/play/release-notes/en-US/default.txt` to match `main_help_whatsnew`. Play caps this at 500 characters per locale.
 
 Then, to build all flavors run:
 
@@ -84,6 +85,8 @@ The APK files will show up in the `onebusaway-android/build/outputs/apk` folder.
 ### Automated publishing with gradle-play-publisher
 
 We use [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) (GPP) to automate building, versioning, and uploading releases to Google Play.
+
+**Releases normally ship from CI**, not from a workstation: the *Release to Google Play* GitHub Actions workflow runs these same tasks with the signing key and Play credentials held as repository secrets. See [RELEASING.md](RELEASING.md) for how to cut a release, and use the local setup below when CI isn't an option.
 
 #### Setup
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -92,7 +92,7 @@ We use [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher
 
 1. In [Google Cloud Console](https://console.cloud.google.com/), create a service account under IAM & Admin → Service Accounts and download the JSON key file.
 2. Enable the [Google Play Android Developer API](https://console.cloud.google.com/apis/library/androidpublisher.googleapis.com) in Google Cloud Console.
-3. In [Google Play Console](https://play.google.com/console), go to Users & permissions, invite the service account email, and grant "Release manager" permissions. Note: it can take up to 36 hours for credentials to become active.
+3. In [Google Play Console](https://play.google.com/console), go to Users & permissions, invite the service account email, and grant it app permissions. For a CI credential grant only *View app information* and *Manage testing tracks*, so it cannot reach production — see [RELEASING.md](RELEASING.md#the-play-service-account). A workstation credential used for production promotion additionally needs *Manage production releases*. Note: it can take up to 36 hours for credentials to become active.
 4. Add the path to `gradle.properties`:
    ```
    PLAY_STORE_JSON_KEY=/path/to/service-account-key.json

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -104,7 +104,7 @@ We use [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher
 |---|---|
 | `./gradlew publishObaGoogleReleaseBundle` | Build release AAB, auto-increment `versionCode`, and upload to the open testing (beta) track |
 | `./gradlew publishObaGoogleReleaseApps` | Same as above, plus upload all Play Store metadata (listing, screenshots, etc.) |
-| `./gradlew promoteObaGoogleReleaseArtifact` | Promote the current beta release to production (e.g., alpha → beta → production) |
+| `./gradlew promoteObaGoogleReleaseArtifact --from-track beta --promote-track production` | Promote the current beta release to production. Name both tracks explicitly: the defaults promote the configured track (`beta`) onto itself. Needs a credential with production rights — the CI service account has testing-track permission only. |
 
 #### Managing Play Store metadata
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,128 @@
+# Releasing OneBusAway for Android
+
+Releases go out through the **Release to Google Play** workflow
+(`.github/workflows/release.yml`), which builds a signed `obaGoogle` release App Bundle and uploads
+it with [gradle-play-publisher][gpp]. The default track is **beta** — Play's open testing channel —
+and production releases are promotions of a beta that has been out long enough to be trusted.
+
+The workflow is **manual dispatch only**. Publishing is outward-facing and hard to undo, so nobody
+ships by pushing a branch or mistyping a tag; a human opens Actions and presses Run workflow.
+
+[gpp]: https://github.com/Triple-T/gradle-play-publisher
+
+## Cutting a release
+
+1. **Pick the commit.** It should be a commit on `main` that is green in
+   [Android CI Build](../.github/workflows/android.yml). The release workflow does not re-run the
+   test suite — it takes ~20 minutes and needs an emulator — though the release build is itself a
+   real compile gate, since it runs R8 and resource shrinking that the debug CI path never touches.
+2. **Set `versionName`** in `onebusaway-android/build.gradle.kts`. This is the only version field
+   you edit by hand: `versionCode` is auto-incremented from the highest code already on Play (the
+   `resolutionStrategy = AUTO` in the `play {}` block), so the number checked into the file is only
+   a fallback for builds without Play credentials.
+3. **Write the release notes**, in two places that must agree:
+   - `onebusaway-android/src/oba/play/release-notes/en-US/default.txt` — the Play "What's new"
+     text, capped at 500 characters per locale. See the [README][playreadme] there for why only
+     `en-US` is checked in.
+   - `main_help_whatsnew` in `onebusaway-android/src/main/res/values/strings.xml` (and the
+     `values-*` translations) — the in-app what's-new dialog. Same release, same audience.
+4. **Run the workflow.** Actions → Release to Google Play → Run workflow, on the commit you picked.
+   - `track`: `beta` for a normal release. `internal` is the safe choice when you're testing the
+     pipeline itself.
+   - `release_status`: `completed` rolls the release out on that track. `draft` uploads the bundle
+     but leaves it unpublished in the Play Console for a human to review and roll out — use it for
+     the first run after any change to the signing or credential setup.
+5. **Tag it.** Once the upload succeeds, tag the released commit and push the tag, so the bundle on
+   Play maps to a commit:
+
+       git tag -a v26.1.0 -m "26.1.0" <commit>
+       git push origin v26.1.0
+
+6. **Promote to production** when the beta has settled:
+
+       ./gradlew promoteObaGoogleReleaseArtifact
+
+[playreadme]: ../onebusaway-android/src/oba/play/README.md
+
+## Repository secrets
+
+The workflow reads six secrets. They are set on the repository (Settings → Secrets and variables →
+Actions) and are readable only by workflow runs.
+
+| Secret | What it is | Where it comes from |
+| --- | --- | --- |
+| `RELEASE_KEYSTORE_BASE64` | The upload keystore, base64-encoded | `base64 -i onebusaway-android/joulespersecond-release-key.keystore \| tr -d '\n'` |
+| `RELEASE_KEY_ALIAS` | Key alias inside that keystore | `key.alias` in `onebusaway-android/secure.properties` |
+| `RELEASE_KEYSTORE_PASSWORD` | Keystore password | `key.storepassword` in the same file |
+| `RELEASE_KEY_PASSWORD` | Key password | `key.keypassword` in the same file |
+| `PELIAS_API_KEY_OBA` | Pelias geocoding key for the `oba` brand | `Pelias_oba` in `onebusaway-android/gradle.properties` |
+| `ANDROID_PUBLISHER_CREDENTIALS` | Google Play service-account JSON | see below |
+
+The keystore and `secure.properties` are gitignored and live only on release managers' machines and
+in these secrets. **Losing the keystore is unrecoverable** if the app is not on Play App Signing —
+keep an offline backup.
+
+The workflow reconstructs `secure.properties` on the runner from the four signing secrets, points
+Gradle at it with `-Psecure.properties=…`, and deletes both it and the decoded keystore in an
+`if: always()` step at the end.
+
+## The Play service account
+
+`ANDROID_PUBLISHER_CREDENTIALS` is a Google Cloud service-account key with permission to publish
+this app. gradle-play-publisher reads it straight from that environment variable (see the `play {}`
+block in `onebusaway-android/build.gradle.kts`, which also accepts a `PLAY_STORE_JSON_KEY` property
+naming a local file, for publishing from a workstation).
+
+The current account is **`play-publisher@oba-android-publish.iam.gserviceaccount.com`**, in the
+Google Cloud project `oba-android-publish`. To recreate it from scratch:
+
+    gcloud projects create oba-android-publish --name="OBA Android Publishing"
+    gcloud services enable androidpublisher.googleapis.com --project=oba-android-publish
+    gcloud iam service-accounts create play-publisher \
+      --project=oba-android-publish \
+      --display-name="Google Play publisher (GitHub Actions)"
+    gcloud iam service-accounts keys create key.json \
+      --iam-account=play-publisher@oba-android-publish.iam.gserviceaccount.com \
+      --project=oba-android-publish
+    gh secret set ANDROID_PUBLISHER_CREDENTIALS -R OneBusAway/onebusaway-android < key.json
+    rm key.json   # the secret is the only copy that needs to exist
+
+The service account needs **no IAM roles in the Cloud project** — its permissions come from the Play
+Console, not from Cloud IAM. Grant them there, once, by hand:
+
+> Play Console → Users and permissions → Invite new users → enter the service-account email →
+> under **App permissions** add OneBusAway (`com.joulespersecond.seattlebusbot`) → grant
+> **Release manager** (or, more narrowly, *View app information*, *Manage testing tracks*, and
+> *Manage production releases*) → Invite user.
+
+To check that the credential works before trusting a release to it, run a read-only Play task
+locally against the key:
+
+    ./gradlew bootstrapObaGoogleReleaseListing -PPLAY_STORE_JSON_KEY=/path/to/key.json
+
+It downloads the live store listing. A 401/403 means the Play Console invitation hasn't landed or
+hasn't propagated yet — Google warns this can take **up to 36 hours**, so don't conclude the key is
+wrong on the first failure. Review the diff rather than committing what bootstrap writes; it
+overwrites the whole `src/oba/play` tree.
+
+### Rotating the key
+
+Service-account keys do not expire, so rotate on staff change or suspected exposure:
+
+    gcloud iam service-accounts keys list --iam-account=play-publisher@oba-android-publish.iam.gserviceaccount.com
+    # create a new key and set the secret as above, then delete the old one:
+    gcloud iam service-accounts keys delete <KEY_ID> --iam-account=play-publisher@oba-android-publish.iam.gserviceaccount.com
+
+## Publishing from a workstation
+
+CI is the normal path. Publishing by hand — the same GPP tasks, plus the local `secure.properties`
+and `PLAY_STORE_JSON_KEY` setup they need — is documented in [BUILD.md][build]; use it when CI is
+unavailable or when you're promoting a track.
+
+One trap worth repeating: **any** `assembleObaGoogleRelease` consults Play, not just the `publish*`
+tasks, because `resolutionStrategy = AUTO` queries the current `versionCode` on every release
+assemble. Without credentials the `play {}` block falls back to `IGNORE` and uses the `versionCode`
+checked into `build.gradle.kts` — so the build succeeds, but the bundle it produces will collide
+with Play's numbering and must not be uploaded.
+
+[build]: BUILD.md#automated-publishing-with-gradle-play-publisher

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -137,8 +137,14 @@ Console, not from Cloud IAM. Grant them there, once, by hand:
 
 > Play Console → Users and permissions → Invite new users → enter the service-account email →
 > under **App permissions** add OneBusAway (`com.joulespersecond.seattlebusbot`) → grant
-> **Release manager** (or, more narrowly, *View app information*, *Manage testing tracks*, and
-> *Manage production releases*) → Invite user.
+> *View app information* and *Manage testing tracks* → Invite user.
+
+Grant those two and **not** *Release manager* or *Manage production releases*. This credential sits
+in a repository secret and is readable by any workflow run, so it should not be able to reach
+production at all — CI's job ends at the testing tracks. That restriction is load-bearing rather
+than decorative: it is the reason `promoteObaGoogleReleaseArtifact` returns 403 from CI, which is
+what keeps production promotion a human decision made in the Console. Promoting from a workstation
+needs a separate, more privileged credential.
 
 To check that the credential works before trusting a release to it, run a read-only Play task
 locally against the key:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,11 +2,24 @@
 
 Releases go out through the **Release to Google Play** workflow
 (`.github/workflows/release.yml`), which builds a signed `obaGoogle` release App Bundle and uploads
-it with [gradle-play-publisher][gpp]. The default track is **beta** — Play's open testing channel —
-and production releases are promotions of a beta that has been out long enough to be trusted.
+it with [gradle-play-publisher][gpp].
 
 The workflow is **manual dispatch only**. Publishing is outward-facing and hard to undo, so nobody
 ships by pushing a branch or mistyping a tag; a human opens Actions and presses Run workflow.
+
+A release climbs the tracks one rung at a time, and every rung is a human decision:
+
+| Track | Who gets it | How it's reached |
+| --- | --- | --- |
+| `alpha` | closed testing — `onebusaway-developers@googlegroups.com` | the workflow's default; where every release starts |
+| `Closed beta` / `internal` | nobody yet — no testers are attached to either | the workflow, once a group is added in the Console |
+| `beta` | **open testing** — anyone who ever joined the programme | the workflow, staged only (see below) |
+| `production` | everyone | promoted by hand in the Play Console |
+
+The rung that deserves care is `beta`. It is Play's *open* testing channel, and enrolment is
+per-programme and sticky rather than per-release: everyone who has ever joined receives beta builds
+as ordinary silent automatic updates, including people who joined years ago and have forgotten. So
+a release starts closed, and graduating it to open testing is a separate, deliberate act.
 
 [gpp]: https://github.com/Triple-T/gradle-play-publisher
 
@@ -31,20 +44,48 @@ ships by pushing a branch or mistyping a tag; a human opens Actions and presses 
    - `main_help_whatsnew` in `onebusaway-android/src/main/res/values/strings.xml` (and the
      `values-*` translations) — the in-app what's-new dialog. Same release, same audience.
 4. **Run the workflow.** Actions → Release to Google Play → Run workflow, on the commit you picked.
-   - `track`: `beta` for a normal release. `internal` is the safe choice when you're testing the
-     pipeline itself.
-   - `release_status`: `completed` rolls the release out on that track. `draft` uploads the bundle
-     but leaves it unpublished in the Play Console for a human to review and roll out — use it for
-     the first run after any change to the signing or credential setup.
+   - `track`: leave it at `alpha`. That is closed testing, and the only track with an audience
+     already attached.
+   - `release_status`: `completed` is right for a closed track — the closed audience is itself the
+     staging mechanism. Use `draft` instead for the first run after any change to the signing or
+     credential setup: it uploads the bundle without publishing it, proving the pipeline without
+     anything reaching a device.
+   - `user_fraction`: ignored unless `release_status` is `inProgress`.
 5. **Tag it.** Once the upload succeeds, tag the released commit and push the tag, so the bundle on
-   Play maps to a commit:
+   Play maps to a commit. Do this every time — the tags fell out of sync with Play once already,
+   which is why step 2 warns you not to trust them:
 
-       git tag -a v26.1.0 -m "26.1.0" <commit>
-       git push origin v26.1.0
+       git tag -a v27.0.0 -m "27.0.0" <commit>
+       git push origin v27.0.0
 
-6. **Promote to production** when the beta has settled:
+6. **Let the closed track sit.** Watch Crashlytics and the Play Console's vitals. This is the whole
+   point of the closed rung — it is the only audience that can be surprised cheaply.
+7. **Graduate to open testing** when it looks clean: run the workflow again with `track: beta` and
+   `release_status: inProgress`, starting at a small `user_fraction`. A full rollout to `beta` is
+   refused by a guard step in the workflow, because that track updates its users silently; widen
+   the rollout from the Play Console once it has proven itself.
+8. **Promote to production** last. This is deliberately *not* something the CI credential can do:
+   the service account holds testing-track permission only, so `promoteObaGoogleReleaseArtifact`
+   returns 403 for it and production promotion is a human action in the Play Console. If you do
+   want to promote from a workstation, it needs a credential with production rights, and both
+   tracks must be named explicitly — the defaults will otherwise promote a track onto itself:
 
-       ./gradlew promoteObaGoogleReleaseArtifact
+       ./gradlew promoteObaGoogleReleaseArtifact --from-track beta --promote-track production
+
+## Staged rollouts
+
+An `inProgress` release is offered to only `user_fraction` of the track and can be halted from the
+Play Console, so it is the required shape on `beta` and `production` — the workflow refuses a
+`completed` release to either. Raising the fraction, halting, and resuming are all Console actions
+on the existing release; none of them needs another build.
+
+On a closed track a stage is usually pointless: the audience is small enough that 10% of it may be
+nobody, and the closed track is already the staging mechanism.
+
+Users do at least get an explanation on the first launch after an update, whichever track they are
+on — `HelpViewModel.maybeAutoShowWhatsNew` shows the what's-new dialog once when the stored
+`whatsNewVer` is below the running `VERSION_CODE`. That is an explanation after the fact, though,
+not consent before it.
 
 [playreadme]: ../onebusaway-android/src/oba/play/README.md
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,10 +20,14 @@ ships by pushing a branch or mistyping a tag; a human opens Actions and presses 
    you edit by hand: `versionCode` is auto-incremented from the highest code already on Play (the
    `resolutionStrategy = AUTO` in the `play {}` block), so the number checked into the file is only
    a fallback for builds without Play credentials.
+
+   Check what's actually live before choosing a name — the git tags have not tracked Play releases
+   and will mislead you. `26.1.0` shipped as versionCode 154 without ever being tagged. The Play
+   Console's release dashboard, or `bootstrapObaGoogleReleaseListing`, is the authority.
 3. **Write the release notes**, in two places that must agree:
    - `onebusaway-android/src/oba/play/release-notes/en-US/default.txt` — the Play "What's new"
-     text, capped at 500 characters per locale. See the [README][playreadme] there for why only
-     `en-US` is checked in.
+     text, capped at 500 characters. `en-US` is the only locale here because it is the only one the
+     store listing declares; adding others would fail the publish. See the [README][playreadme].
    - `main_help_whatsnew` in `onebusaway-android/src/main/res/values/strings.xml` (and the
      `values-*` translations) — the in-app what's-new dialog. Same release, same audience.
 4. **Run the workflow.** Actions → Release to Google Play → Run workflow, on the commit you picked.

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -53,8 +53,12 @@ android {
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
+        // versionCode is a fallback only: the play {} block's AUTO resolution strategy takes the
+        // real one from the highest code already on Play (154 as of 26.1.0), so this value is used
+        // only by builds with no Play credentials — whose output must never be uploaded. Bump
+        // versionName by hand; see docs/RELEASING.md.
         versionCode = 153
-        versionName = "26.1.0"
+        versionName = "27.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/onebusaway-android/src/oba/play/README.md
+++ b/onebusaway-android/src/oba/play/README.md
@@ -14,14 +14,18 @@ Keep it in sync with the in-app what's-new dialog — `main_help_whatsnew` in
 `src/main/res/values/strings.xml` — they describe the same release to the same people. Play caps
 each locale at **500 characters**.
 
-## Only `en-US` is present, on purpose
+## `en-US` is the only locale, because it's the only one the listing has
 
-The app translates `main_help_whatsnew` into es, fi, it, and pl, and those translations are ready
-to copy here. They aren't checked in yet because the Play API rejects release notes for any locale
-the store listing doesn't declare, which would fail the publish. Before adding them, run
+The app translates `main_help_whatsnew` into es, fi, it, and pl, so it's tempting to add matching
+release notes here. Don't, until the store listing declares those languages: the Play API rejects
+release notes for any locale the listing doesn't support, and that rejection fails the whole
+publish. As of 2026-08 the live listing declares exactly one language, `en-US` — confirmed against
+`edits.listings.list`.
+
+If languages are added to the listing later, re-check with
 
     ./gradlew bootstrapObaGoogleReleaseListing
 
-which downloads the live listing (including its supported locales) into this directory, then add
+which downloads the live listing into this directory, then add
 `release-notes/<locale>/default.txt` for each locale that actually appears. Note that bootstrap
 overwrites this tree, so review its diff rather than committing it wholesale.

--- a/onebusaway-android/src/oba/play/README.md
+++ b/onebusaway-android/src/oba/play/README.md
@@ -1,0 +1,27 @@
+# Play Store metadata for the `oba` brand
+
+gradle-play-publisher reads this tree when publishing `obaGoogle*Release`. It lives under
+`src/oba/` — not `src/main/` — so the sample white-label brands (`agencyX`, `agencyY`) and the
+third-party `kiedybus` brand don't inherit OneBusAway's store listing.
+
+## Release notes
+
+`release-notes/<play-locale>/default.txt` is the "What's new" text for a release. `default.txt`
+(rather than `beta.txt`) means the same text carries through when a beta release is promoted to
+production, which is how this app ships.
+
+Keep it in sync with the in-app what's-new dialog — `main_help_whatsnew` in
+`src/main/res/values/strings.xml` — they describe the same release to the same people. Play caps
+each locale at **500 characters**.
+
+## Only `en-US` is present, on purpose
+
+The app translates `main_help_whatsnew` into es, fi, it, and pl, and those translations are ready
+to copy here. They aren't checked in yet because the Play API rejects release notes for any locale
+the store listing doesn't declare, which would fail the publish. Before adding them, run
+
+    ./gradlew bootstrapObaGoogleReleaseListing
+
+which downloads the live listing (including its supported locales) into this directory, then add
+`release-notes/<locale>/default.txt` for each locale that actually appears. Note that bootstrap
+overwrites this tree, so review its diff rather than committing it wholesale.

--- a/onebusaway-android/src/oba/play/release-notes/en-US/default.txt
+++ b/onebusaway-android/src/oba/play/release-notes/en-US/default.txt
@@ -1,0 +1,9 @@
+• Bold new look for a bold new era
+• Arrivals are now grouped by route
+• Micromobility added to the bike overlay
+• Tap a stop to see its routes
+• Zoom in to see nearby routes
+• Vehicle locations extrapolated and animated
+• Track your bus with live notifications
+• Significant improvements to the trip planner
+• Several small bug fixes


### PR DESCRIPTION
Publishing has only ever been a local ritual — a release manager with the keystore, `secure.properties`, and a Play service-account JSON on disk running `publishObaGoogleReleaseBundle` by hand. Nothing in the repo recorded how that setup is produced, so it lived in one person's home directory.

### What this adds

- **`.github/workflows/release.yml`** — manual-dispatch "Release to Google Play". Builds the signed `obaGoogle` release App Bundle and uploads it with gradle-play-publisher, taking the keystore and Play credential from repository secrets. Reconstructs `secure.properties` on the runner, and deletes it and the decoded keystore in an `if: always()` step.
- **`onebusaway-android/src/oba/play/release-notes/en-US/default.txt`** — the Play "What's new", which previously existed only in the store console and had drifted badly (production currently reads "Bugs Fix & improvements"). Matches the nine bullets from #2259.
- **`versionName` → `27.0.0`.**
- **`docs/RELEASING.md`** — the track ladder, the six secrets, the service account, and key rotation.

### The track ladder

A release climbs one rung at a time, each rung a human decision:

| Track | Who gets it | How it's reached |
| --- | --- | --- |
| `alpha` | closed testing — `onebusaway-developers@googlegroups.com` | workflow default; where every release starts |
| `Closed beta` / `internal` | nobody — no testers attached to either | workflow, once a group is added in the Console |
| `beta` | **open testing** — anyone who ever joined | workflow, staged only |
| `production` | everyone | promoted by hand in the Console |

`beta` is Play's *open* testing track and enrolment is per-programme and sticky, not per-release: everyone who ever joined gets beta builds as silent automatic updates, including people who joined years ago and forgot. Since beta currently sits on the same build as production (154), 27.0.0 would have landed for them as an unannounced overnight replacement of the app they know.

So: default to `alpha`, and **refuse** a `completed` release to `beta`/`production` in a guard step that fails before the build rather than after the upload. Those tracks take an `inProgress` release, haltable from the Console.

Which closed track to use was settled by querying the API rather than guessing — `alpha` already has the developers group attached; `Closed beta` and `internal` have no testers, so publishing to either would reach nobody.

### Two things the Play API corrected

1. **`26.1.0` is already live** — versionCode 154, on production *and* beta. The git tags stop at `v2.4.19` (2025) because tagging stopped tracking Play releases, so the version in `build.gradle.kts` wasn't an unshipped release waiting to go out; it was what's already on people's phones. Hence `27.0.0`. RELEASING.md now tells the next person to ask Play, not git.
2. **The store listing declares exactly one language, `en-US`** (via `edits.listings.list`). Play rejects release notes for any locale the listing doesn't declare, and the rejection fails the whole publish — so the es/fi/it/pl translations of `main_help_whatsnew` deliberately do *not* get copied here.

### Verification

- `bundleObaGoogleRelease` builds locally and R8 completes; the resulting `.aab` is signed (`META-INF/JOULESPE.RSA`). **Nothing in CI had ever built the release variant**, so that path was untested across the whole release.
- `--track` / `--release-status` / `--user-fraction` confirmed against `gradlew help --task publishObaGoogleReleaseBundle`.
- The service account is invited and verified end-to-end (`edits.insert` → 200). It holds testing-track permission only, so production promotion returns 403 and stays a Console action.

### Review fixes

From CodeRabbit: job `GITHUB_TOKEN` narrowed to `contents: read`; the `$GITHUB_WORKSPACE` path quoted; track/status/keys passed via `env` rather than interpolated into the shell. The documented promote command was also genuinely wrong — GPP defaults both ends to the configured track, so a bare `promoteObaGoogleReleaseArtifact` promotes beta onto beta. Fixed in both docs to `--from-track beta --promote-track production` (the option is `--promote-track`, not `--track` as suggested — checked against the task's own `--help`).

Action SHA-pinning was **not** adopted: the other workflows all use version tags, and pinning one workflow inconsistently is worse than a repo-wide decision. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a redesigned app appearance.
  - Improved route grouping, stop route visibility, nearby-route zoom behavior, and trip planning.
  - Added micromobility information to the bike overlay.
  - Added live bus notifications and animated vehicle locations.

- **Bug Fixes**
  - Included multiple fixes and usability improvements.

- **Documentation**
  - Added guidance for staged Google Play releases and testing tracks.
  - Documented release-note conventions and synchronization with in-app notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->