### PR TITLE
Stop Dependabot re-proposing navigation 2.10.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
         update-types:
           - minor
           - patch
+    # Navigation 2.10.0 raised its own minSdk to 24; the app is minSdk 23, so the
+    # manifest merge fails outright. The grouped bump has proposed it three times
+    # (#2280, #2298, #2300) and been reverted each time. Drop this once minSdk
+    # reaches 24.
+    ignore:
+      - dependency-name: "androidx.navigation:*"
+        versions: [">=2.10.0"]
     labels:
       - dependencies
 


### PR DESCRIPTION
## Problem

`androidx.navigation` 2.10.0 raised its own `minSdk` to 24. The app is `minSdk 23`, so the bump fails manifest merging ~48s in, before anything compiles:

```
> Task :onebusaway-android:processObaGoogleDebugMainManifest FAILED
Manifest merger failed : uses-sdk:minSdkVersion 23 cannot be smaller than
version 24 declared in library [androidx.navigation:navigation-runtime-android:2.10.0]
```

Because it's part of the `gradle-minor-and-patch` group, it takes the rest of the grouped update down with it — the other bumps in the PR never get exercised at all.

This has now happened three times: #2280 (closed), #2298 (reverted at merge), and #2300 (currently failing). Each round costs a CI failure and a manual revert. `gradle/libs.versions.toml` grew a warning comment after #2280, but a comment can't stop Dependabot — nothing in `.github/dependabot.yml` ever told it to leave the dependency alone.

## Change

Add the `ignore` rule that was the missing half of the #2280 cleanup:

```yaml
ignore:
  - dependency-name: "androidx.navigation:*"
    versions: [">=2.10.0"]
```

The wildcard covers `navigation-runtime` and friends, not just `navigation-compose` — the transitive `navigation-runtime-android` is what actually carries the `minSdk 24` manifest.

Drop this rule once `minSdk` reaches 24.

## Related

#2300 is fixed separately on its own branch, keeping its AGP and Spotless bumps and holding navigation at 2.9.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ViPzphSSZiLqnAHvhS9kw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated maintenance settings to preserve compatibility with the app’s currently supported Android versions.
  - Prevented incompatible framework updates from being applied automatically until the app’s minimum Android version is raised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->