### PR TITLE
Number this release 26.2.0, and write the versioning scheme down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,8 @@ Two things that bite:
 
 - **`versionCode` is not yours to edit, and git tags don't tell you what shipped.** The tags stop
   at `v2.4.19` (2025) while `26.1.0`/code 154 is live on Play — ask Play, not git, before choosing
-  a `versionName`. `resolutionStrategy = AUTO` in the `play {}` block
+  a `versionName`. That name is `YY.RELEASE.PATCH` (year, then which release within the year); the
+  minor is **not** the month — `26.1.0` shipped in March. `resolutionStrategy = AUTO` in the `play {}` block
   auto-increments `versionCode` from the highest code on Play. Only `versionName` is bumped by hand. AUTO is
   consulted on every release *assemble*, not just `publish*` tasks — without credentials the block
   falls back to `IGNORE` and the checked-in `versionCode` is used, so the build works but its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,14 +100,15 @@ account has testing-track permission only.
 
 Two things that bite:
 
-- **`versionCode` is not yours to edit, and git tags don't tell you what shipped.** The tags stop
-  at `v2.4.19` (2025) while `26.1.0`/code 154 is live on Play — ask Play, not git, before choosing
-  a `versionName`. That name is `YY.RELEASE.PATCH` (year, then which release within the year); the
-  minor is **not** the month — `26.1.0` shipped in March. `resolutionStrategy = AUTO` in the `play {}` block
-  auto-increments `versionCode` from the highest code on Play. Only `versionName` is bumped by hand. AUTO is
-  consulted on every release *assemble*, not just `publish*` tasks — without credentials the block
-  falls back to `IGNORE` and the checked-in `versionCode` is used, so the build works but its
-  output must not be uploaded.
+- **`versionCode` is not yours to edit; only `versionName` is.** `resolutionStrategy = AUTO` in the
+  `play {}` block auto-increments `versionCode` from the highest code on Play. AUTO is consulted on
+  every release *assemble*, not just `publish*` tasks — without credentials the block falls back to
+  `IGNORE` and the checked-in `versionCode` is used, so the build works but its output must not be
+  uploaded.
+- **`versionName` is `YY.RELEASE.PATCH`** — the year, then which release it is within that year. The
+  minor is **not** the month: `26.1.0` shipped in March. Tagging only became reliable at `v26.2.0`;
+  earlier releases went out untagged (`26.1.0`/code 154 is live on Play with no tag behind it), so
+  for anything older ask Play rather than git.
 - **Release notes live in two places and must agree**: `main_help_whatsnew` in
   `src/main/res/values/strings.xml` (the in-app what's-new dialog, translated) and
   `src/oba/play/release-notes/en-US/default.txt` (the Play listing, 500-char cap). The Play tree is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,6 +23,23 @@ a release starts closed, and graduating it to open testing is a separate, delibe
 
 [gpp]: https://github.com/Triple-T/gradle-play-publisher
 
+## Version numbering
+
+`versionName` is **`YY.RELEASE.PATCH`**: the two-digit year, then which release it is within that
+year, then any patch on that release. `26.1.0` was the first release of 2026, `26.2.0` the second.
+
+**The minor is not the month.** `26.1.0` shipped in March 2026, which rules that reading out — a
+plausible enough guess that it has already been made once, and it is the reason 27.0.0 briefly
+existed on the alpha track. A release in August is `26.N.0` for whatever N is next, not `26.8.0`.
+
+The year rolls the major: the first release of 2027 is `27.1.0`. Nothing is derived automatically —
+`versionName` is edited by hand, and `versionCode` comes from Play (see below), so the two carry no
+relationship to each other. Don't infer the next number from the git tags either; see step 2.
+
+This convention arrived undocumented — the switch from `2.14.9` to `26.1.0` rode along inside an
+unrelated commit ("Add gradle-play-publisher for automated Play Store releases", 2026-03-19) with no
+rationale — which is precisely how it came to be misread. Hence writing it down here.
+
 ## Cutting a release
 
 1. **Pick the commit.** It should be a commit on `main` that is green in
@@ -55,8 +72,8 @@ a release starts closed, and graduating it to open testing is a separate, delibe
    Play maps to a commit. Do this every time — the tags fell out of sync with Play once already,
    which is why step 2 warns you not to trust them:
 
-       git tag -a v27.0.0 -m "27.0.0" <commit>
-       git push origin v27.0.0
+       git tag -a v26.2.0 -m "26.2.0" <commit>
+       git push origin v26.2.0
 
 6. **Let the closed track sit.** Watch Crashlytics and the Play Console's vitals. This is the whole
    point of the closed rung — it is the only audience that can be surprised cheaply.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,9 +51,10 @@ rationale — which is precisely how it came to be misread. Hence writing it dow
    `resolutionStrategy = AUTO` in the `play {}` block), so the number checked into the file is only
    a fallback for builds without Play credentials.
 
-   Check what's actually live before choosing a name — the git tags have not tracked Play releases
-   and will mislead you. `26.1.0` shipped as versionCode 154 without ever being tagged. The Play
-   Console's release dashboard, or `bootstrapObaGoogleReleaseListing`, is the authority.
+   Check what's actually live before choosing a name. Tagging only became reliable at `v26.2.0` —
+   earlier releases went out untagged, so `26.1.0` is live on Play as versionCode 154 with nothing
+   in git to show for it. For anything older than `v26.2.0`, the Play Console's release dashboard
+   (or `bootstrapObaGoogleReleaseListing`) is the authority, not the tags.
 3. **Write the release notes**, in two places that must agree:
    - `onebusaway-android/src/oba/play/release-notes/en-US/default.txt` — the Play "What's new"
      text, capped at 500 characters. `en-US` is the only locale here because it is the only one the
@@ -74,6 +75,10 @@ rationale — which is precisely how it came to be misread. Hence writing it dow
 
        git tag -a v26.2.0 -m "26.2.0" <commit>
        git push origin v26.2.0
+
+   If a release is superseded before it goes anywhere — a wrong version number caught on a closed
+   track, say — delete the tag along with it, so no tag points at a build that was never graduated:
+   `git push origin :refs/tags/vX.Y.Z && git tag -d vX.Y.Z`.
 
 6. **Let the closed track sit.** Watch Crashlytics and the Play Console's vitals. This is the whole
    point of the closed rung — it is the only audience that can be surprised cheaply.

--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -54,11 +54,15 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         // versionCode is a fallback only: the play {} block's AUTO resolution strategy takes the
-        // real one from the highest code already on Play (154 as of 26.1.0), so this value is used
-        // only by builds with no Play credentials — whose output must never be uploaded. Bump
-        // versionName by hand; see docs/RELEASING.md.
+        // real one from the highest code already on Play, so this value is used only by builds with
+        // no Play credentials — whose output must never be uploaded.
+        //
+        // versionName is YY.RELEASE.PATCH — the two-digit year, then which release it is within that
+        // year, then any patch on it. 26.2.0 is the second release of 2026. The minor is NOT the
+        // month: 26.1.0 shipped in March. See "Version numbering" in docs/RELEASING.md, and bump it
+        // by hand.
         versionCode = 153
-        versionName = "27.0.0"
+        versionName = "26.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionName` is CalVer — `YY.RELEASE.PATCH` — and #2260 shipped `27.0.0`, which misread it as semver and moved the *year* instead of the release ordinal, bringing 2027 four months early. The second release of 2026 is **26.2.0**.

### Why this was easy to get wrong

The scheme was never written down. It arrived inside a commit about something else entirely — `6934a0a73`, "Add gradle-play-publisher for automated Play Store releases" (2026-03-19) — where `2.14.9` silently became `26.1.0`, with no rationale in the message and no note in any doc.

With a single undocumented data point, both obvious readings are guesses:

- **semver** → gave us `27.0.0`
- **`YY.MM.PATCH`** → would give `26.8.0`, and is ruled out only by the fact that **`26.1.0` shipped in March**, which nothing short of `git log -p` over the build file would tell you

So `docs/RELEASING.md` gets a "Version numbering" section that states the scheme *and* records why the month reading is wrong, so the next person doesn't re-derive it from history.

### What this costs

`versionCode` **155 is spent and cannot be reclaimed** — Play never lets a code be reused, and the name is baked into that bundle's manifest. So 26.2.0 goes out as **156** and supersedes 155 on `alpha`. Play only requires `versionCode` to increase, so a version *name* stepping back from 27.0.0 is fine.

Nothing outside the closed developers group ever saw 27.0.0 — `beta` and `production` are still on 26.1.0 / 154. Fixing it now is what keeps the public from seeing it when this build is graduated to beta.

Two visible side effects, both confined to the alpha group: testers who installed 155 get an "update" to a lower-looking number, and the what's-new dialog re-fires once (it gates on `VERSION_CODE`, and 156 > 155).

The `v27.0.0` tag will be replaced with `v26.2.0` once this merges and republishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the `YY.RELEASE.PATCH` version naming format and release numbering rules.
  * Updated release guidance and examples to reflect version `26.2.0`.
  * Documented that release versions are managed independently from build codes and tags.
  * Added guidance for verifying older releases and removing superseded tags.

* **Chores**
  * Updated the app’s displayed version to `26.2.0`.
  * Refined version metadata guidance for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->