### PR TITLE
Fix: Show Tutorial should provide feedback to the user.

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ package org.onebusaway.android.ui.settings
 
 import android.content.Context
 import android.os.Build
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -216,6 +217,7 @@ class SettingsViewModel @Inject constructor(
     fun onTutorialClicked() {
         reportPreferencesEvent(context, R.string.analytics_label_button_press_tutorial)
         TutorialPrefs.resetAllTutorials(context)
+        Toast.makeText(context, R.string.preferences_tutorial_toast, Toast.LENGTH_SHORT).show()
         _effects.trySend(SettingsEffect.GoHomeResetTutorial)
     }
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -758,6 +758,7 @@
     <string name="preferences_analytics_summary">Help us improve the app</string>
     <string name="preferences_tutorial_title">Show tutorial</string>
     <string name="preferences_tutorial_summary">Show instructions for using this app</string>
+    <string name="preferences_tutorial_toast">Tutorials reset. Go back to Home to view them</string>
     <string name="preferences_donate_title">Donate</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <string name="preferences_donate_summary">Support the %1$s open-source project</string>


### PR DESCRIPTION
Fix: #2262

https://github.com/user-attachments/assets/26246649-d6c2-4544-94f4-9876411e7b76

Added Toast to provide feedback to the user.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Format your changes with `./gradlew spotlessApply`.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Added a confirmation message when tutorials are reset from Settings.
  * The message reminds users that tutorials can be viewed again from the Home screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->