### PR TITLE
Restore mapless arrivals boards and remembered home sections

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/LaunchIntentEffectTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/LaunchIntentEffectTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import android.content.Intent
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.nav.DeepLinkUris
+import org.onebusaway.android.ui.nav.LAUNCH_ROOT
+import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.nav.navigateFromHome
+
+/** Saves a real launch effect and NavHost while collection is gated by the Activity lifecycle. */
+class LaunchIntentEffectTest {
+    @get:Rule val compose = createUnconfinedComposeRule()
+    private lateinit var owner: LaunchLifecycleOwner
+    private lateinit var channel: LaunchIntentChannel<Intent>
+    private lateinit var nav: NavHostController
+    private var ready = false
+    private val handled = mutableListOf<Intent>()
+
+    @Test
+    fun shortcutSavedBeforeCollectionIsRoutedAfterRecreation() {
+        val intent = Intent(Intent.ACTION_VIEW, DeepLinkUris.STOPS.buildUpon().appendPath("shortcut-stop").build())
+        val restoration = StateRestorationTester(compose)
+        restoration.setContent { Harness(intent) }
+        compose.runOnIdle {
+            assertFalse(ready)
+            assertTrue(handled.isEmpty())
+        }
+        val oldChannel = channel
+        restoration.emulateSavedInstanceStateRestore()
+        compose.runOnIdle {
+            assertNotSame(oldChannel, channel)
+            assertFalse(ready)
+            assertTrue(handled.isEmpty())
+            owner.registry.currentState = Lifecycle.State.RESUMED
+        }
+        compose.onNodeWithText("Arrivals board").assertIsDisplayed()
+        compose.runOnIdle {
+            assertTrue(ready)
+            assertEquals(listOf(intent), handled)
+            assertEquals("shortcut-stop", nav.currentBackStackEntry!!.arguments!!.getString(NavRoutes.ARG_STOP_ID))
+            assertEquals(true, nav.currentBackStackEntry!!.savedStateHandle.get<Boolean>(LAUNCH_ROOT))
+        }
+    }
+
+    @Test
+    fun mapLaunchSavedBeforeCollectionReleasesTheMapGateAfterRecreation() {
+        // An explicit HOME route avoids depending on the device's remembered drawer section.
+        val intent = Intent().putExtra(NavRoutes.EXTRA_NAV_ROUTE, NavRoutes.HOME)
+        val restoration = StateRestorationTester(compose)
+        restoration.setContent { Harness(intent) }
+        compose.onNodeWithText("Map screen").assertDoesNotExist()
+        restoration.emulateSavedInstanceStateRestore()
+        compose.runOnIdle { owner.registry.currentState = Lifecycle.State.RESUMED }
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        compose.runOnIdle {
+            assertTrue(ready)
+            assertEquals(listOf(intent), handled)
+        }
+    }
+
+    @Test
+    fun handledLaunchRestoresTheCurrentDestinationWithoutRepeatingSideEffects() {
+        val intent = Intent(Intent.ACTION_VIEW, DeepLinkUris.STOPS.buildUpon().appendPath("shortcut-stop").build())
+        val restoration = StateRestorationTester(compose)
+        restoration.setContent { Harness(intent) }
+        compose.runOnIdle { owner.registry.currentState = Lifecycle.State.RESUMED }
+        compose.onNodeWithText("Arrivals board").assertIsDisplayed()
+        compose.runOnIdle { nav.navigateFromHome(NavRoutes.HOME) }
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        restoration.emulateSavedInstanceStateRestore()
+        compose.runOnIdle { owner.registry.currentState = Lifecycle.State.RESUMED }
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        compose.runOnIdle {
+            assertTrue(ready)
+            assertEquals(listOf(intent), handled)
+        }
+    }
+
+    @Test
+    fun warmLaunchesWaitUntilStartedAndAreHandledInOrderWithoutBecomingLaunchRoots() {
+        val initial = Intent().putExtra(NavRoutes.EXTRA_NAV_ROUTE, NavRoutes.HOME)
+        compose.setContent { Harness(initial) }
+        compose.runOnIdle { owner.registry.currentState = Lifecycle.State.RESUMED }
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        val first = Intent(Intent.ACTION_VIEW, DeepLinkUris.STOPS.buildUpon().appendPath("first").build())
+        val second = Intent(Intent.ACTION_VIEW, DeepLinkUris.STOPS.buildUpon().appendPath("second").build())
+        compose.runOnIdle {
+            owner.registry.currentState = Lifecycle.State.CREATED
+            channel.submit(first)
+            channel.submit(second)
+        }
+        compose.runOnIdle {
+            assertEquals(listOf(initial), handled)
+            owner.registry.currentState = Lifecycle.State.RESUMED
+        }
+        compose.onNodeWithText("Arrivals board").assertIsDisplayed()
+        compose.runOnIdle {
+            assertEquals(listOf(initial, first, second), handled)
+            assertEquals("second", nav.currentBackStackEntry!!.arguments!!.getString(NavRoutes.ARG_STOP_ID))
+            assertEquals(null, nav.currentBackStackEntry!!.savedStateHandle.get<Boolean>(LAUNCH_ROOT))
+        }
+    }
+
+    @Composable
+    private fun Harness(intent: Intent) {
+        // Both objects are recreated with the composition, as in a new HomeActivity instance.
+        owner = remember { LaunchLifecycleOwner() }
+        channel = remember { LaunchIntentChannel() }
+        nav = rememberNavController()
+        CompositionLocalProvider(LocalLifecycleOwner provides owner) {
+            val launchReady = LaunchIntentEffect(nav, intent, channel.items) { handled.add(it) }
+            ready = launchReady
+            NavHost(nav, startDestination = NavRoutes.HOME) {
+                composable(NavRoutes.HOME) {
+                    if (launchReady) Text("Map screen")
+                }
+                composable(NavRoutes.ARRIVALS) { Text("Arrivals board") }
+            }
+        }
+    }
+
+    private class LaunchLifecycleOwner : LifecycleOwner {
+        val registry = LifecycleRegistry(this).apply { currentState = Lifecycle.State.CREATED }
+        override val lifecycle: Lifecycle get() = registry
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ArrivalsNavigationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ArrivalsNavigationTest.kt
@@ -244,7 +244,7 @@ class ArrivalsNavigationTest {
             composable(NavRoutes.HOME_STARRED_STOPS) {
                 Column(Modifier.fillMaxSize()) {
                     Text("Starred stops")
-                    Button(onClick = { nav.navigateUpInApp() }) { Text("List up") }
+                    Button(onClick = { nav.popBackStack() }) { Text("List up") }
                     Button(onClick = { nav.showArrivals(StopReveal("stop/1", "My stop")) }) { Text("Open stop") }
                 }
             }
@@ -263,7 +263,7 @@ class ArrivalsNavigationTest {
                 val id = requireNotNull(entry.arguments?.getString(NavRoutes.ARG_STOP_ID))
                 var mode by rememberArrivalDisplayMode(id) { ArrivalDisplayMode.TIME }
                 Column(Modifier.fillMaxSize()) {
-                    Button(onClick = { nav.navigateUpInApp(NavRoutes.HOME_STARRED_STOPS) }) { Text("Board up") }
+                    Button(onClick = { nav.navigateUpFromArrivals(NavRoutes.HOME_STARRED_STOPS) }) { Text("Board up") }
                     Text(if (mode == ArrivalDisplayMode.ROUTE) "Route selected" else "Time selected")
                     Button(onClick = { mode = ArrivalDisplayMode.ROUTE }) { Text("Route") }
                     Button(onClick = { nav.showStopMapFromArrivals(StopReveal(id, "My stop", GeoPoint(0.0, 0.0))) }) { Text("Map") }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ArrivalsNavigationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ArrivalsNavigationTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import android.app.Activity
+import android.content.ComponentName
+import android.content.Intent
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.map.MapParams
+import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
+import org.onebusaway.android.ui.arrivals.ArrivalsIntents
+import org.onebusaway.android.ui.arrivals.components.rememberArrivalDisplayMode
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.util.GeoPoint
+
+/** Exercise real Navigation-Compose entries and saved state, without a network or map SDK. */
+class ArrivalsNavigationTest {
+    @get:Rule val compose = createUnconfinedComposeRule()
+    private lateinit var nav: NavHostController
+    private lateinit var activity: Activity
+
+    @Test
+    fun legacyShortcutAliasesAndNamesResolveToTheBoardWhileExplicitMapExtrasStayMapActions() {
+        val id = "agency_stop/with space"
+        val name = "Pike & 3rd / north"
+        for (alias in listOf("org.onebusaway.android.ui.ArrivalsListActivity", "com.joulespersecond.seattlebusbot.ArrivalsListActivity")) {
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                component = ComponentName("com.joulespersecond.seattlebusbot", alias)
+                data = DeepLinkUris.STOPS.buildUpon().appendPath(id).build()
+                putExtra(ArrivalsIntents.STOP_NAME, name)
+            }
+            assertEquals(NavRoutes.arrivals(id, name), IntentRouteMapper.routeForIntent(intent))
+        }
+        assertNull(IntentRouteMapper.routeForIntent(Intent().putExtra(MapParams.STOP_ID, id)))
+    }
+
+    @Test
+    fun mapVisitKeepsTheBoardEntryScrollAndDisplayChoiceThenBackReturnsToTheList() {
+        compose.setContent { Harness() }
+        openBoard()
+        val board = nav.currentBackStackEntry
+        compose.onNodeWithText("Route").performClick()
+        compose.onNodeWithTag("board_rows").performScrollToIndex(25)
+        compose.onNodeWithText("Map").performClick()
+        compose.runOnIdle {
+            assertEquals(NavRoutes.HOME, nav.currentDestination?.route)
+            assertSame(board, nav.previousBackStackEntry)
+            assertEquals(StopReveal("stop/1", "My stop", GeoPoint(0.0, 0.0)), nav.currentBackStackEntry!!.savedStateHandle.consumeStopReveal())
+            nav.popBackStack()
+        }
+        compose.onNodeWithText("Route selected").assertIsDisplayed()
+        compose.onNodeWithText("Arrival 25").assertIsDisplayed()
+        compose.runOnIdle { nav.popBackStack() }
+        compose.onNodeWithText("Starred stops").assertIsDisplayed()
+    }
+
+    @Test
+    fun savedMapVisitRestoresTheBoardUnderneathWithItsState() {
+        val restoration = StateRestorationTester(compose)
+        restoration.setContent { Harness() }
+        openBoard()
+        compose.onNodeWithTag("board_rows").performScrollToIndex(20)
+        compose.onNodeWithText("Route").performClick()
+        compose.onNodeWithText("Map").performClick()
+        restoration.emulateSavedInstanceStateRestore()
+        compose.runOnIdle {
+            assertEquals(NavRoutes.HOME, nav.currentDestination?.route)
+            nav.popBackStack()
+        }
+        compose.onNodeWithText("Route selected").assertIsDisplayed()
+        compose.onNodeWithText("Arrival 20").assertIsDisplayed()
+    }
+
+    @Test
+    fun explicitRouteMapActionPreservesTheBoardAndTheWholeRequest() {
+        compose.setContent { Harness() }
+        openBoard()
+        compose.runOnIdle {
+            val board = nav.currentBackStackEntry
+            val request = ShowRouteRequest("route", "stop/1", "trip", 1)
+            nav.showRouteMapFromArrivals(request)
+            assertSame(board, nav.previousBackStackEntry)
+            assertEquals(request, nav.currentBackStackEntry!!.savedStateHandle.consumeRouteReveal())
+        }
+    }
+
+    @Test
+    fun shortcutUpOpensStarredStopsAndOpeningAnotherStopDoesNotInheritExitBehavior() {
+        compose.setContent { Harness() }
+        compose.runOnIdle {
+            nav.navigateFromHome(NavRoutes.arrivals("shortcut-stop"))
+            nav.currentBackStackEntry!!.savedStateHandle[LAUNCH_ROOT] = true
+        }
+        compose.onNodeWithText("Board up").performClick()
+        compose.onNodeWithText("Starred stops").assertIsDisplayed()
+        compose.runOnIdle {
+            assertFalse(activity.isFinishing)
+            assertEquals(true, nav.currentBackStackEntry!!.savedStateHandle.get<Boolean>(LAUNCH_ROOT))
+            assertEquals(NavRoutes.HOME, nav.previousBackStackEntry?.destination?.route)
+        }
+        compose.onNodeWithText("Open stop").performClick()
+        compose.runOnIdle {
+            assertNull(nav.currentBackStackEntry!!.savedStateHandle.get<Boolean>(LAUNCH_ROOT))
+        }
+        compose.onNodeWithText("Board up").performClick()
+        compose.onNodeWithText("Starred stops").assertIsDisplayed()
+        compose.onNodeWithText("List up").performClick()
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        compose.runOnIdle { assertFalse(activity.isFinishing) }
+    }
+
+    @Test
+    fun appIconLaunchIntoStarredStopsCanOpenAStopAndNavigateUpWithoutClosing() {
+        val restoration = StateRestorationTester(compose)
+        restoration.setContent { Harness() }
+        compose.runOnIdle {
+            nav.navigateFromHome(NavRoutes.HOME_STARRED_STOPS)
+            nav.currentBackStackEntry!!.savedStateHandle[LAUNCH_ROOT] = true
+        }
+        restoration.emulateSavedInstanceStateRestore()
+        compose.onNodeWithText("Open stop").performClick()
+        compose.runOnIdle { nav.navigateBackOrFinish() }
+        compose.onNodeWithText("Starred stops").assertIsDisplayed()
+        compose.onNodeWithText("List up").performClick()
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        compose.runOnIdle {
+            assertFalse(activity.isFinishing)
+            assertNull(nav.previousBackStackEntry)
+        }
+    }
+
+    private fun openBoard() {
+        compose.runOnIdle { nav.navigate(NavRoutes.HOME_STARRED_STOPS) }
+        compose.onNodeWithText("Open stop").performClick()
+    }
+
+    @Composable
+    private fun Harness() {
+        activity = requireNotNull(LocalActivity.current)
+        nav = rememberNavController()
+        NavHost(nav, startDestination = NavRoutes.HOME) {
+            composable(NavRoutes.HOME) { Text("Map screen") }
+            composable(NavRoutes.HOME_STARRED_STOPS) {
+                Column {
+                    Text("Starred stops")
+                    Button(onClick = { nav.navigateUpInApp() }) { Text("List up") }
+                    Button(onClick = { nav.showArrivals(StopReveal("stop/1", "My stop")) }) { Text("Open stop") }
+                }
+            }
+            composable(
+                NavRoutes.ARRIVALS,
+                arguments = listOf(
+                    navArgument(NavRoutes.ARG_STOP_ID) { type = NavType.StringType },
+                    navArgument(NavRoutes.ARG_STOP_NAME) {
+                        type = NavType.StringType
+                        nullable = true
+                    }
+                )
+            ) { entry ->
+                val id = requireNotNull(entry.arguments?.getString(NavRoutes.ARG_STOP_ID))
+                var mode by rememberArrivalDisplayMode(id) { ArrivalDisplayMode.TIME }
+                Column(Modifier.fillMaxSize()) {
+                    Button(onClick = { nav.navigateUpInApp(NavRoutes.HOME_STARRED_STOPS) }) { Text("Board up") }
+                    Text(if (mode == ArrivalDisplayMode.ROUTE) "Route selected" else "Time selected")
+                    Button(onClick = { mode = ArrivalDisplayMode.ROUTE }) { Text("Route") }
+                    Button(onClick = { nav.showStopMapFromArrivals(StopReveal(id, "My stop", GeoPoint(0.0, 0.0))) }) { Text("Map") }
+                    LazyColumn(Modifier.testTag("board_rows"), state = rememberLazyListState()) {
+                        items((0..50).toList()) { Text("Arrival $it", Modifier.height(50.dp)) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ArrivalsNavigationTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/nav/ArrivalsNavigationTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -175,6 +176,56 @@ class ArrivalsNavigationTest {
         }
     }
 
+    @Test
+    fun boardMapTransitionsResumeWithinFourFramesInBothDirections() {
+        compose.setContent { Harness() }
+        openBoard()
+        // Finish the ordinary list-to-board fade before timing the separate board/map hop.
+        compose.waitForIdle()
+        compose.runOnIdle {
+            assertEquals(Lifecycle.State.RESUMED, nav.currentBackStackEntry!!.lifecycle.currentState)
+        }
+        compose.mainClock.autoAdvance = false
+        compose.runOnIdle { nav.showStopMapFromArrivals(StopReveal("stop/1", "My stop")) }
+        repeat(4) {
+            compose.mainClock.advanceTimeByFrame()
+            compose.waitForIdle()
+        }
+        compose.runOnIdle {
+            assertEquals(NavRoutes.HOME, nav.currentDestination?.route)
+            assertEquals(Lifecycle.State.RESUMED, nav.currentBackStackEntry!!.lifecycle.currentState)
+            nav.popBackStack()
+        }
+        repeat(4) {
+            compose.mainClock.advanceTimeByFrame()
+            compose.waitForIdle()
+        }
+        compose.runOnIdle {
+            assertEquals(NavRoutes.ARRIVALS, nav.currentDestination?.route)
+            assertEquals(Lifecycle.State.RESUMED, nav.currentBackStackEntry!!.lifecycle.currentState)
+        }
+        compose.mainClock.autoAdvance = true
+    }
+
+    @Test
+    fun otherDestinationsKeepTheirNormalTransition() {
+        compose.setContent { Harness() }
+        compose.mainClock.autoAdvance = false
+        compose.runOnIdle { nav.navigate(NavRoutes.HOME_STARRED_STOPS) }
+        repeat(4) {
+            compose.mainClock.advanceTimeByFrame()
+            compose.waitForIdle()
+        }
+        compose.runOnIdle {
+            assertEquals(Lifecycle.State.STARTED, nav.currentBackStackEntry!!.lifecycle.currentState)
+        }
+        compose.mainClock.advanceTimeBy(800)
+        compose.runOnIdle {
+            assertEquals(Lifecycle.State.RESUMED, nav.currentBackStackEntry!!.lifecycle.currentState)
+        }
+        compose.mainClock.autoAdvance = true
+    }
+
     private fun openBoard() {
         compose.runOnIdle { nav.navigate(NavRoutes.HOME_STARRED_STOPS) }
         compose.onNodeWithText("Open stop").performClick()
@@ -184,10 +235,14 @@ class ArrivalsNavigationTest {
     private fun Harness() {
         activity = requireNotNull(LocalActivity.current)
         nav = rememberNavController()
-        NavHost(nav, startDestination = NavRoutes.HOME) {
-            composable(NavRoutes.HOME) { Text("Map screen") }
+        NavHost(nav, startDestination = NavRoutes.HOME, modifier = Modifier.fillMaxSize()) {
+            composable(
+                NavRoutes.HOME,
+                enterTransition = { arrivalsMapEnterTransition() },
+                exitTransition = { arrivalsMapExitTransition() }
+            ) { Text("Map screen", Modifier.fillMaxSize()) }
             composable(NavRoutes.HOME_STARRED_STOPS) {
-                Column {
+                Column(Modifier.fillMaxSize()) {
                     Text("Starred stops")
                     Button(onClick = { nav.navigateUpInApp() }) { Text("List up") }
                     Button(onClick = { nav.showArrivals(StopReveal("stop/1", "My stop")) }) { Text("Open stop") }
@@ -195,6 +250,8 @@ class ArrivalsNavigationTest {
             }
             composable(
                 NavRoutes.ARRIVALS,
+                enterTransition = { arrivalsMapEnterTransition() },
+                exitTransition = { arrivalsMapExitTransition() },
                 arguments = listOf(
                     navArgument(NavRoutes.ARG_STOP_ID) { type = NavType.StringType },
                     navArgument(NavRoutes.ARG_STOP_NAME) {

--- a/onebusaway-android/src/main/AndroidManifest.xml
+++ b/onebusaway-android/src/main/AndroidManifest.xml
@@ -189,9 +189,9 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
-        <!-- A stop is shown on the HomeActivity map, with its arrivals in the drawer (#1898). These
-             frozen component names (old pinned launcher shortcuts) keep resolving via aliases →
-             HomeActivity, which reads the stop data URI and focuses it. Aliases inherit
+        <!-- Legacy pinned stop shortcuts open the mapless arrivals destination. These frozen
+             component names keep resolving via aliases → HomeActivity, which translates the stop
+             data URI into a Compose route. Aliases inherit
              launchMode/configChanges from HomeActivity. -->
         <activity-alias
             android:name="org.onebusaway.android.ui.ArrivalsListActivity"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -26,6 +26,10 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
@@ -61,6 +65,7 @@ import org.onebusaway.android.ui.home.SettingsRehomeEffect
 import org.onebusaway.android.ui.home.donation.DonationViewModel
 import org.onebusaway.android.ui.home.help.HelpAction
 import org.onebusaway.android.ui.home.help.HelpViewModel
+import org.onebusaway.android.ui.home.launchDestination
 import org.onebusaway.android.ui.home.weather.WeatherViewModel
 import org.onebusaway.android.ui.nav.ExternalDeepLinks
 import org.onebusaway.android.ui.nav.IntentRouteMapper
@@ -154,7 +159,10 @@ class HomeActivity : AppCompatActivity() {
             val navController = rememberNavController()
             AccessibilityAnalyticsEffect()
             HomeAnalyticsEffect(viewModel.analyticsEvents)
-            LaunchIntentEffect(navController, launchIntents.items, ::applyLaunchIntentSideEffects)
+            var launchReady by rememberSaveable { mutableStateOf(false) }
+            LaunchIntentEffect(navController, launchIntents.items, ::applyLaunchIntentSideEffects, initialLaunch = !launchReady) {
+                launchReady = true
+            }
             // The welcome tutorial (now the Compose green welcome + map-stop spotlight sequence) is
             // started by HomeScreen off the same showWelcomeTutorial latch — no host effect needed.
             SettingsRehomeEffect(navController)
@@ -164,6 +172,7 @@ class HomeActivity : AppCompatActivity() {
             Box(Modifier.fillMaxSize().semantics { testTagsAsResourceId = true }) {
                 HomeNavHost(
                     navController = navController,
+                    launchReady = launchReady,
                     home = HomeDestinationDeps(
                         homeViewModel = viewModel,
                         mapViewModel = mapViewModel,
@@ -199,7 +208,8 @@ class HomeActivity : AppCompatActivity() {
         // The VM owns the startup region-check decision (defer to the map's permission result on a first
         // launch without permission, else check now). The permission read needs a Context, so it stays here.
         viewModel.onHomeStarted(
-            PermissionUtils.hasGrantedAtLeastOnePermission(this, PermissionUtils.LOCATION_PERMISSIONS)
+            hasLocationPermission = PermissionUtils.hasGrantedAtLeastOnePermission(this, PermissionUtils.LOCATION_PERMISSIONS),
+            mapless = launchDestination(intent, org.onebusaway.android.app.di.PreferencesEntryPoint.get(this)) != NavRoutes.HOME
         )
     }
 
@@ -242,8 +252,10 @@ class HomeActivity : AppCompatActivity() {
         applyIntentSideEffects(intent)
         maybeRestoreDirectionsFromIntent(intent)
         maybePlanToPlaceFromIntent(intent)
+        if (intent.readRouteReveal() == null) {
+            FocusedStop.fromIntent(intent)?.let { viewModel.revealStop(it) }
+        }
         maybeRevealTrackedRouteFromIntent(intent)
-        maybeRevealStopFromIntent(intent)
         if (intent.extras?.getBoolean(TutorialPrefs.TUTORIAL_WELCOME) == true) {
             viewModel.requestWelcomeTutorial()
         }
@@ -267,21 +279,6 @@ class HomeActivity : AppCompatActivity() {
         val stop = FocusedStop.fromIntent(intent) ?: return
         viewModel.revealStop(stop)
         viewModel.selectArrivalRoute(route.request(stop.id), route.routeShortName, route.headsign)
-    }
-
-    /**
-     * A launch that asks for a stop — an exported `oba://…/stops/{id}` deep link, an FCM arrival push,
-     * a pinned stop shortcut — focuses it on the map, with the arrivals drawer over it (#1898). Applied
-     * here, next to the other launch-intent focus changes, because this is where the [HomeViewModel] is;
-     * [IntentRouteMapper] stays a pure translator and correctly resolves these to no destination, since
-     * a stop is map state and not a screen.
-     *
-     * No animation: these arrive from outside the app, where the map is either not yet on screen or
-     * showing somewhere unrelated, so flying the camera would be a long pan from nowhere in particular.
-     */
-    private fun maybeRevealStopFromIntent(intent: Intent) {
-        val reveal = IntentRouteMapper.stopRevealForIntent(intent) ?: return
-        viewModel.revealStop(FocusedStop(reveal.stopId, reveal.name, point = reveal.point))
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -26,10 +26,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
@@ -98,13 +94,9 @@ class HomeActivity : AppCompatActivity() {
     @Inject
     lateinit var reminderRepository: org.onebusaway.android.reminders.ReminderRepository
 
-    // The launch-intent channel: the OS delivers external entry points (deep links, FCM, launcher
-    // shortcuts) to this Activity before/around the composition, so they're surfaced here for the NavHost's
-    // [LaunchIntentEffect] to translate (via IntentRouteMapper) and open once composed. Seeded on a fresh
-    // launch only (onCreate), fed warm relaunches via onNewIntent — the in-app navigation no longer flows
-    // through here (it uses the NavController directly). A [LaunchIntentChannel] (UNLIMITED queue, not a
-    // latch) so a fresh-launch intent staged before the NavHost composes isn't lost, and so rapid, distinct
-    // back-to-back intents are each delivered exactly once rather than overwriting one another (#1582).
+    // Warm external launches queue until the NavHost is started, without dropping rapid, distinct
+    // intents (#1582). LaunchIntentEffect handles the cold intent separately, using its saved readiness
+    // state to retry after recreation if the Activity was saved before collection started.
     private val launchIntents = LaunchIntentChannel<Intent>()
 
     private val viewModel: HomeViewModel by viewModels()
@@ -148,21 +140,12 @@ class HomeActivity : AppCompatActivity() {
 
         val activityActions = buildActivityActions()
 
-        // Surface the launch intent for the NavHost's [LaunchIntentEffect] (it runs the side effects then
-        // opens the translated route once composed). Fresh launch only, so a rotation doesn't re-fire
-        // reminder deletes / URL applies.
-        if (savedInstanceState == null) {
-            launchIntents.submit(intent)
-        }
-
+        val initialIntent = intent
         setContent {
             val navController = rememberNavController()
             AccessibilityAnalyticsEffect()
             HomeAnalyticsEffect(viewModel.analyticsEvents)
-            var launchReady by rememberSaveable { mutableStateOf(false) }
-            LaunchIntentEffect(navController, launchIntents.items, ::applyLaunchIntentSideEffects, initialLaunch = !launchReady) {
-                launchReady = true
-            }
+            val launchReady = LaunchIntentEffect(navController, initialIntent, launchIntents.items, ::applyLaunchIntentSideEffects)
             // The welcome tutorial (now the Compose green welcome + map-stop spotlight sequence) is
             // started by HomeScreen off the same showWelcomeTutorial latch — no host effect needed.
             SettingsRehomeEffect(navController)
@@ -235,7 +218,7 @@ class HomeActivity : AppCompatActivity() {
     /**
      * A warm re-launch (singleTop) carrying an external screen intent — FCM CLEAR_TOP, the
      * NavigationService reminder PendingIntent, a pinned shortcut. Surface it for [LaunchIntentEffect]
-     * (cold launches are seeded in onCreate).
+     * (cold launches are handled from the Activity intent when composition starts).
      */
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -290,9 +273,9 @@ class HomeActivity : AppCompatActivity() {
      * results from those extras — the itineraries are injected as-is (no re-plan). Restores the behavior
      * the retired standalone screen's `maybeRestoreFromIntent` used to provide (#1939).
      *
-     * No re-restore guard is needed: the launch-intent channel submits each real intent exactly once
-     * (cold `onCreate` seed gated on a null `savedInstanceState`, warm `onNewIntent`), so a config change
-     * doesn't re-fire this — and the activity-scoped [tripPlanViewModel] keeps the restored results.
+     * No re-restore guard is needed here: LaunchIntentEffect saves whether the cold intent was handled,
+     * and the channel submits each warm `onNewIntent` once, so a config change doesn't re-fire this —
+     * and the activity-scoped [tripPlanViewModel] keeps the restored results.
      */
     // UnwrappedClockValue: the trip-plan time defaults to device "now" only when the intent carries none.
     @Suppress("UnwrappedClockValue")

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsContent.kt
@@ -109,19 +109,21 @@ internal fun ArrivalsPolling(viewModel: ArrivalsViewModel) {
 @Composable
 internal fun rememberArrivalRowCallbacks(
     handler: ArrivalActionHandler,
-    viewModel: ArrivalsViewModel
-): ArrivalRowCallbacks = remember(handler, viewModel) {
+    viewModel: ArrivalsViewModel,
+    mapless: Boolean = false
+): ArrivalRowCallbacks = remember(handler, viewModel, mapless) {
     ArrivalRowCallbacks(
         onRouteFavorite = handler::onRouteFavorite,
         onShowVehiclesOnMap = handler::onShowVehiclesOnMap,
         onShowRouteOnMap = handler::onShowRouteOnMap,
-        onEtaClick = handler::onFocusVehicleOnMap,
+        onEtaClick = if (mapless) handler::onShowTripStatus else handler::onFocusVehicleOnMap,
         onShowTripStatus = handler::onShowTripStatus,
         onSetReminder = handler::onSetReminder,
         onToggleTracking = handler::onToggleTracking,
         onShowRouteSchedule = handler::onShowRouteSchedule,
         onReportArrivalProblem = handler::onReportArrivalProblem,
-        onShowAlert = handler::onShowAlert
+        onShowAlert = handler::onShowAlert,
+        onRowClick = if (mapless) handler::onShowTripStatus else handler::onShowVehiclesOnMap
     )
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
@@ -235,7 +235,8 @@ private fun ArrivalsBoard(
                     loadingMore = viewModel.loadingMore,
                     listState = listState,
                     displayMode = displayMode,
-                    onDisplayModeChange = { displayMode = it }
+                    onDisplayModeChange = { displayMode = it },
+                    modeSwitchModifier = Modifier.padding(top = 3.dp, end = 3.dp)
                 )
             }
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
@@ -70,6 +70,8 @@ import org.onebusaway.android.ui.home.homeStartDestination
 import org.onebusaway.android.ui.home.map.FocusBannerViewModel
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.StopReveal
+import org.onebusaway.android.ui.nav.arrivalsMapEnterTransition
+import org.onebusaway.android.ui.nav.arrivalsMapExitTransition
 import org.onebusaway.android.ui.nav.navigateUpInApp
 import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
 import org.onebusaway.android.ui.nav.showStopMapFromArrivals
@@ -80,6 +82,8 @@ import org.onebusaway.android.util.GeoPoint
 fun NavGraphBuilder.arrivalsGraph(navController: NavHostController) {
     composable(
         NavRoutes.ARRIVALS,
+        enterTransition = { arrivalsMapEnterTransition() },
+        exitTransition = { arrivalsMapExitTransition() },
         arguments = listOf(
             navArgument(NavRoutes.ARG_STOP_ID) { type = NavType.StringType },
             navArgument(NavRoutes.ARG_STOP_NAME) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import kotlinx.coroutines.launch
+import org.onebusaway.android.R
+import org.onebusaway.android.app.di.ArrivalsViewModelFactoryEntryPoint
+import org.onebusaway.android.app.di.PreferencesEntryPoint
+import org.onebusaway.android.app.di.RegionEntryPoint
+import org.onebusaway.android.ui.arrivals.components.rememberArrivalDisplayMode
+import org.onebusaway.android.ui.common.Shortcuts
+import org.onebusaway.android.ui.compose.components.ObaTopAppBar
+import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.home.FocusedStop
+import org.onebusaway.android.ui.home.homeStartDestination
+import org.onebusaway.android.ui.home.map.FocusBannerViewModel
+import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.nav.StopReveal
+import org.onebusaway.android.ui.nav.navigateUpInApp
+import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
+import org.onebusaway.android.ui.nav.showStopMapFromArrivals
+import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
+import org.onebusaway.android.util.GeoPoint
+
+/** A mapless stop destination. Its VM and scroll position live with the back-stack entry. */
+fun NavGraphBuilder.arrivalsGraph(navController: NavHostController) {
+    composable(
+        NavRoutes.ARRIVALS,
+        arguments = listOf(
+            navArgument(NavRoutes.ARG_STOP_ID) { type = NavType.StringType },
+            navArgument(NavRoutes.ARG_STOP_NAME) {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            }
+        )
+    ) { entry ->
+        val context = LocalContext.current
+        val stopId = requireNotNull(entry.arguments?.getString(NavRoutes.ARG_STOP_ID)) { "Arrivals requires a stop id" }
+        val initialName = entry.arguments?.getString(NavRoutes.ARG_STOP_NAME)
+        val vm: ArrivalsViewModel = viewModel(
+            factory = viewModelFactory {
+                initializer { ArrivalsViewModelFactoryEntryPoint.get(context).create(stopId) }
+            }
+        )
+        val activity = context.findActivity()
+        val snackbar = remember { SnackbarHostState() }
+        val scope = rememberCoroutineScope()
+        val handler = remember(vm, navController) {
+            createArrivalActionHandler(
+                activity = activity,
+                viewModel = vm,
+                currentContent = { vm.state.value as? ArrivalsUiState.Content },
+                revealRoute = { _, request -> navController.showRouteMapFromArrivals(request) },
+                showUndoSnackbar = { message, action, undo ->
+                    scope.launch {
+                        if (snackbar.showSnackbar(activity.getString(message), action?.let(activity::getString)) ==
+                            SnackbarResult.ActionPerformed
+                        ) {
+                            undo?.invoke()
+                        }
+                    }
+                },
+                onShowTrip = { trip, stop ->
+                    navController.navigate(NavRoutes.tripDetails(trip, stop, TripDetailsLauncher.SCROLL_MODE_STOP))
+                },
+                onEditReminder = { navController.navigate(NavRoutes.tripInfo(it)) }
+            )
+        }
+        ObaTheme {
+            ArrivalsBoard(
+                vm,
+                stopId,
+                initialName,
+                handler,
+                snackbar,
+                onBack = { navController.navigateUpInApp(PreferencesEntryPoint.get(context).homeStartDestination()) },
+                onShowMap = { navController.showStopMapFromArrivals(it) },
+                onNightLight = { navController.navigate(NavRoutes.NIGHT_LIGHT) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArrivalsBoard(
+    viewModel: ArrivalsViewModel,
+    stopId: String,
+    initialName: String?,
+    handler: ArrivalActionHandler,
+    snackbar: SnackbarHostState,
+    onBack: () -> Unit,
+    onShowMap: (StopReveal) -> Unit,
+    onNightLight: () -> Unit
+) {
+    val context = LocalContext.current
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val content = state as? ArrivalsUiState.Content
+    val title = initialName ?: content?.header?.name ?: stringResource(R.string.arrivals_board_title)
+    val prefs = remember { PreferencesEntryPoint.get(context) }
+    var displayMode by rememberArrivalDisplayMode(stopId) { prefs.arrivalDisplayDefault() }
+    val listState = rememberLazyListState()
+    val callbacks = rememberArrivalRowCallbacks(handler, viewModel, mapless = true)
+    // Share the existing optimistic, import-gated stop favorite implementation with the map banner.
+    val favorites: FocusBannerViewModel = hiltViewModel()
+    val favoriteIds by favorites.favoriteStopIds.collectAsStateWithLifecycle()
+    val favoritesReady by favorites.stopFavoritesReady.collectAsStateWithLifecycle()
+    var menuOpen by remember { mutableStateOf(false) }
+    val point = content?.let { GeoPoint(it.stopLat, it.stopLon) }
+    // A shortcut can be the first-ever launch. Let the region picker finish before making requests.
+    val regions = remember { RegionEntryPoint.get(context) }
+    val region by regions.region.collectAsStateWithLifecycle()
+    if (region != null) ArrivalsPolling(viewModel)
+
+    Scaffold(
+        modifier = Modifier.testTag("arrivals_board"),
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            ObaTopAppBar(title = title, onBack = onBack) {
+                IconButton(
+                    enabled = favoritesReady && point != null,
+                    onClick = {
+                        favorites.toggleStopFavorite(FocusedStop(stopId, title, content?.stopCode, point))
+                    }
+                ) {
+                    Icon(
+                        painterResource(if (stopId in favoriteIds) R.drawable.star else R.drawable.star_outline),
+                        stringResource(if (stopId in favoriteIds) R.string.stop_remove_star else R.string.stop_add_star)
+                    )
+                }
+                IconButton(onClick = { onShowMap(StopReveal(stopId, initialName ?: content?.header?.name, point)) }) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_action_location_map),
+                        contentDescription = stringResource(R.string.home_map)
+                    )
+                }
+                Box {
+                    IconButton(onClick = { menuOpen = true }) {
+                        Icon(painterResource(R.drawable.more_vert), stringResource(R.string.stop_info_item_options_title))
+                    }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(text = { Text(stringResource(R.string.stop_info_option_refresh)) }, onClick = {
+                            menuOpen = false
+                            viewModel.manualRefresh()
+                        })
+                        DropdownMenuItem(text = { Text(stringResource(R.string.my_context_create_shortcut)) }, onClick = {
+                            menuOpen = false
+                            Shortcuts.createStopShortcut(context, title, StopLauncher.Builder(context, stopId).setStopName(title))
+                        })
+                        DropdownMenuItem(text = { Text(stringResource(R.string.stop_info_option_report_problem)) }, enabled = content != null, onClick = {
+                            menuOpen = false
+                            handler.onReportStopProblem()
+                        })
+                        DropdownMenuItem(text = { Text(stringResource(R.string.stop_info_option_night_light)) }, onClick = {
+                            menuOpen = false
+                            onNightLight()
+                        })
+                    }
+                }
+            }
+        }
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when (val current = state) {
+                ArrivalsUiState.Loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
+                is ArrivalsUiState.Error -> Column(
+                    Modifier.align(Alignment.Center).padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(current.message)
+                    Button(onClick = viewModel::manualRefresh) { Text(stringResource(R.string.retry)) }
+                }
+                is ArrivalsUiState.Content -> ArrivalsList(
+                    content = current,
+                    rowCallbacks = callbacks,
+                    onShowAlert = handler::onShowAlert,
+                    onHideAlert = handler::onHideAlert,
+                    onShowHiddenAlerts = viewModel::showHiddenAlerts,
+                    onLoadMore = viewModel::loadMore,
+                    loadingMore = viewModel.loadingMore,
+                    listState = listState,
+                    displayMode = displayMode,
+                    onDisplayModeChange = { displayMode = it }
+                )
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsDestinations.kt
@@ -60,6 +60,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.di.ArrivalsViewModelFactoryEntryPoint
 import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
+import org.onebusaway.android.region.RegionState
 import org.onebusaway.android.ui.arrivals.components.rememberArrivalDisplayMode
 import org.onebusaway.android.ui.common.Shortcuts
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
@@ -72,7 +73,7 @@ import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.StopReveal
 import org.onebusaway.android.ui.nav.arrivalsMapEnterTransition
 import org.onebusaway.android.ui.nav.arrivalsMapExitTransition
-import org.onebusaway.android.ui.nav.navigateUpInApp
+import org.onebusaway.android.ui.nav.navigateUpFromArrivals
 import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
 import org.onebusaway.android.ui.nav.showStopMapFromArrivals
 import org.onebusaway.android.ui.tripdetails.TripDetailsLauncher
@@ -93,65 +94,44 @@ fun NavGraphBuilder.arrivalsGraph(navController: NavHostController) {
             }
         )
     ) { entry ->
-        val context = LocalContext.current
         val stopId = requireNotNull(entry.arguments?.getString(NavRoutes.ARG_STOP_ID)) { "Arrivals requires a stop id" }
         val initialName = entry.arguments?.getString(NavRoutes.ARG_STOP_NAME)
-        val vm: ArrivalsViewModel = viewModel(
-            factory = viewModelFactory {
-                initializer { ArrivalsViewModelFactoryEntryPoint.get(context).create(stopId) }
-            }
-        )
-        val activity = context.findActivity()
-        val snackbar = remember { SnackbarHostState() }
-        val scope = rememberCoroutineScope()
-        val handler = remember(vm, navController) {
-            createArrivalActionHandler(
-                activity = activity,
-                viewModel = vm,
-                currentContent = { vm.state.value as? ArrivalsUiState.Content },
-                revealRoute = { _, request -> navController.showRouteMapFromArrivals(request) },
-                showUndoSnackbar = { message, action, undo ->
-                    scope.launch {
-                        if (snackbar.showSnackbar(activity.getString(message), action?.let(activity::getString)) ==
-                            SnackbarResult.ActionPerformed
-                        ) {
-                            undo?.invoke()
-                        }
-                    }
-                },
-                onShowTrip = { trip, stop ->
-                    navController.navigate(NavRoutes.tripDetails(trip, stop, TripDetailsLauncher.SCROLL_MODE_STOP))
-                },
-                onEditReminder = { navController.navigate(NavRoutes.tripInfo(it)) }
-            )
-        }
-        ObaTheme {
-            ArrivalsBoard(
-                vm,
-                stopId,
-                initialName,
-                handler,
-                snackbar,
-                onBack = { navController.navigateUpInApp(PreferencesEntryPoint.get(context).homeStartDestination()) },
-                onShowMap = { navController.showStopMapFromArrivals(it) },
-                onNightLight = { navController.navigate(NavRoutes.NIGHT_LIGHT) }
-            )
-        }
+        ObaTheme { ArrivalsBoard(stopId, initialName, navController) }
     }
 }
 
 @Composable
-private fun ArrivalsBoard(
-    viewModel: ArrivalsViewModel,
-    stopId: String,
-    initialName: String?,
-    handler: ArrivalActionHandler,
-    snackbar: SnackbarHostState,
-    onBack: () -> Unit,
-    onShowMap: (StopReveal) -> Unit,
-    onNightLight: () -> Unit
-) {
+private fun ArrivalsBoard(stopId: String, initialName: String?, navController: NavHostController) {
     val context = LocalContext.current
+    val viewModel: ArrivalsViewModel = viewModel(
+        factory = viewModelFactory {
+            initializer { ArrivalsViewModelFactoryEntryPoint.get(context).create(stopId) }
+        }
+    )
+    val activity = context.findActivity()
+    val snackbar = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val handler = remember(viewModel, navController) {
+        createArrivalActionHandler(
+            activity = activity,
+            viewModel = viewModel,
+            currentContent = { viewModel.state.value as? ArrivalsUiState.Content },
+            revealRoute = { _, request -> navController.showRouteMapFromArrivals(request) },
+            showUndoSnackbar = { message, action, undo ->
+                scope.launch {
+                    if (snackbar.showSnackbar(activity.getString(message), action?.let(activity::getString)) ==
+                        SnackbarResult.ActionPerformed
+                    ) {
+                        undo?.invoke()
+                    }
+                }
+            },
+            onShowTrip = { trip, stop ->
+                navController.navigate(NavRoutes.tripDetails(trip, stop, TripDetailsLauncher.SCROLL_MODE_STOP))
+            },
+            onEditReminder = { navController.navigate(NavRoutes.tripInfo(it)) }
+        )
+    }
     val state by viewModel.state.collectAsStateWithLifecycle()
     val content = state as? ArrivalsUiState.Content
     val title = initialName ?: content?.header?.name ?: stringResource(R.string.arrivals_board_title)
@@ -165,16 +145,20 @@ private fun ArrivalsBoard(
     val favoritesReady by favorites.stopFavoritesReady.collectAsStateWithLifecycle()
     var menuOpen by remember { mutableStateOf(false) }
     val point = content?.let { GeoPoint(it.stopLat, it.stopLon) }
-    // A shortcut can be the first-ever launch. Let the region picker finish before making requests.
+    // Wait for endpoint resolution. Active(null) is a configured custom API URL and can poll
+    // without a region; Resolving/NeedsManualChoice/Failed must still wait.
     val regions = remember { RegionEntryPoint.get(context) }
-    val region by regions.region.collectAsStateWithLifecycle()
-    if (region != null) ArrivalsPolling(viewModel)
+    val regionState by regions.state.collectAsStateWithLifecycle()
+    if (regionState is RegionState.Active) ArrivalsPolling(viewModel)
 
     Scaffold(
         modifier = Modifier.testTag("arrivals_board"),
         snackbarHost = { SnackbarHost(snackbar) },
         topBar = {
-            ObaTopAppBar(title = title, onBack = onBack) {
+            ObaTopAppBar(
+                title = title,
+                onBack = { navController.navigateUpFromArrivals(prefs.homeStartDestination()) }
+            ) {
                 IconButton(
                     enabled = favoritesReady && point != null,
                     onClick = {
@@ -186,7 +170,7 @@ private fun ArrivalsBoard(
                         stringResource(if (stopId in favoriteIds) R.string.stop_remove_star else R.string.stop_add_star)
                     )
                 }
-                IconButton(onClick = { onShowMap(StopReveal(stopId, initialName ?: content?.header?.name, point)) }) {
+                IconButton(onClick = { navController.showStopMapFromArrivals(StopReveal(stopId, initialName ?: content?.header?.name, point)) }) {
                     Icon(
                         painter = painterResource(R.drawable.ic_action_location_map),
                         contentDescription = stringResource(R.string.home_map)
@@ -211,7 +195,7 @@ private fun ArrivalsBoard(
                         })
                         DropdownMenuItem(text = { Text(stringResource(R.string.stop_info_option_night_light)) }, onClick = {
                             menuOpen = false
-                            onNightLight()
+                            navController.navigate(NavRoutes.NIGHT_LIGHT)
                         })
                     }
                 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/StopLauncher.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/StopLauncher.kt
@@ -18,19 +18,13 @@ package org.onebusaway.android.ui.arrivals
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.nav.DeepLinkUris
 
 /**
- * Opens the app on a stop: the map focused on it, with its real-time arrivals in the drawer.
- *
- * Not an Activity but a launcher facade that builds an explicit [HomeActivity] intent carrying the
- * stop's `content://…/stops/{id}` data URI (+ an optional name extra); `IntentRouteMapper` reads the
- * data URI back as a stop reveal and the host applies it to the map. The frozen class name
- * `org.onebusaway.android.ui.arrivals.ArrivalsListActivity` keeps resolving (for old pinned launcher
- * shortcuts) via an `<activity-alias>` → HomeActivity in the manifest, so the shortcut contract is
- * unchanged even though the standalone arrivals screen it once named is gone (#1898).
+ * Opens the mapless arrivals board for a stop. The stops data URI is shared with legacy pinned
+ * shortcuts, whose frozen activity aliases still target HomeActivity. IntentRouteMapper translates
+ * both old and new shortcuts into the same Compose destination.
  */
 object StopLauncher {
 
@@ -38,7 +32,7 @@ object StopLauncher {
 
         /** The built intent; Java callers see this as getIntent(). */
         val intent: Intent = Intent(context, HomeActivity::class.java).apply {
-            data = Uri.withAppendedPath(DeepLinkUris.STOPS, stopId)
+            data = DeepLinkUris.STOPS.buildUpon().appendPath(stopId).build()
         }
 
         fun setStopName(stopName: String?): Builder {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -105,7 +105,9 @@ class ArrivalRowCallbacks(
     val onShowRouteSchedule: (String) -> Unit,
     val onReportArrivalProblem: (ArrivalActions) -> Unit,
     /** Opens the service-alert dialog for the given situation id (the per-row alert indicator). */
-    val onShowAlert: (String) -> Unit
+    val onShowAlert: (String) -> Unit,
+    /** Ordinary row taps can open trip details on the mapless board. */
+    val onRowClick: (ArrivalInfo) -> Unit = onShowVehiclesOnMap
 )
 
 /**
@@ -417,7 +419,7 @@ fun RouteArrivalRow(
                     // map / schedule). The ETA pills remain independent children with their own
                     // trip-specific tap/long-press actions.
                     .combinedClickable(
-                        onClick = { callbacks.onShowVehiclesOnMap(representative) },
+                        onClick = { callbacks.onRowClick(representative) },
                         onLongClickLabel = routeMenuLabel,
                         onLongClick = { menuExpanded = true }
                     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeListsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeListsDestinations.kt
@@ -48,9 +48,7 @@ import org.onebusaway.android.ui.mylists.stopActions
 import org.onebusaway.android.ui.mylists.toStopReveal
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.navigateFromHome
-import org.onebusaway.android.ui.nav.navigateUpInApp
 import org.onebusaway.android.ui.nav.revealRouteOnMap
-import org.onebusaway.android.ui.nav.revealStopOnMap
 import org.onebusaway.android.ui.nav.showArrivals
 import org.onebusaway.android.ui.tracking.badgeTracking
 import org.onebusaway.android.util.PreferenceUtils
@@ -68,7 +66,11 @@ fun NavGraphBuilder.homeListsGraph(navController: NavHostController) {
         StarredListScaffold(
             title = R.string.navdrawer_item_starred_stops,
             clearLabel = R.string.my_option_clear_starred_stops,
-            onBack = { navController.navigateUpInApp() },
+            onBack = {
+                // This screen uses its Up arrow as the map section selector, without a duplicate icon.
+                PreferencesEntryPoint.get(host).rememberHomeSection(NavRoutes.HOME)
+                navController.navigateFromHome(NavRoutes.HOME)
+            },
             onSort = {
                 host.chooseSortOrder(
                     PreferenceUtils.getStopSortOrderFromPreferences(host),
@@ -99,7 +101,7 @@ fun NavGraphBuilder.homeListsGraph(navController: NavHostController) {
         StarredListScaffold(
             title = R.string.navdrawer_item_starred_routes,
             clearLabel = R.string.my_option_clear_starred_routes,
-            onBack = { navController.navigateUpInApp() },
+            onBack = { navController.popBackStack() },
             onMap = {
                 PreferencesEntryPoint.get(host).rememberHomeSection(NavRoutes.HOME)
                 navController.navigateFromHome(NavRoutes.HOME)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeListsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeListsDestinations.kt
@@ -31,6 +31,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import org.onebusaway.android.R
+import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -46,8 +47,11 @@ import org.onebusaway.android.ui.mylists.routeActions
 import org.onebusaway.android.ui.mylists.stopActions
 import org.onebusaway.android.ui.mylists.toStopReveal
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.nav.navigateFromHome
+import org.onebusaway.android.ui.nav.navigateUpInApp
 import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.nav.revealStopOnMap
+import org.onebusaway.android.ui.nav.showArrivals
 import org.onebusaway.android.ui.tracking.badgeTracking
 import org.onebusaway.android.util.PreferenceUtils
 
@@ -64,7 +68,7 @@ fun NavGraphBuilder.homeListsGraph(navController: NavHostController) {
         StarredListScaffold(
             title = R.string.navdrawer_item_starred_stops,
             clearLabel = R.string.my_option_clear_starred_stops,
-            onBack = { navController.popBackStack() },
+            onBack = { navController.navigateUpInApp() },
             onSort = {
                 host.chooseSortOrder(
                     PreferenceUtils.getStopSortOrderFromPreferences(host),
@@ -81,7 +85,7 @@ fun NavGraphBuilder.homeListsGraph(navController: NavHostController) {
             StopListDestination(
                 vm,
                 emptyText = R.string.my_no_starred_stops,
-                onClick = { navController.revealStopOnMap(it.toStopReveal()) },
+                onClick = { navController.showArrivals(it.toStopReveal()) },
                 actions = {
                     host.stopActions(it, R.string.my_context_remove_star) { vm.remove(it.id) }
                 },
@@ -95,7 +99,11 @@ fun NavGraphBuilder.homeListsGraph(navController: NavHostController) {
         StarredListScaffold(
             title = R.string.navdrawer_item_starred_routes,
             clearLabel = R.string.my_option_clear_starred_routes,
-            onBack = { navController.popBackStack() },
+            onBack = { navController.navigateUpInApp() },
+            onMap = {
+                PreferencesEntryPoint.get(host).rememberHomeSection(NavRoutes.HOME)
+                navController.navigateFromHome(NavRoutes.HOME)
+            },
             onSort = {
                 host.chooseSortOrder(
                     PreferenceUtils.getStopSortOrderFromPreferences(host),
@@ -135,6 +143,7 @@ private fun StarredListScaffold(
     @StringRes title: Int,
     @StringRes clearLabel: Int,
     onBack: () -> Unit,
+    onMap: (() -> Unit)? = null,
     onSort: () -> Unit,
     onClear: () -> Unit,
     content: @Composable () -> Unit
@@ -143,6 +152,14 @@ private fun StarredListScaffold(
         Scaffold(
             topBar = {
                 ObaTopAppBar(title = stringResource(title), onBack = onBack) {
+                    onMap?.let { showMap ->
+                        IconButton(onClick = showMap) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_action_location_map),
+                                contentDescription = stringResource(R.string.home_map)
+                            )
+                        }
+                    }
                     IconButton(onClick = onSort) {
                         Icon(
                             painter = painterResource(R.drawable.ic_action_content_sort),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -78,6 +78,8 @@ import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.RESULT_MAP_ROUTE_ID
 import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
 import org.onebusaway.android.ui.nav.StopReveal
+import org.onebusaway.android.ui.nav.arrivalsMapEnterTransition
+import org.onebusaway.android.ui.nav.arrivalsMapExitTransition
 import org.onebusaway.android.ui.nav.consumeRouteReveal
 import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateBackOrFinish
@@ -140,7 +142,11 @@ fun HomeNavHost(
         BackHandler(enabled = launchRoot) { navController.navigateBackOrFinish() }
     }
     NavHost(navController = navController, startDestination = NavRoutes.HOME) {
-        composable(NavRoutes.HOME) { entry ->
+        composable(
+            NavRoutes.HOME,
+            enterTransition = { arrivalsMapEnterTransition() },
+            exitTransition = { arrivalsMapExitTransition() }
+        ) { entry ->
             // Navigation retains outgoing content during transitions. A cold launch's blank HOME
             // anchor must stay blank while the board/list enters, even after launch routing completes.
             // Once actually visited, keep normal transition/state-saving behavior for this map entry.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -85,7 +85,6 @@ import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.navigateBackOrFinish
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.nav.revealRouteOnMap
-import org.onebusaway.android.ui.nav.revealStopOnMap
 import org.onebusaway.android.ui.nav.showArrivals
 import org.onebusaway.android.ui.report.reportGraph
 import org.onebusaway.android.ui.routeinfo.routeInfoGraph
@@ -308,17 +307,13 @@ internal fun LaunchIntentEffect(
                 onSideEffects(i)
                 val route = launchDestination(i, prefs)
                 navController.navigateFromHome(route)
-                if (initial &&
-                    (
-                        route.startsWith("arrivals/") ||
-                            route in setOf(
-                                NavRoutes.HOME_STARRED_STOPS,
-                                NavRoutes.HOME_STARRED_ROUTES,
-                                NavRoutes.MY_REMINDERS
-                            )
-                        )
-                ) {
-                    navController.currentBackStackEntry?.savedStateHandle?.set(LAUNCH_ROOT, true)
+                if (initial) {
+                    val entry = navController.currentBackStackEntry
+                    when (entry?.destination?.route) {
+                        NavRoutes.ARRIVALS, NavRoutes.HOME_STARRED_STOPS,
+                        NavRoutes.HOME_STARRED_ROUTES, NavRoutes.MY_REMINDERS ->
+                            entry.savedStateHandle[LAUNCH_ROOT] = true
+                    }
                 }
                 handled()
             }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -277,7 +277,7 @@ fun HomeNavHost(
 }
 
 /**
- * Drains [HomeActivity]'s `launchIntents` channel once the NavHost is composed (cold launch) and as each
+ * Handles [initialIntent] once, then drains [HomeActivity]'s `launchIntents` channel as each
  * `onNewIntent` enqueues more (warm relaunch): for each external intent it runs the intent's domain side
  * effects, translates it to a route via [IntentRouteMapper] (null = stay on the map), then navigates there
  * popping up to HOME. This is the only navigation that can't hold the NavController itself — the OS hands
@@ -288,37 +288,45 @@ fun HomeNavHost(
  * The collect is gated on `repeatOnLifecycle(STARTED)` so we never navigate while the activity is STOPPED.
  * The UNLIMITED channel buffers any intent submitted during that window and replays it when the lifecycle
  * returns to STARTED, so the gate costs no deliveries (#1592).
+ *
+ * Returns the saved launch readiness used to gate HOME's map. If state is saved before the cold intent
+ * is handled, recreation retries it from [initialIntent], even though the new Activity's channel is
+ * empty. Once handled, recreation restores navigation without replaying the launch's side effects.
  */
 @Composable
 internal fun LaunchIntentEffect(
     navController: NavHostController,
+    initialIntent: Intent,
     launchIntents: Flow<Intent>,
-    onSideEffects: (Intent) -> Unit,
-    initialLaunch: Boolean = false,
-    onHandled: () -> Unit = {}
-) {
+    onSideEffects: (Intent) -> Unit
+): Boolean {
     val lifecycleOwner = LocalLifecycleOwner.current
     val prefs = PreferencesEntryPoint.get(LocalContext.current)
-    val handled by rememberUpdatedState(onHandled)
-    val initial by rememberUpdatedState(initialLaunch)
+    val sideEffects by rememberUpdatedState(onSideEffects)
+    var launchReady by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(navController, lifecycleOwner) {
-        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            launchIntents.collect { i ->
-                onSideEffects(i)
-                val route = launchDestination(i, prefs)
-                navController.navigateFromHome(route)
-                if (initial) {
-                    val entry = navController.currentBackStackEntry
-                    when (entry?.destination?.route) {
-                        NavRoutes.ARRIVALS, NavRoutes.HOME_STARRED_STOPS,
-                        NavRoutes.HOME_STARRED_ROUTES, NavRoutes.MY_REMINDERS ->
-                            entry.savedStateHandle[LAUNCH_ROOT] = true
-                    }
+        fun handle(intent: Intent, initial: Boolean) {
+            sideEffects(intent)
+            val route = launchDestination(intent, prefs)
+            navController.navigateFromHome(route)
+            if (initial) {
+                val entry = navController.currentBackStackEntry
+                when (entry?.destination?.route) {
+                    NavRoutes.ARRIVALS, NavRoutes.HOME_STARRED_STOPS,
+                    NavRoutes.HOME_STARRED_ROUTES, NavRoutes.MY_REMINDERS ->
+                        entry.savedStateHandle[LAUNCH_ROOT] = true
                 }
-                handled()
             }
         }
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            if (!launchReady) {
+                handle(initialIntent, initial = true)
+                launchReady = true
+            }
+            launchIntents.collect { handle(it, initial = false) }
+        }
     }
+    return launchReady
 }
 
 /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -20,12 +20,18 @@ package org.onebusaway.android.ui.home
 import android.content.Context
 import android.content.Intent
 import android.view.accessibility.AccessibilityManager
+import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.colorResource
@@ -41,6 +47,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
@@ -54,6 +61,7 @@ import org.onebusaway.android.map.MapViewModel
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
+import org.onebusaway.android.ui.arrivals.arrivalsGraph
 import org.onebusaway.android.ui.compose.components.OptOutInfoDialog
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
@@ -64,15 +72,19 @@ import org.onebusaway.android.ui.home.nav.extraDestinations
 import org.onebusaway.android.ui.home.weather.WeatherViewModel
 import org.onebusaway.android.ui.mylists.myListsGraph
 import org.onebusaway.android.ui.nav.IntentRouteMapper
+import org.onebusaway.android.ui.nav.LAUNCH_ROOT
 import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.RESULT_MAP_ROUTE_ID
 import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
+import org.onebusaway.android.ui.nav.StopReveal
 import org.onebusaway.android.ui.nav.consumeRouteReveal
 import org.onebusaway.android.ui.nav.consumeStopReveal
+import org.onebusaway.android.ui.nav.navigateBackOrFinish
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.nav.revealStopOnMap
+import org.onebusaway.android.ui.nav.showArrivals
 import org.onebusaway.android.ui.report.reportGraph
 import org.onebusaway.android.ui.routeinfo.routeInfoGraph
 import org.onebusaway.android.ui.settings.settingsGraph
@@ -119,10 +131,22 @@ class HomeDestinationDeps(
 @Composable
 fun HomeNavHost(
     navController: NavHostController,
-    home: HomeDestinationDeps
+    home: HomeDestinationDeps,
+    launchReady: Boolean = true
 ) {
+    val currentEntry by navController.currentBackStackEntryAsState()
+    currentEntry?.let { entry ->
+        val launchRoot by entry.savedStateHandle.getStateFlow(LAUNCH_ROOT, false).collectAsStateWithLifecycle()
+        BackHandler(enabled = launchRoot) { navController.navigateBackOrFinish() }
+    }
     NavHost(navController = navController, startDestination = NavRoutes.HOME) {
         composable(NavRoutes.HOME) { entry ->
+            // Navigation retains outgoing content during transitions. A cold launch's blank HOME
+            // anchor must stay blank while the board/list enters, even after launch routing completes.
+            // Once actually visited, keep normal transition/state-saving behavior for this map entry.
+            var mapStarted by rememberSaveable { mutableStateOf(false) }
+            if (!mapStarted && (!launchReady || navController.currentBackStackEntry?.id != entry.id)) return@composable
+            SideEffect { mapStarted = true }
             // Apply a one-shot "reveal on map" handed back by a pushed destination (route info, search,
             // the My* lists) via HOME's own SavedStateHandle, then consume it (set-null) so it neither
             // re-fires on recomposition nor survives a later route-focus exit + process death. The
@@ -164,6 +188,7 @@ fun HomeNavHost(
 
                 // A menu row: navigate (popping to HOME) + report its analytics.
                 fun menuNav(route: String, @StringRes label: Int) {
+                    PreferencesEntryPoint.get(context).rememberHomeSection(route)
                     navController.navigateFromHome(route)
                     home.homeViewModel.reportMenuAnalytics(label)
                 }
@@ -181,9 +206,8 @@ fun HomeNavHost(
                     onSettings = { menuNav(NavRoutes.SETTINGS, R.string.analytics_label_button_press_settings) },
                     onSearch = { query -> navController.navigateFromHome(NavRoutes.search(query)) },
                     onRecentStopsRoutes = { navController.navigateFromHome(NavRoutes.myRecent()) },
-                    // Recents dropdown taps reveal the stop / route on the map (the same stop-focus the
-                    // search results and map markers use).
-                    onRecentStop = { navController.revealStopOnMap(it) },
+                    // Recent stops open arrivals; routes still open on the map.
+                    onRecentStop = { navController.showArrivals(it) },
                     onRecentRoute = { routeId -> navController.revealRouteOnMap(routeId) },
                     onHelpAction = { action ->
                         if (action == HelpAction.AGENCIES) {
@@ -200,7 +224,16 @@ fun HomeNavHost(
                     onEditReminder = { args -> navController.navigateFromHome(NavRoutes.tripInfo(args)) },
                     onNightLight = { navController.navigateFromHome(NavRoutes.NIGHT_LIGHT) },
                     onLearnMore = { navController.navigateFromHome(NavRoutes.DONATION_LEARN_MORE) },
-                    onOpenSurvey = { url -> navController.navigateFromHome(NavRoutes.surveyWebView(url)) }
+                    onOpenSurvey = { url -> navController.navigateFromHome(NavRoutes.surveyWebView(url)) },
+                    onShowArrivals = { stop ->
+                        if (navController.previousBackStackEntry?.destination?.route == NavRoutes.ARRIVALS &&
+                            navController.previousBackStackEntry?.arguments?.getString(NavRoutes.ARG_STOP_ID) == stop.id
+                        ) {
+                            navController.popBackStack()
+                        } else {
+                            navController.showArrivals(StopReveal(stop.id, stop.name, stop.point))
+                        }
+                    }
                 )
             }
             HomeScreen(
@@ -216,11 +249,17 @@ fun HomeNavHost(
                 tripResultsViewModel = home.tripResultsViewModel,
                 pinnedTripViewModel = home.pinnedTripViewModel,
                 arrivalsViewModelFactory = home.arrivalsViewModelFactory,
-                callbacks = callbacks
+                callbacks = callbacks,
+                onBackToArrivals = if (navController.previousBackStackEntry?.destination?.route == NavRoutes.ARRIVALS) {
+                    { navController.popBackStack() }
+                } else {
+                    null
+                }
             )
         }
         // The rest of the graph, grouped by feature (each a NavGraphBuilder extension near its
         // feature; they recover the host via findActivity rather than threading dependencies).
+        arrivalsGraph(navController)
         routeInfoGraph(navController)
         tripGraph(navController)
         myListsGraph(navController)
@@ -249,14 +288,33 @@ fun HomeNavHost(
 internal fun LaunchIntentEffect(
     navController: NavHostController,
     launchIntents: Flow<Intent>,
-    onSideEffects: (Intent) -> Unit
+    onSideEffects: (Intent) -> Unit,
+    initialLaunch: Boolean = false,
+    onHandled: () -> Unit = {}
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
+    val prefs = PreferencesEntryPoint.get(LocalContext.current)
+    val handled by rememberUpdatedState(onHandled)
+    val initial by rememberUpdatedState(initialLaunch)
     LaunchedEffect(navController, lifecycleOwner) {
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             launchIntents.collect { i ->
                 onSideEffects(i)
-                IntentRouteMapper.routeForIntent(i)?.let { navController.navigateFromHome(it) }
+                val route = launchDestination(i, prefs)
+                navController.navigateFromHome(route)
+                if (initial &&
+                    (
+                        route.startsWith("arrivals/") ||
+                            route in setOf(
+                                NavRoutes.HOME_STARRED_STOPS,
+                                NavRoutes.HOME_STARRED_ROUTES,
+                                NavRoutes.MY_REMINDERS
+                            )
+                        )
+                ) {
+                    navController.currentBackStackEntry?.savedStateHandle?.set(LAUNCH_ROOT, true)
+                }
+                handled()
             }
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -78,7 +78,9 @@ import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.ui.arrivals.ArrivalsLoaded
 import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
+import org.onebusaway.android.ui.arrivals.StopLauncher
 import org.onebusaway.android.ui.arrivals.components.etaPillFocus
+import org.onebusaway.android.ui.common.Shortcuts
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
@@ -183,7 +185,8 @@ class HomeCallbacks(
     // The focused stop's overflow "night light" item — the driver-flagging flasher screen.
     val onNightLight: () -> Unit,
     val onLearnMore: () -> Unit,
-    val onOpenSurvey: (url: String) -> Unit
+    val onOpenSurvey: (url: String) -> Unit,
+    val onShowArrivals: (FocusedStop) -> Unit = {}
 )
 
 /**
@@ -246,7 +249,8 @@ fun HomeScreen(
     arrivalsViewModelFactory: ArrivalsViewModel.Factory,
     // All the screen's tap/UI lambdas, bundled (see [HomeCallbacks]); brought into scope below via
     // `with` so the body references them unqualified.
-    callbacks: HomeCallbacks
+    callbacks: HomeCallbacks,
+    onBackToArrivals: (() -> Unit)? = null
 ) {
     with(callbacks) {
         with(activityActions) {
@@ -636,7 +640,11 @@ fun HomeScreen(
                 // drawer consumes nothing — it's ambient, with nothing behind it to go back to — so back
                 // falls through to the system (see [sheetBackAction]).
                 val sheetExpanded = sheetShown && sheetState.currentValue == SheetValue.Expanded
-                BackHandler(enabled = canUndoMapAction || sheetExpanded) {
+                BackHandler(enabled = onBackToArrivals != null || canUndoMapAction || sheetExpanded) {
+                    if (onBackToArrivals != null) {
+                        onBackToArrivals()
+                        return@BackHandler
+                    }
                     val sheetAction = if (sheetShown) {
                         sheetBackAction(sheetState.currentValue.toArrivalsSheetState(), sheetContent)
                     } else {
@@ -920,7 +928,18 @@ fun HomeScreen(
                                                 stopMenu = arrivalsSession?.let { session ->
                                                     StopFocusMenu(
                                                         onReportStopProblem = session.handler::onReportStopProblem,
-                                                        onNightLight = callbacks.onNightLight
+                                                        onNightLight = callbacks.onNightLight,
+                                                        onCreateShortcut = {
+                                                            stopFocus?.stop?.let { stop ->
+                                                                val name = stop.name?.takeIf { it.isNotBlank() } ?: stop.id
+                                                                Shortcuts.createStopShortcut(
+                                                                    app,
+                                                                    name,
+                                                                    StopLauncher.Builder(app, stop.id).setStopName(stop.name)
+                                                                )
+                                                            }
+                                                        },
+                                                        onShowArrivals = { stopFocus?.stop?.let(callbacks.onShowArrivals) }
                                                     )
                                                 },
                                                 // The direction menu calls straight into the map VM (which

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeStartDestination.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeStartDestination.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import android.content.Intent
+import org.onebusaway.android.map.MapParams
+import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.ui.nav.IntentRouteMapper
+import org.onebusaway.android.ui.nav.NavRoutes
+
+/** Reuse March's persisted drawer selection, including values imported from SharedPreferences. */
+internal const val HOME_SECTION_KEY = "selected_navigation_drawer_position"
+
+internal fun homeSectionRoute(section: Int): String = when (section) {
+    1 -> NavRoutes.HOME_STARRED_STOPS
+    2 -> NavRoutes.HOME_STARRED_ROUTES
+    3 -> NavRoutes.MY_REMINDERS
+    else -> NavRoutes.HOME
+}
+
+internal fun PreferencesRepository.homeStartDestination(): String = homeSectionRoute(getInt(HOME_SECTION_KEY, 0))
+
+/** Only explicit section choices change the next launch; visiting a map or a detail screen does not. */
+internal fun PreferencesRepository.rememberHomeSection(route: String) {
+    val section = when (route) {
+        NavRoutes.HOME -> 0
+        NavRoutes.HOME_STARRED_STOPS -> 1
+        NavRoutes.HOME_STARRED_ROUTES -> 2
+        NavRoutes.MY_REMINDERS -> 3
+        else -> return
+    }
+    setInt(HOME_SECTION_KEY, section)
+}
+
+/** Explicit destinations win over the remembered section; only an ordinary launcher opening uses it. */
+internal fun launchDestination(intent: Intent, prefs: PreferencesRepository): String = IntentRouteMapper.routeForIntent(intent) ?: if (
+    intent.action == Intent.ACTION_MAIN &&
+    intent.hasCategory(Intent.CATEGORY_LAUNCHER) &&
+    intent.data == null &&
+    !intent.hasExtra(MapParams.STOP_ID) &&
+    !intent.hasExtra(MapParams.ROUTE_ID)
+) {
+    prefs.homeStartDestination()
+} else {
+    NavRoutes.HOME
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -1393,11 +1393,12 @@ class HomeViewModel @Inject constructor(
     /**
      * Home was created. On the very first launch ever we defer the region check until the map's
      * location-permission result (so an auto-select has a location to work with); otherwise — or once
-     * permission is already granted — check now. [hasLocationPermission] is read by the activity
+     * permission is already granted — check now. Mapless launches resolve immediately so a known
+     * stop can load without waiting for a map permission callback. [hasLocationPermission] is read by the activity
      * (it needs a Context); the decision lives here.
      */
-    fun onHomeStarted(hasLocationPermission: Boolean) {
-        if (startupRepo.isInitialStartup() && !hasLocationPermission) {
+    fun onHomeStarted(hasLocationPermission: Boolean, mapless: Boolean = false) {
+        if (!mapless && startupRepo.isInitialStartup() && !hasLocationPermission) {
             return
         }
         refreshRegions()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/LaunchIntentChannel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/LaunchIntentChannel.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 /**
  * The Activity's queue of external launch intents (deep links, FCM, launcher shortcuts) awaiting the
  * NavHost. Backed by an UNLIMITED-buffered [Channel] so:
- *  - a [submit] made before the NavHost composes (the cold-launch intent staged in `onCreate`) isn't
+ *  - a [submit] made before the NavHost composes (a warm intent arriving in `onNewIntent`) isn't
  *    lost, and
  *  - rapid, distinct back-to-back intents are each delivered exactly once, in order, rather than one
  *    overwriting another before [items] is collected (#1582 — the bug a conflating latch reintroduces).

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -120,8 +120,8 @@ private const val MAX_TITLE_LINES = 2
 
 /**
  * The focused stop's overflow actions. They act on the stop's arrivals session — which HOME owns, not
- * the banner — so they arrive as one bundle rather than as two more lambdas on a banner that already
- * carries eight. Null hides the menu: there is no session to act on until a stop's arrivals are up.
+ * the banner — so they arrive as one bundle. Null hides the menu: there is no session to act on until
+ * a stop's arrivals are up.
  *
  * These outlived the standalone arrivals screen whose top bar used to hold them (#1898); the banner is
  * where a focused stop's actions live now. Its "show stop details" item did not: the banner itself
@@ -130,7 +130,9 @@ private const val MAX_TITLE_LINES = 2
  */
 data class StopFocusMenu(
     val onReportStopProblem: () -> Unit,
-    val onNightLight: () -> Unit
+    val onNightLight: () -> Unit,
+    val onCreateShortcut: () -> Unit,
+    val onShowArrivals: (() -> Unit)? = null
 )
 
 /**
@@ -583,8 +585,8 @@ private fun HeaderIconButton(
 
 /**
  * The focused stop's overflow: the stop actions that are neither frequent enough for their own icon nor
- * expressible on the map — a problem report against the stop, and the night-light flasher a rider holds
- * up to a driver. Inherited from the retired standalone arrivals screen's top bar (#1898).
+ * expressible on the map: the mapless board, a home-screen shortcut, a problem report against the stop,
+ * and the night-light flasher a rider holds up to a driver.
  */
 @Composable
 private fun StopMenuAction(menu: StopFocusMenu) {
@@ -596,6 +598,16 @@ private fun StopMenuAction(menu: StopFocusMenu) {
             onClick = { expanded = true }
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            menu.onShowArrivals?.let { showArrivals ->
+                MenuRow(R.string.view_arrivals_only) {
+                    expanded = false
+                    showArrivals()
+                }
+            }
+            MenuRow(R.string.my_context_create_shortcut) {
+                expanded = false
+                menu.onCreateShortcut()
+            }
             MenuRow(R.string.stop_info_option_report_problem) {
                 expanded = false
                 menu.onReportStopProblem()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -132,7 +132,7 @@ data class StopFocusMenu(
     val onReportStopProblem: () -> Unit,
     val onNightLight: () -> Unit,
     val onCreateShortcut: () -> Unit,
-    val onShowArrivals: (() -> Unit)? = null
+    val onShowArrivals: () -> Unit
 )
 
 /**
@@ -598,11 +598,9 @@ private fun StopMenuAction(menu: StopFocusMenu) {
             onClick = { expanded = true }
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            menu.onShowArrivals?.let { showArrivals ->
-                MenuRow(R.string.view_arrivals_only) {
-                    expanded = false
-                    showArrivals()
-                }
+            MenuRow(R.string.view_arrivals_only) {
+                expanded = false
+                menu.onShowArrivals()
             }
             MenuRow(R.string.my_context_create_shortcut) {
                 expanded = false

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListNav.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListNav.kt
@@ -44,14 +44,23 @@ internal fun StopListItem.toStopReveal() = StopReveal(id, name, GeoPoint(lat, lo
 /**
  * A stop row's long-press actions; [removeLabel] is the only per-list delta.
  *
- * No "show on map" item: it is what tapping the row now does (#1898), and the search rows dropped
- * theirs for the same reason when they moved to map focus.
+ * Tapping the row opens arrivals; the map remains an explicit context action.
  */
 internal fun AppCompatActivity.stopActions(
     stop: StopListItem,
     @StringRes removeLabel: Int,
     onRemove: () -> Unit
 ): List<RowAction> = listOf(
+    RowAction(getString(R.string.my_context_showonmap)) {
+        startActivity(
+            android.content.Intent(this, org.onebusaway.android.ui.HomeActivity::class.java).apply {
+                putExtra(org.onebusaway.android.map.MapParams.STOP_ID, stop.id)
+                putExtra(org.onebusaway.android.map.MapParams.STOP_NAME, stop.name)
+                putExtra(org.onebusaway.android.map.MapParams.CENTER_LAT, stop.lat)
+                putExtra(org.onebusaway.android.map.MapParams.CENTER_LON, stop.lon)
+            }
+        )
+    },
     RowAction(getString(R.string.my_context_create_shortcut)) {
         Shortcuts.createStopShortcut(this, stop.name, stopLauncherBuilder(stop))
     },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListsDestinations.kt
@@ -37,10 +37,13 @@ import org.onebusaway.android.app.di.PreferencesEntryPoint
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.home.rememberHomeSection
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.navigateFromHome
+import org.onebusaway.android.ui.nav.navigateUpInApp
 import org.onebusaway.android.ui.nav.revealRouteOnMap
 import org.onebusaway.android.ui.nav.revealStopOnMap
+import org.onebusaway.android.ui.nav.showArrivals
 import org.onebusaway.android.util.PreferenceUtils
 
 /**
@@ -65,8 +68,8 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
             MyStopsDestination(
                 initialTag = entry.arguments?.getString(NavRoutes.ARG_TAB),
                 prefsRepository = PreferencesEntryPoint.get(LocalContext.current),
-                onBack = { navController.popBackStack() },
-                onRevealStop = { navController.revealStopOnMap(it) }
+                onBack = { navController.navigateUpInApp() },
+                onRevealStop = { navController.showArrivals(it) }
             )
         }
     }
@@ -75,7 +78,7 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
             MyRoutesDestination(
                 initialTag = entry.arguments?.getString(NavRoutes.ARG_TAB),
                 prefsRepository = PreferencesEntryPoint.get(LocalContext.current),
-                onBack = { navController.popBackStack() },
+                onBack = { navController.navigateUpInApp() },
                 onShowRouteOnMap = { navController.revealRouteOnMap(it) },
                 onOpenRoute = { navController.navigateFromHome(NavRoutes.routeInfo(it)) }
             )
@@ -86,8 +89,8 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
             MyRecentDestination(
                 initialTag = entry.arguments?.getString(NavRoutes.ARG_TAB),
                 prefsRepository = PreferencesEntryPoint.get(LocalContext.current),
-                onBack = { navController.popBackStack() },
-                onRevealStop = { navController.revealStopOnMap(it) },
+                onBack = { navController.navigateUpInApp() },
+                onRevealStop = { navController.showArrivals(it) },
                 onShowRouteOnMap = { navController.revealRouteOnMap(it) }
             )
         }
@@ -105,8 +108,17 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
                 topBar = {
                     ObaTopAppBar(
                         title = stringResource(R.string.navdrawer_item_my_reminders),
-                        onBack = { navController.popBackStack() }
+                        onBack = { navController.navigateUpInApp() }
                     ) {
+                        IconButton(onClick = {
+                            PreferencesEntryPoint.get(activity).rememberHomeSection(NavRoutes.HOME)
+                            navController.navigateFromHome(NavRoutes.HOME)
+                        }) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_action_location_map),
+                                contentDescription = stringResource(R.string.home_map)
+                            )
+                        }
                         IconButton(onClick = {
                             activity.chooseSortOrder(
                                 PreferenceUtils.getReminderSortOrderFromPreferences(activity),
@@ -135,7 +147,7 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
                                 onEdit = onEditReminder,
                                 onShowRoute = { navController.navigate(NavRoutes.routeInfo(it)) },
                                 // A reminder stores only its stop's id — enough for a reveal.
-                                onShowStop = { navController.revealStopOnMap(it) }
+                                onShowStop = { navController.showArrivals(org.onebusaway.android.ui.nav.StopReveal(it)) }
                             )
                         }
                     )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListsDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/mylists/MyListsDestinations.kt
@@ -40,9 +40,7 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.home.rememberHomeSection
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.navigateFromHome
-import org.onebusaway.android.ui.nav.navigateUpInApp
 import org.onebusaway.android.ui.nav.revealRouteOnMap
-import org.onebusaway.android.ui.nav.revealStopOnMap
 import org.onebusaway.android.ui.nav.showArrivals
 import org.onebusaway.android.util.PreferenceUtils
 
@@ -68,7 +66,7 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
             MyStopsDestination(
                 initialTag = entry.arguments?.getString(NavRoutes.ARG_TAB),
                 prefsRepository = PreferencesEntryPoint.get(LocalContext.current),
-                onBack = { navController.navigateUpInApp() },
+                onBack = { navController.popBackStack() },
                 onRevealStop = { navController.showArrivals(it) }
             )
         }
@@ -78,7 +76,7 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
             MyRoutesDestination(
                 initialTag = entry.arguments?.getString(NavRoutes.ARG_TAB),
                 prefsRepository = PreferencesEntryPoint.get(LocalContext.current),
-                onBack = { navController.navigateUpInApp() },
+                onBack = { navController.popBackStack() },
                 onShowRouteOnMap = { navController.revealRouteOnMap(it) },
                 onOpenRoute = { navController.navigateFromHome(NavRoutes.routeInfo(it)) }
             )
@@ -89,7 +87,7 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
             MyRecentDestination(
                 initialTag = entry.arguments?.getString(NavRoutes.ARG_TAB),
                 prefsRepository = PreferencesEntryPoint.get(LocalContext.current),
-                onBack = { navController.navigateUpInApp() },
+                onBack = { navController.popBackStack() },
                 onRevealStop = { navController.showArrivals(it) },
                 onShowRouteOnMap = { navController.revealRouteOnMap(it) }
             )
@@ -108,7 +106,7 @@ fun NavGraphBuilder.myListsGraph(navController: NavHostController) {
                 topBar = {
                     ObaTopAppBar(
                         title = stringResource(R.string.navdrawer_item_my_reminders),
-                        onBack = { navController.navigateUpInApp() }
+                        onBack = { navController.popBackStack() }
                     ) {
                         IconButton(onClick = {
                             PreferencesEntryPoint.get(activity).rememberHomeSection(NavRoutes.HOME)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ArrivalsTransitions.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/ArrivalsTransitions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.navigation.NavBackStackEntry
+
+// Both ends must opt out: an outgoing fade also keeps the incoming map below RESUMED until
+// it finishes. Null preserves the NavHost's normal transition for every other destination pair.
+internal fun AnimatedContentTransitionScope<NavBackStackEntry>.arrivalsMapEnterTransition(): EnterTransition? = if (isArrivalsMapTransition()) EnterTransition.None else null
+
+internal fun AnimatedContentTransitionScope<NavBackStackEntry>.arrivalsMapExitTransition(): ExitTransition? = if (isArrivalsMapTransition()) ExitTransition.None else null
+
+private fun AnimatedContentTransitionScope<NavBackStackEntry>.isArrivalsMapTransition(): Boolean {
+    val from = initialState.destination.route
+    val to = targetState.destination.route
+    return (from == NavRoutes.ARRIVALS && to == NavRoutes.HOME) ||
+        (from == NavRoutes.HOME && to == NavRoutes.ARRIVALS)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/IntentRouteMapper.kt
@@ -24,8 +24,7 @@ import org.onebusaway.android.util.ReminderUtils
 
 /**
  * Translates an incoming external [Intent] into what it asks the app to show: the in-app NavHost route
- * to open ([routeForIntent]), the stop to focus on the map ([stopRevealForIntent]), or neither — leaving
- * the home/map path untouched. Lifted out of `HomeActivity` so the precedence/dispatch is a pure,
+ * to open ([routeForIntent]), or null for an ordinary home/map launch. Lifted out of `HomeActivity` so the precedence/dispatch is a pure,
  * JVM-testable decision ([decide]) sitting behind the thin Android `Intent`/`Uri`/JSON reads ([read]).
  *
  * Routing only — side-effect free: the domain mutations some intents imply (the `add-region` URL apply,
@@ -78,13 +77,8 @@ object IntentRouteMapper {
         data class Verbatim(val route: String) : RouteDecision
         data class Search(val query: String) : RouteDecision
 
-        /**
-         * Show a stop — which is map state, not a screen: the map focuses it and the arrivals drawer
-         * opens over it (the standalone arrivals page it used to open was retired in #1898). So this
-         * is the one decision [toRoute] resolves to *no* destination; the host applies it through
-         * [stopRevealForIntent] instead.
-         */
-        data class StopOnMap(val reveal: StopReveal) : RouteDecision
+        /** Open the mapless board, including legacy pinned stop shortcuts. */
+        data class Arrivals(val reveal: StopReveal) : RouteDecision
         data class RouteInfo(val routeId: String) : RouteDecision
         data class TripDetails(val tripId: String, val stopId: String?, val scrollMode: String?) : RouteDecision
         object NightLight : RouteDecision
@@ -96,29 +90,19 @@ object IntentRouteMapper {
     fun routeForIntent(intent: Intent?): String? = intent?.let { decide(read(it)).toRoute() }
 
     /**
-     * The stop [intent] asks the map to focus, or null when it asks for something else. The map half of
-     * [routeForIntent] — the two read the same [decide] so an intent can't be classified one way for
-     * navigation and another for the map — and the counterpart, for the URI/payload contracts this
-     * object owns, of the `MapParams` extras contract `FocusedStop.fromIntent` parses.
-     */
-    fun stopRevealForIntent(intent: Intent?): StopReveal? = intent
-        ?.let { decide(read(it)) as? RouteDecision.StopOnMap }
-        ?.reveal
-
-    /**
      * The pure route-precedence decision over [input] — the exact branch order of the former
      * `HomeActivity.routeForIntent`.
      */
     fun decide(input: RouteIntent): RouteDecision {
         // In-app / cross-screen launches carry their destination route verbatim (see [navIntent]).
         input.navRoute?.let { return RouteDecision.Verbatim(it) }
-        // The exported (iOS-parity) deep links. A stop link focuses that stop on the map; a web trip
+        // The exported (iOS-parity) deep links. A stop link opens its arrivals board; a web trip
         // link names the stop it was shared from, so open the trip scrolled to that stop; add-region is
         // staged for the rider's confirmation as a side effect (HomeActivity) and for routing stays on
         // the home/map path.
         input.deepLink?.let { target ->
             return when (target) {
-                is ExternalDeepLinks.Target.Stop -> RouteDecision.StopOnMap(StopReveal(target.stopId))
+                is ExternalDeepLinks.Target.Stop -> RouteDecision.Arrivals(StopReveal(target.stopId))
                 is ExternalDeepLinks.Target.Trip -> RouteDecision.TripDetails(
                     tripId = target.tripId,
                     stopId = target.stopId,
@@ -129,11 +113,11 @@ object IntentRouteMapper {
         }
         // System search (HomeActivity is the default_searchable target): open the search destination.
         if (input.isSearch) return RouteDecision.Search(input.searchQuery)
-        // The FCM arrival payload clears its fired reminder as a side effect; here it just focuses the
-        // stop (or stays put if the stop id couldn't be parsed). Its presence short-circuits the later
+        // The FCM arrival payload clears its fired reminder as a side effect; here it opens the
+        // stop board (or stays put if the stop id couldn't be parsed). Its presence short-circuits the later
         // branches.
         if (input.hasArrivalPayload) {
-            return input.arrivalStopId?.let { RouteDecision.StopOnMap(StopReveal(it)) }
+            return input.arrivalStopId?.let { RouteDecision.Arrivals(StopReveal(it)) }
                 ?: RouteDecision.None
         }
         // Trip details carries its args as extras (no data URI).
@@ -148,12 +132,11 @@ object IntentRouteMapper {
         }
         // Explicit-component screen intents carrying a content://<authority>/<path>/{id} data URI (read by
         // path segment, since the authority is flavor-specific). MapParams.* focus / route-mode launches
-        // have no data URI and resolve to None — they stay map behavior, as does the stops URI, which is
-        // now a map focus rather than a destination.
+        // have no data URI and resolve to None, while stop URIs open the mapless board.
         return when (input.pathSegments.firstOrNull()) {
             DeepLinkUris.STOPS_PATH ->
                 input.pathSegments.lastOrNull()
-                    ?.let { RouteDecision.StopOnMap(StopReveal(it, input.arrivalsStopName)) }
+                    ?.let { RouteDecision.Arrivals(StopReveal(it, input.arrivalsStopName)) }
                     ?: RouteDecision.None
             DeepLinkUris.ROUTES_PATH ->
                 input.pathSegments.lastOrNull()?.let { RouteDecision.RouteInfo(it) } ?: RouteDecision.None
@@ -163,9 +146,9 @@ object IntentRouteMapper {
 
     /** Encodes a [RouteDecision] into its navigable [NavRoutes] string (or null for [RouteDecision.None]). */
     private fun RouteDecision.toRoute(): String? = when (this) {
-        // Both mean "no destination": None stays on the map untouched, StopOnMap is applied to it by
-        // the host (see [stopRevealForIntent]) rather than navigated to.
-        RouteDecision.None, is RouteDecision.StopOnMap -> null
+        // Stop links open the board; explicit map extras still resolve to None.
+        RouteDecision.None -> null
+        is RouteDecision.Arrivals -> NavRoutes.arrivals(reveal.stopId, reveal.name)
         is RouteDecision.Verbatim -> route
         is RouteDecision.Search -> NavRoutes.search(query)
         is RouteDecision.RouteInfo -> NavRoutes.routeInfo(routeId)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
@@ -20,9 +20,51 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import org.onebusaway.android.map.MapParams
 import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.home.FocusedStop
 import org.onebusaway.android.util.GeoPoint
 import org.onebusaway.android.util.geoPointOrNull
+
+/** A directly launched board/list exits on Back, without exposing the map underneath. */
+const val LAUNCH_ROOT = "navigation.launchRoot"
+
+fun NavController.navigateBackOrFinish() {
+    if (currentBackStackEntry?.savedStateHandle?.get<Boolean>(LAUNCH_ROOT) == true) {
+        context.findActivity().finish()
+    } else {
+        popBackStack()
+    }
+}
+
+/** Toolbar Up stays in the app, even when Android Back would exit a shortcut/launcher root. */
+fun NavController.navigateUpInApp(parentRoute: String = NavRoutes.HOME) {
+    if (currentBackStackEntry?.savedStateHandle?.get<Boolean>(LAUNCH_ROOT) == true) {
+        navigateFromHome(parentRoute)
+        // A shortcut has no list underneath it. Its parent becomes the new launch root, so
+        // system Back still exits from that list without unexpectedly opening the map.
+        if (parentRoute != NavRoutes.HOME) {
+            currentBackStackEntry?.savedStateHandle?.set(LAUNCH_ROOT, true)
+        }
+    } else {
+        popBackStack()
+    }
+}
+
+/** Open a board without discarding the list that led to it. */
+fun NavController.showArrivals(reveal: StopReveal) = navigate(NavRoutes.arrivals(reveal.stopId, reveal.name)) {
+    launchSingleTop = true
+}
+
+/** Push the map above the board so Back returns to its existing state. */
+fun NavController.showStopMapFromArrivals(reveal: StopReveal) {
+    navigate(NavRoutes.HOME)
+    revealStopOnMap(reveal)
+}
+
+fun NavController.showRouteMapFromArrivals(request: ShowRouteRequest) {
+    navigate(NavRoutes.HOME)
+    revealRouteOnMap(request)
+}
 
 /**
  * Navigate to an in-app [route], popping up to HOME and de-duping the top — the single navigation
@@ -97,7 +139,7 @@ fun SavedStateHandle.consumeRouteReveal(): ShowRouteRequest? {
 /**
  * "Show me this stop" — the one currency every stop affordance in the app speaks, whether it is a
  * navigation hand-back ([revealStopOnMap]), an external launch translated at the entry boundary
- * ([IntentRouteMapper.stopRevealForIntent]), or a list row handing one to its host.
+ * ([IntentRouteMapper.routeForIntent]), or a list row handing one to its host.
  *
  * Only [stopId] is required, because it is the only thing every requester has: a deep link, an FCM
  * arrival push, a pinned shortcut and a reminder row carry nothing else. [name] is the arrivals sheet's

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
@@ -37,7 +37,7 @@ fun NavController.navigateBackOrFinish() {
 }
 
 /** Toolbar Up stays in the app, even when Android Back would exit a shortcut/launcher root. */
-fun NavController.navigateUpInApp(parentRoute: String = NavRoutes.HOME) {
+fun NavController.navigateUpFromArrivals(parentRoute: String) {
     if (currentBackStackEntry?.savedStateHandle?.get<Boolean>(LAUNCH_ROOT) == true) {
         navigateFromHome(parentRoute)
         // A shortcut has no list underneath it. Its parent becomes the new launch root, so
@@ -58,12 +58,12 @@ fun NavController.showArrivals(reveal: StopReveal) = navigate(NavRoutes.arrivals
 /** Push the map above the board so Back returns to its existing state. */
 fun NavController.showStopMapFromArrivals(reveal: StopReveal) {
     navigate(NavRoutes.HOME)
-    revealStopOnMap(reveal)
+    getBackStackEntry(NavRoutes.HOME).savedStateHandle.putStopReveal(reveal)
 }
 
 fun NavController.showRouteMapFromArrivals(request: ShowRouteRequest) {
     navigate(NavRoutes.HOME)
-    revealRouteOnMap(request)
+    getBackStackEntry(NavRoutes.HOME).savedStateHandle.putRouteReveal(request)
 }
 
 /**
@@ -156,13 +156,15 @@ data class StopReveal(
 
 /** Reveal the map focused on [reveal]'s stop, popping back to HOME. */
 fun NavController.revealStopOnMap(reveal: StopReveal) {
-    getBackStackEntry(NavRoutes.HOME).savedStateHandle.apply {
-        set(RESULT_MAP_STOP_ID, reveal.stopId)
-        set(RESULT_MAP_STOP_NAME, reveal.name)
-        set(RESULT_MAP_STOP_LAT, reveal.point?.latitude)
-        set(RESULT_MAP_STOP_LON, reveal.point?.longitude)
-    }
+    getBackStackEntry(NavRoutes.HOME).savedStateHandle.putStopReveal(reveal)
     popBackStack(NavRoutes.HOME, false)
+}
+
+internal fun SavedStateHandle.putStopReveal(reveal: StopReveal) {
+    set(RESULT_MAP_STOP_ID, reveal.stopId)
+    set(RESULT_MAP_STOP_NAME, reveal.name)
+    set(RESULT_MAP_STOP_LAT, reveal.point?.latitude)
+    set(RESULT_MAP_STOP_LON, reveal.point?.longitude)
 }
 
 /** Reveal the stop [stopId] on the map, knowing nothing else about it. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/NavRoutes.kt
@@ -187,10 +187,12 @@ object NavRoutes {
     /** Builds a navigable [ROUTE_INFO] route, encoding the id (route ids can contain `/`, spaces). */
     fun routeInfo(routeId: String): String = "routeInfo/${Uri.encode(routeId)}"
 
-    // --- Stop nav-args ---
-    // A stop is no longer a destination of its own: showing one is map state (focus + the arrivals
-    // drawer), reached through `NavController.revealStopOnMap` rather than a route (#1898). These keys
-    // survive because the trip destinations below carry a stop alongside their trip.
+    // --- Mapless arrivals and shared stop nav-args ---
+    const val ARRIVALS = "arrivals/{stopId}?stopName={stopName}"
+
+    fun arrivals(stopId: String, stopName: String? = null): String = "arrivals/${Uri.encode(stopId)}" +
+        if (stopName != null) "?stopName=${Uri.encode(stopName)}" else ""
+
     const val ARG_STOP_ID = "stopId"
     const val ARG_STOP_NAME = "stopName"
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1532,4 +1532,9 @@
     <string name="tutorial_scripted_arrival_time_text">Time shows one departure per row, with the earliest first. Use Time and Route to switch views whenever you like. Settings controls which view new drawers open in.</string>
     <string name="arrival_display_sample_downtown">Downtown</string>
     <string name="arrival_display_sample_northgate">Northgate</string>
+    <string name="view_arrivals_only">View arrivals only</string>
+    <string name="arrivals_board_title">Arrivals</string>
+    <string name="home_map">Map</string>
+    <string name="stop_add_star">Add star to stop</string>
+    <string name="stop_remove_star">Remove star from stop</string>
 </resources>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeStartDestinationTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeStartDestinationTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.onebusaway.android.testing.FakePreferencesRepository
+import org.onebusaway.android.ui.nav.NavRoutes
+
+class HomeStartDestinationTest {
+    @Test
+    fun `honors March selections and safely falls back for retired sections`() {
+        val prefs = FakePreferencesRepository()
+        assertEquals(NavRoutes.HOME, prefs.homeStartDestination())
+        listOf(
+            1 to NavRoutes.HOME_STARRED_STOPS,
+            2 to NavRoutes.HOME_STARRED_ROUTES,
+            3 to NavRoutes.MY_REMINDERS,
+            8 to NavRoutes.HOME,
+            -1 to NavRoutes.HOME
+        ).forEach { (oldValue, route) ->
+            prefs.setInt(HOME_SECTION_KEY, oldValue)
+            assertEquals(route, prefs.homeStartDestination())
+        }
+    }
+
+    @Test
+    fun `detail and settings visits preserve the section but choosing Map resets it`() {
+        val prefs = FakePreferencesRepository()
+        prefs.rememberHomeSection(NavRoutes.HOME_STARRED_STOPS)
+        prefs.rememberHomeSection(NavRoutes.SETTINGS)
+        prefs.rememberHomeSection("arrivals/stop")
+        assertEquals(NavRoutes.HOME_STARRED_STOPS, prefs.homeStartDestination())
+        prefs.rememberHomeSection(NavRoutes.HOME)
+        assertEquals(NavRoutes.HOME, prefs.homeStartDestination())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -2283,6 +2283,15 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `first mapless launch resolves the region without a map permission callback`() = runTest {
+        val region = FakeRegionRepository()
+        viewModel(regionRepo = region, startupRepo = FakeStartupPreferencesRepository(initial = true))
+            .onHomeStarted(hasLocationPermission = false, mapless = true)
+        advanceUntilIdle()
+        assertEquals(1, region.refreshCount)
+    }
+
+    @Test
     fun `first launch with permission checks the region now`() = runTest {
         val region = FakeRegionRepository()
         viewModel(regionRepo = region, startupRepo = FakeStartupPreferencesRepository(initial = true))

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/LaunchIntentChannelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/LaunchIntentChannelTest.kt
@@ -51,7 +51,7 @@ class LaunchIntentChannelTest {
     @Test
     fun `an item submitted before the collector subscribes is not lost`() = runTest {
         val channel = LaunchIntentChannel<String>()
-        channel.submit("home") // staged in onCreate, before the NavHost (collector) composes
+        channel.submit("home") // staged before the NavHost (collector) composes
 
         val received = mutableListOf<String>()
         val job = launch { channel.items.collect { received.add(it) } }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/IntentRouteMapperTest.kt
@@ -89,9 +89,9 @@ class IntentRouteMapperTest {
     // --- FCM arrival payload (present-ness short-circuits) ---
 
     @Test
-    fun `an arrival payload with a parsed stop id focuses that stop on the map`() {
+    fun `an arrival payload with a parsed stop id opens that stop on the arrivals board`() {
         assertEquals(
-            RouteDecision.StopOnMap(StopReveal("1_75403")),
+            RouteDecision.Arrivals(StopReveal("1_75403")),
             decide(RouteIntent(hasArrivalPayload = true, arrivalStopId = "1_75403"))
         )
     }
@@ -155,7 +155,7 @@ class IntentRouteMapperTest {
     @Test
     fun `a stops data-URI focuses the stop, carrying the optional pre-load title`() {
         assertEquals(
-            RouteDecision.StopOnMap(StopReveal("1_75403", "Pike St & 3rd Ave")),
+            RouteDecision.Arrivals(StopReveal("1_75403", "Pike St & 3rd Ave")),
             decide(
                 RouteIntent(
                     pathSegments = listOf(DeepLinkUris.STOPS_PATH, "1_75403"),
@@ -184,9 +184,9 @@ class IntentRouteMapperTest {
     // --- cross-platform (iOS-parity) deep links; the URI parsing itself is ExternalDeepLinksTest ---
 
     @Test
-    fun `a view-stop deep link focuses that stop on the map`() {
+    fun `a view-stop deep link opens that stop on the arrivals board`() {
         assertEquals(
-            RouteDecision.StopOnMap(StopReveal("1_75403")),
+            RouteDecision.Arrivals(StopReveal("1_75403")),
             decide(RouteIntent(deepLink = ExternalDeepLinks.Target.Stop("1_75403")))
         )
     }
@@ -209,7 +209,7 @@ class IntentRouteMapperTest {
     @Test
     fun `a deep-link target beats the content data-URI path branches`() {
         assertEquals(
-            RouteDecision.StopOnMap(StopReveal("1_75403")),
+            RouteDecision.Arrivals(StopReveal("1_75403")),
             decide(
                 RouteIntent(
                     deepLink = ExternalDeepLinks.Target.Stop("1_75403"),


### PR DESCRIPTION
Opening a saved stop currently forces riders into the map and arrivals drawer. Restore a dedicated mapless arrivals board within the existing Compose navigation so riders can check arrivals and choose when to open the map.

Closes #2283.

- Open stop-list selections, stop deep links, and existing home-screen stop shortcuts in the board. Explicit map actions continue to open the map.
- Reuse the shared arrivals list, Time/Route picker, favorites, and arrival actions. Add Create shortcut to the stop banner overflow menu.
- Restore the remembered home section using the March-era preference. The Starred Stops toolbar Back button selects the map and restores map-first launching, without adding a duplicate map icon.
- Keep toolbar Up inside the app after shortcut launches while retaining normal system Back behavior. Visiting the map preserves the board’s scroll position and display mode; remove the crossfade only between the board and map.
- Defer map initialization on mapless launches and start arrivals polling once endpoint resolution is active, including custom API URLs without a region object.

Validation:

- [x] Format changes with `./gradlew spotlessApply`; `git diff --check` passes.
- [x] Build `assembleObaGoogleDebug` and `assembleObaGoogleDebugAndroidTest`.
- [x] Run 164 focused JVM tests covering region state, arrivals, home behavior, launch preferences, intent routing, and map reveal results.
- [x] Run all 8 `ArrivalsNavigationTest` instrumentation tests on a connected Pixel 7 Pro via `am instrument`, covering shortcut navigation, saved state, board/map round trips, and transition timing.
- [x] The new `LaunchIntentEffectTest` (recreation before the cold launch intent is collected) passed in CI's API 33 instrumented run; it has not been run on a physical device.

The updated app is installed on the test phone. The full instrumentation suite was not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a map-free arrivals board with refresh, favorites, alerts, trip details, and map access.
  * Stop links, shortcuts, notifications, recents, saved stops, and reminders now open arrivals directly.
  * Added options to view arrivals only, create stop shortcuts, and return to the map.
  * Added a compact stop icon setting.
  * Home navigation remembers the selected section and restores it when reopening the app.

* **Bug Fixes**
  * Preserved arrivals display and scroll state when switching to the map and back.
  * Improved back navigation and first-launch handling for stop links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->