### PR TITLE
Add Compact stop icons setting

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -283,7 +283,7 @@ class GoogleMapRenderer(
     fun renderStatic(snapshot: MapRenderSnapshot = renderState.snapshot.value) {
         clearStatic()
 
-        stopMarkerLayer.render(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
+        stopMarkerLayer.render(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand, snapshot.compactStopIcons)
         routeStopLayer.render(
             snapshot.stops,
             snapshot.focusedStopId,

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleStopMarkerLayer.kt
@@ -52,7 +52,7 @@ internal class GoogleStopMarkerLayer(
     private val labelIcons =
         BitmapDescriptorCache(LABEL_ICON_CACHE_SIZE) { BitmapDescriptorFactory.fromBitmap(it) }
 
-    fun render(stops: List<StopMarker>, focusedStopId: String?, band: StopBand) {
+    fun render(stops: List<StopMarker>, focusedStopId: String?, band: StopBand, compact: Boolean) {
         val markerStops = stops.filterNot(StopMarker::routeStop)
         val liveIds = markerStops.mapTo(HashSet(), StopMarker::id)
         val gone = markerByStopId.iterator()
@@ -71,7 +71,8 @@ internal class GoogleStopMarkerLayer(
             val kind = stopIconKind(
                 focused = stop.id == focusedStopId,
                 band = band,
-                favorite = stop.favorite
+                favorite = stop.favorite,
+                compact = compact
             )
             val existing = markerByStopId[stop.id]
             if (existing == null) {
@@ -179,6 +180,8 @@ internal class GoogleStopMarkerLayer(
     private fun icon(stop: StopMarker, kind: StopIconKind): BitmapDescriptor = when (kind) {
         StopIconKind.FULL -> StopIconFactory.stopIcon(context, stop.direction, stop.routeType)
         StopIconKind.FULL_FOCUSED -> StopIconFactory.focusedStopIcon(context, stop.direction, stop.routeType)
+        StopIconKind.COMPACT -> StopIconFactory.compactStopIcon(context, stop.direction)
+        StopIconKind.COMPACT_FOCUSED -> StopIconFactory.compactStopIcon(context, stop.direction, focused = true)
         StopIconKind.DOT -> StopIconFactory.dotStopIcon(context)
         StopIconKind.DOT_FOCUSED -> StopIconFactory.focusedDotStopIcon(context)
         StopIconKind.FAVORITE -> StopIconFactory.favoriteStopIcon(context, stop.direction)
@@ -188,7 +191,7 @@ internal class GoogleStopMarkerLayer(
     }
 
     private fun anchor(stop: StopMarker, kind: StopIconKind): Pair<Float, Float> = when (kind) {
-        StopIconKind.FULL, StopIconKind.FULL_FOCUSED ->
+        StopIconKind.FULL, StopIconKind.FULL_FOCUSED, StopIconKind.COMPACT, StopIconKind.COMPACT_FOCUSED ->
             StopIconFactory.anchorX(context, stop.direction) to
                 StopIconFactory.anchorY(context, stop.direction)
         else -> 0.5f to 0.5f

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.kt
@@ -62,6 +62,10 @@ object StopIconFactory {
     /** Focused (selected) variant of [stopDescriptors]. */
     private val stopDescriptorsFocused = SparseArray<Array<BitmapDescriptor>>()
 
+    /** Original-size circle and arrow without a vehicle glyph, indexed by direction (#2284). */
+    private lateinit var compactDescriptors: Array<BitmapDescriptor>
+    private lateinit var compactDescriptorsFocused: Array<BitmapDescriptor>
+
     /** The small directionless dot shown in place of the full icon at distant zoom (declutter). */
     private lateinit var dotDescriptor: BitmapDescriptor
 
@@ -154,6 +158,13 @@ object StopIconFactory {
     fun stopIcon(context: Context, direction: String, routeType: Int): BitmapDescriptor {
         ensureLoaded(context)
         return lookupStopIcon(stopDescriptors, direction, routeType)
+    }
+
+    @Synchronized
+    fun compactStopIcon(context: Context, direction: String, focused: Boolean = false): BitmapDescriptor {
+        ensureLoaded(context)
+        val descriptors = if (focused) compactDescriptorsFocused else compactDescriptors
+        return descriptors[StopDirection.fromKey(direction).ordinal]
     }
 
     /** The focused (1.5x) stop icon for a direction + primary route type. */
@@ -262,6 +273,15 @@ object StopIconFactory {
             stopDescriptorsFocused.put(routeType, toDescriptors(iconsFocused))
         }
 
+        fun compactIcons(selected: Boolean): Array<BitmapDescriptor> = toDescriptors(
+            StopDirection.entries.map { direction ->
+                val bitmap = createStopIcon(context, direction, selected, ObaRoute.TYPE_BUS, arrowTip, arrowBase, compact = true)
+                if (selected) StopBitmaps.scale(bitmap, FOCUS_ICON_SCALE) else bitmap
+            }.toTypedArray()
+        )
+        compactDescriptors = compactIcons(selected = false)
+        compactDescriptorsFocused = compactIcons(selected = true)
+
         // Star colors: the normal star is the gold gradient (light→dark); a selected star uses the same
         // focus color as every other selected stop (solid). The arrow keeps the theme primary→accent.
         val starLight = ContextCompat.getColor(context, R.color.map_stop_favorite_light)
@@ -327,10 +347,11 @@ object StopIconFactory {
         selected: Boolean,
         routeType: Int,
         arrowTip: Int,
-        arrowBase: Int
+        arrowBase: Int,
+        compact: Boolean = false
     ): Bitmap {
-        // All stops get a slightly larger circle so the vehicle glyph is clearly visible
-        val px = (basePx * GLYPH_ICON_SCALE).toInt()
+        // Compact uses the original circle size; detailed icons grow to fit the vehicle glyph.
+        val px = if (compact) basePx else (basePx * GLYPH_ICON_SCALE).toInt()
         val shape = requireNotNull(
             ContextCompat.getDrawable(
                 context,
@@ -338,7 +359,7 @@ object StopIconFactory {
             )
         )
         return StopBitmaps.directionalStopMarker(shape, direction, px, arrowTip, arrowBase) { canvas, bounds ->
-            drawRouteTypeSymbol(canvas, bounds, routeType)
+            if (!compact) drawRouteTypeSymbol(canvas, bounds, routeType)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -111,6 +111,12 @@ class MapHost(
     val renderState = MapRenderState()
 
     init {
+        renderState.setCompactStopIcons(prefsRepository.getBoolean(R.string.preference_key_compact_stop_icons, false))
+        scope.launch {
+            prefsRepository.observeBoolean(R.string.preference_key_compact_stop_icons, false)
+                .collect(renderState::setCompactStopIcons)
+        }
+
         // Re-center when the region changes from the one present at startup (replaces the host's
         // onRegionChanged push). We compare each emission's id against the last-seen id, seeded with the
         // region at construction — rather than dropping the first emission — so it's race-free: even if

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -504,6 +504,7 @@ data class MapRenderSnapshot(
     // by StopsMapController and carried here so a pure zoom re-fires the renderer like any other
     // snapshot change — keeping the renderer a pure function of the snapshot (no live camera reads).
     val stopBand: StopBand = StopBand.FULL,
+    val compactStopIcons: Boolean = false,
     // The selected vehicle's route continuation (#1691), or null. A discrete, infrequently-changing
     // annotation like the fields above, so it rides the same renderStatic() redraw path rather than
     // the 20Hz vehicle-motion sampler.
@@ -815,6 +816,10 @@ class MapRenderState {
     /** Sets the stop zoom band (full icon vs dot); a no-op emission when unchanged (StateFlow dedups). */
     fun setStopBand(band: StopBand) {
         _snapshot.update { it.copy(stopBand = band) }
+    }
+
+    fun setCompactStopIcons(compact: Boolean) {
+        _snapshot.update { it.copy(compactStopIcons = compact) }
     }
 
     /** Selects (or deselects with null) a vehicle by trip id; the renderer shows its data marker. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -117,6 +117,8 @@ fun focusedRouteStopScale(zoom: Float): Float = detailZoomRamp(
 enum class StopIconKind {
     FULL,
     FULL_FOCUSED,
+    COMPACT,
+    COMPACT_FOCUSED,
     DOT,
     DOT_FOCUSED,
     FAVORITE,
@@ -134,16 +136,19 @@ enum class StopIconKind {
  *
  * [StopBand.ROUTES] takes the same icon as [StopBand.FULL]: what that band adds is the separate route
  * label beside the marker (#2107, see [stopRouteLabel]), not a different icon.
+ * [compact] replaces only full ordinary icons with the smaller, glyph-free circle and arrow (#2284).
  */
 fun stopIconKind(
     focused: Boolean,
     band: StopBand,
-    favorite: Boolean = false
+    favorite: Boolean = false,
+    compact: Boolean = false
 ): StopIconKind = when {
     favorite && band == StopBand.DOT ->
         if (focused) StopIconKind.FAVORITE_DOT_FOCUSED else StopIconKind.FAVORITE_DOT
     favorite -> if (focused) StopIconKind.FAVORITE_FOCUSED else StopIconKind.FAVORITE
     band == StopBand.DOT -> if (focused) StopIconKind.DOT_FOCUSED else StopIconKind.DOT
+    compact -> if (focused) StopIconKind.COMPACT_FOCUSED else StopIconKind.COMPACT
     focused -> StopIconKind.FULL_FOCUSED
     else -> StopIconKind.FULL
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -133,6 +133,7 @@ fun SettingsRoute(
         onShowNegativeArrivals = viewModel::onShowNegativeArrivalsChanged,
         onHideAlerts = viewModel::onHideAlertsChanged,
         onShowZoomControls = viewModel::onShowZoomControlsChanged,
+        onCompactStopIcons = viewModel::onCompactStopIconsChanged,
         onShowRentalButton = viewModel::onShowRentalButtonChanged,
         onDisplayWeatherView = viewModel::onDisplayWeatherViewChanged,
         onShowAvailableStudies = viewModel::onShowAvailableStudiesChanged,
@@ -170,6 +171,7 @@ class SettingsActions(
     val onShowNegativeArrivals: (Boolean) -> Unit,
     val onHideAlerts: (Boolean) -> Unit,
     val onShowZoomControls: (Boolean) -> Unit,
+    val onCompactStopIcons: (Boolean) -> Unit,
     val onShowRentalButton: (Boolean) -> Unit,
     val onDisplayWeatherView: (Boolean) -> Unit,
     val onShowAvailableStudies: (Boolean) -> Unit,
@@ -243,6 +245,14 @@ fun SettingsScreen(
                     checked = state.showZoomControls,
                     onCheckedChange = actions.onShowZoomControls
                 )
+                if (state.showCompactStopIcons) {
+                    SwitchPreferenceItem(
+                        title = stringResource(R.string.preferences_compact_stop_icons_title),
+                        summary = stringResource(R.string.preferences_compact_stop_icons_summary),
+                        checked = state.compactStopIcons,
+                        onCheckedChange = actions.onCompactStopIcons
+                    )
+                }
                 // The map's own long-press menu is the other way to turn this off, and the only way a
                 // rider is likely to find it; this row is how it comes back (#2168).
                 SwitchPreferenceItem(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
@@ -36,6 +36,7 @@ data class SettingsPrefSnapshot(
     val showNegativeArrivals: Boolean,
     val hideAlerts: Boolean,
     val showZoomControls: Boolean,
+    val compactStopIcons: Boolean,
     val showRentalButton: Boolean,
     val displayWeatherView: Boolean,
     val showAvailableStudies: Boolean,
@@ -55,7 +56,8 @@ data class RegionSummaryInfo(val name: String, val hasOtp: Boolean)
 data class SettingsEnvironment(
     val useFixedRegion: Boolean,
     val sdkInt: Int,
-    val isObaFlavor: Boolean
+    val isObaFlavor: Boolean,
+    val isGoogleMaps: Boolean
 )
 
 data class SettingsUiState(
@@ -63,12 +65,14 @@ data class SettingsUiState(
     val showLegacyNotificationControls: Boolean,
     val showTripPlanNotifications: Boolean,
     val showDonate: Boolean,
+    val showCompactStopIcons: Boolean,
     val showPoweredByOba: Boolean,
     val regionSummary: String,
     val autoSelectRegion: Boolean,
     val showNegativeArrivals: Boolean,
     val hideAlerts: Boolean,
     val showZoomControls: Boolean,
+    val compactStopIcons: Boolean,
     val showRentalButton: Boolean,
     val displayWeatherView: Boolean,
     val showAvailableStudies: Boolean,
@@ -100,12 +104,14 @@ fun buildSettingsUiState(
     showTripPlanNotifications = region == null || region.hasOtp,
     // OBA-branded builds solicit donations; white-label builds show "powered by OneBusAway" instead.
     showDonate = env.isObaFlavor,
+    showCompactStopIcons = env.isGoogleMaps,
     showPoweredByOba = !env.isObaFlavor,
     regionSummary = region?.name ?: customApiRegionSummary,
     autoSelectRegion = prefs.autoSelectRegion,
     showNegativeArrivals = prefs.showNegativeArrivals,
     hideAlerts = prefs.hideAlerts,
     showZoomControls = prefs.showZoomControls,
+    compactStopIcons = prefs.compactStopIcons,
     showRentalButton = prefs.showRentalButton,
     displayWeatherView = prefs.displayWeatherView,
     showAvailableStudies = prefs.showAvailableStudies,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -66,7 +66,8 @@ class SettingsViewModel @Inject constructor(
     private val env = SettingsEnvironment(
         useFixedRegion = BuildConfig.USE_FIXED_REGION,
         sdkInt = Build.VERSION.SDK_INT,
-        isObaFlavor = BuildFlavorUtils.isOBABuildFlavor()
+        isObaFlavor = BuildFlavorUtils.isOBABuildFlavor(),
+        isGoogleMaps = BuildConfig.FLAVOR_platform == "google"
     )
 
     val state: StateFlow<SettingsUiState> =
@@ -92,6 +93,7 @@ class SettingsViewModel @Inject constructor(
         showNegativeArrivals = prefs.getBoolean(R.string.preference_key_show_negative_arrivals, true),
         hideAlerts = prefs.getBoolean(R.string.preference_key_hide_alerts, false),
         showZoomControls = prefs.getBoolean(R.string.preference_key_show_zoom_controls, false),
+        compactStopIcons = prefs.getBoolean(R.string.preference_key_compact_stop_icons, false),
         showRentalButton = prefs.getBoolean(R.string.preference_key_show_rental_button, true),
         displayWeatherView = prefs.getBoolean(R.string.preference_key_display_weather_view, true),
         showAvailableStudies = prefs.getBoolean(R.string.preference_key_show_available_studies, true),
@@ -151,6 +153,8 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onShowZoomControlsChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_show_zoom_controls, value)
+
+    fun onCompactStopIconsChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_compact_stop_icons, value)
 
     fun onShowRentalButtonChanged(value: Boolean) = prefs.setBoolean(R.string.preference_key_show_rental_button, value)
 

--- a/onebusaway-android/src/main/res/values/donottranslate.xml
+++ b/onebusaway-android/src/main/res/values/donottranslate.xml
@@ -36,6 +36,7 @@
     <string name="preference_key_display_weather_view">preference_key_display_weather_view</string>
     <string name="preference_key_app_theme">preference_app_theme</string>
     <string name="preference_key_show_negative_arrivals">preference_show_negative_arrivals</string>
+    <string name="preference_key_compact_stop_icons">preference_compact_stop_icons</string>
     <string name="preference_key_show_zoom_controls">preference_show_zoom_controls</string>
     <string name="preference_key_show_available_studies">preference_show_available_studies</string>
     <string name="preference_key_hide_alerts">preference_hide_alerts</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -679,6 +679,8 @@
 
     <string name="preferences_show_rental_button_title">Show bike and scooter button</string>
     <string name="preferences_show_rental_button_summary">Display the bike and scooter layer button on the map</string>
+    <string name="preferences_compact_stop_icons_title">Compact stop icons</string>
+    <string name="preferences_compact_stop_icons_summary">Use smaller stop markers without vehicle symbols</string>
     <string name="preferences_show_zoom_controls_title">Show zoom controls</string>
     <string name="preferences_show_zoom_controls_summary">Display zoom controls on map
     </string>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopMarkerLayer.kt
@@ -171,8 +171,8 @@ internal class MapLibreStopMarkerLayer(
     }
 
     private fun icon(stop: StopMarker, kind: StopIconKind): Icon = when (kind) {
-        StopIconKind.FULL -> MapLibreStopIcons.iconForDirection(context, stop.direction)
-        StopIconKind.FULL_FOCUSED -> MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
+        StopIconKind.FULL, StopIconKind.COMPACT -> MapLibreStopIcons.iconForDirection(context, stop.direction)
+        StopIconKind.FULL_FOCUSED, StopIconKind.COMPACT_FOCUSED -> MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
         StopIconKind.DOT -> MapLibreStopIcons.dotIcon(context)
         StopIconKind.DOT_FOCUSED -> MapLibreStopIcons.focusedDotIcon(context)
         StopIconKind.FAVORITE -> MapLibreStopIcons.favoriteIcon(context, stop.direction)

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
@@ -121,4 +121,35 @@ class StopZoomBandTest {
         assertEquals(StopIconKind.FULL, stopIconKind(focused = false, band = StopBand.FULL))
         assertEquals(StopIconKind.DOT, stopIconKind(focused = false, band = StopBand.DOT))
     }
+
+    @Test
+    fun `compact icons retain focus and route labels at detailed zooms`() {
+        for (band in listOf(StopBand.FULL, StopBand.ROUTES)) {
+            assertEquals(StopIconKind.COMPACT, stopIconKind(focused = false, band = band, compact = true))
+            assertEquals(StopIconKind.COMPACT_FOCUSED, stopIconKind(focused = true, band = band, compact = true))
+        }
+        val state = MapRenderState()
+        state.setStopBand(StopBand.ROUTES)
+        state.setCompactStopIcons(true)
+        assertEquals(StopBand.ROUTES, state.snapshot.value.stopBand)
+        assertEquals(true, state.snapshot.value.compactStopIcons)
+        state.setCompactStopIcons(false)
+        assertEquals(false, state.snapshot.value.compactStopIcons)
+    }
+
+    @Test
+    fun `compact preference preserves dots and favorite stars in every zoom band`() {
+        for (focused in listOf(false, true)) {
+            for (band in StopBand.entries) {
+                assertEquals(
+                    stopIconKind(focused, band, favorite = true),
+                    stopIconKind(focused, band, favorite = true, compact = true)
+                )
+            }
+            assertEquals(
+                stopIconKind(focused, StopBand.DOT),
+                stopIconKind(focused, StopBand.DOT, compact = true)
+            )
+        }
+    }
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
@@ -32,6 +32,7 @@ class SettingsUiStateTest {
         showNegativeArrivals = true,
         hideAlerts = false,
         showZoomControls = false,
+        compactStopIcons = false,
         showRentalButton = true,
         displayWeatherView = true,
         showAvailableStudies = true,
@@ -44,12 +45,26 @@ class SettingsUiStateTest {
         appTheme = "System default"
     )
 
-    private fun env(useFixedRegion: Boolean = false, sdkInt: Int = 30, isObaFlavor: Boolean = true) = SettingsEnvironment(useFixedRegion, sdkInt, isObaFlavor)
+    private fun env(useFixedRegion: Boolean = false, sdkInt: Int = 30, isObaFlavor: Boolean = true, isGoogleMaps: Boolean = true) = SettingsEnvironment(useFixedRegion, sdkInt, isObaFlavor, isGoogleMaps)
 
     private fun build(
         region: RegionSummaryInfo? = RegionSummaryInfo("Puget Sound", hasOtp = true),
         env: SettingsEnvironment = env()
     ) = buildSettingsUiState(prefs, region, env, customApiRegionSummary = "Custom API")
+
+    @Test
+    fun `compact stop option is available only on Google Maps which has detailed icons`() {
+        assertTrue(build().showCompactStopIcons)
+        assertFalse(build(env = env(isGoogleMaps = false)).showCompactStopIcons)
+        assertFalse(build().compactStopIcons)
+        val enabled = buildSettingsUiState(
+            prefs.copy(compactStopIcons = true),
+            region = null,
+            env = env(),
+            customApiRegionSummary = "Custom API"
+        )
+        assertTrue(enabled.compactStopIcons)
+    }
 
     // --- region category / summary ---
 


### PR DESCRIPTION
Adds **Compact stop icons** under Settings → Display, off by default. Enabling it uses the original-size stop circle and direction arrow without the vehicle symbol, matching the older presentation. The preference persists and updates the map when returning from Settings.

The switch is shown in Google Maps builds; MapLibre already uses the smaller, glyph-free style. Favorite stars, zoomed-out dots, selected-stop emphasis, and focused-route circles retain their existing behavior.

Fixes #2284.

Validation:

- [x] Formatted with `./gradlew spotlessApply`.
- [x] 29 focused unit tests passed (`SettingsUiStateTest` and `StopZoomBandTest`).
- [x] Google debug APK built and MapLibre debug Kotlin compiled.
- [x] Verified on Pixel 7 Pro: switching both ways, compact appearance, and persistence after force-stop/relaunch.
- [x] Ran `ANDROID_SERIAL=36141FDH3000J2 ./gradlew connectedObaGoogleDebugAndroidTest`. The suite completed with one failure in `TripPlanFormRenderTest.reverseSitsBetweenTheTwoEndpointFields`: expected vertical center 139px, actual 140px. This assertion concerns trip-planner layout, outside the changed code; two notification-channel tests were skipped.

The initial connected-test attempt launched duplicate USB/Wi-Fi sessions on the same phone and failed; the result above is from the subsequent USB-only run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to enable compact stop icons on Google Maps.
  * Compact icons display smaller stop markers without vehicle symbols while retaining directional, focus, and favorite indicators.
  * The preference is saved and applied automatically across map updates.
* **Bug Fixes**
  * Updated map rendering to consistently support compact stop icons across supported map views.
* **Tests**
  * Added coverage for compact icon rendering, settings visibility, and preference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->