### PR TITLE
Clear the 22 Android Lint errors failing the nightly

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/LaunchIntentEffectTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/LaunchIntentEffectTest.kt
@@ -144,7 +144,7 @@ class LaunchIntentEffectTest {
         channel = remember { LaunchIntentChannel() }
         nav = rememberNavController()
         CompositionLocalProvider(LocalLifecycleOwner provides owner) {
-            val launchReady = LaunchIntentEffect(nav, intent, channel.items) { handled.add(it) }
+            val launchReady = launchIntentEffect(nav, intent, channel.items) { handled.add(it) }
             ready = launchReady
             NavHost(nav, startDestination = NavRoutes.HOME) {
                 composable(NavRoutes.HOME) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/demo/DemoScenario.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/demo/DemoScenario.kt
@@ -176,6 +176,10 @@ object DemoScenario {
      * The service day [nowMs] falls in, as the epoch millis of local midnight in the agency's zone —
      * the `serviceDate` every OBA arrival and trip status carries.
      */
+    // UnwrappedClockValue: no clock is read here — this is a calendar computation over the caller's
+    // [nowMs], and the bare Long it returns is the wire contract for OBA's `serviceDate` field, which
+    // the demo responses carry unchanged (cf. TripDepartureTime.toEpochMillis).
+    @Suppress("UnwrappedClockValue")
     fun serviceDateMs(fixture: DemoTransitFixture, nowMs: Long): Long {
         val zone = runCatching { ZoneId.of(fixture.agency.timezone.orEmpty()) }.getOrElse { ZoneId.systemDefault() }
         return LocalDate.ofInstant(Instant.ofEpochMilli(nowMs), zone).atStartOfDay(zone).toInstant().toEpochMilli()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShape.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/extrapolation/math/prob/IncompleteGammaShape.kt
@@ -143,7 +143,10 @@ internal object IncompleteGammaShape {
     /** [level]'s table, evicting round-robin on a miss. */
     private fun tableFor(level: Double): DoubleArray {
         for (slot in 0 until CACHE_SIZE) {
-            if (levels[slot] == level) return tables[slot]!!
+            // Read the table first and hit on the pair: a slot is only this level's when it is both
+            // keyed to it and filled, which is what [levels] and [tables] being written together means.
+            val table = tables[slot]
+            if (table != null && levels[slot] == level) return table
         }
         val fresh = DoubleArray(TABLE_SIZE) { Double.NaN }
         levels[nextSlot] = level

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/VehicleBitmaps.kt
@@ -297,7 +297,6 @@ object VehicleBitmaps {
      * That rule: a vehicle without real-time reports nothing, whatever its status field says. It has no
      * observed occupancy, and a gray marker that grew a tab would be claiming data it doesn't have (#959).
      */
-    @VisibleForTesting
     internal fun occupancyBucket(vehicle: VehicleMarker): OccupancyBucket? = if (vehicle.isRealtime) OccupancyBucket.of(vehicle.status.occupancyStatus) else null
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/tracking/TripTrackingNotifications.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/tracking/TripTrackingNotifications.kt
@@ -20,6 +20,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -208,6 +209,10 @@ class TripTrackingNotifications @Inject constructor(
         return builder
     }
 
+    // The gate is at the only call site (above), but lint doesn't carry an SDK_INT check across a
+    // method boundary — so the level is restated here rather than suppressed, which also keeps any
+    // future caller honest.
+    @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
     private fun metricStyle(card: TrackedRouteCard): NotificationCompat.MetricStyle = NotificationCompat.MetricStyle()
         .setMetrics(
             card.metrics.map { metric ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -53,7 +53,6 @@ import org.onebusaway.android.ui.home.HomeNavHost
 import org.onebusaway.android.ui.home.HomeScreen
 import org.onebusaway.android.ui.home.HomeViewModel
 import org.onebusaway.android.ui.home.LaunchIntentChannel
-import org.onebusaway.android.ui.home.LaunchIntentEffect
 import org.onebusaway.android.ui.home.PaymentWarningDialog
 import org.onebusaway.android.ui.home.RegionPickerHost
 import org.onebusaway.android.ui.home.ReportTarget
@@ -62,6 +61,7 @@ import org.onebusaway.android.ui.home.donation.DonationViewModel
 import org.onebusaway.android.ui.home.help.HelpAction
 import org.onebusaway.android.ui.home.help.HelpViewModel
 import org.onebusaway.android.ui.home.launchDestination
+import org.onebusaway.android.ui.home.launchIntentEffect
 import org.onebusaway.android.ui.home.weather.WeatherViewModel
 import org.onebusaway.android.ui.nav.ExternalDeepLinks
 import org.onebusaway.android.ui.nav.IntentRouteMapper
@@ -95,7 +95,7 @@ class HomeActivity : AppCompatActivity() {
     lateinit var reminderRepository: org.onebusaway.android.reminders.ReminderRepository
 
     // Warm external launches queue until the NavHost is started, without dropping rapid, distinct
-    // intents (#1582). LaunchIntentEffect handles the cold intent separately, using its saved readiness
+    // intents (#1582). launchIntentEffect handles the cold intent separately, using its saved readiness
     // state to retry after recreation if the Activity was saved before collection started.
     private val launchIntents = LaunchIntentChannel<Intent>()
 
@@ -145,7 +145,7 @@ class HomeActivity : AppCompatActivity() {
             val navController = rememberNavController()
             AccessibilityAnalyticsEffect()
             HomeAnalyticsEffect(viewModel.analyticsEvents)
-            val launchReady = LaunchIntentEffect(navController, initialIntent, launchIntents.items, ::applyLaunchIntentSideEffects)
+            val launchReady = launchIntentEffect(navController, initialIntent, launchIntents.items, ::applyLaunchIntentSideEffects)
             // The welcome tutorial (now the Compose green welcome + map-stop spotlight sequence) is
             // started by HomeScreen off the same showWelcomeTutorial latch — no host effect needed.
             SettingsRehomeEffect(navController)
@@ -217,7 +217,7 @@ class HomeActivity : AppCompatActivity() {
 
     /**
      * A warm re-launch (singleTop) carrying an external screen intent — FCM CLEAR_TOP, the
-     * NavigationService reminder PendingIntent, a pinned shortcut. Surface it for [LaunchIntentEffect]
+     * NavigationService reminder PendingIntent, a pinned shortcut. Surface it for [launchIntentEffect]
      * (cold launches are handled from the Activity intent when composition starts).
      */
     override fun onNewIntent(intent: Intent) {
@@ -227,7 +227,7 @@ class HomeActivity : AppCompatActivity() {
     }
 
     /**
-     * The domain mutations a launch intent implies, run by [LaunchIntentEffect] before it opens the
+     * The domain mutations a launch intent implies, run by [launchIntentEffect] before it opens the
      * translated route: the `add-region`/FCM side effects (see [applyIntentSideEffects]) and the
      * "show tutorials again" welcome re-request. Kept off [IntentRouteMapper] so it stays a pure translator.
      */
@@ -273,7 +273,7 @@ class HomeActivity : AppCompatActivity() {
      * results from those extras — the itineraries are injected as-is (no re-plan). Restores the behavior
      * the retired standalone screen's `maybeRestoreFromIntent` used to provide (#1939).
      *
-     * No re-restore guard is needed here: LaunchIntentEffect saves whether the cold intent was handled,
+     * No re-restore guard is needed here: launchIntentEffect saves whether the cold intent was handled,
      * and the channel submits each warm `onNewIntent` once, so a config change doesn't re-fire this —
      * and the activity-scoped [tripPlanViewModel] keeps the restored results.
      */
@@ -348,7 +348,7 @@ class HomeActivity : AppCompatActivity() {
         // The web intent-filter is necessarily broader than the parser (it can't see the query string,
         // and pathPattern globs span '/'), so we can be launched for a onebusaway.co URL that routes
         // nowhere. Give it back to the browser instead of stranding the user on the map. This activity
-        // deliberately stays alive behind it: the same call runs for warm relaunches (LaunchIntentEffect
+        // deliberately stays alive behind it: the same call runs for warm relaunches (launchIntentEffect
         // feeds it both cold and onNewIntent intents), and finishing there would tear down a session the
         // user is in the middle of. If no browser will take it we fall through and land on home/map.
         // `deepLink == null` short-circuits the check for anything that already routed — a link with a

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTime.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalClockTime.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -117,11 +117,13 @@ internal fun CorrectedClockTime(
         )
         return
     }
-    val context = LocalContext.current
+    // Resources rather than LocalContext.current: a context read isn't configuration-aware, so the
+    // string would go stale across a locale or configuration change (lint: LocalContextResourcesRead).
+    val resources = LocalResources.current
     // Held across recompositions: a corrected pill recomposes on every ETA rollover, and this is a
     // getString + format each time. It only changes when a fresh poll brings a new pair.
-    val spoken = remember(clock, context) {
-        context.getString(R.string.stop_info_clock_corrected, corrects, clock.expected)
+    val spoken = remember(clock, resources) {
+        resources.getString(R.string.stop_info_clock_corrected, corrects, clock.expected)
     }
     // No verticalArrangement: [style]'s trimmed line boxes already sit flush, which is what these two
     // want — they are one reading, not two lines of text.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalRows.kt
@@ -473,14 +473,14 @@ fun RouteArrivalRow(
                 Spacer(Modifier.width(10.dp))
                 if (chronological) {
                     ChronologicalArrivalContent(
-                        representative,
-                        direction,
-                        stopLabel,
-                        routeActions,
-                        callbacks,
-                        anchors.eta,
-                        pillFocus,
-                        Modifier.weight(1f)
+                        arrival = representative,
+                        direction = direction,
+                        stopLabel = stopLabel,
+                        actions = routeActions,
+                        callbacks = callbacks,
+                        focus = pillFocus,
+                        modifier = Modifier.weight(1f),
+                        etaModifier = anchors.eta
                     )
                 } else {
                     Column(Modifier.weight(1f)) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalsPanel.kt
@@ -47,6 +47,7 @@ fun ArrivalsPanel(
     state: ArrivalsUiState,
     listState: LazyListState,
     handler: ArrivalActionHandler,
+    modifier: Modifier = Modifier,
     mapRouteColors: Map<RouteDirectionKey, Int> = emptyMap(),
     // The selected trip's band tint (#1990), or null when no vehicle is selected.
     selectedTripBandColor: Int? = null,
@@ -68,12 +69,13 @@ fun ArrivalsPanel(
 
     if (content == null) {
         // Reserve the available sheet space while the first response loads.
-        Box(Modifier.fillMaxSize()) {
+        Box(modifier.fillMaxSize()) {
             LinearProgressIndicator(Modifier.fillMaxWidth())
         }
     } else {
         ArrivalsList(
             content = content,
+            modifier = modifier,
             displayMode = displayMode,
             onDisplayModeChange = onDisplayModeChange,
             modeSwitchModifier = modeSwitchModifier,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ChronologicalArrivalContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ChronologicalArrivalContent.kt
@@ -47,9 +47,10 @@ internal fun ChronologicalArrivalContent(
     stopLabel: String?,
     actions: ArrivalActions?,
     callbacks: ArrivalRowCallbacks,
-    etaModifier: Modifier,
     focus: EtaPillFocus?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // A spotlight anchor for the ETA pill, threaded down from the host (see ArrivalRowAnchors).
+    etaModifier: Modifier = Modifier
 ) {
     val description: @Composable () -> Unit = {
         val decoration = strikeThroughIf(arrival.status == Status.CANCELED)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -294,7 +294,7 @@ fun HomeNavHost(
  * empty. Once handled, recreation restores navigation without replaying the launch's side effects.
  */
 @Composable
-internal fun LaunchIntentEffect(
+internal fun launchIntentEffect(
     navController: NavHostController,
     initialIntent: Intent,
     launchIntents: Flow<Intent>,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/LaunchIntentChannel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/LaunchIntentChannel.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
  *
  * Generic in [T] purely so the no-drop / in-order contract is unit-testable on the JVM without an Android
  * `Intent`; the Activity uses `LaunchIntentChannel<Intent>`. [items] is a cold [receiveAsFlow] with a
- * single intended collector: the NavHost's `LaunchIntentEffect`.
+ * single intended collector: the NavHost's `launchIntentEffect`.
  */
 class LaunchIntentChannel<T> {
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -473,9 +474,9 @@ internal fun DirectionStopEtaStrip(
         routeLeg = routeLeg,
         reachStop = reachStop,
         session = session,
-        rowPadding = rowPadding,
         pillFocus = pillFocus,
-        modifier = modifier
+        modifier = modifier,
+        rowPadding = rowPadding
     )
 }
 
@@ -485,9 +486,10 @@ private fun DirectionStopEtaStripContent(
     routeLeg: RouteLegRef,
     reachStop: ReachStop?,
     session: ArrivalsSession,
-    rowPadding: Modifier,
     pillFocus: EtaPillFocus?,
-    modifier: Modifier
+    modifier: Modifier = Modifier,
+    // The shared per-row inset every branch below composes onto [modifier].
+    rowPadding: Modifier = Modifier
 ) {
     val state by session.viewModel.state.collectAsStateWithLifecycle()
     val callbacks = rememberArrivalRowCallbacks(session.handler, session.viewModel)
@@ -552,13 +554,17 @@ private fun DirectionStopEtaStripContent(
  */
 @Composable
 private fun rememberReachStopMarker(reachStop: ReachStop): EtaStripMarker {
+    // The context is still needed for the *time* format (a device setting, not a resource); the
+    // resource read goes through LocalResources so it isn't stale after a configuration change
+    // (lint: LocalContextResourcesRead).
     val context = LocalContext.current
+    val resources = LocalResources.current
     val passedStateDescription = stringResource(R.string.directions_stop_eta_departure_missed)
-    return remember(reachStop, context, passedStateDescription) {
+    return remember(reachStop, context, resources, passedStateDescription) {
         EtaStripMarker(
             at = reachStop::resolvedAt,
             contentDescription = { at ->
-                context.getString(R.string.directions_stop_eta_reach_stop, DisplayFormat.formatTime(context, at.epochMs))
+                resources.getString(R.string.directions_stop_eta_reach_stop, DisplayFormat.formatTime(context, at.epochMs))
             },
             passedStateDescription = passedStateDescription
         )

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/FocusBanner.kt
@@ -171,12 +171,12 @@ fun FocusBanner(
     onToggleFavorite: () -> Unit,
     onShowAlerts: () -> Unit,
     onRecenterStop: () -> Unit,
-    stopMenu: StopFocusMenu? = null,
     onSelectDirection: (Int?) -> Unit,
     onFrameRoute: () -> Unit,
     onShowSchedule: (String) -> Unit,
     onHeight: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    stopMenu: StopFocusMenu? = null
 ) {
     Surface(
         modifier = modifier.onSizeChanged { onHeight(it.height) },

--- a/onebusaway-android/src/main/res/drawable/ic_add_white_24dp.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_add_white_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="#000000"
-        android:pathData="M11,13H5V11h6V5h2v6h6v2H13v6H11V13Z"/>
-</vector>

--- a/onebusaway-android/src/main/res/drawable/ic_layers_white_24dp.xml
+++ b/onebusaway-android/src/main/res/drawable/ic_layers_white_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="#000000"
-        android:pathData="M12,21.05l-9,-7L4.65,12.8L12,18.5l7.35,-5.7L21,14.05l-9,7ZM12,16L3,9l9,-7l9,7l-9,7ZM12,13.45L17.75,9L12,4.55L6.25,9L12,13.45Z"/>
-</vector>

--- a/onebusaway-android/src/main/res/values-es/strings.xml
+++ b/onebusaway-android/src/main/res/values-es/strings.xml
@@ -1030,7 +1030,6 @@
     <string name="close_donation_card">Cerrar tarjeta de donación</string>
     <string name="map_option_zoom_out">Alejar</string>
     <string name="map_option_zoom_in">Acercar</string>
-    <string name="map_option_layers_close">Cerrar botón de capas del mapa</string>
 
     <!-- Destination reminder -->
     <string name="destination_reminder_title">Recordatorio de destino</string>
@@ -1054,9 +1053,6 @@
     <string name="feedback_notify_title">Comentarios sobre el recordatorio</string>
     <string name="feedback_notify_dialog_msg">¿El recordatorio de destino te fue útil?</string>
     <string name="feedback_notify_confirmation">Gracias por compartir tus comentarios</string>
-
-    <!-- Accessibility content descriptions for ETA rows -->
-    <string name="map_option_layers">Botón de capas del mapa</string>
 
     <!-- Travel behavior study -->
 

--- a/onebusaway-android/src/main/res/values-fi/strings.xml
+++ b/onebusaway-android/src/main/res/values-fi/strings.xml
@@ -684,15 +684,10 @@
     <string name="trip_plan_date">Päivämäärä</string>
     <string name="map_option_zoom_out">Loitontaa</string>
     <string name="map_option_zoom_in">Lähentää</string>
-    <string name="map_option_layers_close">Sulje karttatasojen painike</string>
 
     <!-- Destination reminder feedback Activity -->
     <string name="feedback_like_button_description">Kyllä, minulle ilmoitettiin oikeaan aikaan</string>
     <string name="feedback_dislike_button_description">Ei, minulle ei ilmoitettu oikeaan aikaan</string>
-
-    <!-- Accessibility content descriptions for ETA rows -->
-
-    <string name="map_option_layers">Karttatasojen painike</string>
 
     <!-- Occupancy -->
     <string name="realtime_empty">Tyhjä</string>

--- a/onebusaway-android/src/main/res/values-it/strings.xml
+++ b/onebusaway-android/src/main/res/values-it/strings.xml
@@ -901,8 +901,4 @@
     <string name="my_option_clear_starred_routes_confirm">Questa operazione rimuoverà definitivamente tutti i percorsi contrassegnati con una stella.</string>
     <string name="map_option_zoom_out">Riduci</string>
     <string name="map_option_zoom_in">Ingrandisci</string>
-    <string name="map_option_layers_close">Chiudi pulsante livelli mappa</string>
-
-    <!-- Accessibility content descriptions for ETA rows -->
-    <string name="map_option_layers">Pulsante livelli mappa</string>
 </resources>

--- a/onebusaway-android/src/main/res/values-night/colors.xml
+++ b/onebusaway-android/src/main/res/values-night/colors.xml
@@ -30,11 +30,6 @@
     <!-- The selected-stop highlight is a deeper orange in dark mode. -->
     <color name="map_stop_focus">#FB8C00</color>
 
-
-    <color name="stop_info_arrival_list_background">@android:color/black</color>
-
-    <!-- Arrival times header -->
-
     <!-- Schedule-deviation foreground tier on a dark ground (#2043) — the iOS dark variants
          (Theme.swift:125-172), which is exactly the mitigation iOS added after its own
          small-colored-text legibility reports (their #506/#508) and which this app previously

--- a/onebusaway-android/src/main/res/values-pl/strings.xml
+++ b/onebusaway-android/src/main/res/values-pl/strings.xml
@@ -939,13 +939,10 @@
     <string name="remind_me_latter">Przypomnij mi później</string>
     <string name="map_option_zoom_out">Oddal</string>
     <string name="map_option_zoom_in">Przybliż</string>
-    <string name="map_option_layers_close">Zamknij przycisk warstw mapy</string>
 
     <!-- Destination reminder feedback Activity -->
     <string name="feedback_like_button_description">Tak, zostałem powiadomiony we właściwym czasie</string>
     <string name="feedback_dislike_button_description">Nie, nie zostałem powiadomiony we właściwym czasie</string>
-
-    <string name="map_option_layers">Przycisk warstw mapy</string>
 
     <!-- Ekran obsługiwanych przewoźników -->
     <string name="agencies_title">Obsługiwani przewoźnicy</string>

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -94,8 +94,6 @@
     <color name="stop_info_delayed_fill">#006EE5</color>
     <color name="stop_info_early_fill">#D63228</color>
 
-    <color name="stop_info_arrival_list_background">#eaeaea</color>
-
     <!--Reporting-->
     <color name="material_gray">#6A6A6A</color>
 
@@ -106,8 +104,6 @@
     <!-- Trip details colors -->
     <color name="trip_details_passed">@color/body_text_disabled</color>
     <color name="trip_details_not_passed">@color/body_text_2</color>
-    <color name="trip_details_background">@color/stop_info_arrival_list_background</color>
-
 
     <!-- Tutorials -->
     <color name="tutorial_background">#df4CAF50</color>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1489,10 +1489,6 @@
     <string name="close_donation_card">Close donation card</string>
     <string name="map_option_zoom_out">Zoom out</string>
     <string name="map_option_zoom_in">Zoom in</string>
-    <string name="map_option_layers_close">Close Map Layers Button</string>
-
-    <!-- Accessibility content descriptions for ETA rows -->
-    <string name="map_option_layers">Maps Layers Button</string>
 
     <!-- Supported agencies screen -->
     <string name="agencies_title">Supported Agencies</string>


### PR DESCRIPTION
## Why

The nightly `lint` job has failed **every night since 2026-08-04** — 36 consecutive runs. The error count climbed steadily as ordinary feature PRs landed:

| date | errors |
|---|---|
| Aug 4 | 1 |
| Aug 6 | 7 |
| Aug 10–16 | 13–14 |
| Aug 19 – Sep 3 | 16 |
| Sep 6 | 18 |
| Sep 8 | 21 |

Android Lint is deliberately not a PR gate (`android.yml` passes `-x lint` because `lintObaGoogleDebug` is heavyweight, ~7–15 min), so every lint regression lands on `main` unchallenged and only the nightly sees it. The nightly had been red long enough that nobody was reading it, and the findings accumulated one PR at a time.

Every other nightly leg — `smoke-api23`, `all-brands`, `regions-drift` — has been green throughout.

## What

Fixes all 21 findings from last night's run (34198100895), plus a 22nd that #2297 introduced *after* that run and that tonight's nightly would otherwise have hit.

| check | n | fix |
|---|---|---|
| `NewApi` | 5 | `metricStyle()` is only reached under the `SDK_INT >= 37` gate at its call site, but lint doesn't carry an `SDK_INT` check across a method boundary. Restated with `@RequiresApi` rather than suppressed — it also keeps any future caller honest. **No behaviour change; the guard was already correct.** (from #2173) |
| `VisibleForTests` | 1 | `VehicleBitmaps.occupancyBucket` is called from production (the marker's accessibility title), so the `@VisibleForTesting` annotation is stale. (from #2199) |
| `UnwrappedClockValue` | 1 | `DemoScenario.serviceDateMs` reads no clock — it's a calendar computation over the caller's `nowMs`, and the bare `Long` is the wire contract for OBA's `serviceDate`. Suppressed with a rationale, matching the existing `TripDepartureTime.toEpochMillis` precedent. (from #2236) |
| `ForcedNonNull` | 1 | Hit the cache on the `(table, level)` pair instead of asserting the parallel-array invariant with `!!`. (from #2192) |
| `LocalContextResourcesRead` | 2 | Read through `LocalResources` so the strings don't go stale across a configuration change — the pattern already used in `AdvancedSettingsScreen` / `HomeScreen` / `MapFeature`. `rememberReachStopMarker` keeps its `Context` for the *time* format, which is a device setting rather than a resource. |
| `ModifierParameter` | 5 | Give each Composable a `modifier` that is both the first `Modifier`-typed and the first optional parameter, with any secondary modifier (`etaModifier`, `rowPadding`, `modeSwitchModifier`) after it — the shape `ArrivalsList` already has and which lint accepts. `ArrivalsPanel` had no `modifier` at all and now threads one to its root. |
| `UnusedResources` | 6 | Delete two colors, two drawables and two strings nothing references, translations included. |
| `ComposableNaming` | 1 | `LaunchIntentEffect` gained a `Boolean` return in #2297, so it's named as a normal function now. |

The `ModifierParameter` reordering is source-compatible: every call site already used named arguments, except the one positional `ChronologicalArrivalContent` call, which this PR converts.

## Verification

```
./gradlew test check :onebusaway-android:compileObaGoogleDebugAndroidTestKotlin -PwarningsAsErrors=true
```

passes locally — including `lintObaGoogleDebug` (0 errors) and `spotlessCheck`, plus unit tests on both `obaGoogle` and `obaMaplibre`.

## Not in scope

A month of unnoticed red nightlies is the underlying process defect. Worth deciding separately whether to run lint on PRs anyway, or to wire a failure notification so a red night gets triaged the next morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUJUkLbCEhEpxH4ubDihHD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented potential crashes when cached arrival prediction data is incomplete.
  - Improved accessibility text handling for arrival times and destination guidance across localized configurations.

- **UI Improvements**
  - Improved layout integration for arrival lists and loading states.
  - Refined handling of arrival-time focus and highlighting behavior.

- **Maintenance**
  - Removed unused map-layer assets, labels, and obsolete color resources.
  - Updated platform compatibility handling for notification styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->