### PR TITLE
Increase arrivals board clock time text size from 10sp to 12sp (#2292)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/EtaStrip.kt
@@ -611,7 +611,7 @@ internal fun EtaPill(
     val nowSize = 26.sp
     val labelSize = 14.sp
     val indicatorSize = 13.8.dp // 1.5× the base accent, then +15%; overlaid, so the extra size overlaps, not widens
-    val clockTimeSize = 10.sp
+    val clockTimeSize = 12.sp
     val topPadding = 3.dp
     val bottomPadding = 3.5.dp
     // Negative: tightLineStyle's trim gets the ETA row and clock-time line close but not flush (some


### PR DESCRIPTION
## Summary

Fixes #2292

The arrival time text inside ETA pills was too small to read comfortably.

## What was changed and why

`clockTimeSize` in `EtaPill` (`EtaStrip.kt`) bumped from `10sp` → `12sp`.

This single constant controls two elements:

- The scheduled/predicted arrival time shown below the ETA countdown in each pill (e.g. "3:05 PM")
- The struck-through old timetable time displayed when a real-time prediction differs from the schedule (`CorrectedClockTime`)

The dominant ETA countdown numbers (28sp/26sp) are unchanged — only the subline clock text grows.

## Testing

- Navigate to any stop in the arrivals screen — the clock time text below each ETA pill is now larger and more legible
- For the strikethrough case: find a stop where the real-time prediction differs from the timetable; the crossed-out old time will also be visibly larger
- Compose previews `EtaStripCorrectedPreview` and `EtaPillVariantsPreview` in `EtaStrip.kt` render both cases without a device

## Screenshots

| Before | After |
|--------|-------|
| <img width="320" alt="Before" src="https://github.com/user-attachments/assets/fb0a492d-f1a9-49e8-ae48-dbed7f38641e" /> | <img width="320" alt="After" src="https://github.com/user-attachments/assets/9cc7ce5f-f43d-493c-9741-060b5ae64004" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the timetable clock-time text size within ETA pills for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->