### PR TITLE
Don't offer trip planning where there is no trip planner (#2264)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,25 @@ refreshed its region cache.
 - Branching on a **new** region field means adding it to `CHECKED_FIELDS` in that script, with the
   default `RegionDto` decodes for it.
 
+### Not every region has a trip planner (#2264)
+
+Trip planning is the one feature whose server is **per region and published by a third party**, so it
+can be missing or dead in one region while everything else there works. Three of the seven directory
+regions today — Washington, D.C., MTA New York, Davis — publish neither `otpBaseUrl` nor
+`otpBaseGraphqlUrl`, and Tampa Bay publishes an `otpBaseUrl` whose host no longer resolves.
+
+- **One gate, asked everywhere**: `OtpTarget.isAvailable` (custom URL → region OTP2 → region OTP1).
+  Every affordance that can start a plan — the nav-drawer row, the map long-press "navigate here"
+  offer, a `geo:` place shared in from another app — asks `tripPlanningUnavailableMessage(context)`
+  and refuses with its message rather than opening a form that can only fail. Don't restate the
+  branch: a duplicate check is what left the drawer blind to OTP2-only regions.
+- A planner-less region is **not** "no region selected" — say which one it is. That contradiction is
+  the whole of #2264.
+- **`tools/check-region-routing.py`** asks every region's planner for a real plan, building the
+  endpoints exactly as the app does (`otpPlanUrl` / `otp2GraphQlEndpoint`). On-demand, not CI —
+  it depends on servers this project doesn't run, so a third party's outage must not redden the
+  nightly. Run it when routing is reported broken somewhere, or when a region's OTP config changes.
+
 ## White-Label / Branding
 
 The app supports white-labeling via Gradle product flavors. See `docs/REBRANDING.md` for full documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,9 @@ regions today — Washington, D.C., MTA New York, Davis — publish neither `otp
   endpoints exactly as the app does (`otpPlanUrl` / `otp2GraphQlEndpoint`). On-demand, not CI —
   it depends on servers this project doesn't run, so a third party's outage must not redden the
   nightly. Run it when routing is reported broken somewhere, or when a region's OTP config changes.
+  Exit `1` is a broken planner; exit `2` is the run not being a complete answer — the check couldn't
+  start, or a region publishing a planner had no bounds to plan between, so it got no verdict. Only
+  `0` means every published planner actually answered.
 
 ## White-Label / Branding
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
@@ -52,7 +52,15 @@ data class OtpTarget(
      * row, the map's "navigate here" offer and the request itself can't disagree about whether this
      * rider has a planner (#2264).
      */
-    val isAvailable: Boolean get() = !baseUrl.isNullOrBlank()
+    val isAvailable: Boolean get() = usableBaseUrl != null
+
+    /**
+     * [baseUrl] if there is actually a server in it, else null — blank is "no server" exactly as null
+     * is, and a region cached with an empty `otpBaseUrl` is the way blank arrives. The one place that
+     * rule lives: the request path reads this rather than re-deriving it, so it cannot drift from
+     * [isAvailable].
+     */
+    val usableBaseUrl: String? get() = baseUrl?.takeUnless { it.isBlank() }
 
     /** Why no plan can be attempted, or null exactly when [isAvailable]. */
     val unavailable: Unavailable? get() = when {
@@ -116,8 +124,10 @@ data class OtpTarget(
             // OTP1 REST server); route to it when present, else the OTP1 REST base URL. Reads
             // [org.onebusaway.android.region.Region.usesOtp2] rather than re-deriving it, so a
             // region's endpoint and its per-protocol capability flags are resolved from one
-            // definition. A region that publishes neither (Washington, D.C., MTA New York, Davis)
-            // leaves baseUrl null with [regionSelected] true — that is [Unavailable.REGION_HAS_NO_PLANNER].
+            // definition. A region that publishes neither leaves baseUrl null with [regionSelected]
+            // true — that is [Unavailable.REGION_HAS_NO_PLANNER]. Which regions those are is
+            // directory data that changes without this repo touching anything; CLAUDE.md carries the
+            // current list, deliberately in one place.
             return OtpTarget(
                 baseUrl = if (region.usesOtp2) region.otpBaseGraphqlUrl else region.otpBaseUrl,
                 usesOtp2 = region.usesOtp2,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/OtpTarget.kt
@@ -21,18 +21,53 @@ import androidx.core.net.toUri
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
+import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.region.Region
 
 /**
  * The OTP server a trip-plan request targets: its [baseUrl] and whether it speaks OTP 2.x GraphQL.
  *
- * Lifted out of [TripRequestBuilder] so the two callers that need the protocol answer share one
- * definition: the builder itself (which endpoint to hit, and which request shape to build) and the
+ * Lifted out of [TripRequestBuilder] so the callers that need the protocol answer share one
+ * definition: the builder itself (which endpoint to hit, and which request shape to build), the
  * advanced-settings UI (which street preferences are even expressible — OTP2 has no
- * `maxWalkDistance`, OTP1 has no cycling-optimization knob that doesn't collide with `optimize`).
- * Duplicating the resolution in the UI would let the dialog and the request disagree about which
- * server the plan is going to.
+ * `maxWalkDistance`, OTP1 has no cycling-optimization knob that doesn't collide with `optimize`), and
+ * the gates that decide whether to offer trip planning at all ([isAvailable]). Duplicating the
+ * resolution would let the dialog, the offer and the request disagree about which server the plan is
+ * going to.
  */
-data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean) {
+data class OtpTarget(
+    val baseUrl: String?,
+    val usesOtp2: Boolean,
+    /**
+     * Whether a region was selected at all when this target was resolved. Only consulted when no
+     * [baseUrl] resolved, to tell the two very different "can't plan" situations apart — see
+     * [unavailable].
+     */
+    val regionSelected: Boolean
+) {
+
+    /**
+     * Whether a trip plan can be attempted at all: some OTP server — the region's or a custom one — is
+     * configured for this device. The single gate every trip-planning affordance asks, so the drawer
+     * row, the map's "navigate here" offer and the request itself can't disagree about whether this
+     * rider has a planner (#2264).
+     */
+    val isAvailable: Boolean get() = !baseUrl.isNullOrBlank()
+
+    /** Why no plan can be attempted, or null exactly when [isAvailable]. */
+    val unavailable: Unavailable? get() = when {
+        isAvailable -> null
+        regionSelected -> Unavailable.REGION_HAS_NO_PLANNER
+        else -> Unavailable.NO_REGION
+    }
+
+    /**
+     * The two reasons a device has no planner to ask, which read as completely different things to a
+     * rider: [NO_REGION] means the app doesn't yet know which transit system they are in, while
+     * [REGION_HAS_NO_PLANNER] means it does and that system simply publishes no trip planner — the
+     * case that made Washington, D.C. report "No region selected" with D.C. plainly selected (#2264).
+     */
+    enum class Unavailable { NO_REGION, REGION_HAS_NO_PLANNER }
 
     companion object {
 
@@ -40,37 +75,53 @@ data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean) {
 
         /**
          * Resolves the custom-URL-or-region branch once so a caller's base URL and its protocol
-         * can't disagree (#1780). Protocol selection is explicit — a custom server's manual
-         * `..._is_graphql` preference, or a region publishing an `otpBaseGraphqlUrl` — never sniffed
-         * from the URL shape or a failed request. [baseUrl] is null when neither a custom URL nor a
-         * region is available.
+         * can't disagree (#1780), reading both from the app-global seams.
          */
         fun resolve(context: Context): OtpTarget {
             val appContext = context.applicationContext
-            val customUrl = customOtpApiUrl(appContext)
+            val prefs = PreferencesEntryPoint.get(appContext)
+            val customUrl = customOtpApiUrl(prefs)
             if (customUrl != null) {
                 // Host only, never the whole URL: a hand-entered one can carry credentials in its
                 // userinfo or a token in its query, and Log.d is not stripped from release builds.
                 // The host is the part that actually answers "which server am I talking to?".
                 Log.d(TAG, "Using custom OTP API URL set by user (host: ${customUrl.toUri().host ?: "unparsed"}).")
+            }
+            return resolve(
+                customUrl = customUrl,
                 // No [Region] to carry the setting for a custom server, so the user sets it.
-                return OtpTarget(
-                    baseUrl = customUrl,
-                    usesOtp2 = PreferencesEntryPoint.get(appContext)
-                        .getBoolean(R.string.preference_key_otp_api_url_is_graphql, false)
-                )
+                customUrlUsesOtp2 = prefs.getBoolean(R.string.preference_key_otp_api_url_is_graphql, false),
+                region = RegionEntryPoint.get(appContext).currentRegion()
+            )
+        }
+
+        /**
+         * The resolution itself, over values a caller already holds — `Context`-free so it is
+         * JVM-unit-testable and so the nav drawer's "offer trip planning?" gate can reach the same
+         * answer from its injected region/preference seams instead of restating the branch.
+         *
+         * Protocol selection is explicit — a custom server's manual `..._is_graphql` preference, or a
+         * region publishing an `otpBaseGraphqlUrl` — never sniffed from the URL shape or a failed
+         * request. [baseUrl] is null when neither a custom URL nor a planner-carrying region is
+         * available.
+         */
+        fun resolve(customUrl: String?, customUrlUsesOtp2: Boolean, region: Region?): OtpTarget {
+            if (customUrl != null) {
+                return OtpTarget(customUrl, usesOtp2 = customUrlUsesOtp2, regionSelected = region != null)
             }
             // No custom URL and no selected region: baseUrl stays null so the caller
             // (TripPlanRepository) surfaces a "no server selected" error instead of crashing.
-            val region = RegionEntryPoint.get(appContext).currentRegion() ?: return OtpTarget(null, false)
+            region ?: return OtpTarget(null, usesOtp2 = false, regionSelected = false)
             // An OTP2 region publishes its GraphQL endpoint separately (a different host than the
             // OTP1 REST server); route to it when present, else the OTP1 REST base URL. Reads
             // [org.onebusaway.android.region.Region.usesOtp2] rather than re-deriving it, so a
             // region's endpoint and its per-protocol capability flags are resolved from one
-            // definition.
+            // definition. A region that publishes neither (Washington, D.C., MTA New York, Davis)
+            // leaves baseUrl null with [regionSelected] true — that is [Unavailable.REGION_HAS_NO_PLANNER].
             return OtpTarget(
                 baseUrl = if (region.usesOtp2) region.otpBaseGraphqlUrl else region.otpBaseUrl,
-                usesOtp2 = region.usesOtp2
+                usesOtp2 = region.usesOtp2,
+                regionSelected = true
             )
         }
 
@@ -84,8 +135,8 @@ data class OtpTarget(val baseUrl: String?, val usesOtp2: Boolean) {
          * storing (`AdvancedSettingsViewModel.onCustomOtpApiUrlChanged`) — but this is the reader that
          * decides which server the app talks to, so it should not depend on every writer behaving.
          */
-        private fun customOtpApiUrl(context: Context): String? = PreferencesEntryPoint.get(context)
-            .getString(context.getString(R.string.preference_key_otp_api_url), null as String?)
+        fun customOtpApiUrl(prefs: PreferencesRepository): String? = prefs
+            .getString(R.string.preference_key_otp_api_url, null as String?)
             ?.trim()
             ?.takeUnless { it.isEmpty() }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -210,7 +210,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
     }
 
     /** The OTP server this request targets; see [OtpTarget.resolve]. */
-    private val otpTarget: OtpTarget
+    val otpTarget: OtpTarget
         get() = OtpTarget.resolve(mContext)
 
     /**
@@ -219,7 +219,10 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
      */
     val formattedOtpBaseUrl: String?
         get() {
-            var otpBaseUrl = otpTarget.baseUrl ?: return null
+            // Blank is "no server" just as null is, so this stays exactly the negation of
+            // [OtpTarget.isAvailable] — otherwise a region cached with an empty otpBaseUrl would get
+            // an https:// prefix glued to nothing and fail as a connectivity error instead.
+            var otpBaseUrl = otpTarget.baseUrl?.takeUnless { it.isBlank() } ?: return null
             try {
                 // URI.parse() doesn't tell us if the scheme is missing, so use URL() instead (#126)
                 URL(otpBaseUrl)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/directions/util/TripRequestBuilder.kt
@@ -219,10 +219,7 @@ class TripRequestBuilder(context: Context, private val mBundle: Bundle) {
      */
     val formattedOtpBaseUrl: String?
         get() {
-            // Blank is "no server" just as null is, so this stays exactly the negation of
-            // [OtpTarget.isAvailable] — otherwise a region cached with an empty otpBaseUrl would get
-            // an https:// prefix glued to nothing and fail as a connectivity error instead.
-            var otpBaseUrl = otpTarget.baseUrl?.takeUnless { it.isBlank() } ?: return null
+            var otpBaseUrl = otpTarget.usableBaseUrl ?: return null
             try {
                 // URI.parse() doesn't tell us if the scheme is missing, so use URL() instead (#126)
                 URL(otpBaseUrl)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/rental/RentalPlacesRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/rental/RentalPlacesRepository.kt
@@ -132,11 +132,11 @@ sealed interface RentalSource {
  * Mirrors [org.onebusaway.android.directions.util.OtpTarget.resolve]'s branch exactly — a custom
  * server wins over the region, and the protocol is always an explicit setting (the custom URL's own
  * `..._is_graphql` preference, or a region publishing an `otpBaseGraphqlUrl`) rather than anything
- * sniffed from the URL. It is a separate function rather than a call into `OtpTarget` because that
- * one resolves through `Context` EntryPoints, while this repository already holds the injected region
- * and preference seams — and because the rental layer asks a question trip planning doesn't: a region
- * can speak OTP2 while publishing **no** rental data over it, in which case there is still an OTP1
- * server with rentals to fall back to.
+ * sniffed from the URL. It is a separate function rather than a call into `OtpTarget.resolve` — which
+ * since #2264 has a `Context`-free overload this repository's injected seams could feed — because the
+ * rental layer asks a question trip planning doesn't: a region can speak OTP2 while publishing **no**
+ * rental data over it, in which case there is still an OTP1 server with rentals to fall back to. That
+ * fallback is the whole difference, and it is why the two answers must be allowed to differ.
  *
  * Pure, so `RentalSourceTest` can cover the grid without a device.
  */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -21,6 +21,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -76,6 +77,7 @@ import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.pinned.PinnedTripViewModel
 import org.onebusaway.android.ui.tripplan.toGeocoded
+import org.onebusaway.android.ui.tripplan.tripPlanningUnavailableMessage
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tutorial.TutorialPrefs
 import org.onebusaway.android.util.ExternalIntents
@@ -332,6 +334,12 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun maybePlanToPlaceFromIntent(intent: Intent) {
         val place = PlaceIntents.placeForIntent(intent) ?: return
+        // A region with no OTP server can't plan anything, so opening the form on a shared address
+        // would only walk the rider into a failure; say why instead (#2264).
+        tripPlanningUnavailableMessage(this)?.let { message ->
+            Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+            return
+        }
         viewModel.enterDirections()
         when (place) {
             is PlaceIntents.Place.Point ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -21,7 +21,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -76,8 +75,8 @@ import org.onebusaway.android.ui.survey.SurveyViewModel
 import org.onebusaway.android.ui.tripplan.TripEndpointSlot
 import org.onebusaway.android.ui.tripplan.TripPlanViewModel
 import org.onebusaway.android.ui.tripplan.pinned.PinnedTripViewModel
+import org.onebusaway.android.ui.tripplan.refuseTripPlanIfUnavailable
 import org.onebusaway.android.ui.tripplan.toGeocoded
-import org.onebusaway.android.ui.tripplan.tripPlanningUnavailableMessage
 import org.onebusaway.android.ui.tripresults.TripResultsViewModel
 import org.onebusaway.android.ui.tutorial.TutorialPrefs
 import org.onebusaway.android.util.ExternalIntents
@@ -334,12 +333,9 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun maybePlanToPlaceFromIntent(intent: Intent) {
         val place = PlaceIntents.placeForIntent(intent) ?: return
-        // A region with no OTP server can't plan anything, so opening the form on a shared address
-        // would only walk the rider into a failure; say why instead (#2264).
-        tripPlanningUnavailableMessage(this)?.let { message ->
-            Toast.makeText(this, message, Toast.LENGTH_LONG).show()
-            return
-        }
+        // Opening the form on a shared address in a region with no planner would only walk the rider
+        // into a failure; say why instead (#2264).
+        if (refuseTripPlanIfUnavailable()) return
         viewModel.enterDirections()
         when (place) {
             is PlaceIntents.Place.Point ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/NavItemsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/drawer/NavItemsRepository.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.home.drawer
 import android.text.TextUtils
 import javax.inject.Inject
 import org.onebusaway.android.R
+import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.push.FirebaseMessagingManager
 import org.onebusaway.android.region.RegionRepository
@@ -42,8 +43,8 @@ interface NavItemsRepository {
 
 /**
  * Default implementation reading the app-global region + reminder preference (the static reads lifted
- * out of HomeActivity.refreshDrawerItems). Trip-planning needs a region OTP url (or a custom one); fare
- * payment needs the region's payment app id; reminders follow the preference.
+ * out of HomeActivity.refreshDrawerItems). Trip-planning needs an OTP server to ask (the region's or a
+ * custom one); fare payment needs the region's payment app id; reminders follow the preference.
  */
 class DefaultNavItemsRepository @Inject constructor(
     private val regionRepository: RegionRepository,
@@ -55,11 +56,14 @@ class DefaultNavItemsRepository @Inject constructor(
         val region = regionRepository.region.value
         return NavItemAvailability(
             showReminders = firebaseMessagingManager.hasPushToken(),
-            planTripAvailable = region != null &&
-                (
-                    !TextUtils.isEmpty(region.otpBaseUrl) ||
-                        !TextUtils.isEmpty(prefs.getString(R.string.preference_key_otp_api_url, null))
-                    ),
+            // Asks [OtpTarget] rather than restating "has an otpBaseUrl or a custom url": that check
+            // never learned about OTP2 regions, so a region publishing only an `otpBaseGraphqlUrl`
+            // would have had its drawer row hidden while a plan against it would have worked (#2264).
+            planTripAvailable = OtpTarget.resolve(
+                customUrl = OtpTarget.customOtpApiUrl(prefs),
+                customUrlUsesOtp2 = prefs.getBoolean(R.string.preference_key_otp_api_url_is_graphql, false),
+                region = region
+            ).isAvailable,
             payFareAvailable = region != null && !TextUtils.isEmpty(region.paymentAndroidAppId)
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -114,7 +114,7 @@ import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.home.focusedBikeStationId
 import org.onebusaway.android.ui.home.focusedStop
 import org.onebusaway.android.ui.home.nearby.NearbyArrivalsViewModel
-import org.onebusaway.android.ui.tripplan.tripPlanningUnavailableMessage
+import org.onebusaway.android.ui.tripplan.refuseTripPlanIfUnavailable
 import org.onebusaway.android.ui.tutorial.LocalTutorialState
 import org.onebusaway.android.ui.tutorial.MapPointSpotlight
 import org.onebusaway.android.ui.tutorial.MapStopSpotlight
@@ -231,14 +231,8 @@ fun MapFeature(
 
             override fun onMapLongClick(point: GeoPoint) {
                 // The offer's only destination is the trip planner, so it is made only where there is
-                // one to reach. In a region that publishes no OTP server the bubble could only ever end
-                // in a failed plan, so the gesture is answered with the reason instead — naming the
-                // region, because "no trip planning" arriving as "No region selected" is exactly the
-                // confusion this replaces (#2264).
-                tripPlanningUnavailableMessage(context)?.let { message ->
-                    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-                    return
-                }
+                // one to reach; where there isn't, the gesture is answered with the reason (#2264).
+                if (context.refuseTripPlanIfUnavailable()) return
                 // The one gesture that *raises* the offer: drop the pin, which is what the home screen
                 // hangs its "navigate here" bubble off (#2243).
                 mapViewModel.setNavigateHerePin(point)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -114,6 +114,7 @@ import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.home.focusedBikeStationId
 import org.onebusaway.android.ui.home.focusedStop
 import org.onebusaway.android.ui.home.nearby.NearbyArrivalsViewModel
+import org.onebusaway.android.ui.tripplan.tripPlanningUnavailableMessage
 import org.onebusaway.android.ui.tutorial.LocalTutorialState
 import org.onebusaway.android.ui.tutorial.MapPointSpotlight
 import org.onebusaway.android.ui.tutorial.MapStopSpotlight
@@ -229,6 +230,15 @@ fun MapFeature(
             }
 
             override fun onMapLongClick(point: GeoPoint) {
+                // The offer's only destination is the trip planner, so it is made only where there is
+                // one to reach. In a region that publishes no OTP server the bubble could only ever end
+                // in a failed plan, so the gesture is answered with the reason instead — naming the
+                // region, because "no trip planning" arriving as "No region selected" is exactly the
+                // confusion this replaces (#2264).
+                tripPlanningUnavailableMessage(context)?.let { message ->
+                    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+                    return
+                }
                 // The one gesture that *raises* the offer: drop the pin, which is what the home screen
                 // hangs its "navigate here" bubble off (#2243).
                 mapViewModel.setNavigateHerePin(point)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -34,6 +34,7 @@ import org.onebusaway.android.api.contract.TripPlanRequest
 import org.onebusaway.android.directions.model.TripItinerary
 import org.onebusaway.android.directions.model.TripMode
 import org.onebusaway.android.directions.util.CustomAddress
+import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.util.runCatchingCancellable
@@ -86,9 +87,7 @@ class DefaultTripPlanRepository @Inject constructor(
      */
     private fun planInternal(builder: TripRequestBuilder): List<TripItinerary> {
         val baseUrl = builder.formattedOtpBaseUrl
-            ?: throw TripPlanException(
-                TripPlanError(TripPlanError.Category.REQUEST, R.string.tripplanner_no_server_selected_error)
-            )
+            ?: throw TripPlanException(noPlannerError(builder.otpTarget.unavailable))
 
         if (builder.usesOtp2) {
             return otp2Planner.plan(builder, baseUrl)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -87,7 +87,7 @@ class DefaultTripPlanRepository @Inject constructor(
      */
     private fun planInternal(builder: TripRequestBuilder): List<TripItinerary> {
         val baseUrl = builder.formattedOtpBaseUrl
-            ?: throw TripPlanException(noPlannerError(builder.otpTarget.unavailable))
+            ?: throw TripPlanException(noPlannerError(builder.otpTarget))
 
         if (builder.usesOtp2) {
             return otp2Planner.plan(builder, baseUrl)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
@@ -136,12 +136,15 @@ class TripPlanViewModel @Inject constructor(
         // region's planner can only fail on — and in a region with no planner at all it can't even be
         // asked (#2264). Clearing takes the drawn result with it, so nothing outlives the switch.
         //
-        // Only a switch *between* regions counts. The first resolution — null until the directory
-        // lands, or until the rider picks — is not a switch, and treating it as one would wipe a trip
-        // that a notification restore or a pinned resume put here while the region was still settling.
+        // Only a switch *away from* a region counts. The leading null — the region is unresolved
+        // until the directory lands, or until the rider picks — is not a switch, and treating it as
+        // one would wipe a trip that a notification restore or a pinned resume put here while the
+        // region was still settling. Dropped by [dropWhile] rather than by filtering nulls out
+        // altogether, so a *later* null — the rider clearing the region, a refresh that finds none —
+        // still strands the trip and still clears it.
         regionRepository.region
             .map { it?.id }
-            .filterNotNull()
+            .dropWhile { it == null }
             .distinctUntilChanged()
             .drop(1)
             .onEach { clearTrip() }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -36,7 +36,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -127,6 +131,22 @@ class TripPlanViewModel @Inject constructor(
     private val planInputs = Channel<TripPlanParams?>(Channel.CONFLATED)
 
     init {
+        // A trip is a pair of places in one transit system, so a region switch invalidates both ends at
+        // once: the rider is now in Seattle holding a Tampa origin and destination, which the new
+        // region's planner can only fail on — and in a region with no planner at all it can't even be
+        // asked (#2264). Clearing takes the drawn result with it, so nothing outlives the switch.
+        //
+        // Only a switch *between* regions counts. The first resolution — null until the directory
+        // lands, or until the rider picks — is not a switch, and treating it as one would wipe a trip
+        // that a notification restore or a pinned resume put here while the region was still settling.
+        regionRepository.region
+            .map { it?.id }
+            .filterNotNull()
+            .distinctUntilChanged()
+            .drop(1)
+            .onEach { clearTrip() }
+            .launchIn(viewModelScope)
+
         queries.forEach { (slot, typed) ->
             typed
                 .debounce(SUGGEST_DEBOUNCE_MS)
@@ -282,11 +302,13 @@ class TripPlanViewModel @Inject constructor(
     /**
      * Clears the whole trip — both endpoints and any planned result — back to an empty form.
      *
-     * Not a rider-facing control (the pills clear one end at a time, [clearEndpoint]): this is for the
-     * scripted tour's teardown (#2164). The tour fills the planner in with the demo transit system's
-     * Seattle endpoints and plans them, and this ViewModel is activity-scoped, so without this the
-     * rider's next visit to Plan Trip opens on a trip they never asked for, drawn on the map, that only
-     * the demo deployment could have produced — and re-planning it against the real OTP just errors.
+     * Not a rider-facing control (the pills clear one end at a time, [clearEndpoint]). Two things ask
+     * for it, and they are the same situation: a trip left over from a transit system that is no longer
+     * the one the app is pointed at. The scripted tour's teardown (#2164) — the tour fills the planner
+     * in with the demo system's Seattle endpoints and plans them, and this ViewModel is activity-scoped,
+     * so without this the rider's next visit to Plan Trip opens on a trip they never asked for, drawn on
+     * the map, that only the demo deployment could have produced. And a region switch, above, which
+     * strands a real trip the same way.
      *
      * Both ends are emptied in one form write, so the submit below sees an unsubmittable form and drops
      * the result to [PlanResult.Idle] rather than putting a plan on the wire.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanningAvailability.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanningAvailability.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripplan
 
 import android.content.Context
+import android.widget.Toast
 import org.onebusaway.android.R
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.directions.util.OtpTarget
@@ -24,12 +25,13 @@ import org.onebusaway.android.directions.util.OtpTarget
  * What to tell a rider who asked for a trip plan on a device that has no trip planner to ask — and, by
  * returning null, that there is one and the gesture may go ahead (#2264).
  *
- * Not every OneBusAway region publishes an OpenTripPlanner server: of the seven in the directory today
- * three (Washington, D.C., MTA New York, Davis) publish none at all. The nav drawer has always hidden
- * its "Plan a trip" row for those, but the map's long-press "navigate here" offer and a place shared in
- * from another app both entered the trip planner regardless, and the plan then failed with "No region
- * selected" — while the region sat plainly selected in the drawer. So the gate and its wording live
- * here, together, and every affordance that can start a plan asks this one function.
+ * Not every OneBusAway region publishes an OpenTripPlanner server, and which ones don't is directory
+ * data that changes without this repo touching anything (CLAUDE.md carries the current list). The nav
+ * drawer has always hidden its "Plan a trip" row for those regions, but the map's long-press "navigate
+ * here" offer and a place shared in from another app both entered the trip planner regardless, and the
+ * plan then failed with "No region selected" — while the region sat plainly selected in the drawer. So
+ * the gate and its wording live here, together, and every affordance that can start a plan asks this
+ * one function.
  *
  * The two "no planner" cases are kept apart because they read as completely different things: with no
  * region resolved the app really doesn't know which transit system to ask, and "No region selected" is
@@ -48,20 +50,36 @@ fun tripPlanningUnavailableMessage(context: Context): String? = when (OtpTarget.
 }
 
 /**
+ * Refuses a trip-planning gesture that has nowhere to go, telling the rider why: shows
+ * [tripPlanningUnavailableMessage] and returns true, or does nothing and returns false when there is a
+ * planner and the gesture should proceed.
+ *
+ * The one home for *how* the app declines — a toast, because the gesture is the rider's whole
+ * interaction here and there is no surface of ours yet on screen to seat a snackbar in. Each caller
+ * then reads as the single line it is, and the third affordance that needs this gate inherits the
+ * decision instead of copying it.
+ */
+fun Context.refuseTripPlanIfUnavailable(): Boolean {
+    val message = tripPlanningUnavailableMessage(this) ?: return false
+    Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+    return true
+}
+
+/**
  * The error for a plan that never left the device because there is no OTP server to send it to — the
  * same fact as [tripPlanningUnavailableMessage], classified for the directions error snackbar (which
  * renders a bare string resource, so this side can't name the region).
  *
  * Reached when a plan is submitted from a directions form that was already open — a region switch
- * underneath it, a pinned trip resumed, a notification restored — rather than from a gesture the gate
- * above can refuse.
+ * underneath it, a pinned trip resumed, a notification restored — rather than from a gesture
+ * [refuseTripPlanIfUnavailable] can turn away. Takes the resolved [target] rather than a nullable
+ * reason so there is no "no reason" case to write an unreachable branch for.
  */
-internal fun noPlannerError(unavailable: OtpTarget.Unavailable?): TripPlanError = TripPlanError(
+internal fun noPlannerError(target: OtpTarget): TripPlanError = TripPlanError(
     TripPlanError.Category.REQUEST,
-    when (unavailable) {
-        OtpTarget.Unavailable.REGION_HAS_NO_PLANNER -> R.string.tripplanner_error_region_no_planner
-        // NO_REGION, and defensively the "shouldn't happen" null: a base URL did resolve, yet the
-        // request path decided it had no server.
-        else -> R.string.tripplanner_no_server_selected_error
+    if (target.regionSelected) {
+        R.string.tripplanner_error_region_no_planner
+    } else {
+        R.string.tripplanner_no_server_selected_error
     }
 )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanningAvailability.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanningAvailability.kt
@@ -30,8 +30,8 @@ import org.onebusaway.android.directions.util.OtpTarget
  * drawer has always hidden its "Plan a trip" row for those regions, but the map's long-press "navigate
  * here" offer and a place shared in from another app both entered the trip planner regardless, and the
  * plan then failed with "No region selected" — while the region sat plainly selected in the drawer. So
- * the gate and its wording live here, together, and every affordance that can start a plan asks this
- * one function.
+ * the gate and its wording live here, together; affordances reach them through
+ * [refuseTripPlanIfUnavailable], which is this answer plus the one way the app delivers it.
  *
  * The two "no planner" cases are kept apart because they read as completely different things: with no
  * region resolved the app really doesn't know which transit system to ask, and "No region selected" is

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanningAvailability.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanningAvailability.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripplan
+
+import android.content.Context
+import org.onebusaway.android.R
+import org.onebusaway.android.app.di.RegionEntryPoint
+import org.onebusaway.android.directions.util.OtpTarget
+
+/**
+ * What to tell a rider who asked for a trip plan on a device that has no trip planner to ask — and, by
+ * returning null, that there is one and the gesture may go ahead (#2264).
+ *
+ * Not every OneBusAway region publishes an OpenTripPlanner server: of the seven in the directory today
+ * three (Washington, D.C., MTA New York, Davis) publish none at all. The nav drawer has always hidden
+ * its "Plan a trip" row for those, but the map's long-press "navigate here" offer and a place shared in
+ * from another app both entered the trip planner regardless, and the plan then failed with "No region
+ * selected" — while the region sat plainly selected in the drawer. So the gate and its wording live
+ * here, together, and every affordance that can start a plan asks this one function.
+ *
+ * The two "no planner" cases are kept apart because they read as completely different things: with no
+ * region resolved the app really doesn't know which transit system to ask, and "No region selected" is
+ * the honest answer; with one resolved, naming it is what stops the message from contradicting the
+ * region the rider can see the app using.
+ */
+fun tripPlanningUnavailableMessage(context: Context): String? = when (OtpTarget.resolve(context).unavailable) {
+    null -> null
+    OtpTarget.Unavailable.NO_REGION -> context.getString(R.string.tripplanner_no_server_selected_error)
+    // Read here rather than carried on [OtpTarget]: the region is a cached StateFlow value, so a second
+    // read costs nothing, and the target stays a statement about servers rather than about names.
+    OtpTarget.Unavailable.REGION_HAS_NO_PLANNER -> context.getString(
+        R.string.trip_plan_unavailable_in_region,
+        RegionEntryPoint.get(context.applicationContext).currentRegion()?.name.orEmpty()
+    )
+}
+
+/**
+ * The error for a plan that never left the device because there is no OTP server to send it to — the
+ * same fact as [tripPlanningUnavailableMessage], classified for the directions error snackbar (which
+ * renders a bare string resource, so this side can't name the region).
+ *
+ * Reached when a plan is submitted from a directions form that was already open — a region switch
+ * underneath it, a pinned trip resumed, a notification restored — rather than from a gesture the gate
+ * above can refuse.
+ */
+internal fun noPlannerError(unavailable: OtpTarget.Unavailable?): TripPlanError = TripPlanError(
+    TripPlanError.Category.REQUEST,
+    when (unavailable) {
+        OtpTarget.Unavailable.REGION_HAS_NO_PLANNER -> R.string.tripplanner_error_region_no_planner
+        // NO_REGION, and defensively the "shouldn't happen" null: a base URL did resolve, yet the
+        // request path decided it had no server.
+        else -> R.string.tripplanner_no_server_selected_error
+    }
+)

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1186,6 +1186,13 @@
 
 
     <string name="tripplanner_no_server_selected_error">No region selected</string>
+    <!-- Shown when the app knows perfectly well which region the rider is in, and that region simply
+         publishes no trip planner (Washington, D.C., MTA New York, Davis) — the case that used to
+         report "No region selected" with the region plainly selected. -->
+    <string name="tripplanner_error_region_no_planner">This region doesn&#8217;t offer trip planning</string>
+    <!-- Toast shown when a trip-planning gesture is made in a region with no trip planner; %1$s is the
+         region name, so the rider can see which region the app thinks they are in. -->
+    <string name="trip_plan_unavailable_in_region">%1$s doesn&#8217;t offer trip planning</string>
     <!-- Errors -->
     <!-- Trip-plan error category headers (the consistent heading on the error snackbar; the specific
          wire message is shown as the reason line beneath). One header per category, so e.g. every

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1187,11 +1187,14 @@
 
     <string name="tripplanner_no_server_selected_error">No region selected</string>
     <!-- Shown when the app knows perfectly well which region the rider is in, and that region simply
-         publishes no trip planner (Washington, D.C., MTA New York, Davis) — the case that used to
-         report "No region selected" with the region plainly selected. -->
+         publishes no trip planner — the case that used to report "No region selected" with the region
+         plainly selected. The trip-plan error snackbar renders a bare string with no arguments, which
+         is why this one can't name the region the way trip_plan_unavailable_in_region does; the two
+         say the same thing and should read alike in a given locale. -->
     <string name="tripplanner_error_region_no_planner">This region doesn&#8217;t offer trip planning</string>
     <!-- Toast shown when a trip-planning gesture is made in a region with no trip planner; %1$s is the
-         region name, so the rider can see which region the app thinks they are in. -->
+         region name, so the rider can see which region the app thinks they are in. The unnamed
+         sibling of tripplanner_error_region_no_planner — keep the two worded consistently. -->
     <string name="trip_plan_unavailable_in_region">%1$s doesn&#8217;t offer trip planning</string>
     <!-- Errors -->
     <!-- Trip-plan error category headers (the consistent heading on the error snackbar; the specific

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/OtpTargetTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/OtpTargetTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.onebusaway.android.region.Region
+import org.onebusaway.android.region.region
 
 /**
  * Unit tests for [OtpTarget.resolve] — which OTP server a plan targets, and whether there is one to
@@ -30,10 +31,9 @@ import org.onebusaway.android.region.Region
  */
 class OtpTargetTest {
 
-    private fun region(otpBaseUrl: String? = null, otpBaseGraphqlUrl: String? = null) = Region(
+    // Region 4 is Washington, D.C. — the planner-less region #2264 was reported against.
+    private fun dcRegion(otpBaseUrl: String? = null, otpBaseGraphqlUrl: String? = null) = region(
         id = 4,
-        name = "Washington, D.C.",
-        active = true,
         otpBaseUrl = otpBaseUrl,
         otpBaseGraphqlUrl = otpBaseGraphqlUrl
     )
@@ -42,7 +42,7 @@ class OtpTargetTest {
 
     @Test
     fun `an OTP1 region targets its REST base url`() {
-        val target = resolve(region = region(otpBaseUrl = "https://otp.example.org/otp"))
+        val target = resolve(region = dcRegion(otpBaseUrl = "https://otp.example.org/otp"))
 
         assertEquals("https://otp.example.org/otp", target.baseUrl)
         assertFalse(target.usesOtp2)
@@ -53,7 +53,7 @@ class OtpTargetTest {
     @Test
     fun `a region publishing a GraphQL endpoint targets it over the REST one`() {
         val target = resolve(
-            region = region(
+            region = dcRegion(
                 otpBaseUrl = "https://otp1.example.org/otp",
                 otpBaseGraphqlUrl = "https://otp2.example.org/otp"
             )
@@ -67,7 +67,7 @@ class OtpTargetTest {
     /** The gap the old drawer check had: OTP2-only regions are planner-carrying regions. */
     @Test
     fun `a GraphQL-only region is available`() {
-        val target = resolve(region = region(otpBaseGraphqlUrl = "https://otp2.example.org/otp"))
+        val target = resolve(region = dcRegion(otpBaseGraphqlUrl = "https://otp2.example.org/otp"))
 
         assertTrue(target.isAvailable)
         assertTrue(target.usesOtp2)
@@ -75,7 +75,7 @@ class OtpTargetTest {
 
     @Test
     fun `a region with no planner is unavailable but is still a selected region`() {
-        val target = resolve(region = region())
+        val target = resolve(region = dcRegion())
 
         assertFalse(target.isAvailable)
         assertEquals(OtpTarget.Unavailable.REGION_HAS_NO_PLANNER, target.unavailable)
@@ -84,7 +84,7 @@ class OtpTargetTest {
     /** An empty otpBaseUrl is the same fact as a missing one — see `formattedOtpBaseUrl`. */
     @Test
     fun `a region with a blank planner url is unavailable`() {
-        val target = resolve(region = region(otpBaseUrl = ""))
+        val target = resolve(region = dcRegion(otpBaseUrl = ""))
 
         assertFalse(target.isAvailable)
         assertEquals(OtpTarget.Unavailable.REGION_HAS_NO_PLANNER, target.unavailable)
@@ -103,7 +103,7 @@ class OtpTargetTest {
         val target = resolve(
             customUrl = "https://custom.example.org/otp",
             customUrlUsesOtp2 = true,
-            region = region(otpBaseUrl = "https://otp.example.org/otp")
+            region = dcRegion(otpBaseUrl = "https://otp.example.org/otp")
         )
 
         assertEquals("https://custom.example.org/otp", target.baseUrl)
@@ -114,6 +114,6 @@ class OtpTargetTest {
     /** A custom server is a planner even where the region has none — the D.C. rider who set one. */
     @Test
     fun `a custom url makes a planner-less region available`() {
-        assertTrue(resolve(customUrl = "https://custom.example.org/otp", region = region()).isAvailable)
+        assertTrue(resolve(customUrl = "https://custom.example.org/otp", region = dcRegion()).isAvailable)
     }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/OtpTargetTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/directions/util/OtpTargetTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.directions.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.region.Region
+
+/**
+ * Unit tests for [OtpTarget.resolve] — which OTP server a plan targets, and whether there is one to
+ * target at all (#2264). The rule that matters here is the second one: three of the seven regions in
+ * the directory publish no planner, and telling *that* apart from "no region selected" is what the
+ * whole availability gate rests on.
+ */
+class OtpTargetTest {
+
+    private fun region(otpBaseUrl: String? = null, otpBaseGraphqlUrl: String? = null) = Region(
+        id = 4,
+        name = "Washington, D.C.",
+        active = true,
+        otpBaseUrl = otpBaseUrl,
+        otpBaseGraphqlUrl = otpBaseGraphqlUrl
+    )
+
+    private fun resolve(customUrl: String? = null, customUrlUsesOtp2: Boolean = false, region: Region? = null) = OtpTarget.resolve(customUrl, customUrlUsesOtp2, region)
+
+    @Test
+    fun `an OTP1 region targets its REST base url`() {
+        val target = resolve(region = region(otpBaseUrl = "https://otp.example.org/otp"))
+
+        assertEquals("https://otp.example.org/otp", target.baseUrl)
+        assertFalse(target.usesOtp2)
+        assertTrue(target.isAvailable)
+        assertNull(target.unavailable)
+    }
+
+    @Test
+    fun `a region publishing a GraphQL endpoint targets it over the REST one`() {
+        val target = resolve(
+            region = region(
+                otpBaseUrl = "https://otp1.example.org/otp",
+                otpBaseGraphqlUrl = "https://otp2.example.org/otp"
+            )
+        )
+
+        assertEquals("https://otp2.example.org/otp", target.baseUrl)
+        assertTrue(target.usesOtp2)
+        assertTrue(target.isAvailable)
+    }
+
+    /** The gap the old drawer check had: OTP2-only regions are planner-carrying regions. */
+    @Test
+    fun `a GraphQL-only region is available`() {
+        val target = resolve(region = region(otpBaseGraphqlUrl = "https://otp2.example.org/otp"))
+
+        assertTrue(target.isAvailable)
+        assertTrue(target.usesOtp2)
+    }
+
+    @Test
+    fun `a region with no planner is unavailable but is still a selected region`() {
+        val target = resolve(region = region())
+
+        assertFalse(target.isAvailable)
+        assertEquals(OtpTarget.Unavailable.REGION_HAS_NO_PLANNER, target.unavailable)
+    }
+
+    /** An empty otpBaseUrl is the same fact as a missing one — see `formattedOtpBaseUrl`. */
+    @Test
+    fun `a region with a blank planner url is unavailable`() {
+        val target = resolve(region = region(otpBaseUrl = ""))
+
+        assertFalse(target.isAvailable)
+        assertEquals(OtpTarget.Unavailable.REGION_HAS_NO_PLANNER, target.unavailable)
+    }
+
+    @Test
+    fun `no region and no custom url is the no-region case`() {
+        val target = resolve()
+
+        assertFalse(target.isAvailable)
+        assertEquals(OtpTarget.Unavailable.NO_REGION, target.unavailable)
+    }
+
+    @Test
+    fun `a custom url wins over the region and carries its own protocol setting`() {
+        val target = resolve(
+            customUrl = "https://custom.example.org/otp",
+            customUrlUsesOtp2 = true,
+            region = region(otpBaseUrl = "https://otp.example.org/otp")
+        )
+
+        assertEquals("https://custom.example.org/otp", target.baseUrl)
+        assertTrue(target.usesOtp2)
+        assertTrue(target.isAvailable)
+    }
+
+    /** A custom server is a planner even where the region has none — the D.C. rider who set one. */
+    @Test
+    fun `a custom url makes a planner-less region available`() {
+        assertTrue(resolve(customUrl = "https://custom.example.org/otp", region = region()).isAvailable)
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/region/RegionTestFixtures.kt
@@ -89,7 +89,13 @@ internal class FakeRegionRepository(initial: Region? = null) : RegionRepository 
     }
 }
 
-/** Minimal [Region] fixture — only the id matters to the selection logic (compared by id). */
+/**
+ * Minimal [Region] fixture — only the id matters to the selection logic (compared by id).
+ *
+ * The two OTP endpoints are parameters rather than fixed nulls because whether a region publishes a
+ * planner at all is itself behaviour under test (#2264), and every combination of the two is a real
+ * region in the directory: OTP1 only, GraphQL only, both, and neither.
+ */
 internal fun region(
     id: Long,
     obaBaseUrl: String? = null,
@@ -98,7 +104,9 @@ internal fun region(
     otpContactEmail: String? = null,
     custom: Boolean = false,
     sidecarBaseUrl: String? = null,
-    sidecarRegionId: Long? = null
+    sidecarRegionId: Long? = null,
+    otpBaseUrl: String? = null,
+    otpBaseGraphqlUrl: String? = null
 ): Region = Region(
     id = id,
     name = "Region $id",
@@ -115,10 +123,10 @@ internal fun region(
     twitterUrl = twitterUrl,
     experimental = false,
     stopInfoUrl = null,
-    otpBaseUrl = null,
+    otpBaseUrl = otpBaseUrl,
     otpContactEmail = otpContactEmail,
     supportsOtpBikeshare = supportsOtpBikeshare,
-    otpBaseGraphqlUrl = null,
+    otpBaseGraphqlUrl = otpBaseGraphqlUrl,
     supportsOtpGraphqlBikeshare = false,
     supportsEmbeddedSocial = false,
     paymentAndroidAppId = null,

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
@@ -24,6 +24,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.api.contract.OtpErrorId
 import org.onebusaway.android.api.graphql.type.InputField
 import org.onebusaway.android.api.graphql.type.RoutingErrorCode
+import org.onebusaway.android.directions.util.OtpTarget
 import org.onebusaway.android.ui.tripplan.TripPlanError.Category
 
 /**
@@ -229,6 +230,28 @@ class TripPlanErrorMappingTest {
         val errors = listOf(graphQlError("DataFetchingException"), graphQlError("ValidationError"))
 
         assertEquals(TripPlanError.RequestRejected, otp2GraphQlErrorFor(errors))
+    }
+
+    // ---- No planner at all (nothing reached the wire) ----
+
+    /**
+     * The #2264 distinction: a region that publishes no OTP server must not be reported as no region
+     * selected, because the region *is* selected and the rider can see it.
+     */
+    @Test
+    fun noPlanner_tells_a_planner_less_region_apart_from_no_region() {
+        assertError(
+            Category.REQUEST,
+            R.string.tripplanner_error_region_no_planner,
+            noPlannerError(OtpTarget.Unavailable.REGION_HAS_NO_PLANNER)
+        )
+        assertError(
+            Category.REQUEST,
+            R.string.tripplanner_no_server_selected_error,
+            noPlannerError(OtpTarget.Unavailable.NO_REGION)
+        )
+        // Defensive: a target that says it has a server, on the path that only runs when it hasn't.
+        assertError(Category.REQUEST, R.string.tripplanner_no_server_selected_error, noPlannerError(null))
     }
 
     private fun graphQlError(classification: Any?, message: String = "boom") = GraphQlError.Builder(message)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanErrorMappingTest.kt
@@ -243,15 +243,13 @@ class TripPlanErrorMappingTest {
         assertError(
             Category.REQUEST,
             R.string.tripplanner_error_region_no_planner,
-            noPlannerError(OtpTarget.Unavailable.REGION_HAS_NO_PLANNER)
+            noPlannerError(OtpTarget(baseUrl = null, usesOtp2 = false, regionSelected = true))
         )
         assertError(
             Category.REQUEST,
             R.string.tripplanner_no_server_selected_error,
-            noPlannerError(OtpTarget.Unavailable.NO_REGION)
+            noPlannerError(OtpTarget(baseUrl = null, usesOtp2 = false, regionSelected = false))
         )
-        // Defensive: a target that says it has a server, on the path that only runs when it hasn't.
-        assertError(Category.REQUEST, R.string.tripplanner_no_server_selected_error, noPlannerError(null))
     }
 
     private fun graphQlError(classification: Any?, message: String = "boom") = GraphQlError.Builder(message)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -679,6 +679,57 @@ class TripPlanViewModelTest {
     }
 
     @Test
+    fun `switching regions clears both endpoints and the plan`() = runTest {
+        val regionRepo = FakeRegionRepository(region(id = 1))
+        val vm = viewModel(region = regionRepo)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertTrue(vm.planState.value is PlanResult.Success)
+
+        regionRepo.emit(region(id = 2))
+        advanceUntilIdle()
+
+        // A trip is a pair of places in one transit system; neither end survives the move to another.
+        assertEquals(TripEndpoint.FreeText(), vm.formState.value.from)
+        assertEquals(TripEndpoint.FreeText(), vm.formState.value.to)
+        assertTrue(vm.planState.value is PlanResult.Idle)
+    }
+
+    /**
+     * The region *resolving* — null until the directory lands — is not a switch. Treating it as one
+     * would wipe a trip a notification restore or a pinned resume put here while it was still settling.
+     */
+    @Test
+    fun `the first region to resolve leaves an existing trip alone`() = runTest {
+        val regionRepo = FakeRegionRepository()
+        val vm = viewModel(region = regionRepo)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+
+        regionRepo.emit(region(id = 1))
+        advanceUntilIdle()
+
+        assertEquals(origin, vm.formState.value.from)
+        assertEquals(destination, vm.formState.value.to)
+        assertTrue(vm.planState.value is PlanResult.Success)
+    }
+
+    /** Re-emitting the same region (a directory refresh) is not a switch either. */
+    @Test
+    fun `re-emitting the same region leaves the trip alone`() = runTest {
+        val regionRepo = FakeRegionRepository(region(id = 1))
+        val vm = viewModel(region = regionRepo)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+
+        regionRepo.emit(region(id = 1, otpContactEmail = "refreshed@example.com"))
+        advanceUntilIdle()
+
+        assertEquals(origin, vm.formState.value.from)
+        assertEquals(destination, vm.formState.value.to)
+    }
+
+    @Test
     fun `setDateTime refreshes the date and time labels`() = runTest {
         val vm = viewModel()
         vm.setDateTime(1_700_000_000_000L)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -714,6 +714,26 @@ class TripPlanViewModelTest {
         assertTrue(vm.planState.value is PlanResult.Success)
     }
 
+    /**
+     * Losing the region *is* a switch away from one: deleting the custom region you are on leaves the
+     * trip with no transit system behind it, exactly as moving to another region would.
+     */
+    @Test
+    fun `losing the region clears the trip`() = runTest {
+        val regionRepo = FakeRegionRepository(region(id = 1))
+        val vm = viewModel(region = regionRepo)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertTrue(vm.planState.value is PlanResult.Success)
+
+        regionRepo.emit(null)
+        advanceUntilIdle()
+
+        assertEquals(TripEndpoint.FreeText(), vm.formState.value.from)
+        assertEquals(TripEndpoint.FreeText(), vm.formState.value.to)
+        assertTrue(vm.planState.value is PlanResult.Idle)
+    }
+
     /** Re-emitting the same region (a directory refresh) is not a switch either. */
     @Test
     fun `re-emitting the same region leaves the trip alone`() = runTest {
@@ -721,12 +741,17 @@ class TripPlanViewModelTest {
         val vm = viewModel(region = regionRepo)
         setBothEndpoints(vm)
         advanceUntilIdle()
+        val planned = vm.planState.value
+        assertTrue(planned is PlanResult.Success)
 
         regionRepo.emit(region(id = 1, otpContactEmail = "refreshed@example.com"))
         advanceUntilIdle()
 
         assertEquals(origin, vm.formState.value.from)
         assertEquals(destination, vm.formState.value.to)
+        // The drawn result survives too: clearing the endpoints would drop it back to Idle, so
+        // asserting only the endpoints would pass on a refresh that had quietly wiped the plan.
+        assertEquals(planned, vm.planState.value)
     }
 
     @Test

--- a/tools/check-region-routing.py
+++ b/tools/check-region-routing.py
@@ -78,6 +78,9 @@ OTP_PLAN_LOCATION = "/plan"
 OTP2_GTFS_GRAPHQL_PATH = "/gtfs/v1"
 
 TIMEOUT_SECONDS = 45
+# Built once: create_default_context() reads the platform trust store from disk, and a run makes one
+# request per region.
+SSL_CONTEXT = ssl.create_default_context()
 # How far north-east of a region's centre the destination probe point sits, in degrees -- roughly
 # 2km, far enough to want transit and close enough to stay inside the smallest region's box.
 PROBE_OFFSET_DEGREES = 0.02
@@ -119,7 +122,7 @@ def fetch(url, data=None, content_type=None):
         headers["Content-Type"] = content_type
     request = urllib.request.Request(url, data=data, headers=headers)
     try:
-        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS, context=ssl.create_default_context()) as response:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS, context=SSL_CONTEXT) as response:
             return response.status, response.read().decode("utf-8", "replace")
     except urllib.error.HTTPError as e:
         return e.code, e.read().decode("utf-8", "replace")

--- a/tools/check-region-routing.py
+++ b/tools/check-region-routing.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Open Transit Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ask every region's trip planner for a plan, the way the app would (issue #2264).
+
+Trip planning is the one app feature whose server is *per region* and published by a third party,
+so it can be missing or dead for one region while every other feature there works -- and neither
+state is visible from the code. #2264 was exactly that: Washington, D.C. publishes no OTP server at
+all, and the app answered a trip-plan attempt there with "No region selected" while D.C. sat
+plainly selected.
+
+This walks the region directory (bundled by default, since that is what a first-launch device
+reads) and, for each region, reports one of:
+
+  * no planner       -- the region publishes neither otpBaseUrl nor otpBaseGraphqlUrl. The app must
+                        not offer trip planning there at all; see tripPlanningUnavailableMessage.
+  * plans            -- the server answered a real plan request.
+  * no route         -- the server answered, but found no itinerary between the probe points. Not a
+                        failure of the *server*; the probe points are synthetic (see below).
+  * unreachable/err  -- DNS, TLS, timeout or a non-2xx. Trip planning is broken for that region.
+
+Endpoint construction deliberately mirrors the app: `otpPlanUrl` for OTP1 (a `/routers/default`
+base gets only `/plan` appended, a server-root base gets the segment inserted, and a pre-1.0 server
+is retried at the bare `/plan`) and `otp2GraphQlEndpoint` for OTP2 (`otpBaseGraphqlUrl` + `/gtfs/v1`,
+which is also the signal that a region speaks OTP2 at all). Probing a URL the app would never build
+would prove nothing about the app.
+
+The probe points are the centre of the region's first bounding box and a point a short way
+north-east of it. That is enough to tell a working planner from a dead host, which is what this
+checks; it is not a coverage test, so "no route" is reported, not failed on.
+
+Network-bound and dependent on servers this project does not run, so it is an **on-demand** tool
+rather than a CI check: a third party's outage should not turn the nightly red. Run it when trip
+planning is reported broken somewhere, and when a region is added or its OTP config changes.
+
+Usage (from the repo root):
+    tools/check-region-routing.py                 # the bundled regions file
+    tools/check-region-routing.py --live          # the live regions directory instead
+    tools/check-region-routing.py --regions f.json
+
+Exit status: 0 every region with a planner answered, 1 at least one planner is broken, 2 the check
+itself could not run.
+"""
+
+import argparse
+import datetime
+import json
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+# Mirrors RegionsClient (and check-regions-drift.py): the bundled file is what a first-launch device
+# reads, and the directory URL comes from the string resource rather than being restated here.
+BUNDLED_REGIONS = "onebusaway-android/src/main/res/raw/regions_v3.json"
+REGIONS_URL_RESOURCE = "onebusaway-android/src/main/res/values/donottranslate.xml"
+REGIONS_URL_RESOURCE_NAME = "regions_api_url"
+USER_AGENT = "onebusaway-android region-routing-check (+https://github.com/OneBusAway/onebusaway-android)"
+
+# TripPlanRepository.OTP_ROUTERS_SEGMENT / OTP_PLAN_LOCATION, and Otp2Planner.OTP2_GTFS_GRAPHQL_PATH.
+OTP_ROUTERS_SEGMENT = "/routers/default"
+OTP_PLAN_LOCATION = "/plan"
+OTP2_GTFS_GRAPHQL_PATH = "/gtfs/v1"
+
+TIMEOUT_SECONDS = 45
+# How far north-east of a region's centre the destination probe point sits, in degrees -- roughly
+# 2km, far enough to want transit and close enough to stay inside the smallest region's box.
+PROBE_OFFSET_DEGREES = 0.02
+
+# The OTP2 equivalent of the OTP1 /plan probe: the same planConnection root the app's Plan.graphql
+# query uses, cut down to the one field needed to tell "it planned" from "it didn't".
+OTP2_PROBE_QUERY = """
+query Probe($origin: PlanLabeledLocationInput!, $destination: PlanLabeledLocationInput!) {
+  planConnection(origin: $origin, destination: $destination, first: 3) {
+    routingErrors { code description }
+    edges { node { duration } }
+  }
+}
+"""
+
+
+class CheckError(Exception):
+    """The check could not run (bad input, unreadable resource) -- distinct from a broken planner."""
+
+
+def regions_directory_url(resource_path):
+    """The live regions directory URL, read from the `regions_api_url` string resource."""
+    path = Path(resource_path)
+    if not path.is_file():
+        raise CheckError(f"{resource_path} not found (run from the repo root)")
+    for string in ElementTree.parse(path).getroot().iter("string"):
+        if string.get("name") == REGIONS_URL_RESOURCE_NAME:
+            url = (string.text or "").strip()
+            if not url.startswith(("http://", "https://")):
+                raise CheckError(f"{REGIONS_URL_RESOURCE_NAME} is not an http(s) URL: {url!r}")
+            return url
+    raise CheckError(f'no <string name="{REGIONS_URL_RESOURCE_NAME}"> in {resource_path}')
+
+
+def fetch(url, data=None, content_type=None):
+    """GET (or POST, with `data`) `url`, returning (status, body-text). Raises on transport failure."""
+    headers = {"User-Agent": USER_AGENT}
+    if content_type:
+        headers["Content-Type"] = content_type
+    request = urllib.request.Request(url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS, context=ssl.create_default_context()) as response:
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+def load_regions(source, live):
+    """The region list from `source` -- a local path, or the live directory when `live`."""
+    if live:
+        _, text = fetch(source)
+    else:
+        path = Path(source)
+        if not path.is_file():
+            raise CheckError(f"{source} not found (run from the repo root)")
+        text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise CheckError(f"{source} is not valid JSON: {e}") from e
+    regions = (payload.get("data") or {}).get("list")
+    if not isinstance(regions, list):
+        raise CheckError(f"{source} has no data.list array")
+    return regions
+
+
+def probe_points(region):
+    """(from, to) as OTP `lat,lon` strings, or None when the region publishes no bounds."""
+    bounds = region.get("bounds") or []
+    if not bounds:
+        return None
+    box = bounds[0]
+    lat, lon = box["lat"], box["lon"]
+    # Clamped to a quarter of the box so the destination stays inside even a small region.
+    offset_lat = min(PROBE_OFFSET_DEGREES, box.get("latSpan", 0) / 4)
+    offset_lon = min(PROBE_OFFSET_DEGREES, box.get("lonSpan", 0) / 4)
+    return f"{lat:g},{lon:g}", f"{lat + offset_lat:g},{lon + offset_lon:g}"
+
+
+def otp_plan_url(base_url, query, old_server):
+    """TripPlanRepository.otpPlanUrl, verbatim: which /plan path this base URL's server exposes."""
+    base = base_url.rstrip("/")
+    if OTP_ROUTERS_SEGMENT in base or old_server:
+        return base + OTP_PLAN_LOCATION + query
+    return base + OTP_ROUTERS_SEGMENT + OTP_PLAN_LOCATION + query
+
+
+def probe_otp1(base_url, origin, destination, when):
+    """Plan over OTP1 REST. Returns (ok, summary)."""
+    parameters = {
+        "fromPlace": origin,
+        "toPlace": destination,
+        "optimize": "QUICK",
+        "wheelchair": "false",
+        "arriveBy": "false",
+        "date": when.strftime("%m-%d-%Y"),
+        "time": when.strftime("%I:%M%p"),
+        "showIntermediateStops": "true",
+        "mode": "TRANSIT,WALK",
+    }
+    query = "?" + "&".join(f"{k}={urllib.parse.quote(v)}" for k, v in parameters.items())
+
+    base = base_url.rstrip("/")
+    # A router-rooted base is unambiguously a modern server, so only a server-root base gets the
+    # app's pre-1.0 retry at the bare /plan path.
+    attempts = [False] if OTP_ROUTERS_SEGMENT in base else [False, True]
+    last = None
+    for old_server in attempts:
+        url = otp_plan_url(base, query, old_server)
+        try:
+            status, body = fetch(url)
+        except Exception as e:  # noqa: BLE001 -- any transport failure is the same verdict here
+            return False, f"unreachable: {type(e).__name__}: {e}"
+        if status != 200:
+            last = f"HTTP {status} from {url}"
+            continue
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return False, f"HTTP 200 but not JSON from {url}"
+        error = payload.get("error")
+        itineraries = ((payload.get("plan") or {}).get("itineraries")) or []
+        if error:
+            # The planner answered; a planner error is a routing verdict, not a broken server.
+            return True, f"no route: OTP error {error.get('id')} {error.get('msg')!r}"
+        if not itineraries:
+            return True, "no route: empty plan"
+        return True, f"plans: {len(itineraries)} itineraries"
+    return False, last or "no usable response"
+
+
+def probe_otp2(graphql_base_url, origin, destination):
+    """Plan over the OTP2 GraphQL endpoint. Returns (ok, summary)."""
+    url = graphql_base_url.rstrip("/") + OTP2_GTFS_GRAPHQL_PATH
+
+    def coordinate(point):
+        lat, lon = point.split(",")
+        return {"location": {"coordinate": {"latitude": float(lat), "longitude": float(lon)}}}
+
+    body = json.dumps(
+        {
+            "query": OTP2_PROBE_QUERY,
+            "variables": {"origin": coordinate(origin), "destination": coordinate(destination)},
+        }
+    ).encode()
+    try:
+        status, text = fetch(url, data=body, content_type="application/json")
+    except Exception as e:  # noqa: BLE001
+        return False, f"unreachable: {type(e).__name__}: {e}"
+    if status != 200:
+        return False, f"HTTP {status} from {url}"
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return False, f"HTTP 200 but not JSON from {url}"
+    if payload.get("errors"):
+        # A GraphQL error is the server rejecting the query, which for this fixed probe query means
+        # the endpoint is not the OTP2 gtfs mount the app would talk to.
+        return False, f"GraphQL errors: {json.dumps(payload['errors'])[:200]}"
+    connection = (payload.get("data") or {}).get("planConnection") or {}
+    if connection.get("routingErrors"):
+        return True, f"no route: {json.dumps(connection['routingErrors'])[:160]}"
+    edges = connection.get("edges") or []
+    if not edges:
+        return True, "no route: empty plan"
+    return True, f"plans: {len(edges)} itineraries"
+
+
+def check(regions, when):
+    """Probe every region; returns the list of regions whose planner is broken."""
+    broken = []
+    for region in sorted(regions, key=lambda r: r.get("id", 0)):
+        name = f"{region.get('regionName')} (id {region.get('id')})"
+        otp1 = (region.get("otpBaseUrl") or "").strip()
+        otp2 = (region.get("otpBaseGraphqlUrl") or "").strip()
+        if not otp1 and not otp2:
+            # Region.usesOtp2 / OtpTarget: publishing neither URL is "this region has no planner".
+            print(f"  {name}: no planner published")
+            continue
+        points = probe_points(region)
+        if points is None:
+            print(f"  {name}: skipped, region publishes no bounds to probe within")
+            continue
+        origin, destination = points
+        # OtpTarget.resolve: a published GraphQL endpoint is what routes a plan to OTP2, and the
+        # OTP1 base is then not the server the app would ask.
+        if otp2:
+            ok, summary = probe_otp2(otp2, origin, destination)
+            print(f"  {name}: OTP2 {summary}")
+        else:
+            ok, summary = probe_otp1(otp1, origin, destination, when)
+            print(f"  {name}: OTP1 {summary}")
+        if not ok:
+            broken.append(f"{name}: {summary}")
+    return broken
+
+
+def main(argv):
+    """Run the check and return the process exit status: 0 every planner answered, 1 one didn't."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--regions", default=BUNDLED_REGIONS, help="path to a regions file to probe")
+    parser.add_argument("--live", action="store_true", help="probe the live regions directory instead")
+    args = parser.parse_args(argv)
+
+    source = regions_directory_url(REGIONS_URL_RESOURCE) if args.live else args.regions
+    regions = load_regions(source, live=args.live)
+    # Tomorrow morning: a weekday-ish, mid-service time that no server has already run past.
+    when = (datetime.datetime.now() + datetime.timedelta(days=1)).replace(hour=9, minute=0)
+
+    print(f"regions: {source} ({len(regions)} regions)")
+    print(f"planning at: {when:%Y-%m-%d %H:%M} local\n")
+    broken = check(regions, when)
+
+    if not broken:
+        print("\nEvery region that publishes a planner answered.")
+        return 0
+    print(f"\nTrip planning is broken in {len(broken)} region(s):\n")
+    for line in broken:
+        print(f"  * {line}")
+    print(
+        "\nThe app can only report these as a connectivity failure -- the region directory says\n"
+        "there is a server. Fixing one means fixing the server, or getting the region's otpBaseUrl\n"
+        "corrected in the regions directory (https://github.com/OneBusAway/regions)."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except CheckError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/tools/check-region-routing.py
+++ b/tools/check-region-routing.py
@@ -128,7 +128,11 @@ def fetch(url, data=None, content_type=None):
 def load_regions(source, live):
     """The region list from `source` -- a local path, or the live directory when `live`."""
     if live:
-        _, text = fetch(source)
+        status, text = fetch(source)
+        # Report the status rather than letting an error page fall through to "not valid JSON",
+        # which is what a 403 from the directory actually looks like.
+        if status != 200:
+            raise CheckError(f"{source} returned HTTP {status}")
     else:
         path = Path(source)
         if not path.is_file():
@@ -145,7 +149,7 @@ def load_regions(source, live):
 
 
 def probe_points(region):
-    """(from, to) as OTP `lat,lon` strings, or None when the region publishes no bounds."""
+    """((lat, lon), (lat, lon)) to plan between, or None when the region publishes no bounds."""
     bounds = region.get("bounds") or []
     if not bounds:
         return None
@@ -154,7 +158,7 @@ def probe_points(region):
     # Clamped to a quarter of the box so the destination stays inside even a small region.
     offset_lat = min(PROBE_OFFSET_DEGREES, box.get("latSpan", 0) / 4)
     offset_lon = min(PROBE_OFFSET_DEGREES, box.get("lonSpan", 0) / 4)
-    return f"{lat:g},{lon:g}", f"{lat + offset_lat:g},{lon + offset_lon:g}"
+    return (lat, lon), (lat + offset_lat, lon + offset_lon)
 
 
 def otp_plan_url(base_url, query, old_server):
@@ -168,8 +172,9 @@ def otp_plan_url(base_url, query, old_server):
 def probe_otp1(base_url, origin, destination, when):
     """Plan over OTP1 REST. Returns (ok, summary)."""
     parameters = {
-        "fromPlace": origin,
-        "toPlace": destination,
+        # OTP1 places are "lat,lon" text; %g keeps them short without losing probe precision.
+        "fromPlace": "%g,%g" % origin,
+        "toPlace": "%g,%g" % destination,
         "optimize": "QUICK",
         "wheelchair": "false",
         "arriveBy": "false",
@@ -214,8 +219,8 @@ def probe_otp2(graphql_base_url, origin, destination):
     url = graphql_base_url.rstrip("/") + OTP2_GTFS_GRAPHQL_PATH
 
     def coordinate(point):
-        lat, lon = point.split(",")
-        return {"location": {"coordinate": {"latitude": float(lat), "longitude": float(lon)}}}
+        lat, lon = point
+        return {"location": {"coordinate": {"latitude": lat, "longitude": lon}}}
 
     body = json.dumps(
         {

--- a/tools/check-region-routing.py
+++ b/tools/check-region-routing.py
@@ -29,7 +29,10 @@ reads) and, for each region, reports one of:
   * plans            -- the server answered a real plan request.
   * no route         -- the server answered, but found no itinerary between the probe points. Not a
                         failure of the *server*; the probe points are synthetic (see below).
-  * unreachable/err  -- DNS, TLS, timeout or a non-2xx. Trip planning is broken for that region.
+  * unreachable/err  -- DNS, TLS, timeout, a non-2xx, or a 200 that isn't a planner's answer at
+                        all. Trip planning is broken for that region.
+  * not probed       -- the region publishes a planner but no bounds this tool can plan between, so
+                        it has *no* verdict. Reported, never counted as an answer.
 
 Endpoint construction deliberately mirrors the app: `otpPlanUrl` for OTP1 (a `/routers/default`
 base gets only `/plan` appended, a server-root base gets the segment inserted, and a pre-1.0 server
@@ -50,8 +53,9 @@ Usage (from the repo root):
     tools/check-region-routing.py --live          # the live regions directory instead
     tools/check-region-routing.py --regions f.json
 
-Exit status: 0 every region with a planner answered, 1 at least one planner is broken, 2 the check
-itself could not run.
+Exit status: 0 every region with a planner answered, 1 at least one planner is broken, 2 nothing is
+broken but the run is not a complete answer -- a region could not be probed, or the check itself
+could not run at all.
 """
 
 import argparse
@@ -78,8 +82,9 @@ OTP_PLAN_LOCATION = "/plan"
 OTP2_GTFS_GRAPHQL_PATH = "/gtfs/v1"
 
 TIMEOUT_SECONDS = 45
-# Built once: create_default_context() reads the platform trust store from disk, and a run makes one
-# request per region.
+# Built once: create_default_context() reads the platform trust store from disk, and a run opens
+# several connections -- one or two planner requests per region (see probe_otp1), plus the region
+# directory itself under --live.
 SSL_CONTEXT = ssl.create_default_context()
 # How far north-east of a region's centre the destination probe point sits, in degrees -- roughly
 # 2km, far enough to want transit and close enough to stay inside the smallest region's box.
@@ -88,8 +93,12 @@ PROBE_OFFSET_DEGREES = 0.02
 # The OTP2 equivalent of the OTP1 /plan probe: the same planConnection root the app's Plan.graphql
 # query uses, cut down to the one field needed to tell "it planned" from "it didn't".
 OTP2_PROBE_QUERY = """
-query Probe($origin: PlanLabeledLocationInput!, $destination: PlanLabeledLocationInput!) {
-  planConnection(origin: $origin, destination: $destination, first: 3) {
+query Probe(
+  $origin: PlanLabeledLocationInput!
+  $destination: PlanLabeledLocationInput!
+  $dateTime: PlanDateTimeInput
+) {
+  planConnection(origin: $origin, destination: $destination, dateTime: $dateTime, first: 3) {
     routingErrors { code description }
     edges { node { duration } }
   }
@@ -101,6 +110,10 @@ class CheckError(Exception):
     """The check could not run (bad input, unreadable resource) -- distinct from a broken planner."""
 
 
+class UnusableUrl(CheckError):
+    """A URL this tool won't open. Reaching a *region's* planner this way is that region's verdict."""
+
+
 def regions_directory_url(resource_path):
     """The live regions directory URL, read from the `regions_api_url` string resource."""
     path = Path(resource_path)
@@ -108,15 +121,18 @@ def regions_directory_url(resource_path):
         raise CheckError(f"{resource_path} not found (run from the repo root)")
     for string in ElementTree.parse(path).getroot().iter("string"):
         if string.get("name") == REGIONS_URL_RESOURCE_NAME:
-            url = (string.text or "").strip()
-            if not url.startswith(("http://", "https://")):
-                raise CheckError(f"{REGIONS_URL_RESOURCE_NAME} is not an http(s) URL: {url!r}")
-            return url
+            # Not checked for a scheme here: fetch() is the one gate on what this tool opens.
+            return (string.text or "").strip()
     raise CheckError(f'no <string name="{REGIONS_URL_RESOURCE_NAME}"> in {resource_path}')
 
 
 def fetch(url, data=None, content_type=None):
     """GET (or POST, with `data`) `url`, returning (status, body-text). Raises on transport failure."""
+    # urlopen also speaks file: and ftp:, and every URL that reaches here -- the planner endpoints
+    # most of all -- comes from a third party's region directory rather than from this repo.
+    scheme = urllib.parse.urlsplit(url).scheme
+    if scheme not in ("http", "https"):
+        raise UnusableUrl(f"refusing to open a {scheme or 'scheme-less'} URL: {url!r}")
     headers = {"User-Agent": USER_AGENT}
     if content_type:
         headers["Content-Type"] = content_type
@@ -152,15 +168,25 @@ def load_regions(source, live):
 
 
 def probe_points(region):
-    """((lat, lon), (lat, lon)) to plan between, or None when the region publishes no bounds."""
+    """((lat, lon), (lat, lon)) to plan between, or None when the region's bounds can't be probed.
+
+    Every field is required rather than defaulted: a missing span would clamp the offset to zero and
+    ask the planner to route from a point to itself, which every planner answers "no route" to -- a
+    verdict about this tool's arithmetic, not about the server. No points means no verdict.
+    """
     bounds = region.get("bounds") or []
-    if not bounds:
+    if not bounds or not isinstance(bounds[0], dict):
         return None
     box = bounds[0]
-    lat, lon = box["lat"], box["lon"]
+    try:
+        lat, lon, lat_span, lon_span = (float(box[key]) for key in ("lat", "lon", "latSpan", "lonSpan"))
+    except (KeyError, TypeError, ValueError):
+        return None
+    if lat_span <= 0 or lon_span <= 0:
+        return None
     # Clamped to a quarter of the box so the destination stays inside even a small region.
-    offset_lat = min(PROBE_OFFSET_DEGREES, box.get("latSpan", 0) / 4)
-    offset_lon = min(PROBE_OFFSET_DEGREES, box.get("lonSpan", 0) / 4)
+    offset_lat = min(PROBE_OFFSET_DEGREES, lat_span / 4)
+    offset_lon = min(PROBE_OFFSET_DEGREES, lon_span / 4)
     return (lat, lon), (lat + offset_lat, lon + offset_lon)
 
 
@@ -207,18 +233,24 @@ def probe_otp1(base_url, origin, destination, when):
             payload = json.loads(body)
         except json.JSONDecodeError:
             return False, f"HTTP 200 but not JSON from {url}"
-        error = payload.get("error")
-        itineraries = ((payload.get("plan") or {}).get("itineraries")) or []
-        if error:
+        # An OTP1 plan response is one of these two envelopes. Anything else that came back 200 --
+        # a captive portal, a bare {}, some other service at that host -- is not this planner
+        # answering, and reading it as "no route" would report a dead endpoint as a healthy one.
+        plan = payload.get("plan") if isinstance(payload, dict) else None
+        error = payload.get("error") if isinstance(payload, dict) else None
+        if isinstance(error, dict) and error:
             # The planner answered; a planner error is a routing verdict, not a broken server.
             return True, f"no route: OTP error {error.get('id')} {error.get('msg')!r}"
+        if not isinstance(plan, dict):
+            return False, f"HTTP 200 but not an OTP plan response from {url}"
+        itineraries = plan.get("itineraries") or []
         if not itineraries:
             return True, "no route: empty plan"
         return True, f"plans: {len(itineraries)} itineraries"
     return False, last or "no usable response"
 
 
-def probe_otp2(graphql_base_url, origin, destination):
+def probe_otp2(graphql_base_url, origin, destination, when):
     """Plan over the OTP2 GraphQL endpoint. Returns (ok, summary)."""
     url = graphql_base_url.rstrip("/") + OTP2_GTFS_GRAPHQL_PATH
 
@@ -229,7 +261,14 @@ def probe_otp2(graphql_base_url, origin, destination):
     body = json.dumps(
         {
             "query": OTP2_PROBE_QUERY,
-            "variables": {"origin": coordinate(origin), "destination": coordinate(destination)},
+            "variables": {
+                "origin": coordinate(origin),
+                "destination": coordinate(destination),
+                # Otp2PlanRequestBuilder.build: an ISO-8601 offset instant in the local zone. Without
+                # it OTP2 departs "now", so the two probes would ask different questions and this one
+                # could answer "no route" simply for running outside the region's service hours.
+                "dateTime": {"earliestDeparture": when.astimezone().isoformat(timespec="seconds")},
+            },
         }
     ).encode()
     try:
@@ -246,7 +285,11 @@ def probe_otp2(graphql_base_url, origin, destination):
         # A GraphQL error is the server rejecting the query, which for this fixed probe query means
         # the endpoint is not the OTP2 gtfs mount the app would talk to.
         return False, f"GraphQL errors: {json.dumps(payload['errors'])[:200]}"
-    connection = (payload.get("data") or {}).get("planConnection") or {}
+    data = payload.get("data") if isinstance(payload, dict) else None
+    connection = data.get("planConnection") if isinstance(data, dict) else None
+    # As in probe_otp1: only the envelope this query asked for counts as the planner answering.
+    if not isinstance(connection, dict) or "edges" not in connection:
+        return False, f"HTTP 200 but not an OTP2 plan response from {url}"
     if connection.get("routingErrors"):
         return True, f"no route: {json.dumps(connection['routingErrors'])[:160]}"
     edges = connection.get("edges") or []
@@ -256,8 +299,9 @@ def probe_otp2(graphql_base_url, origin, destination):
 
 
 def check(regions, when):
-    """Probe every region; returns the list of regions whose planner is broken."""
+    """Probe every region; returns (regions whose planner is broken, regions left without a verdict)."""
     broken = []
+    not_probed = []
     for region in sorted(regions, key=lambda r: r.get("id", 0)):
         name = f"{region.get('regionName')} (id {region.get('id')})"
         otp1 = (region.get("otpBaseUrl") or "").strip()
@@ -268,24 +312,25 @@ def check(regions, when):
             continue
         points = probe_points(region)
         if points is None:
-            print(f"  {name}: skipped, region publishes no bounds to probe within")
+            print(f"  {name}: not probed, region publishes no usable bounds to plan within")
+            not_probed.append(name)
             continue
         origin, destination = points
         # OtpTarget.resolve: a published GraphQL endpoint is what routes a plan to OTP2, and the
         # OTP1 base is then not the server the app would ask.
         if otp2:
-            ok, summary = probe_otp2(otp2, origin, destination)
+            ok, summary = probe_otp2(otp2, origin, destination, when)
             print(f"  {name}: OTP2 {summary}")
         else:
             ok, summary = probe_otp1(otp1, origin, destination, when)
             print(f"  {name}: OTP1 {summary}")
         if not ok:
             broken.append(f"{name}: {summary}")
-    return broken
+    return broken, not_probed
 
 
 def main(argv):
-    """Run the check and return the process exit status: 0 every planner answered, 1 one didn't."""
+    """Run the check and return the process exit status (see this module's docstring)."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--regions", default=BUNDLED_REGIONS, help="path to a regions file to probe")
     parser.add_argument("--live", action="store_true", help="probe the live regions directory instead")
@@ -298,25 +343,42 @@ def main(argv):
 
     print(f"regions: {source} ({len(regions)} regions)")
     print(f"planning at: {when:%Y-%m-%d %H:%M} local\n")
-    broken = check(regions, when)
+    broken, not_probed = check(regions, when)
 
-    if not broken:
-        print("\nEvery region that publishes a planner answered.")
-        return 0
-    print(f"\nTrip planning is broken in {len(broken)} region(s):\n")
-    for line in broken:
-        print(f"  * {line}")
-    print(
-        "\nThe app can only report these as a connectivity failure -- the region directory says\n"
-        "there is a server. Fixing one means fixing the server, or getting the region's otpBaseUrl\n"
-        "corrected in the regions directory (https://github.com/OneBusAway/regions)."
-    )
-    return 1
+    if broken:
+        print(f"\nTrip planning is broken in {len(broken)} region(s):\n")
+        for line in broken:
+            print(f"  * {line}")
+        print(
+            "\nThe app can only report these as a connectivity failure -- the region directory says\n"
+            "there is a server. Fixing one means fixing the server, or getting the region's otpBaseUrl\n"
+            "corrected in the regions directory (https://github.com/OneBusAway/regions)."
+        )
+    if not_probed:
+        print(f"\n{len(not_probed)} region(s) publish a planner this run could not ask:\n")
+        for name in not_probed:
+            print(f"  * {name}")
+        print(
+            "\nThat is a gap in this check, not a verdict on those servers: the region publishes no\n"
+            "bounds to plan within, so there is nowhere to plan between. Getting the bounds into the\n"
+            "regions directory is what would let this run answer for them."
+        )
+    # A broken planner is the actionable failure, so it takes the exit status when both happen; an
+    # unasked region only has to stop the run being reported as a clean bill of health.
+    if broken:
+        return 1
+    if not_probed:
+        return 2
+    print("\nEvery region that publishes a planner answered.")
+    return 0
 
 
 if __name__ == "__main__":
     try:
         sys.exit(main(sys.argv[1:]))
-    except CheckError as e:
+    # OSError covers urllib's URLError (a failed directory fetch); ParseError, a string resource that
+    # isn't XML. Both are the check failing to get started, same as CheckError -- not a broken planner,
+    # and not something to hand the operator as a traceback.
+    except (CheckError, OSError, UnicodeError, ElementTree.ParseError) as e:
         print(f"error: {e}", file=sys.stderr)
         sys.exit(2)

--- a/tools/check-region-routing.py
+++ b/tools/check-region-routing.py
@@ -191,7 +191,8 @@ def probe_otp1(base_url, origin, destination, when):
     base = base_url.rstrip("/")
     # A router-rooted base is unambiguously a modern server, so only a server-root base gets the
     # app's pre-1.0 retry at the bare /plan path.
-    attempts = [False] if OTP_ROUTERS_SEGMENT in base else [False, True]
+    router_rooted = OTP_ROUTERS_SEGMENT in base
+    attempts = [False] if router_rooted else [False, True]
     last = None
     for old_server in attempts:
         url = otp_plan_url(base, query, old_server)


### PR DESCRIPTION
Fixes #2264.

## What was wrong

Planning a trip in Washington, D.C. failed with **"Couldn't plan this trip — No region selected"**, with D.C. plainly selected. D.C. publishes no OpenTripPlanner server at all, and every "no server" case shared the one string, which names the wrong cause.

Three of the seven directory regions publish neither `otpBaseUrl` nor `otpBaseGraphqlUrl`: **Washington D.C., MTA New York, Davis**. The nav drawer has always hidden its "Plan a trip" row for those — but the map long-press *"navigate here"* offer (#2243) and a `geo:` place shared in from another app (#1936) both entered the trip planner regardless. So the drawer's gate was never *the* gate, just one of them, and the long-press is almost certainly how the reporter got there.

## The fix

- **One gate, asked everywhere.** `OtpTarget` gains `isAvailable` and, when it isn't, *which* of the two very different reasons applies (`NO_REGION` vs `REGION_HAS_NO_PLANNER`). Its resolution is now also callable over plain values (`Context`-free), so the nav drawer asks it instead of restating the branch — that restatement had never learned about OTP2, and would have hidden the row for a region publishing only an `otpBaseGraphqlUrl`.
- **Affordances refuse instead of leading nowhere.** The map long-press and the shared-place intent call `Context.refuseTripPlanIfUnavailable()` first and turn the gesture away rather than opening a form that can only fail. The message **names the region** — which is what stops it contradicting the region the rider can see the app using. That one function is also the single home for *how* the app declines, so a third affordance inherits the decision instead of copying it.
- **The residual error path is honest.** A plan submitted from a form that was already open (a region switch underneath it, a restored notification) now reports "This region doesn't offer trip planning" rather than "No region selected".
- `OtpTarget.usableBaseUrl` is the one place the blank-URL rule lives, and `isAvailable` is defined in terms of it — a region cached with `""` would otherwise have got `https://` glued to nothing and failed as a *connectivity* error.

Nothing changes in a region that has a planner.

## "Test routing on all built-in regions"

Added `tools/check-region-routing.py`, which asks every region's planner for a real plan, building the endpoints exactly as the app does (`otpPlanUrl` for OTP1, `otp2GraphQlEndpoint` for OTP2). **On-demand rather than CI** — it depends on servers this project doesn't run, so a third party's outage must not redden the nightly.

Today, against both the bundled file and the live directory:

```
  Tampa Bay (id 0): OTP1 unreachable: URLError: nodename nor servname provided
  Puget Sound (id 1): OTP2 plans: 3 itineraries
  MTA New York (id 2): no planner published
  Washington, D.C. (id 4): no planner published
  San Diego (id 11): OTP1 plans: 6 itineraries
  Adelaide Metro (id 15): OTP1 plans: 5 itineraries
  Davis, CA (id 16): no planner published
```

**Tampa Bay's routing is dead**, separately from this issue: `otp.prod.obahart.org` CNAMEs to `otp-elb-prod-340500145.us-east-1.elb.amazonaws.com`, which has no A records — the load balancer is gone. The app can only report that as a connectivity failure, correctly, since the directory says there is a server; fixing it means fixing the server or correcting the directory entry. Worth its own issue against [OneBusAway/regions](https://github.com/OneBusAway/regions) or the HART deployment.

## Also: clearing the trip on a region switch

A trip is a pair of places in one transit system, so a region switch invalidates both ends at once — and the endpoints survived it. A rider who moved from Tampa to Puget Sound came back to Plan Trip holding two Tampa addresses and a drawn Tampa itinerary, which the new region's planner can only fail on, and which in a planner-less region can't even be asked. `TripPlanViewModel` already held the `RegionRepository`, so it now watches the region id and calls the existing `clearTrip()`.

Only a switch *between* regions counts. The first resolution (null until the directory lands) is not a switch — treating it as one would wipe a trip that a notification restore or a pinned resume put in the form while the region was still settling — and neither is a re-emitted same region from a directory refresh. Both are pinned by tests.

## Cleanup pass

Commits 2-5 are a `/simplify` pass over commit 1 — no behaviour change. The substantive ones: the list of planner-less regions was written out in four places (it is directory data that changes without this repo touching anything, so CLAUDE.md now carries it alone); the duplicated refuse-and-return became `Context.refuseTripPlanIfUnavailable()`; `OtpTarget.usableBaseUrl` retired a "keep these in sync" comment by construction; `noPlannerError` stopped taking a nullable reason, deleting an unreachable branch and a test of an input its only caller cannot produce; and `OtpTargetTest` uses the shared `RegionTestFixtures.region()` helper rather than becoming a third local copy of the `Region` constructor.

## Testing

- `./gradlew test check -x lint -PwarningsAsErrors=true` — green.
- New `OtpTargetTest` pins the resolution grid: OTP1 region, OTP2-over-OTP1, GraphQL-only, planner-less region, blank URL, no region, custom URL wins, custom URL rescues a planner-less region.
- `TripPlanErrorMappingTest` gains the #2264 distinction.
- Not yet exercised on a device — the D.C. long-press path is worth a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013i69XYDQk7phNajUcVpWiD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent trip-planning availability checks across map, shared-place, and directions entry points.
  * Added support for OTP1, OTP2, custom planners, and region-specific availability messages.

* **Bug Fixes**
  * Prevented trip-planning actions when routing is unavailable.
  * Improved messages for missing regions and regions without planners.
  * Cleared trip details when switching between transit regions to prevent stale results.

* **Tests**
  * Added coverage for planner resolution, availability, custom servers, error mapping, and region switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

