### PR TITLE
Update Spotless and MapLibre while retaining API 23 support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ playPublisher = "4.1.1"
 # google-java-format (the handful of *.java files). See root build.gradle.kts's spotless {} block
 # and .editorconfig (ktlint_code_style = android_studio). ktlint's version is pinned separately so
 # formatting output is reproducible across machines regardless of Spotless's bundled default.
-spotless = "8.10.0"
+spotless = "8.10.1"
 ktlint = "1.7.0"
 # Lint tooling tracks AGP: lintVersion == agpVersion + 23.0.0 (AGP 9.2.0 -> 32.2.0). Consumed by
 # the :lint-rules module.
@@ -60,6 +60,7 @@ datastore = "1.2.1"
 work = "2.11.2"
 room = "2.8.4"
 lifecycle = "2.11.0"
+# Navigation 2.10.0 requires minSdk 24; keep 2.9.x while supporting API 23 (#2280).
 navigationCompose = "2.9.8"
 hiltNavigationCompose = "1.4.0"
 composeBom = "2026.08.00"
@@ -69,7 +70,7 @@ kotlinxSerializationJson = "1.11.0"
 coroutines = "1.11.0"
 material = "1.14.0"
 gtfsRealtime = "0.2.0"
-maplibre = "13.5.1"
+maplibre = "13.6.0"
 # Test-only
 androidxTestRunner = "1.7.0"
 androidxTestJunit = "1.3.0"

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.statusBars
@@ -856,7 +857,7 @@ fun HomeScreen(
                                 } else {
                                     0.dp
                                 },
-                                navigationBarInset = peekBottomPadding
+                                navigationBarInset = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
                             )
                             Box(Modifier.fillMaxSize()) {
                                 // The map, with the chrome drawn over it: weather/donation/route-header/survey. The


### PR DESCRIPTION
Navigation 2.10.0 makes the manifest merge fail because it requires API 24 while the app supports API 23. Apply the compatible updates from #2280: Spotless 8.10.0 → 8.10.1 and MapLibre 13.5.1 → 13.6.0. Keep Navigation at 2.9.8 and document the API constraint in the version catalog.

Current main also fails compilation after #2278 because `HomeScreen` references the removed `peekBottomPadding`. Read the navigation-bar bottom inset directly to preserve the intended FAB clearance and restore compilation.

Supersedes the dependency updates proposed in #2280.

Validation passed locally:
- Manifest merging for `obaGoogleDebug` and `obaMaplibreDebug` with minSdk 23.
- Kotlin compilation for both platforms with `-PwarningsAsErrors=true`.
- `testObaGoogleDebugUnitTest` and `testObaMaplibreDebugUnitTest` with `-PwarningsAsErrors=true`.
- `git diff --check`.

- [x] Format changes with `./gradlew spotlessApply`; `spotlessCheck` passed.
- [ ] Run `connectedObaGoogleDebugAndroidTest` — left to the PR's API 33 CI workflow; not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map control positioning by using the device’s navigation-bar inset, helping prevent overlap with system navigation areas.

- **Chores**
  - Updated mapping and code-formatting components.
  - Documented the Android API compatibility constraint for the current navigation component version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->