### PR TITLE
Remove obsolete settings and restore access to trip notifications

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -136,13 +136,10 @@ fun SettingsRoute(
         onShowRentalButton = viewModel::onShowRentalButtonChanged,
         onDisplayWeatherView = viewModel::onDisplayWeatherViewChanged,
         onShowAvailableStudies = viewModel::onShowAvailableStudiesChanged,
-        onShowTutorialScreens = viewModel::onShowTutorialScreensChanged,
         onLeftHandMode = viewModel::onLeftHandModeChanged,
-        onShowHeaderArrivals = viewModel::onShowHeaderArrivalsChanged,
         onVibrateAllowed = viewModel::onVibrateAllowedChanged,
         onTripPlanNotifications = viewModel::onTripPlanNotificationsChanged,
         onAnalytics = viewModel::onAnalyticsChanged,
-        onMapMode = viewModel::onMapModeChanged,
         onPreferredUnits = viewModel::onPreferredUnitsChanged,
         onPreferredTempUnits = viewModel::onPreferredTempUnitsChanged,
         onAppTheme = viewModel::onAppThemeChanged,
@@ -176,13 +173,10 @@ class SettingsActions(
     val onShowRentalButton: (Boolean) -> Unit,
     val onDisplayWeatherView: (Boolean) -> Unit,
     val onShowAvailableStudies: (Boolean) -> Unit,
-    val onShowTutorialScreens: (Boolean) -> Unit,
     val onLeftHandMode: (Boolean) -> Unit,
-    val onShowHeaderArrivals: (Boolean) -> Unit,
     val onVibrateAllowed: (Boolean) -> Unit,
     val onTripPlanNotifications: (Boolean) -> Unit,
     val onAnalytics: (Boolean) -> Unit,
-    val onMapMode: (String) -> Unit,
     val onPreferredUnits: (String) -> Unit,
     val onPreferredTempUnits: (String) -> Unit,
     val onAppTheme: (String) -> Unit,
@@ -257,14 +251,6 @@ fun SettingsScreen(
                     checked = state.showRentalButton,
                     onCheckedChange = actions.onShowRentalButton
                 )
-                val mapOptions = stringArrayResource(R.array.preferred_map_options).toList()
-                ListPreferenceItem(
-                    title = stringResource(R.string.preferences_preferred_maps_title),
-                    entries = mapOptions,
-                    entryValues = mapOptions,
-                    selectedValue = state.mapMode,
-                    onValueSelected = actions.onMapMode
-                )
                 SwitchPreferenceItem(
                     title = stringResource(R.string.preferences_show_weather_view),
                     summary = stringResource(R.string.preferences_show_weather_view_on_map),
@@ -278,22 +264,10 @@ fun SettingsScreen(
                     onCheckedChange = actions.onShowAvailableStudies
                 )
                 SwitchPreferenceItem(
-                    title = stringResource(R.string.preferences_show_tutorial_screens_title),
-                    summary = stringResource(R.string.preferences_show_tutorial_screens_summary),
-                    checked = state.showTutorialScreens,
-                    onCheckedChange = actions.onShowTutorialScreens
-                )
-                SwitchPreferenceItem(
                     title = stringResource(R.string.preferences_left_hand_mode_title),
                     summary = stringResource(R.string.preferences_left_hand_mode_summary),
                     checked = state.leftHandMode,
                     onCheckedChange = actions.onLeftHandMode
-                )
-                SwitchPreferenceItem(
-                    title = stringResource(R.string.preferences_show_header_arrivals_title),
-                    summary = stringResource(R.string.preferences_show_header_arrivals_summary),
-                    checked = state.showHeaderArrivals,
-                    onCheckedChange = actions.onShowHeaderArrivals
                 )
                 val unitOptions = stringArrayResource(R.array.preferred_units_options).toList()
                 ListPreferenceItem(
@@ -323,17 +297,19 @@ fun SettingsScreen(
 
             if (state.showNotificationsCategory) {
                 PreferenceCategory(stringResource(R.string.preferences_category_notifications)) {
-                    ClickPreferenceItem(
-                        title = stringResource(R.string.preferences_preferred_sound_title),
-                        summary = stringResource(R.string.preferences_preferred_sound_summary, appName),
-                        onClick = actions.onRingtoneClick
-                    )
-                    SwitchPreferenceItem(
-                        title = stringResource(R.string.preferences_preferred_vibration_title),
-                        summary = stringResource(R.string.preferences_preferred_vibration_summary, appName),
-                        checked = state.vibrateAllowed,
-                        onCheckedChange = actions.onVibrateAllowed
-                    )
+                    if (state.showLegacyNotificationControls) {
+                        ClickPreferenceItem(
+                            title = stringResource(R.string.preferences_preferred_sound_title),
+                            summary = stringResource(R.string.preferences_preferred_sound_summary, appName),
+                            onClick = actions.onRingtoneClick
+                        )
+                        SwitchPreferenceItem(
+                            title = stringResource(R.string.preferences_preferred_vibration_title),
+                            summary = stringResource(R.string.preferences_preferred_vibration_summary, appName),
+                            checked = state.vibrateAllowed,
+                            onCheckedChange = actions.onVibrateAllowed
+                        )
+                    }
                     if (state.showTripPlanNotifications) {
                         SwitchPreferenceItem(
                             title = stringResource(R.string.preferences_trip_plan_notifications_title),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
@@ -39,13 +39,10 @@ data class SettingsPrefSnapshot(
     val showRentalButton: Boolean,
     val displayWeatherView: Boolean,
     val showAvailableStudies: Boolean,
-    val showTutorialScreens: Boolean,
     val leftHandMode: Boolean,
-    val showHeaderArrivals: Boolean,
     val vibrateAllowed: Boolean,
     val tripPlanNotifications: Boolean,
     val analyticsEnabled: Boolean,
-    val mapMode: String?,
     val preferredUnits: String?,
     val preferredTempUnits: String?,
     val appTheme: String?
@@ -63,7 +60,7 @@ data class SettingsEnvironment(
 
 data class SettingsUiState(
     val showRegionCategory: Boolean,
-    val showNotificationsCategory: Boolean,
+    val showLegacyNotificationControls: Boolean,
     val showTripPlanNotifications: Boolean,
     val showDonate: Boolean,
     val showPoweredByOba: Boolean,
@@ -75,17 +72,17 @@ data class SettingsUiState(
     val showRentalButton: Boolean,
     val displayWeatherView: Boolean,
     val showAvailableStudies: Boolean,
-    val showTutorialScreens: Boolean,
     val leftHandMode: Boolean,
-    val showHeaderArrivals: Boolean,
     val vibrateAllowed: Boolean,
     val tripPlanNotifications: Boolean,
     val analyticsEnabled: Boolean,
-    val mapMode: String?,
     val preferredUnits: String?,
     val preferredTempUnits: String?,
     val appTheme: String?
-)
+) {
+    val showNotificationsCategory: Boolean
+        get() = showLegacyNotificationControls || showTripPlanNotifications
+}
 
 /**
  * @param customApiRegionSummary the "Custom API" region summary string, shown when [region] is null.
@@ -97,8 +94,8 @@ fun buildSettingsUiState(
     customApiRegionSummary: String
 ): SettingsUiState = SettingsUiState(
     showRegionCategory = !env.useFixedRegion,
-    // Android 8+ manages notification channels itself, so the legacy category is dropped there.
-    showNotificationsCategory = env.sdkInt < SDK_O,
+    // Android 8+ owns sound/vibration via channels; the in-app trip toggle still applies on every SDK.
+    showLegacyNotificationControls = env.sdkInt < SDK_O,
     // Trip-plan notifications are dropped only when a region is set but has no OTP endpoint.
     showTripPlanNotifications = region == null || region.hasOtp,
     // OBA-branded builds solicit donations; white-label builds show "powered by OneBusAway" instead.
@@ -112,13 +109,10 @@ fun buildSettingsUiState(
     showRentalButton = prefs.showRentalButton,
     displayWeatherView = prefs.displayWeatherView,
     showAvailableStudies = prefs.showAvailableStudies,
-    showTutorialScreens = prefs.showTutorialScreens,
     leftHandMode = prefs.leftHandMode,
-    showHeaderArrivals = prefs.showHeaderArrivals,
     vibrateAllowed = prefs.vibrateAllowed,
     tripPlanNotifications = prefs.tripPlanNotifications,
     analyticsEnabled = prefs.analyticsEnabled,
-    mapMode = prefs.mapMode,
     preferredUnits = prefs.preferredUnits,
     preferredTempUnits = prefs.preferredTempUnits,
     appTheme = prefs.appTheme

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -95,16 +95,10 @@ class SettingsViewModel @Inject constructor(
         showRentalButton = prefs.getBoolean(R.string.preference_key_show_rental_button, true),
         displayWeatherView = prefs.getBoolean(R.string.preference_key_display_weather_view, true),
         showAvailableStudies = prefs.getBoolean(R.string.preference_key_show_available_studies, true),
-        showTutorialScreens = prefs.getBoolean(R.string.preference_key_show_tutorial_screens, true),
         leftHandMode = prefs.getBoolean(R.string.preference_key_left_hand_mode, false),
-        showHeaderArrivals = prefs.getBoolean(R.string.preference_key_show_header_arrivals, false),
         vibrateAllowed = prefs.getBoolean(R.string.preference_key_preference_vibrate_allowed, true),
         tripPlanNotifications = prefs.getBoolean(R.string.preference_key_trip_plan_notifications, true),
         analyticsEnabled = prefs.getBoolean(R.string.preferences_key_analytics, true),
-        mapMode = prefs.getString(
-            R.string.preference_key_map_mode,
-            context.getString(R.string.preferences_preferred_map_option_normal2d)
-        ),
         preferredUnits = prefs.getString(
             R.string.preference_key_preferred_units,
             context.getString(R.string.preferences_preferred_units_option_automatic)
@@ -164,14 +158,10 @@ class SettingsViewModel @Inject constructor(
 
     fun onShowAvailableStudiesChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_show_available_studies, value)
 
-    fun onShowTutorialScreensChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_show_tutorial_screens, value)
-
     fun onLeftHandModeChanged(value: Boolean) {
         prefs.setBoolean(R.string.preference_key_left_hand_mode, value)
         obaAnalytics.setLeftHanded(value)
     }
-
-    fun onShowHeaderArrivalsChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_show_header_arrivals, value)
 
     fun onVibrateAllowedChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_preference_vibrate_allowed, value)
 
@@ -185,8 +175,6 @@ class SettingsViewModel @Inject constructor(
     // endregion
 
     // region List actions
-
-    fun onMapModeChanged(value: String) = prefs.setString(R.string.preference_key_map_mode, value)
 
     fun onPreferredUnitsChanged(value: String) = prefs.setString(R.string.preference_key_preferred_units, value)
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/TutorialPrefs.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tutorial/TutorialPrefs.kt
@@ -23,7 +23,7 @@ import org.onebusaway.android.app.di.PreferencesEntryPoint
  * Tutorial preference-flag constants and reset, kept after the ShowcaseView-based tutorials were
  * replaced by Compose onboarding: [TUTORIAL_WELCOME] gates the launch flow's "show the tutorial?"
  * prompt and [TUTORIAL_OPT_OUT_DIALOG] the help dialog. [resetAllTutorials] re-arms onboarding from
- * Settings.
+ * Help.
  *
  * Five further flags used to live here — the arrival sort, Recent stops/routes, the two starred-stops
  * hints and the Open311 categories. Each was declared and dutifully reset, and none had been *read*

--- a/onebusaway-android/src/main/res/values-es/arrays.xml
+++ b/onebusaway-android/src/main/res/values-es/arrays.xml
@@ -70,11 +70,6 @@
         <item>@string/preferences_preferred_units_option_metric</item>
         <item>@string/preferences_preferred_units_option_imperial</item>
     </string-array>
-    <string-array name="preferred_map_options">
-        <item>@string/preferences_preferred_map_option_normal2d</item>
-        <item>@string/preferences_preferred_map_option_normal3d</item>
-        <item>@string/preferences_preferred_map_option_satellite</item>
-    </string-array>
 
     <!-- Spoken directions based on 16 compass points, but pointing from the user's current location
          towards the selected bus stop instead of N/S/E/W. -->

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -568,19 +568,9 @@
     <string name="preferences_show_zoom_controls_summary">Mostrar los controles de Zoom en el mapa
     </string>
 
-    <string name="preferences_show_header_arrivals_title">Ver llegadas sobre el nombre de parada</string>
-    <string name="preferences_show_header_arrivals_summary">Cuando se visualizan paradas favoritas,
-        muestra la información de llegadas en el encabezado en la parte superior de la pantalla (esto no afecta en la vista del mapa)
-    </string>
-
     <string name="preferences_trip_plan_notifications_title">Notificaciones del Planeador de Viajes (beta)</string>
     <string name="preferences_trip_plan_notifications_summary">Después de que planeas un viaje, enviar
         notificaciones sobre si el viaje esta atrasado o ya no es recomendado.
-    </string>
-
-    <string name="preferences_show_tutorial_screens_title">Mostrar las pantallas del tutorial</string>
-    <string name="preferences_show_tutorial_screens_summary">Desplegar las ventanas emergentes informacionales explicando
-        como usar las funciones
     </string>
 
     <string name="preferences_left_hand_mode_title">Modo de mano izquierda</string>
@@ -1013,10 +1003,6 @@
     <string name="preferences_reset_donation_timestamps_title">Restablecer las marcas de tiempo de donación</string>
     <string name="preferences_reset_donation_timestamps_summary">Al tocar esta opción se borrarán las marcas de tiempo de ’Recuérdame más tarde’ y ’No me molestes’ asociadas con las solicitudes de donación.</string>
     <string name="preferences_show_weather_view">Mostrar vista del clima</string>
-    <string name="preferences_preferred_maps_title">Tipo de Mapa Preferido</string>
-    <string name="preferences_preferred_map_option_normal2d">Mapa predeterminado</string>
-    <string name="preferences_preferred_map_option_normal3d">Mapa predeterminado con edificios 3D</string>
-    <string name="preferences_preferred_map_option_satellite">Mapa satelital</string>
 
     <!-- Survey -->
     <string name="preferences_show_available_studies_title">Mostrar estudios disponibles</string>

--- a/onebusaway-android/src/main/res/values-fi/arrays.xml
+++ b/onebusaway-android/src/main/res/values-fi/arrays.xml
@@ -65,11 +65,6 @@
         <item>@string/preferences_preferred_units_option_metric</item>
         <item>@string/preferences_preferred_units_option_imperial</item>
     </string-array>
-    <string-array name="preferred_map_options">
-        <item>@string/preferences_preferred_map_option_normal2d</item>
-        <item>@string/preferences_preferred_map_option_normal3d</item>
-        <item>@string/preferences_preferred_map_option_satellite</item>
-    </string-array>
 
     <!-- Spoken directions based on 16 compass points, but pointing from the user's current location
          towards the selected bus stop instead of N/S/E/W. -->

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -461,12 +461,6 @@
         negatiivisina saapumisaikoina
     </string>
 
-    <string name="preferences_show_header_arrivals_title">Näytä saapuvat bussit pysäkin yläpuolella</string>
-    <string name="preferences_show_header_arrivals_summary">Näyttää suosikkipysäkeille
-        saapuvien bussien tiedot otsikosssa (ei vaikuta karttaan)
-    </string>
-
-
     <string name="preferences_oba_api_servername_title">%1$s API palvelin</string>
     <string name="preferences_oba_api_servername_summary">Määrittää käytettävän palvelimen %1$s
         API kutsuille
@@ -512,8 +506,6 @@
     <string name="preferences_left_hand_mode_summary">Siirtää joidenkin painikkeiden sijainnin näytön vasemmalle puolelle</string>
     <string name="preferences_show_zoom_controls_title">Näytä zoomaussäätimet</string>
     <string name="preferences_show_zoom_controls_summary">Näytä zoomaussäätimet kartalla</string>
-    <string name="preferences_show_tutorial_screens_title">Näytä opastusnäytöt</string>
-    <string name="preferences_show_tutorial_screens_summary">Näytä tiedottavat ponnahdusikkunat, jotka selittävät ominaisuuksien käyttöä</string>
     <string name="preferences_otp_api_servername_title">OpenTripPlanner API -palvelin</string>
     <string name="preferences_otp_api_servername_summary">Määrittää OpenTripPlanner API-kutsuissa käytettävän palvelimen</string>
     <string name="preferences_otp_api_servername_hint">esimerkki.opentripplanner.org/otp</string>
@@ -662,10 +654,6 @@
     <string name="preferences_reset_donation_timestamps_title">Nollaa Lahjoituksen Aikaleimat</string>
     <string name="preferences_reset_donation_timestamps_summary">Tämän vaihtoehdon napauttaminen poistaa sekä ’Muistuta minua myöhemmin’ että ’Älä vaivaudu’ aikaleimat, jotka liittyvät lahjoituspyyntöihin.</string>
     <string name="preferences_show_weather_view">Näytä säätönäkymä</string>
-    <string name="preferences_preferred_maps_title">Ensisijainen Karttatyyppi</string>
-    <string name="preferences_preferred_map_option_normal2d">Oletuskartta</string>
-    <string name="preferences_preferred_map_option_normal3d">Oletuskartta 3D-rakennuksilla</string>
-    <string name="preferences_preferred_map_option_satellite">Satelliitti kartta</string>
 
     <!-- Survey -->
     <string name="preferences_show_available_studies_title">Näytä saatavilla olevat tutkimukset</string>

--- a/onebusaway-android/src/main/res/values-it/arrays.xml
+++ b/onebusaway-android/src/main/res/values-it/arrays.xml
@@ -69,11 +69,6 @@
         <item>@string/preferences_preferred_units_option_metric</item>
         <item>@string/preferences_preferred_units_option_imperial</item>
     </string-array>
-    <string-array name="preferred_map_options">
-        <item>@string/preferences_preferred_map_option_normal2d</item>
-        <item>@string/preferences_preferred_map_option_normal3d</item>
-        <item>@string/preferences_preferred_map_option_satellite</item>
-    </string-array>
 
     <!-- Spoken directions based on 16 compass points, but pointing from the user's current location
          towards the selected bus stop instead of N/S/E/W. -->

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -449,14 +449,8 @@
     <string name="preferences_show_zoom_controls_title">Mostra controlli zoom</string>
     <string name="preferences_show_zoom_controls_summary">Mostra controlli zoom sulla mappa</string>
 
-    <string name="preferences_show_header_arrivals_title">Mostra arrivi sopra nome fermata</string>
-    <string name="preferences_show_header_arrivals_summary">Quando visualizzi i preferiti, mostra informazioni sugli arrivi nell’intestazione (la visuale della mappa resta invariata)</string>
-
     <string name="preferences_trip_plan_notifications_title">Notifiche sul piano di viaggio (beta)</string>
     <string name="preferences_trip_plan_notifications_summary">Dopo aver pianificato un viaggio, invia notifiche se ci sono ritardi o se il viaggio non è più consigliato.</string>
-
-    <string name="preferences_show_tutorial_screens_title">Mostra schermate tutorial</string>
-    <string name="preferences_show_tutorial_screens_summary">Mostra popup informativi sull’utilizzo delle funzionalità</string>
 
     <string name="preferences_left_hand_mode_title">Modalità mano sinistra</string>
     <string name="preferences_left_hand_mode_summary">Sposta alcuni pulsanti sul lato sinistro dello schermo</string>
@@ -868,10 +862,6 @@
     <string name="preferences_reset_donation_timestamps_title">Reimposta i Timestamp delle Donazioni</string>
     <string name="preferences_reset_donation_timestamps_summary">Toccando questa opzione verranno cancellati i timestamp di ’Ricordamelo più tardi’ e ’Non disturbarmi’ associati alle richieste di donazione.</string>
     <string name="preferences_show_weather_view">Mostra vista meteo</string>
-    <string name="preferences_preferred_maps_title">Tipo Di Mappa Preferito</string>
-    <string name="preferences_preferred_map_option_normal2d">Mappa predefinita</string>
-    <string name="preferences_preferred_map_option_normal3d">Mappa predefinita con edifici 3D</string>
-    <string name="preferences_preferred_map_option_satellite">Mappa satellitare</string>
 
     <!-- Survey -->
     <string name="preferences_show_available_studies_title">Mostra studi disponibili</string>

--- a/onebusaway-android/src/main/res/values-pl/arrays.xml
+++ b/onebusaway-android/src/main/res/values-pl/arrays.xml
@@ -70,11 +70,6 @@
         <item>@string/preferences_preferred_units_option_metric</item>
         <item>@string/preferences_preferred_units_option_imperial</item>
     </string-array>
-    <string-array name="preferred_map_options">
-        <item>@string/preferences_preferred_map_option_normal2d</item>
-        <item>@string/preferences_preferred_map_option_normal3d</item>
-        <item>@string/preferences_preferred_map_option_satellite</item>
-    </string-array>
 
     <!-- Spoken directions based on 16 compass points, but pointing from the user's current location
          towards the selected bus stop instead of N/S/E/W. -->

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -477,17 +477,8 @@
     <string name="preferences_show_zoom_controls_summary">Wyświetl kontrolki powiększenia na mapie
     </string>
 
-    <string name="preferences_show_header_arrivals_title">Pokaż przyjazd nad nazwą przystanku</string>
-    <string name="preferences_show_header_arrivals_summary">Kiedy oglądasz ulubione przystanki,
-        pokaż przyjazdy w nagłówku u góry ekranu (nie wpływa na widok mapy)
-    </string>
-
     <string name="preferences_trip_plan_notifications_title">Powiadomienia o planowaniu podróży (beta)</string>
     <string name="preferences_trip_plan_notifications_summary">Po zaplanowaniu podróży wysyłaj powiadomienia, jeśli podróż jest opóźniona lub nie jest już zalecana.
-    </string>
-
-    <string name="preferences_show_tutorial_screens_title">Pokaż ekrany samouczka</string>
-    <string name="preferences_show_tutorial_screens_summary">Wyświetlaj wyskakujące okienka informacyjne wyjaśniające jak korzystać z funkcji
     </string>
 
     <string name="preferences_left_hand_mode_title">Tryb leworęczny</string>
@@ -790,10 +781,6 @@
     <string name="preferences_reset_donation_timestamps_title">Zresetuj Znaczniki Czasu Dotacji</string>
     <string name="preferences_reset_donation_timestamps_summary">Dotknięcie tej opcji spowoduje wyczyszczenie znaczników czasu ’Przypomnij mi później’ i ’Nie przeszkadzaj mi’ związanych z prośbami o darowizny.</string>
     <string name="preferences_show_weather_view">Pokaż widok pogody</string>
-    <string name="preferences_preferred_maps_title">Preferowany Typ Mapy</string>
-    <string name="preferences_preferred_map_option_normal2d">Domyślna mapa</string>
-    <string name="preferences_preferred_map_option_normal3d">Domyślna mapa z budynkami 3D</string>
-    <string name="preferences_preferred_map_option_satellite">Mapa satelitarna</string>
 
     <!-- Survey -->
     <string name="preferences_show_available_studies_title">Pokaż dostępne badania</string>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -65,11 +65,6 @@
         <item>The bus doesn’t stop here</item>
         <item>Something else</item>
     </string-array>
-    <string-array name="preferred_map_options">
-        <item>@string/preferences_preferred_map_option_normal2d</item>
-        <item>@string/preferences_preferred_map_option_normal3d</item>
-        <item>@string/preferences_preferred_map_option_satellite</item>
-    </string-array>
     <string-array name="preferred_units_options">
         <item>@string/preferences_preferred_units_option_automatic</item>
         <item>@string/preferences_preferred_units_option_metric</item>

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -37,13 +37,11 @@
     <string name="preference_key_app_theme">preference_app_theme</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>
     <string name="preference_key_show_zoom_controls">preference_show_zoom_controls</string>
-    <string name="preference_key_map_mode">preference_key_map_mode</string>
     <string name="preference_key_show_available_studies">preference_show_available_studies</string>
     <string name="preference_key_hide_alerts">preference_hide_alerts</string>
     <string name="preference_key_default_stop_sort">preference_default_stop_sort</string>
     <string name="preference_key_default_reminder_time">preference_default_reminder_time</string>
     <string name="preference_key_default_reminder_sort">preference_default_reminder_sort</string>
-    <string name="preference_key_show_header_arrivals">preference_key_show_header_arrivals</string>
     <string name="preference_key_show_tutorial_screens">preference_key_show_tutorial_screens</string>
     <string name="preference_key_trip_plan_notifications">preference_key_trip_plan_notifications</string>
     <string name="preference_key_left_hand_mode">preference_key_left_hand_mode</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -683,19 +683,9 @@
     <string name="preferences_show_zoom_controls_summary">Display zoom controls on map
     </string>
 
-    <string name="preferences_show_header_arrivals_title">Show arrivals above stop name</string>
-    <string name="preferences_show_header_arrivals_summary">When viewing starred stops,
-        show arrival info in the header at the top of the screen (doesn’t affect map view)
-    </string>
-
     <string name="preferences_trip_plan_notifications_title">Trip plan notifications (beta)</string>
     <string name="preferences_trip_plan_notifications_summary">After planning a trip, send
         notifications if the trip is delayed or no longer recommended.
-    </string>
-
-    <string name="preferences_show_tutorial_screens_title">Show tutorial screens</string>
-    <string name="preferences_show_tutorial_screens_summary">Display informational popups explaining
-        how to use features
     </string>
 
     <string name="preferences_left_hand_mode_title">Left hand mode</string>
@@ -1460,10 +1450,6 @@
     <string name="preferences_reset_donation_timestamps_title">Reset Donation Timestamps</string>
     <string name="preferences_reset_donation_timestamps_summary">Tapping this option will clear both the ’Remind Me Later’ and ’Don’t Bother Me’ timestamps associated with donation requests.</string>
     <string name="preferences_show_weather_view">Show weather view</string>
-    <string name="preferences_preferred_maps_title">Preferred Map Type</string>
-    <string name="preferences_preferred_map_option_normal2d">Default Map</string>
-    <string name="preferences_preferred_map_option_normal3d">Default Map with 3D Buildings</string>
-    <string name="preferences_preferred_map_option_satellite">Satellite Map</string>
 
     <!-- Survey -->
     <string name="preferences_show_available_studies_title">Show available studies</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
@@ -35,13 +35,10 @@ class SettingsUiStateTest {
         showRentalButton = true,
         displayWeatherView = true,
         showAvailableStudies = true,
-        showTutorialScreens = true,
         leftHandMode = false,
-        showHeaderArrivals = false,
         vibrateAllowed = true,
         tripPlanNotifications = true,
         analyticsEnabled = true,
-        mapMode = "normal",
         preferredUnits = "Automatic",
         preferredTempUnits = "Automatic",
         appTheme = "System default"
@@ -71,10 +68,40 @@ class SettingsUiStateTest {
     // --- notifications / trip plan ---
 
     @Test
-    fun `notifications category hidden on Android 8 and up`() {
-        assertTrue(build(env = env(sdkInt = 25)).showNotificationsCategory)
-        assertFalse(build(env = env(sdkInt = 26)).showNotificationsCategory)
-        assertFalse(build(env = env(sdkInt = 33)).showNotificationsCategory)
+    fun `trip notification toggle remains accessible on every Android version`() {
+        for (sdk in listOf(23, 25, 26, 33, 36)) {
+            val state = build(env = env(sdkInt = sdk))
+            assertTrue(state.showNotificationsCategory)
+            assertTrue(state.showTripPlanNotifications)
+            assertEquals(sdk < 26, state.showLegacyNotificationControls)
+        }
+    }
+
+    @Test
+    fun `region without trip planning only shows legacy notification controls`() {
+        val region = RegionSummaryInfo("R", hasOtp = false)
+        val legacy = build(region = region, env = env(sdkInt = 25))
+        assertTrue(legacy.showNotificationsCategory)
+        assertTrue(legacy.showLegacyNotificationControls)
+        assertFalse(legacy.showTripPlanNotifications)
+
+        val modern = build(region = region, env = env(sdkInt = 26))
+        assertFalse(modern.showNotificationsCategory)
+        assertFalse(modern.showLegacyNotificationControls)
+        assertFalse(modern.showTripPlanNotifications)
+    }
+
+    @Test
+    fun `disabled trip notifications can be re-enabled on modern Android`() {
+        val state = buildSettingsUiState(
+            prefs.copy(tripPlanNotifications = false),
+            region = null,
+            env = env(sdkInt = 33),
+            customApiRegionSummary = "Custom API"
+        )
+        assertTrue(state.showNotificationsCategory)
+        assertTrue(state.showTripPlanNotifications)
+        assertFalse(state.tripPlanNotifications)
     }
 
     @Test
@@ -107,7 +134,6 @@ class SettingsUiStateTest {
     fun `toggle and list values are copied through to the state`() {
         val s = build()
         assertTrue(s.autoSelectRegion)
-        assertEquals("normal", s.mapMode)
         assertEquals("System default", s.appTheme)
     }
 


### PR DESCRIPTION
Settings exposed map-type and starred-stop-header preferences that no current renderer reads, plus a tutorial switch that does not replay completed tutorials. Remove these three rows and their unused state/resources; tutorial replay remains available through Help.

The audit also found that Android 8+ hid the entire notification category even though the trip monitor honors the saved trip-notification preference on every Android version. Keep the trip toggle accessible when the region supports trip planning (or a custom API is in use), while leaving legacy sound/vibration controls limited to Android versions before notification channels.

Fixes #2287.

Validation:

- [x] Format changes with `./gradlew spotlessApply`.
- [x] All 60 settings/tutorial JVM tests passed with `-PwarningsAsErrors=true`, including notification visibility across SDK levels, regions without trip planning, and re-enabling a saved disabled toggle.
- [x] `git diff --check`.
- [ ] `./gradlew connectedObaGoogleDebugAndroidTest` (not run locally).

Test command: `./gradlew :onebusaway-android:testObaGoogleDebugUnitTest --tests 'org.onebusaway.android.ui.settings.*' --tests 'org.onebusaway.android.ui.tutorial.*' -PwarningsAsErrors=true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Settings**
  * Removed settings for preferred map type, tutorial screens, and header arrivals.
  * Ringtone and vibration controls now appear only on devices that support legacy notification settings.
  * Updated notification-setting visibility across Android versions.

* **Documentation**
  * Updated tutorial guidance to reference Help instead of Settings.

* **Localization**
  * Removed translations for the discontinued settings and map options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->