### PR TITLE
Offer a trip to the stop you are already looking at (#2272)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/map/FocusBannerTest.kt
@@ -80,6 +80,10 @@ class FocusBannerTest {
         }
     }
 
+    private fun openStopMenu() = composeRule.onNodeWithContentDescription(
+        context.getString(R.string.stop_info_item_options_title)
+    ).performClick()
+
     @Test
     fun stopBannerLongPressAndOverflowOpenTheSameMenu() {
         var recentered = 0
@@ -90,7 +94,8 @@ class FocusBannerTest {
                 onReportStopProblem = {},
                 onNightLight = {},
                 onCreateShortcut = {},
-                onShowArrivals = { openedArrivals++ }
+                onShowArrivals = { openedArrivals++ },
+                onNavigateHere = {}
             )
         )
         val banner = composeRule.onNodeWithText(STOP_NAME)
@@ -98,6 +103,7 @@ class FocusBannerTest {
         assertEquals(1, recentered)
         banner.performTouchInput { longClick() }
         val menuItems = listOf(
+            R.string.map_navigate_here,
             R.string.view_arrivals_only,
             R.string.my_context_create_shortcut,
             R.string.stop_info_option_report_problem,
@@ -109,10 +115,58 @@ class FocusBannerTest {
         assertEquals(1, recentered)
         composeRule.onNodeWithText(context.getString(R.string.view_arrivals_only)).assertDoesNotExist()
 
-        composeRule.onNodeWithContentDescription(context.getString(R.string.stop_info_item_options_title)).performClick()
+        openStopMenu()
         menuItems.forEach { composeRule.onNodeWithText(context.getString(it)).assertIsDisplayed() }
         composeRule.onNodeWithText(context.getString(R.string.view_arrivals_only)).performClick()
         assertEquals(2, openedArrivals)
+    }
+
+    /**
+     * #2272: a rider looking at a stop can plan a trip to it from the stop's own overflow, without
+     * having to leave and long-press the map at a place they can already see is focused.
+     */
+    @Test
+    fun stopMenuOffersATripToTheFocusedStop() {
+        var navigated = 0
+        setStopBanner(
+            stopMenu = StopFocusMenu(
+                onReportStopProblem = {},
+                onNightLight = {},
+                onCreateShortcut = {},
+                onShowArrivals = {},
+                onNavigateHere = { navigated++ }
+            )
+        )
+
+        openStopMenu()
+        composeRule.onNodeWithText(context.getString(R.string.map_navigate_here))
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(1, navigated)
+    }
+
+    /**
+     * A stop whose own location hasn't landed yet has nothing to route to, so the offer is withheld
+     * rather than made and then failed. The rest of the menu still stands.
+     */
+    @Test
+    fun stopMenuWithholdsTheTripWhenTheStopHasNoLocation() {
+        setStopBanner(
+            stopMenu = StopFocusMenu(
+                onReportStopProblem = {},
+                onNightLight = {},
+                onCreateShortcut = {},
+                onShowArrivals = {},
+                onNavigateHere = null
+            )
+        )
+
+        openStopMenu()
+        composeRule.onNodeWithText(context.getString(R.string.map_navigate_here))
+            .assertDoesNotExist()
+        composeRule.onNodeWithText(context.getString(R.string.stop_info_option_report_problem))
+            .assertIsDisplayed()
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -550,6 +550,30 @@ fun HomeScreen(
                     CurrentFocus.None, is CurrentFocus.BikeStation, is CurrentFocus.Directions -> null
                 }
 
+                // A trip to the stop the banner is naming — the map long press's offer, asked of the stop
+                // the rider already has focused (#2272). It names the destination with the banner's own
+                // title so the trip's pill reads as the stop they were looking at, rather than as whatever
+                // the planner would reverse-geocode the coordinate back into. Null — and so no menu row —
+                // until the stop's location is known, since until then there is nothing to route to.
+                val navigateToFocusedStop: (() -> Unit)? =
+                    (focusBannerState as? FocusBannerState.Stop)?.let { banner ->
+                        stopFocus?.stop?.point?.let { at ->
+                            {
+                                navigateTo(
+                                    TripEndpoint.namedPlace(
+                                        name = banner.title,
+                                        lat = at.latitude,
+                                        lon = at.longitude,
+                                        isTransit = true
+                                    ),
+                                    homeViewModel,
+                                    mapViewModel,
+                                    tripPlanViewModel
+                                )
+                            }
+                        }
+                    }
+
                 // Whether the reveal slide (peek 0 -> cap) has finished at a resting peek. The peek only shrinks
                 // to fit short content once settled: retargeting mid-open would move the AnchoredDraggable anchor
                 // and strand the sheet, so we slide up to the constant cap first, then shrink (flipped by the
@@ -938,7 +962,8 @@ fun HomeScreen(
                                                                 )
                                                             }
                                                         },
-                                                        onShowArrivals = { stopFocus?.stop?.let(callbacks.onShowArrivals) }
+                                                        onShowArrivals = { stopFocus?.stop?.let(callbacks.onShowArrivals) },
+                                                        onNavigateHere = navigateToFocusedStop
                                                     )
                                                 },
                                                 // The direction menu calls straight into the map VM (which
@@ -1133,14 +1158,15 @@ fun HomeScreen(
                                         }
                                     )
                                 }
-                                // The bubble over a long press's dropped pin: taking it enters directions
-                                // with the pinned point as the trip's far end and the rider's own position
-                                // paired into the near one (see setEndpointPaired).
+                                // The bubble over a long press's dropped pin. A pressed point has nothing
+                                // to call it, so it travels as a bare map point; see navigateTo for the
+                                // rest, which the focused stop's menu item shares.
                                 NavigateHereOverlay(mapViewModel) { point ->
-                                    homeViewModel.enterDirections(mapViewModel.viewport)
-                                    tripPlanViewModel.setEndpointPaired(
-                                        TripEndpointSlot.TO,
-                                        TripEndpoint.MapPoint(point.latitude, point.longitude)
+                                    navigateTo(
+                                        TripEndpoint.MapPoint(point.latitude, point.longitude),
+                                        homeViewModel,
+                                        mapViewModel,
+                                        tripPlanViewModel
                                     )
                                 }
                                 // Neither Back nor a tap on the map background leaves outright while a trip
@@ -1239,6 +1265,25 @@ private fun NavigateHereOverlay(mapViewModel: MapViewModel, onNavigate: (GeoPoin
             onDismiss = { mapViewModel.setNavigateHerePin(null) }
         )
     }
+}
+
+/**
+ * Take the rider to [destination]: enter directions with it as the trip's far end and the rider's own
+ * position paired into the near one, which plans the trip on the spot (see `setEndpointPaired`).
+ *
+ * The one path behind every "take me there" gesture on the map — the long press's bubble (#2243) and the
+ * focused stop's menu item (#2272). They differ only in what the destination *is*, and they say so by
+ * handing a different [TripEndpoint]; everything after that is the same act, so it is spelled out once
+ * here rather than at each gesture.
+ */
+private fun navigateTo(
+    destination: TripEndpoint,
+    homeViewModel: HomeViewModel,
+    mapViewModel: MapViewModel,
+    tripPlanViewModel: TripPlanViewModel
+) {
+    homeViewModel.enterDirections(mapViewModel.viewport)
+    tripPlanViewModel.setEndpointPaired(TripEndpointSlot.TO, destination)
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -132,7 +132,15 @@ data class StopFocusMenu(
     val onReportStopProblem: () -> Unit,
     val onNightLight: () -> Unit,
     val onCreateShortcut: () -> Unit,
-    val onShowArrivals: () -> Unit
+    val onShowArrivals: () -> Unit,
+    /**
+     * Plan a trip to this stop — the map long press's "navigate here" offer, asked of the stop the rider
+     * already has focused instead of a point they have to press for (#2272). Null while the stop's own
+     * location is still unknown (a stop revealed by id alone has none until its arrivals land), since
+     * there is nothing to route to yet; that is the same beat the banner's star waits on, and it has
+     * passed by the time the menu itself is up in every entry point but that one.
+     */
+    val onNavigateHere: (() -> Unit)?
 )
 
 /**
@@ -600,8 +608,11 @@ private fun HeaderIconButton(
 
 /**
  * The focused stop's overflow: the stop actions that are neither frequent enough for their own icon nor
- * expressible on the map: the mapless board, a home-screen shortcut, a problem report against the stop,
- * and the night-light flasher a rider holds up to a driver.
+ * expressible on the map: a trip planned to the stop, the mapless board, a home-screen shortcut, a
+ * problem report against the stop, and the night-light flasher a rider holds up to a driver.
+ *
+ * "Navigate here" leads because it is the one item a rider looking at a stop is likely to want (#2272);
+ * the rest answer situations, not intentions.
  */
 @Composable
 private fun StopMenuAction(menu: StopFocusMenu, expanded: Boolean, onExpandedChange: (Boolean) -> Unit) {
@@ -612,6 +623,13 @@ private fun StopMenuAction(menu: StopFocusMenu, expanded: Boolean, onExpandedCha
             onClick = { onExpandedChange(true) }
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { onExpandedChange(false) }) {
+            // The same words the map long press's bubble offers, because it is the same offer.
+            menu.onNavigateHere?.let { navigate ->
+                MenuRow(R.string.map_navigate_here) {
+                    onExpandedChange(false)
+                    navigate()
+                }
+            }
             MenuRow(R.string.view_arrivals_only) {
                 onExpandedChange(false)
                 menu.onShowArrivals()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/PlaceIntents.kt
@@ -323,15 +323,13 @@ object PlaceIntents {
 }
 
 /**
- * An incoming place that arrived with coordinates, as a trip-plan endpoint: [TripEndpoint.Geocoded] when
- * the sender named it, and otherwise [TripEndpoint.MapPoint] — whose fixed "Selected location" label is
- * the honest one for a bare coordinate, and whose terminals a plan reverse-geocodes for the itinerary
- * anyway (`TripPlanViewModel.placeNameOf`).
+ * An incoming place that arrived with coordinates, as a trip-plan endpoint — named by the sender when it
+ * named it, and otherwise the bare map point ([TripEndpoint.namedPlace] holds that rule, shared with the
+ * app's other named-place endpoint). An unnamed terminal is reverse-geocoded for the itinerary anyway
+ * (`TripPlanViewModel.placeNameOf`), so nothing is lost by not guessing one here.
  *
  * Top-level and `internal` — like [org.onebusaway.android.ui.tripplan.toGeocoded], the sibling adapter
  * that turns a geocoder result into the same type — so this stays JVM-unit-testable rather than being
  * buried in the Activity that consumes it.
  */
-internal fun PlaceIntents.Place.Point.toEndpoint(): TripEndpoint = label
-    ?.let { TripEndpoint.Geocoded(displayName = it, lat = lat, lon = lon) }
-    ?: TripEndpoint.MapPoint(lat = lat, lon = lon)
+internal fun PlaceIntents.Place.Point.toEndpoint(): TripEndpoint = TripEndpoint.namedPlace(name = label, lat = lat, lon = lon)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -88,6 +88,29 @@ sealed interface TripEndpoint {
 
     /** A point chosen on the map. Its label is a fixed string resolved by the UI. */
     data class MapPoint(override val lat: Double, override val lon: Double) : TripEndpoint
+
+    companion object {
+
+        /**
+         * A place with coordinates that the app can already name, as an endpoint: [Geocoded] under that
+         * name, or — with no name to show — the bare [MapPoint], whose fixed "Selected location" label is
+         * the honest one for a coordinate there is nothing to call.
+         *
+         * Every surface that hands the planner a place the rider chose *as a named thing* goes through
+         * here — a place another app shared in (#1936), the focused stop's "navigate here" (#2272) —
+         * rather than each restating the same fallback. [isTransit] is for the callers that know the
+         * place is a transit stop or station; it only drives the pill's icon.
+         */
+        fun namedPlace(
+            name: String?,
+            lat: Double,
+            lon: Double,
+            isTransit: Boolean = false
+        ): TripEndpoint = name
+            ?.takeIf { it.isNotBlank() }
+            ?.let { Geocoded(displayName = it, lat = lat, lon = lon, isTransit = isTransit) }
+            ?: MapPoint(lat = lat, lon = lon)
+    }
 }
 
 /**

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanFormStateTest.kt
@@ -174,4 +174,27 @@ class TripPlanFormStateTest {
         assertFalse(pressed.isEmpty)
         assertFalse(here.isEmpty)
     }
+
+    // --- a place the app can name ---------------------------------------------------------------
+
+    /** The focused stop's "navigate here" (#2272) and a place shared in from another app (#1936). */
+    @Test
+    fun `a named place becomes a geocoded endpoint carrying its name`() {
+        assertEquals(
+            TripEndpoint.Geocoded("Pike St & 3rd Ave", lat = 47.61, lon = -122.34, isTransit = true),
+            TripEndpoint.namedPlace("Pike St & 3rd Ave", lat = 47.61, lon = -122.34, isTransit = true)
+        )
+    }
+
+    /**
+     * Nothing to call it, so it becomes the same kind of endpoint a map press makes — whose fixed
+     * "Selected location" label is honest, where an empty pill would just look broken.
+     */
+    @Test
+    fun `a place with no name to show becomes a map point`() {
+        val bare = TripEndpoint.MapPoint(lat = 47.61, lon = -122.34)
+        assertEquals(bare, TripEndpoint.namedPlace(null, lat = 47.61, lon = -122.34))
+        assertEquals(bare, TripEndpoint.namedPlace("", lat = 47.61, lon = -122.34))
+        assertEquals(bare, TripEndpoint.namedPlace("   ", lat = 47.61, lon = -122.34, isTransit = true))
+    }
 }


### PR DESCRIPTION
Closes #2272.

"Navigate here" existed only as a map long press. To plan a trip to a stop they had already focused, a rider had to close the banner, find the stop's marker again, and long-press it — asking them to re-select something the screen was already showing. The offer now **leads the focused stop's overflow menu**, where a rider looking at a stop can reach it directly.

### One act, two gestures

It is the same act as the long press, so both now go through one `navigateTo` in `HomeScreen`: enter directions with the destination as the trip's far end and the rider's own position paired into the near one (`setEndpointPaired`), which plans the trip on the spot.

They differ only in **what the destination is**, and they say so by handing a different `TripEndpoint`:

- a pressed point has nothing to call it, so it travels as a bare `MapPoint` ("Selected location");
- a stop does, so it travels **named** — the destination pill reads as the stop the banner was naming, rather than as whatever the planner would reverse-geocode the coordinate back into.

That named-or-bare rule already existed for a place shared in from another app (#1936), so it moves to `TripEndpoint.namedPlace` and both callers ask it instead of each restating the fallback.

### When the row is withheld

`StopFocusMenu.onNavigateHere` is nullable and null hides the row. That is the case only while the stop's own location is still unknown — a stop revealed by id alone (deep link, arrival push, pinned shortcut) has none until its arrivals land — since until then there is nothing to route to. It is the same beat the banner's star already waits on, and it has passed by the time the menu is up in every other entry point.

### Testing

- `compileObaGoogleDebugKotlin` and `compileObaGoogleDebugAndroidTestKotlin` with `-PwarningsAsErrors=true`; full JVM unit suite; `spotlessCheck`.
- New: two tests in `FocusBannerTest` (the row invokes its action; the row is withheld when the stop has no location, with the rest of the menu intact) and two in `TripPlanFormStateTest` covering `namedPlace` in both directions.
- No device was attached locally, so the instrumented tests compiled but did not run here — CI exercises them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013i69XYDQk7phNajUcVpWiD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Navigate here” option to focused stop menus when location data is available.
  * Selecting the option opens directions with the stop set as the destination.
  * Long-press map navigation now uses the same directions flow.
  * Added stop-list and arrivals actions to stop and route menus, including routes without schedules.

* **Bug Fixes**
  * Stops without location data no longer display an unusable navigation option.

* **Tests**
  * Added coverage for navigation, menu actions, and named place destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
