### PR TITLE
Lift map's 'my location' FAB above the navigation bar

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/VehicleMarkerPipTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/map/render/VehicleMarkerPipTest.kt
@@ -121,7 +121,10 @@ class VehicleMarkerPipTest {
             )
         }
         assertTrue("an all-empty row must still draw its washed pips (saw $whites)", whites.first() > 0)
-        assertTrue("a full row must leave no washed pips (saw $whites)", whites.last() == 0)
+        assertTrue(
+            "a full row must leave next to no washed pips (saw $whites)",
+            whites.last() <= FULL_ROW_WASH_TOLERANCE
+        )
     }
 
     /**
@@ -238,5 +241,14 @@ class VehicleMarkerPipTest {
 
         /** The tab's half-width, for locating its thirds. Independent of the production constant. */
         const val TAB_HALF_WIDTH_GRID = 10.7f
+
+        /**
+         * How many washed pixels a fully-inked row is still allowed, to absorb anti-aliasing rounding at a
+         * black pip's edge — not a real gap, since a black-tinted pip blends *darker* into the tab as its
+         * silhouette antialiases, not lighter, except for sub-pixel coverage rounding that varies by
+         * device/Skia version. Tiny next to the hundreds of washed pixels an actual unfilled pip leaves (see
+         * the empty/one-filled rungs above), so a real regression still fails this loudly.
+         */
+        const val FULL_ROW_WASH_TOLERANCE = 4
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -863,7 +863,8 @@ fun HomeScreen(
                                     with(density) { directionsSheetHeightPx.toDp() }
                                 } else {
                                     0.dp
-                                }
+                                },
+                                navigationBarInset = peekBottomPadding
                             )
                             Box(Modifier.fillMaxSize()) {
                                 // The map, with the chrome drawn over it: weather/donation/route-header/survey. The

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeSheetLogic.kt
@@ -132,7 +132,10 @@ internal fun focusBannerTopEdge(
 
 /**
  * How far to lift the map's floating controls (my-location, zoom, layers) off the bottom edge so they
- * stay in the visible map band above whichever bottom sheet is resting over it.
+ * stay in the visible map band above whichever bottom sheet is resting over it — and never sit lower
+ * than the system navigation bar / gesture inset ([navigationBarInset]), which the edge-to-edge map
+ * draws behind. With no sheet showing there is nothing else to clear, but the inset floor still
+ * applies: without it the controls sit at the literal window edge, under the gesture bar.
  *
  * [arrivalsPeek] is the collapsed arrivals peek, counted only while the arrivals sheet rests *at* that
  * peek ([arrivalsAtPeek]) — an expanded arrivals sheet covers the controls outright, so lifting to it
@@ -147,8 +150,9 @@ internal fun focusBannerTopEdge(
 internal fun mapControlsBottomInset(
     arrivalsPeek: Dp,
     arrivalsAtPeek: Boolean,
-    directionsSheet: Dp
-): Dp = maxOf(if (arrivalsAtPeek) arrivalsPeek else 0.dp, directionsSheet)
+    directionsSheet: Dp,
+    navigationBarInset: Dp
+): Dp = maxOf(if (arrivalsAtPeek) arrivalsPeek else 0.dp, directionsSheet, navigationBarInset)
 
 /** The drag-handle toggle target: a full sheet collapses to peek; anything else expands to full. */
 internal fun toggleSheetTarget(current: ArrivalsSheetState): ArrivalsSheetState = if (current == ArrivalsSheetState.Expanded) ArrivalsSheetState.Collapsed else ArrivalsSheetState.Expanded

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeSheetLogicTest.kt
@@ -142,22 +142,50 @@ class HomeSheetLogicTest {
     // --- mapControlsBottomInset ---
 
     @Test
-    fun `the map controls sit at the bottom edge with no sheet over the map`() {
+    fun `with no sheet over the map the controls still clear the navigation bar inset`() {
         assertEquals(
-            0.dp,
-            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = false, directionsSheet = 0.dp)
+            24.dp,
+            mapControlsBottomInset(
+                arrivalsPeek = 200.dp,
+                arrivalsAtPeek = false,
+                directionsSheet = 0.dp,
+                navigationBarInset = 24.dp
+            )
         )
     }
 
     @Test
-    fun `a peeking arrivals sheet lifts the map controls, an expanded one does not`() {
-        assertEquals(
-            200.dp,
-            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = true, directionsSheet = 0.dp)
-        )
+    fun `zero navigation bar inset leaves the controls at the bottom edge with no sheet over the map`() {
         assertEquals(
             0.dp,
-            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = false, directionsSheet = 0.dp)
+            mapControlsBottomInset(
+                arrivalsPeek = 200.dp,
+                arrivalsAtPeek = false,
+                directionsSheet = 0.dp,
+                navigationBarInset = 0.dp
+            )
+        )
+    }
+
+    @Test
+    fun `a peeking arrivals sheet lifts the map controls, an expanded one falls back to the nav bar inset`() {
+        assertEquals(
+            200.dp,
+            mapControlsBottomInset(
+                arrivalsPeek = 200.dp,
+                arrivalsAtPeek = true,
+                directionsSheet = 0.dp,
+                navigationBarInset = 24.dp
+            )
+        )
+        assertEquals(
+            24.dp,
+            mapControlsBottomInset(
+                arrivalsPeek = 200.dp,
+                arrivalsAtPeek = false,
+                directionsSheet = 0.dp,
+                navigationBarInset = 24.dp
+            )
         )
     }
 
@@ -166,11 +194,21 @@ class HomeSheetLogicTest {
         // Expanded (a fraction of the window) and collapsed to its handle-only peek.
         assertEquals(
             320.dp,
-            mapControlsBottomInset(arrivalsPeek = 0.dp, arrivalsAtPeek = false, directionsSheet = 320.dp)
+            mapControlsBottomInset(
+                arrivalsPeek = 0.dp,
+                arrivalsAtPeek = false,
+                directionsSheet = 320.dp,
+                navigationBarInset = 24.dp
+            )
         )
         assertEquals(
             48.dp,
-            mapControlsBottomInset(arrivalsPeek = 0.dp, arrivalsAtPeek = false, directionsSheet = 48.dp)
+            mapControlsBottomInset(
+                arrivalsPeek = 0.dp,
+                arrivalsAtPeek = false,
+                directionsSheet = 48.dp,
+                navigationBarInset = 24.dp
+            )
         )
     }
 
@@ -178,11 +216,21 @@ class HomeSheetLogicTest {
     fun `with both sheets reporting a height the controls clear the taller one`() {
         assertEquals(
             320.dp,
-            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = true, directionsSheet = 320.dp)
+            mapControlsBottomInset(
+                arrivalsPeek = 200.dp,
+                arrivalsAtPeek = true,
+                directionsSheet = 320.dp,
+                navigationBarInset = 24.dp
+            )
         )
         assertEquals(
             200.dp,
-            mapControlsBottomInset(arrivalsPeek = 200.dp, arrivalsAtPeek = true, directionsSheet = 48.dp)
+            mapControlsBottomInset(
+                arrivalsPeek = 200.dp,
+                arrivalsAtPeek = true,
+                directionsSheet = 48.dp,
+                navigationBarInset = 24.dp
+            )
         )
     }
 


### PR DESCRIPTION
# Fix

Fixes the map's "current location" floating action bar getting hidden behind the system nav bar when no bottom sheet is showing over the map.

`mapControlsBottomInset()` only lifted the FAB to clear an active arrivals peek or directions drawer. With neither showing, it returned `0.dp`, leaving the FAB just `fab_margin_vertical` (32dp) above the literal window edge which is physically behind the nav bar.

The inset now takes the navigation bar height as a floor via `WindowInsets.navigationBars`, so the FAB (and any other map control sharing this inset) never sits lower than the gesture bar, sheet or no sheet.

Before this change: 
<img width="400" height="866" alt="image" src="https://github.com/user-attachments/assets/d642c081-f44b-4118-9c45-6db8d2333aeb" />

After this change: 

<img width="400" height="866" alt="image" src="https://github.com/user-attachments/assets/7fad05d7-80d6-4c81-a87c-b7252e781437" />


# Unrelated test update

This PR also tightens `VehicleMarkerPipTest.eachFilledPipInksMoreOfTheTab`, found flaky while verifying this on a physical device: it asserted a fully-inked occupancy row leaves zero washed pixels, but anti-aliasing at a black pip's edge can leave a stray sub-pixel blend that varies by device (reproduced deterministically on-device, not on the API 33 CI emulator). Replaced the exact-zero check with a small tolerance (`FULL_ROW_WASH_TOLERANCE = 4`), tiny next to the hundreds of washed pixels a real unfilled pip leaves, so the assertion still catches an actual regression.

```
Execute org.onebusaway.android.map.render.VehicleMarkerPipTest.eachFilledPipInksMoreOfTheTab: FAILED
java.lang.AssertionError: java.lang.AssertionError: a full row must leave no washed pips (saw [973, 649, 325, 1])
```

(off by 1 pixel)

---

- [x] Format your changes with `./gradlew spotlessApply`.

- [x] Run the unit tests with `./gradlew connectedObaGoogleDebugAndroidTest` to make sure you didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Floating map controls now stay above the system navigation bar or gesture area, including when no bottom sheet is open.
  * Improved handling of expanded arrivals and directions sheets to prevent controls from being obscured.
  * Relaxed map marker rendering test tolerances to accommodate minor anti-aliasing variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->