### PR TITLE
Fix: Remove the "show tutorial" link in Settings

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsDestinations.kt
@@ -103,7 +103,6 @@ fun NavGraphBuilder.settingsGraph(navController: NavHostController) {
                 },
                 onBack = { navController.popBackStack() },
                 onRecreate = { activity.recreate() },
-                onGoHomeResetTutorial = { NavHelp.goHome(activity, true) },
                 onOpenDonate = {
                     activity.startActivity(
                         DonationsEntryPoint.get(activity).buildOpenDonationsPageIntent()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -65,7 +65,6 @@ fun SettingsRoute(
     onNavigateToAdvanced: () -> Unit,
     onBack: () -> Unit,
     onRecreate: () -> Unit,
-    onGoHomeResetTutorial: () -> Unit,
     onOpenDonate: () -> Unit,
     onOpenPoweredByOba: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
@@ -108,7 +107,6 @@ fun SettingsRoute(
         viewModel.effects.collect { effect ->
             when (effect) {
                 SettingsEffect.RecreateActivity -> onRecreate()
-                SettingsEffect.GoHomeResetTutorial -> onGoHomeResetTutorial()
             }
         }
     }
@@ -155,7 +153,6 @@ fun SettingsRoute(
         onSaveBackup = { saveBackupLauncher.launch(BackupUtils.buildCreateBackupFileIntent()) },
         onRestoreBackup = { restoreBackupLauncher.launch(BackupUtils.buildSelectBackupFileIntent()) },
         onAdvancedClick = onNavigateToAdvanced,
-        onTutorialClick = viewModel::onTutorialClicked,
         onDonateClick = onOpenDonate,
         onPoweredByObaClick = {
             viewModel.onPoweredByObaClicked()
@@ -194,7 +191,6 @@ class SettingsActions(
     val onSaveBackup: () -> Unit,
     val onRestoreBackup: () -> Unit,
     val onAdvancedClick: () -> Unit,
-    val onTutorialClick: () -> Unit,
     val onDonateClick: () -> Unit,
     val onPoweredByObaClick: () -> Unit,
     val onAboutClick: () -> Unit
@@ -376,11 +372,6 @@ fun SettingsScreen(
                     summary = stringResource(R.string.preferences_analytics_summary),
                     checked = state.analyticsEnabled,
                     onCheckedChange = actions.onAnalytics
-                )
-                ClickPreferenceItem(
-                    title = stringResource(R.string.preferences_tutorial_title),
-                    summary = stringResource(R.string.preferences_tutorial_summary),
-                    onClick = actions.onTutorialClick
                 )
                 if (state.showDonate) {
                     ClickPreferenceItem(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -38,7 +38,6 @@ import org.onebusaway.android.database.oba.ServiceAlertDao
 import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
-import org.onebusaway.android.ui.tutorial.TutorialPrefs
 import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.ThemeUtils
 
@@ -46,9 +45,6 @@ import org.onebusaway.android.util.ThemeUtils
 sealed interface SettingsEffect {
     /** Re-create the Activity so a just-applied app theme takes effect. */
     object RecreateActivity : SettingsEffect
-
-    /** Reset-tutorials was tapped: return home (and replay the tutorials there). */
-    object GoHomeResetTutorial : SettingsEffect
 }
 
 /**
@@ -212,12 +208,6 @@ class SettingsViewModel @Inject constructor(
 
     /** Persists the ringtone the host's picker returned (empty string == silent). */
     fun onRingtonePicked(value: String) = prefs.setString(R.string.preference_key_notification_sound, value)
-
-    fun onTutorialClicked() {
-        reportPreferencesEvent(context, R.string.analytics_label_button_press_tutorial)
-        TutorialPrefs.resetAllTutorials(context)
-        _effects.trySend(SettingsEffect.GoHomeResetTutorial)
-    }
 
     fun onPoweredByObaClicked() = reportPreferencesEvent(context, R.string.analytics_label_button_press_powered_by_oba)
 

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -625,8 +625,6 @@
     </string>
     <string name="preferences_analytics_title">Enviar datos anónimos de uso</string>
     <string name="preferences_analytics_summary">Ayudanos a mejorar la aplicación</string>
-    <string name="preferences_tutorial_title">Mostrar tutorial</string>
-    <string name="preferences_tutorial_summary">Aprende a utilizar la aplicación con este tutorial</string>
     <string name="preferences_donate_title">Donar</string>
     <string name="preferences_donate_summary">Apoyar el proyecto de código abierto %1$s</string>
     <string name="preferences_powered_by_oba_title">Desarrollado por %1$s</string>

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -499,8 +499,6 @@
     </string>
     <string name="preferences_analytics_title">Lähetä anonyymeja käyttötietoja</string>
     <string name="preferences_analytics_summary">Auta meitä parantamaan sovellusta. Tiedot lähetetään anonyymisti.</string>
-    <string name="preferences_tutorial_title">Näytä ohje</string>
-    <string name="preferences_tutorial_summary">Tarkemmat ohjeet kuinka käyttää tätä sovellusta</string>
     <string name="preferences_donate_title">Lahjoita</string>
     <string name="preferences_donate_summary">Tue %1$sn avoimen lähdekoodin projektia</string>
     <string name="preferences_powered_by_oba_title">Powered by %1$s</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -489,8 +489,6 @@
     <string name="preferences_experimental_regions_disable_warning">L’area sperimentale corrente non sarà disponibile! Vuoi procedere?</string>
     <string name="preferences_analytics_title">Invia dati di utilizzo anonimi</string>
     <string name="preferences_analytics_summary">Aiutaci a migliorare l’app</string>
-    <string name="preferences_tutorial_title">Mostra tutorial</string>
-    <string name="preferences_tutorial_summary">Mostra istruzioni per utilizzare questa app</string>
     <string name="preferences_donate_title">Dona</string>
     <string name="preferences_donate_summary">Supporta il progetto open-source %1$s</string>
     <string name="preferences_powered_by_oba_title">Powered by %1$s</string>

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -536,8 +536,6 @@
     </string>
     <string name="preferences_analytics_title">Wysyłaj anonimowo dane o użyciu</string>
     <string name="preferences_analytics_summary">Pomóż nam ulepszać aplikację</string>
-    <string name="preferences_tutorial_title">Pokaż samouczek</string>
-    <string name="preferences_tutorial_summary">Pokaż instrukcję jak używać aplikację</string>
     <string name="preferences_donate_title">Dotacja</string>
     <string name="preferences_donate_summary">Wspieraj %1$s</string>
     <string name="preferences_powered_by_oba_title">Napędzane przez %1$s</string>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -131,7 +131,6 @@
     <string name="analytics_label_button_press_help">help</string>
     <string name="analytics_label_button_press_feedback">send_feedback</string>
     <string name="analytics_label_button_press_open_source">github</string>
-    <string name="analytics_label_button_press_tutorial">preference_tutorial</string>
     <string name="analytics_label_button_press_donate">preference_donate</string>
     <string name="analytics_label_button_press_powered_by_oba">preference_power_by_oba</string>
     <string name="analytics_label_button_press_about">preference_about</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -756,8 +756,6 @@
     </string>
     <string name="preferences_analytics_title">Send anonymous usage data</string>
     <string name="preferences_analytics_summary">Help us improve the app</string>
-    <string name="preferences_tutorial_title">Show tutorial</string>
-    <string name="preferences_tutorial_summary">Show instructions for using this app</string>
     <string name="preferences_donate_title">Donate</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <string name="preferences_donate_summary">Support the %1$s open-source project</string>


### PR DESCRIPTION
Fixes: #2267

<img width="720" height="1600" alt="WhatsApp Image 2026-08-23 at 3 31 06 PM" src="https://github.com/user-attachments/assets/f2089246-dde0-4330-9030-108d0f37007e" />

Removed the "Show Tutorial" link in settings.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Format your changes with `./gradlew spotlessApply`.

- [X] Run the unit tests with `gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed the Tutorial option from the Settings screen.
  * The Tutorial action is no longer available from Settings.
  * Removed obsolete tutorial text and analytics labels from the app’s supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->