### PR TITLE
Degrade stop selection state after 4h of inactivity (#2294)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -38,6 +38,7 @@ internal object CurrentFocusPersistence {
     private const val KEY_ROUTE_LEG_NAMES = "home.currentFocus.route.legNames"
     private const val KEY_ROUTE_LEG_DIRECTIONS = "home.currentFocus.route.legDirections"
     private const val KEY_ROUTE_SELECTED_TRIP = "home.currentFocus.route.selectedTripId"
+    private const val KEY_FOCUS_TIMESTAMP = "home.currentFocus.timestamp"
 
     private const val FOCUS_NONE = "none"
     private const val FOCUS_STOP = "stop"
@@ -46,7 +47,13 @@ internal object CurrentFocusPersistence {
     private const val FOCUS_DIRECTIONS = "directions"
     private const val NO_DIRECTION = Int.MIN_VALUE
 
-    fun read(state: SavedStateHandle): CurrentFocus {
+    // Focus is discarded after 4 hours of inactivity (#2294).
+    internal const val FOCUS_EXPIRY_MS = 4 * 60 * 60 * 1000L
+
+    fun read(state: SavedStateHandle, now: Long = System.currentTimeMillis()): CurrentFocus {
+        val timestamp = state.get<Long>(KEY_FOCUS_TIMESTAMP)
+        if (timestamp != null && now - timestamp > FOCUS_EXPIRY_MS) return CurrentFocus.None
+
         val stop = readStop(state)
         return when (state.get<String>(KEY_FOCUS_KIND)) {
             FOCUS_STOP -> stop?.let { CurrentFocus.Stop(it, readStopRoute(state)) }
@@ -65,7 +72,8 @@ internal object CurrentFocusPersistence {
         }
     }
 
-    fun write(state: SavedStateHandle, focus: CurrentFocus) {
+    fun write(state: SavedStateHandle, focus: CurrentFocus, now: Long = System.currentTimeMillis()) {
+        state[KEY_FOCUS_TIMESTAMP] = now
         state[KEY_FOCUS_KIND] = when (focus) {
             CurrentFocus.None -> FOCUS_NONE
             is CurrentFocus.Stop -> FOCUS_STOP


### PR DESCRIPTION
## Summary

Fixes #2294

The app was restoring the last selected stop indefinitely, requiring extra taps to dismiss it before searching again.

## What was changed and why

Added a 4-hour expiry to the saved focus state in `CurrentFocusPersistence.kt`.

- `write()` stamps the current time to `KEY_FOCUS_TIMESTAMP` on every focus change
- `read()` returns `CurrentFocus.None` if the saved timestamp is older than `FOCUS_EXPIRY_MS` (4 hours)

In-session use resets the clock continuously, so the focus only expires when the app hasn't been interacted with for 4+ hours. Saves written before this change (no timestamp) are left untouched.

**Note on the 4-hour value:** This is a judgment call based on the typical transit task lifespan — long enough to cover a multi-hour journey without false positives, short enough to reliably reset between commutes. Happy to adjust if maintainers prefer a different threshold (e.g. 2 hours or 8 hours). The constant `FOCUS_EXPIRY_MS` is in one place and easy to change.

## Testing

- Focus a stop, then background the app for 4+ hours — on next open the map should show no selected stop
- Focus a stop and reopen within 4 hours — the stop should still be selected
- To test quickly: set `FOCUS_EXPIRY_MS` temporarily to a small value (e.g. `10_000L`), background and reopen after 10 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Persisted home-screen focus now expires after four hours, preventing outdated focus states from being restored.
  - Focus state records now include the time they were saved for more accurate restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->