### PR TITLE
Open feedback in email apps and keep region messages above navigation bars

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/FeedbackEmailIntentTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/FeedbackEmailIntentTest.kt
@@ -3,7 +3,6 @@ package org.onebusaway.android.util.test
 import android.content.ActivityNotFoundException
 import android.content.ContextWrapper
 import android.content.Intent
-import android.content.IntentFilter
 import androidx.core.net.MailTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -22,10 +21,7 @@ class FeedbackEmailIntentTest {
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
 
     // Capture the real launch without opening a mail app or sending any feedback.
-    private class EmailContext(val noEmailApp: Boolean = false) :
-        ContextWrapper(
-            InstrumentationRegistry.getInstrumentation().targetContext
-        ) {
+    private class EmailContext(private val noEmailApp: Boolean = false) : ContextWrapper(InstrumentationRegistry.getInstrumentation().targetContext) {
         lateinit var launched: Intent
 
         override fun startActivity(intent: Intent) {
@@ -42,11 +38,8 @@ class FeedbackEmailIntentTest {
 
         val intent = context.launched
         assertEquals(Intent.ACTION_SENDTO, intent.action)
+        assertEquals("mailto", intent.scheme)
         assertNull(intent.type)
-        val emailFilter = IntentFilter(Intent.ACTION_SENDTO).apply { addDataScheme("mailto") }
-        assertTrue(emailFilter.match(context.contentResolver, intent, false, "test") >= 0)
-        val shareFilter = IntentFilter(Intent.ACTION_SEND).apply { addDataType("*/*") }
-        assertTrue(shareFilter.match(context.contentResolver, intent, false, "test") < 0)
 
         // AndroidX implements RFC 6068; android.net.MailTo decodes before splitting query fields
         // and misreads encoded ampersands inside a report body as additional headers.

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/FeedbackEmailIntentTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/util/test/FeedbackEmailIntentTest.kt
@@ -1,0 +1,93 @@
+package org.onebusaway.android.util.test
+
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.net.MailTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onebusaway.android.R
+import org.onebusaway.android.util.ExternalIntents
+
+@RunWith(AndroidJUnit4::class)
+class FeedbackEmailIntentTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+    // Capture the real launch without opening a mail app or sending any feedback.
+    private class EmailContext(val noEmailApp: Boolean = false) :
+        ContextWrapper(
+            InstrumentationRegistry.getInstrumentation().targetContext
+        ) {
+        lateinit var launched: Intent
+
+        override fun startActivity(intent: Intent) {
+            launched = intent
+            if (noEmailApp) throw ActivityNotFoundException("No email app installed")
+        }
+    }
+
+    @Test
+    fun feedbackOpensEmailComposerWithRecipientAndReport() {
+        val context = EmailContext()
+        val email = context.getString(R.string.ri_app_feedback_email)
+        instrumentation.runOnMainSync { ExternalIntents.sendEmail(context, email, null) }
+
+        val intent = context.launched
+        assertEquals(Intent.ACTION_SENDTO, intent.action)
+        assertNull(intent.type)
+        val emailFilter = IntentFilter(Intent.ACTION_SENDTO).apply { addDataScheme("mailto") }
+        assertTrue(emailFilter.match(context.contentResolver, intent, false, "test") >= 0)
+        val shareFilter = IntentFilter(Intent.ACTION_SEND).apply { addDataType("*/*") }
+        assertTrue(shareFilter.match(context.contentResolver, intent, false, "test") < 0)
+
+        // AndroidX implements RFC 6068; android.net.MailTo decodes before splitting query fields
+        // and misreads encoded ampersands inside a report body as additional headers.
+        val draft = MailTo.parse(requireNotNull(intent.data))
+        assertEquals(email, draft.to)
+        assertArrayEquals(arrayOf(email), intent.getStringArrayExtra(Intent.EXTRA_EMAIL))
+        assertEquals(context.getString(R.string.bug_report_subject, context.getString(R.string.app_name)), draft.subject)
+        assertEquals(intent.getStringExtra(Intent.EXTRA_SUBJECT), draft.subject)
+        assertEquals(intent.getStringExtra(Intent.EXTRA_TEXT), draft.body)
+        assertFalse(draft.body.isNullOrBlank())
+    }
+
+    @Test
+    fun locationAndTripUrlSurviveMailtoEncodingWithoutAddingHeaders() {
+        val context = EmailContext()
+        val email = "feedback+android@example.com"
+        val location = "47.61, -122.33 (Pine & 3rd #1 / café)"
+        val tripUrl = "https://example.com/plan?from=A%20B&to=C+D&subject=other#route"
+        instrumentation.runOnMainSync {
+            ExternalIntents.sendEmail(context, email, location, tripUrl, true)
+        }
+
+        val draft = MailTo.parse(requireNotNull(context.launched.data))
+        assertEquals(email, draft.to)
+        assertEquals(
+            context.getString(R.string.bug_report_subject_trip_plan_fail, context.getString(R.string.app_name)),
+            draft.subject
+        )
+        assertEquals(context.launched.getStringExtra(Intent.EXTRA_TEXT), draft.body)
+        val body = requireNotNull(draft.body)
+        assertTrue(body.contains(location))
+        assertTrue(body.contains(tripUrl))
+        assertEquals(setOf("to", "subject", "body"), draft.headers?.keys)
+    }
+
+    @Test
+    fun missingEmailAppIsHandledWithoutLaunchingAShareChooser() {
+        val context = EmailContext(noEmailApp = true)
+        instrumentation.runOnMainSync {
+            ExternalIntents.sendEmail(context, "feedback@example.com", null)
+        }
+        assertEquals(Intent.ACTION_SENDTO, context.launched.action)
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.statusBars
@@ -368,6 +370,7 @@ fun HomeScreen(
                 // clearance is the same one every other top-of-map overlay insets by, so the sheet's top
                 // edge lines up with them instead of drifting when the FAB row is resized.
                 val topSystemInsetPx = WindowInsets.safeDrawing.getTop(density)
+                val navigationBarInsetPx = WindowInsets.navigationBars.getBottom(density)
                 val maxSheetContentDp = with(density) {
                     arrivalsSheetCeiling(
                         windowHeight = LocalWindowInfo.current.containerSize.height.toDp(),
@@ -671,7 +674,9 @@ fun HomeScreen(
                         BottomSheetScaffold(
                             modifier = Modifier.fillMaxSize(),
                             scaffoldState = scaffoldState,
-                            snackbarHost = { SnackbarHost(snackbarHostState) },
+                            snackbarHost = {
+                                SnackbarHost(snackbarHostState, Modifier.navigationBarsPadding())
+                            },
                             // The animated peek: real peek while shown, 0 while hidden — slides the sheet in/out.
                             sheetPeekHeight = visiblePeekDp,
                             // Paint the sheet container (incl. the strip behind the drag handle) the same color
@@ -856,7 +861,7 @@ fun HomeScreen(
                                 } else {
                                     0.dp
                                 },
-                                navigationBarInset = peekBottomPadding
+                                navigationBarInset = with(density) { navigationBarInsetPx.toDp() }
                             )
                             Box(Modifier.fillMaxSize()) {
                                 // The map, with the chrome drawn over it: weather/donation/route-header/survey. The

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -85,6 +84,7 @@ import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_HEIGHT
 import org.onebusaway.android.ui.compose.components.DRAG_HANDLE_VERTICAL_PADDING
 import org.onebusaway.android.ui.compose.components.DragHandleBar
 import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.ui.compose.navigationBarBottomPadding
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.home.arrivals.ArrivalsSheetHost
 import org.onebusaway.android.ui.home.arrivals.ServiceAlertsDialog
@@ -370,7 +370,6 @@ fun HomeScreen(
                 // clearance is the same one every other top-of-map overlay insets by, so the sheet's top
                 // edge lines up with them instead of drifting when the FAB row is resized.
                 val topSystemInsetPx = WindowInsets.safeDrawing.getTop(density)
-                val navigationBarInsetPx = WindowInsets.navigationBars.getBottom(density)
                 val maxSheetContentDp = with(density) {
                     arrivalsSheetCeiling(
                         windowHeight = LocalWindowInfo.current.containerSize.height.toDp(),
@@ -861,7 +860,7 @@ fun HomeScreen(
                                 } else {
                                     0.dp
                                 },
-                                navigationBarInset = with(density) { navigationBarInsetPx.toDp() }
+                                navigationBarInset = navigationBarBottomPadding()
                             )
                             Box(Modifier.fillMaxSize()) {
                                 // The map, with the chrome drawn over it: weather/donation/route-header/survey. The

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -345,11 +345,6 @@ object ExternalIntents {
             }
         }
 
-        val send = Intent(Intent.ACTION_SEND)
-        send.putExtra(
-            Intent.EXTRA_EMAIL,
-            arrayOf(email)
-        )
         // Show trip planner subject line if we have a trip planning URL
         val appName = context.getString(R.string.app_name)
         val subject: String
@@ -366,11 +361,22 @@ object ExternalIntents {
                 subject = context.getString(R.string.bug_report_subject_trip_plan, appName)
             }
         }
-        send.putExtra(Intent.EXTRA_SUBJECT, subject)
-        send.putExtra(Intent.EXTRA_TEXT, body)
-        send.setType("message/rfc822")
+        // SEND + message/rfc822 also matches generic sharing apps (#2296). SENDTO + mailto
+        // opens an email composer. Put the draft in the URI as well as extras for email clients
+        // that only read mailto fields; encode each value so report URLs cannot become headers.
+        val uri = (
+            "mailto:${Uri.encode(email, "@")}" +
+                "?subject=${Uri.encode(subject)}&body=${Uri.encode(body)}"
+            ).toUri()
+        val send = Intent(Intent.ACTION_SENDTO, uri).apply {
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(email))
+            putExtra(Intent.EXTRA_SUBJECT, subject)
+            putExtra(Intent.EXTRA_TEXT, body)
+        }
         try {
-            context.startActivity(Intent.createChooser(send, subject))
+            // Launch directly so a missing email handler reaches the error below. Wrapping this
+            // in a chooser can open an empty system chooser instead. Android resolves email apps.
+            context.startActivity(send)
         } catch (e: ActivityNotFoundException) {
             Toast.makeText(context, R.string.bug_report_error, Toast.LENGTH_LONG)
                 .show()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/util/ExternalIntents.kt
@@ -361,21 +361,16 @@ object ExternalIntents {
                 subject = context.getString(R.string.bug_report_subject_trip_plan, appName)
             }
         }
-        // SEND + message/rfc822 also matches generic sharing apps (#2296). SENDTO + mailto
-        // opens an email composer. Put the draft in the URI as well as extras for email clients
-        // that only read mailto fields; encode each value so report URLs cannot become headers.
-        val uri = (
-            "mailto:${Uri.encode(email, "@")}" +
-                "?subject=${Uri.encode(subject)}&body=${Uri.encode(body)}"
-            ).toUri()
+        // SENDTO + mailto restricts feedback to email apps (#2296). Encode the draft in the URI
+        // as well as extras for clients that read only mailto fields, including reports with URLs.
+        val uri = "mailto:${Uri.encode(email, "@")}?subject=${Uri.encode(subject)}&body=${Uri.encode(body)}".toUri()
         val send = Intent(Intent.ACTION_SENDTO, uri).apply {
             putExtra(Intent.EXTRA_EMAIL, arrayOf(email))
             putExtra(Intent.EXTRA_SUBJECT, subject)
             putExtra(Intent.EXTRA_TEXT, body)
         }
         try {
-            // Launch directly so a missing email handler reaches the error below. Wrapping this
-            // in a chooser can open an empty system chooser instead. Android resolves email apps.
+            // A chooser can open even without an email handler; launch directly to catch that case.
             context.startActivity(send)
         } catch (e: ActivityNotFoundException) {
             Toast.makeText(context, R.string.bug_report_error, Toast.LENGTH_LONG)


### PR DESCRIPTION
The app feedback action used `ACTION_SEND` with `message/rfc822`, which opens a generic share sheet. Selecting an email app could still produce a correctly addressed report, but unrelated sharing apps also appeared. On the connected phone the old intent matched 13 destinations, including Drive, Slack, and Kindle. The reporter's exact reason for abandoning the flow remains unconfirmed.

Use `ACTION_SENDTO` with a `mailto:` URI to open an email composer. Preserve the recipient, subject, and diagnostic body in both encoded URI fields and intent extras. Launch directly so a missing email handler reaches the existing error message. Feedback still requires an email app.

Also apply navigation-bar padding to the home snackbar host so the region-found message stays above the system controls. Related PR #2278 fixed the map controls, but did not inset this snackbar. Replace its stale `peekBottomPadding` reference with the current navigation-bar inset; the unresolved reference otherwise prevents main from compiling.

Fixes #2296.

Validation:

- [x] Format changes with `./gradlew spotlessApply`.
- [x] Run `connectedObaGoogleDebugAndroidTest` with `-Pandroid.testInstrumentationRunnerArguments.class=org.onebusaway.android.util.test.FeedbackEmailIntentTest -PwarningsAsErrors=true`: all 3 tests pass on a Pixel 7 Pro running Android 17. Covers email-only intent matching, recipient/report preservation and reserved characters, and a missing email handler. This was the targeted suite, not the full instrumented suite.
- The app and test APKs compile with warnings treated as errors.
- Android resolves the new intent to Gmail's composer on the connected phone. Tests intercept the launch; no feedback is sent. The reported Moto device and snackbar layout have not been visually tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report email handling by opening the device’s email composer with the recipient, subject, and message details filled in.
  * Ensured report emails do not appear in general sharing options when no email app is available.
  * Preserved report details correctly when composing emails, including location and trip links.
  * Adjusted the arrivals notification and map controls to account for the navigation bar, improving positioning on supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->