### PR TITLE
Expire map focus after a configurable idle timeout

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -215,6 +215,19 @@ class HomeActivity : AppCompatActivity() {
         onArrivalsLoaded = ::onArrivalsLoaded
     )
 
+    // The focus timeout's two lifecycle edges (#2294). The stamp goes in *before* super: ComponentActivity
+    // snapshots the ViewModels' SavedStateHandles inside super.onSaveInstanceState, and on API < 28 that
+    // snapshot is taken before onPause/onStop, so this is the one hook that precedes it on every level.
+    override fun onSaveInstanceState(outState: Bundle) {
+        viewModel.onSavingState()
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.onHomeForegrounded()
+    }
+
     /**
      * A warm re-launch (singleTop) carrying an external screen intent — FCM CLEAR_TOP, the
      * NavigationService reminder PendingIntent, a pinned shortcut. Surface it for [launchIntentEffect]

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -18,6 +18,7 @@ package org.onebusaway.android.ui.home
 import androidx.lifecycle.SavedStateHandle
 import org.onebusaway.android.map.MapParams
 import org.onebusaway.android.models.WheelchairBoarding
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.util.geoPointOrNull
 
 /** Mechanical SavedStateHandle encoding for [CurrentFocus], kept out of focus transition logic. */
@@ -38,6 +39,7 @@ internal object CurrentFocusPersistence {
     private const val KEY_ROUTE_LEG_NAMES = "home.currentFocus.route.legNames"
     private const val KEY_ROUTE_LEG_DIRECTIONS = "home.currentFocus.route.legDirections"
     private const val KEY_ROUTE_SELECTED_TRIP = "home.currentFocus.route.selectedTripId"
+    private const val KEY_LAST_ACTIVE = "home.currentFocus.lastActiveEpochMs"
 
     private const val FOCUS_NONE = "none"
     private const val FOCUS_STOP = "stop"
@@ -97,6 +99,23 @@ internal object CurrentFocusPersistence {
         // The drilled-into trip off whichever focus holds it (#2224) — one key, because the focus kinds
         // that can carry the rung are mutually exclusive and only the current one is ever written.
         state[KEY_ROUTE_SELECTED_TRIP] = focus.selectedTripId
+    }
+
+    /**
+     * When the rider last left the home screen with the focus in place, or null if they haven't since
+     * it was made (or the save predates the stamp). Read against [FocusTimeout] to decide whether a
+     * restored focus is still worth keeping (#2294).
+     */
+    fun readLastActive(state: SavedStateHandle): WallTime? = state.get<Long>(KEY_LAST_ACTIVE)?.let(::WallTime)
+
+    /**
+     * Stamps [now] as the moment the rider left the screen. Lives in the handle beside the focus it
+     * dates, so the two share one lifetime: both survive a process death, and both go when the task is
+     * dismissed. Wall-clock rather than the monotonic clock because the gap it measures is the one the
+     * rider perceives, and the monotonic clock restarts on reboot.
+     */
+    fun markActive(state: SavedStateHandle, now: WallTime) {
+        state[KEY_LAST_ACTIVE] = now.epochMs
     }
 
     private fun readLegacyFocus(state: SavedStateHandle, stop: FocusedStop?): CurrentFocus {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -101,19 +101,10 @@ internal object CurrentFocusPersistence {
         state[KEY_ROUTE_SELECTED_TRIP] = focus.selectedTripId
     }
 
-    /**
-     * When the rider last left the home screen with the focus in place, or null if they haven't since
-     * it was made (or the save predates the stamp). Read against [FocusTimeout] to decide whether a
-     * restored focus is still worth keeping (#2294).
-     */
+    /** Last saved background timestamp, or null for state saved before timeout tracking. */
     fun readLastActive(state: SavedStateHandle): WallTime? = state.get<Long>(KEY_LAST_ACTIVE)?.let(::WallTime)
 
-    /**
-     * Stamps [now] as the moment the rider left the screen. Lives in the handle beside the focus it
-     * dates, so the two share one lifetime: both survive a process death, and both go when the task is
-     * dismissed. Wall-clock rather than the monotonic clock because the gap it measures is the one the
-     * rider perceives, and the monotonic clock restarts on reboot.
-     */
+    /** Persist beside the focus, using wall time so the timestamp remains valid across reboots. */
     fun markActive(state: SavedStateHandle, now: WallTime) {
         state[KEY_LAST_ACTIVE] = now.epochMs
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/CurrentFocusPersistence.kt
@@ -101,7 +101,7 @@ internal object CurrentFocusPersistence {
         state[KEY_ROUTE_SELECTED_TRIP] = focus.selectedTripId
     }
 
-    /** Last saved background timestamp, or null for state saved before timeout tracking. */
+    /** Last recorded activity timestamp, or null if none has been recorded. */
     fun readLastActive(state: SavedStateHandle): WallTime? = state.get<Long>(KEY_LAST_ACTIVE)?.let(::WallTime)
 
     /** Persist beside the focus, using wall time so the timestamp remains valid across reboots. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusTimeout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusTimeout.kt
@@ -24,13 +24,8 @@ import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.time.WallTime
 
 /**
- * How long the home screen keeps its map focus — the selected stop, route, bike station or trip plan —
- * after the rider last left the screen (#2294). Saved state is otherwise kept faithfully for as long
- * as the task sits in recents, so a stop chosen yesterday is still selected this morning; forgetting
- * it on roughly the schedule the rider's own errand expires is what the OS used to do by accident.
- *
- * The [value] is the persisted form (stable across locales and reorderings); [labelRes] is the
- * settings label. [ALWAYS] never expires.
+ * How long map focus survives in the background (#2294). [value] is the stable preference token;
+ * [labelRes] is its settings label. A null duration ([ALWAYS]) disables expiration.
  */
 enum class FocusTimeout(val value: String, val duration: Duration?, @param:StringRes val labelRes: Int) {
     THIRTY_MINUTES("30m", 30.minutes, R.string.preferences_focus_timeout_30_minutes),
@@ -40,11 +35,7 @@ enum class FocusTimeout(val value: String, val duration: Duration?, @param:Strin
     EIGHT_HOURS("8h", 8.hours, R.string.preferences_focus_timeout_8_hours),
     ALWAYS("always", null, R.string.preferences_focus_timeout_always);
 
-    /**
-     * Whether a focus the rider last left at [lastActive] has sat idle past this timeout as of [now].
-     * A null [lastActive] means nothing has been measured yet — the rider has not left the screen
-     * since the focus was made, or the save predates the stamp — so the focus is kept.
-     */
+    /** An absent timestamp (including older saved state) leaves the focus intact. */
     fun hasExpired(lastActive: WallTime?, now: WallTime): Boolean {
         val limit = duration ?: return false
         if (lastActive == null) return false

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusTimeout.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/FocusTimeout.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import androidx.annotation.StringRes
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import org.onebusaway.android.R
+import org.onebusaway.android.preferences.PreferencesRepository
+import org.onebusaway.android.time.WallTime
+
+/**
+ * How long the home screen keeps its map focus — the selected stop, route, bike station or trip plan —
+ * after the rider last left the screen (#2294). Saved state is otherwise kept faithfully for as long
+ * as the task sits in recents, so a stop chosen yesterday is still selected this morning; forgetting
+ * it on roughly the schedule the rider's own errand expires is what the OS used to do by accident.
+ *
+ * The [value] is the persisted form (stable across locales and reorderings); [labelRes] is the
+ * settings label. [ALWAYS] never expires.
+ */
+enum class FocusTimeout(val value: String, val duration: Duration?, @param:StringRes val labelRes: Int) {
+    THIRTY_MINUTES("30m", 30.minutes, R.string.preferences_focus_timeout_30_minutes),
+    ONE_HOUR("1h", 1.hours, R.string.preferences_focus_timeout_1_hour),
+    TWO_HOURS("2h", 2.hours, R.string.preferences_focus_timeout_2_hours),
+    FOUR_HOURS("4h", 4.hours, R.string.preferences_focus_timeout_4_hours),
+    EIGHT_HOURS("8h", 8.hours, R.string.preferences_focus_timeout_8_hours),
+    ALWAYS("always", null, R.string.preferences_focus_timeout_always);
+
+    /**
+     * Whether a focus the rider last left at [lastActive] has sat idle past this timeout as of [now].
+     * A null [lastActive] means nothing has been measured yet — the rider has not left the screen
+     * since the focus was made, or the save predates the stamp — so the focus is kept.
+     */
+    fun hasExpired(lastActive: WallTime?, now: WallTime): Boolean {
+        val limit = duration ?: return false
+        if (lastActive == null) return false
+        return now - lastActive >= limit
+    }
+
+    companion object {
+        const val PREFERENCE_KEY = "focus_timeout"
+        val DEFAULT = FOUR_HOURS
+
+        fun fromPreference(value: String?): FocusTimeout = entries.firstOrNull { it.value == value } ?: DEFAULT
+    }
+}
+
+fun PreferencesRepository.focusTimeout(): FocusTimeout = FocusTimeout.fromPreference(getString(FocusTimeout.PREFERENCE_KEY, null))

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -98,40 +98,10 @@ class HomeViewModel @Inject constructor(
     private val prefs: PreferencesRepository
 ) : ViewModel() {
 
-    // One-shot outbound map interactions (recenter / show route / adjacency / focus) that can't be
-    // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
-    // reference to the map's VM (the seam the old MapInteractionBus filled). A Channel, not a
-    // replay-0 SharedFlow: MapFeature's collector lives in HOME's composition, so a directive emitted
-    // before it (re)subscribes — e.g. a route reveal consumed right after popping back from the search
-    // destination — must queue for the single consumer instead of vanishing. UNLIMITED (not a fixed
-    // capacity): the whole point is to never drop a queued directive, and trySend on a bounded channel
-    // fails silently once it fills — reviving the very drop bug this Channel replaced. Directives are
-    // tiny and low-frequency, so an unbounded buffer costs nothing in practice.
-    private val _mapDirectives = Channel<MapDirective>(capacity = Channel.UNLIMITED)
-    val mapDirectives: Flow<MapDirective> = _mapDirectives.receiveAsFlow()
-
-    // The single source of truth, replaced atomically by replaceFocus(). Seeded from the
-    // SavedStateHandle-restored focus so a recreation reflects the restore by construction — unless
-    // that focus has outlived its timeout, in which case it is never adopted (#2294).
-    private val _currentFocus = MutableStateFlow(restoreFocus())
+    // The single source of truth, replaced atomically by replaceFocus(). Expired saved focus is
+    // cleared in init before callers can observe this ViewModel.
+    private val _currentFocus = MutableStateFlow(CurrentFocusPersistence.read(savedState))
     val currentFocus: StateFlow<CurrentFocus> = _currentFocus.asStateFlow()
-
-    /**
-     * The persisted focus, or [CurrentFocus.None] if the rider left it behind longer ago than the
-     * focus timeout allows. An expired focus is written back as None so a later recreation doesn't
-     * re-judge it under a since-relaxed timeout.
-     */
-    private fun restoreFocus(): CurrentFocus {
-        val restored = CurrentFocusPersistence.read(savedState)
-        if (restored == CurrentFocus.None || !focusHasExpired()) return restored
-        CurrentFocusPersistence.write(savedState, CurrentFocus.None)
-        // MapViewModel restores its route from a separate handle. Queue the clear before MapFeature
-        // subscribes so that route and its vehicle polling expire along with the home focus.
-        emitMapDirective(MapDirective.ClearFocus)
-        return CurrentFocus.None
-    }
-
-    private fun focusHasExpired(): Boolean = prefs.focusTimeout().hasExpired(CurrentFocusPersistence.readLastActive(savedState), WallTime.now())
 
     // Semantic map actions live on HOME and keep a local undo history of their preceding focus and,
     // when the action moved the camera, viewport. Only current focus is persisted, so reconstruct its
@@ -169,6 +139,18 @@ class HomeViewModel @Inject constructor(
     fun setDirectionsResultsInset(px: Int) {
         _directionsBottomInset.value = px
     }
+
+    // One-shot outbound map interactions (recenter / show route / adjacency / focus) that can't be
+    // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
+    // reference to the map's VM (the seam the old MapInteractionBus filled). A Channel, not a
+    // replay-0 SharedFlow: MapFeature's collector lives in HOME's composition, so a directive emitted
+    // before it (re)subscribes — e.g. a route reveal consumed right after popping back from the search
+    // destination — must queue for the single consumer instead of vanishing. UNLIMITED (not a fixed
+    // capacity): the whole point is to never drop a queued directive, and trySend on a bounded channel
+    // fails silently once it fills — reviving the very drop bug this Channel replaced. Directives are
+    // tiny and low-frequency, so an unbounded buffer costs nothing in practice.
+    private val _mapDirectives = Channel<MapDirective>(capacity = Channel.UNLIMITED)
+    val mapDirectives: Flow<MapDirective> = _mapDirectives.receiveAsFlow()
 
     // Telemetry events the host's single HomeAnalyticsEffect reports (region auto-selects, nav/help menu
     // selections) — so the imperative ObaAnalytics calls live in one Compose effect, not scattered here.
@@ -792,18 +774,7 @@ class HomeViewModel @Inject constructor(
         emitMapDirective(MapDirective.ClearFocus)
     }
 
-    /**
-     * Clears the focus hierarchy *and* the undo history behind it, so nothing is left to go back to.
-     * Also how an expired focus is forgotten ([onHomeForegrounded], #2294): the trail behind it is
-     * the same finished errand.
-     *
-     * Written for the scripted tour's teardown (#2164). Every step the tour drives — the demo stop,
-     * its route, the vehicle, the demo trip plan — goes through the same [pushFocus] a real tap does,
-     * and so leaves the same undo trail. [clearMapFocus] only pushes one more entry onto that trail, so
-     * the first Back press after the tour walked the rider back into a demo stop and a demo route, now
-     * resolved against their own region's server: a 404, an empty arrivals sheet, and a camera flying
-     * to Seattle. There is no rider-authored history to preserve here — the tour drove all of it.
-     */
+    /** Clears focus and its undo history after expiration or scripted-tour teardown. */
     fun clearMapFocusAndUndoHistory() {
         clearMapFocus()
         mapUndoHistory.clear()
@@ -1406,27 +1377,16 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /**
-     * The host is about to snapshot its saved state — the rider is leaving the screen (a background,
-     * a screen-off, a task switch), which is where the focus timeout's clock starts. Stamped into the
-     * same handle as the focus so it rides along into the snapshot; the host must call this *before*
-     * the snapshot is taken (see HomeActivity.onSaveInstanceState), since on API < 28 the snapshot
-     * precedes onPause/onStop and a stamp from either of those would miss it.
-     */
+    /** Called before HomeActivity snapshots saved state, so the background timestamp is included. */
     fun onSavingState() {
         CurrentFocusPersistence.markActive(savedState, WallTime.now())
     }
 
-    /**
-     * The rider is back on the home screen. If the focus they left behind has outlived the focus
-     * timeout ([FocusTimeout], #2294), forget it — the errand it belonged to is over, and the map
-     * should open on nearby stops rather than yesterday's, with nothing stale to Back into. Covers the
-     * process that survived its hours in the background; a process that didn't is judged on restore
-     * ([restoreFocus]) and reaches here with nothing to expire.
-     */
+    /** Expire focus and undo history on restoration or return from the background. */
     fun onHomeForegrounded() {
         // Closing the banner leaves undo history even when the current focus is already empty.
-        if (focusHasExpired()) clearMapFocusAndUndoHistory()
+        val lastActive = CurrentFocusPersistence.readLastActive(savedState)
+        if (prefs.focusTimeout().hasExpired(lastActive, WallTime.now())) clearMapFocusAndUndoHistory()
     }
 
     /**
@@ -1452,6 +1412,13 @@ class HomeViewModel @Inject constructor(
             startupRepo.clearInitialStartup()
             refreshRegions()
         }
+    }
+
+    // Run after all fields are initialized: clearing focus also resets undo and directions state.
+    // The queued ClearFocus reaches MapFeature when it subscribes, clearing MapViewModel's separately
+    // restored route and vehicle polling before the rider resumes using the map.
+    init {
+        onHomeForegrounded()
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -98,6 +98,18 @@ class HomeViewModel @Inject constructor(
     private val prefs: PreferencesRepository
 ) : ViewModel() {
 
+    // One-shot outbound map interactions (recenter / show route / adjacency / focus) that can't be
+    // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
+    // reference to the map's VM (the seam the old MapInteractionBus filled). A Channel, not a
+    // replay-0 SharedFlow: MapFeature's collector lives in HOME's composition, so a directive emitted
+    // before it (re)subscribes — e.g. a route reveal consumed right after popping back from the search
+    // destination — must queue for the single consumer instead of vanishing. UNLIMITED (not a fixed
+    // capacity): the whole point is to never drop a queued directive, and trySend on a bounded channel
+    // fails silently once it fills — reviving the very drop bug this Channel replaced. Directives are
+    // tiny and low-frequency, so an unbounded buffer costs nothing in practice.
+    private val _mapDirectives = Channel<MapDirective>(capacity = Channel.UNLIMITED)
+    val mapDirectives: Flow<MapDirective> = _mapDirectives.receiveAsFlow()
+
     // The single source of truth, replaced atomically by replaceFocus(). Seeded from the
     // SavedStateHandle-restored focus so a recreation reflects the restore by construction — unless
     // that focus has outlived its timeout, in which case it is never adopted (#2294).
@@ -113,6 +125,9 @@ class HomeViewModel @Inject constructor(
         val restored = CurrentFocusPersistence.read(savedState)
         if (restored == CurrentFocus.None || !focusHasExpired()) return restored
         CurrentFocusPersistence.write(savedState, CurrentFocus.None)
+        // MapViewModel restores its route from a separate handle. Queue the clear before MapFeature
+        // subscribes so that route and its vehicle polling expire along with the home focus.
+        emitMapDirective(MapDirective.ClearFocus)
         return CurrentFocus.None
     }
 
@@ -154,18 +169,6 @@ class HomeViewModel @Inject constructor(
     fun setDirectionsResultsInset(px: Int) {
         _directionsBottomInset.value = px
     }
-
-    // One-shot outbound map interactions (recenter / show route / adjacency / focus) that can't be
-    // modeled as state. MapFeature collects these and calls the map view model — so this VM needs no
-    // reference to the map's VM (the seam the old MapInteractionBus filled). A Channel, not a
-    // replay-0 SharedFlow: MapFeature's collector lives in HOME's composition, so a directive emitted
-    // before it (re)subscribes — e.g. a route reveal consumed right after popping back from the search
-    // destination — must queue for the single consumer instead of vanishing. UNLIMITED (not a fixed
-    // capacity): the whole point is to never drop a queued directive, and trySend on a bounded channel
-    // fails silently once it fills — reviving the very drop bug this Channel replaced. Directives are
-    // tiny and low-frequency, so an unbounded buffer costs nothing in practice.
-    private val _mapDirectives = Channel<MapDirective>(capacity = Channel.UNLIMITED)
-    val mapDirectives: Flow<MapDirective> = _mapDirectives.receiveAsFlow()
 
     // Telemetry events the host's single HomeAnalyticsEffect reports (region auto-selects, nav/help menu
     // selections) — so the imperative ObaAnalytics calls live in one Compose effect, not scattered here.
@@ -1422,7 +1425,7 @@ class HomeViewModel @Inject constructor(
      * ([restoreFocus]) and reaches here with nothing to expire.
      */
     fun onHomeForegrounded() {
-        if (_currentFocus.value == CurrentFocus.None) return
+        // Closing the banner leaves undo history even when the current focus is already empty.
         if (focusHasExpired()) clearMapFocusAndUndoHistory()
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -45,9 +45,11 @@ import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.models.WheelchairBoarding
+import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionStatus
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
@@ -90,13 +92,31 @@ class HomeViewModel @Inject constructor(
     private val regionRepo: RegionRepository,
     // The last-known device location: the report-target fallback reads it here, so the
     // focused-stop-vs-location decision lives with the focused stop instead of in the activity.
-    private val locationRepository: LocationRepository
+    private val locationRepository: LocationRepository,
+    // Read for the focus timeout ([FocusTimeout]) at each expiry check, so a settings change applies
+    // the next time the rider comes back rather than after a restart.
+    private val prefs: PreferencesRepository
 ) : ViewModel() {
 
     // The single source of truth, replaced atomically by replaceFocus(). Seeded from the
-    // SavedStateHandle-restored focus so a recreation reflects the restore by construction.
-    private val _currentFocus = MutableStateFlow(CurrentFocusPersistence.read(savedState))
+    // SavedStateHandle-restored focus so a recreation reflects the restore by construction — unless
+    // that focus has outlived its timeout, in which case it is never adopted (#2294).
+    private val _currentFocus = MutableStateFlow(restoreFocus())
     val currentFocus: StateFlow<CurrentFocus> = _currentFocus.asStateFlow()
+
+    /**
+     * The persisted focus, or [CurrentFocus.None] if the rider left it behind longer ago than the
+     * focus timeout allows. An expired focus is written back as None so a later recreation doesn't
+     * re-judge it under a since-relaxed timeout.
+     */
+    private fun restoreFocus(): CurrentFocus {
+        val restored = CurrentFocusPersistence.read(savedState)
+        if (restored == CurrentFocus.None || !focusHasExpired()) return restored
+        CurrentFocusPersistence.write(savedState, CurrentFocus.None)
+        return CurrentFocus.None
+    }
+
+    private fun focusHasExpired(): Boolean = prefs.focusTimeout().hasExpired(CurrentFocusPersistence.readLastActive(savedState), WallTime.now())
 
     // Semantic map actions live on HOME and keep a local undo history of their preceding focus and,
     // when the action moved the camera, viewport. Only current focus is persisted, so reconstruct its
@@ -771,13 +791,15 @@ class HomeViewModel @Inject constructor(
 
     /**
      * Clears the focus hierarchy *and* the undo history behind it, so nothing is left to go back to.
+     * Also how an expired focus is forgotten ([onHomeForegrounded], #2294): the trail behind it is
+     * the same finished errand.
      *
-     * For the scripted tour's teardown (#2164). Every step the tour drives — the demo stop, its route,
-     * the vehicle, the demo trip plan — goes through the same [pushFocus] a real tap does, and so leaves
-     * the same undo trail. [clearMapFocus] only pushes one more entry onto that trail, so the first Back
-     * press after the tour walked the rider back into a demo stop and a demo route, now resolved against
-     * their own region's server: a 404, an empty arrivals sheet, and a camera flying to Seattle. There
-     * is no rider-authored history to preserve here — the tour drove all of it.
+     * Written for the scripted tour's teardown (#2164). Every step the tour drives — the demo stop,
+     * its route, the vehicle, the demo trip plan — goes through the same [pushFocus] a real tap does,
+     * and so leaves the same undo trail. [clearMapFocus] only pushes one more entry onto that trail, so
+     * the first Back press after the tour walked the rider back into a demo stop and a demo route, now
+     * resolved against their own region's server: a 404, an empty arrivals sheet, and a camera flying
+     * to Seattle. There is no rider-authored history to preserve here — the tour drove all of it.
      */
     fun clearMapFocusAndUndoHistory() {
         clearMapFocus()
@@ -1379,6 +1401,29 @@ class HomeViewModel @Inject constructor(
                 _analyticsEvents.tryEmit(HomeAnalyticsEvent.RegionSelected(status.region.name))
             }
         }
+    }
+
+    /**
+     * The host is about to snapshot its saved state — the rider is leaving the screen (a background,
+     * a screen-off, a task switch), which is where the focus timeout's clock starts. Stamped into the
+     * same handle as the focus so it rides along into the snapshot; the host must call this *before*
+     * the snapshot is taken (see HomeActivity.onSaveInstanceState), since on API < 28 the snapshot
+     * precedes onPause/onStop and a stamp from either of those would miss it.
+     */
+    fun onSavingState() {
+        CurrentFocusPersistence.markActive(savedState, WallTime.now())
+    }
+
+    /**
+     * The rider is back on the home screen. If the focus they left behind has outlived the focus
+     * timeout ([FocusTimeout], #2294), forget it — the errand it belonged to is over, and the map
+     * should open on nearby stops rather than yesterday's, with nothing stale to Back into. Covers the
+     * process that survived its hours in the background; a process that didn't is judged on restore
+     * ([restoreFocus]) and reaches here with nothing to expire.
+     */
+    fun onHomeForegrounded() {
+        if (_currentFocus.value == CurrentFocus.None) return
+        if (focusHasExpired()) clearMapFocusAndUndoHistory()
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -1385,8 +1385,13 @@ class HomeViewModel @Inject constructor(
     /** Expire focus and undo history on restoration or return from the background. */
     fun onHomeForegrounded() {
         // Closing the banner leaves undo history even when the current focus is already empty.
+        val now = WallTime.now()
         val lastActive = CurrentFocusPersistence.readLastActive(savedState)
-        if (prefs.focusTimeout().hasExpired(lastActive, WallTime.now())) clearMapFocusAndUndoHistory()
+        if (prefs.focusTimeout().hasExpired(lastActive, now)) {
+            clearMapFocusAndUndoHistory()
+            // Consume the expiration so onStart cannot clear a fresh link applied after restoration.
+            CurrentFocusPersistence.markActive(savedState, now)
+        }
     }
 
     /**

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -237,11 +237,7 @@ fun SettingsScreen(
                 }
             }
 
-            // What the app does over time, as distinct from what it shows (Display). One row so far.
             PreferenceCategory(stringResource(R.string.preferences_category_behavior)) {
-                // How long a selected stop (or route / bike station / trip plan) outlives the rider's
-                // last visit before the home screen forgets it (#2294). The stored values are the
-                // enum's stable tokens, not the labels, so the choice survives a locale change.
                 ListPreferenceItem(
                     title = stringResource(R.string.preferences_focus_timeout_title),
                     entries = FocusTimeout.entries.map { stringResource(it.labelRes) },

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
 import org.onebusaway.android.ui.arrivals.components.ArrivalDisplayModeSwitch
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.findActivity
+import org.onebusaway.android.ui.home.FocusTimeout
 import org.onebusaway.android.ui.settings.components.ClickPreferenceItem
 import org.onebusaway.android.ui.settings.components.ListPreferenceItem
 import org.onebusaway.android.ui.settings.components.PreferenceCategory
@@ -136,6 +137,7 @@ fun SettingsRoute(
 
     val actions = SettingsActions(
         onArrivalDisplayDefault = viewModel::onArrivalDisplayDefaultChanged,
+        onFocusTimeout = viewModel::onFocusTimeoutChanged,
         onAutoSelectRegion = viewModel::onAutoSelectRegionChanged,
         onShowNegativeArrivals = viewModel::onShowNegativeArrivalsChanged,
         onHideAlerts = viewModel::onHideAlertsChanged,
@@ -175,6 +177,7 @@ fun SettingsRoute(
 /** All the user actions the [SettingsScreen] can fire, wired by [SettingsRoute]. */
 class SettingsActions(
     val onArrivalDisplayDefault: (ArrivalDisplayMode) -> Unit = {},
+    val onFocusTimeout: (FocusTimeout) -> Unit = {},
     val onAutoSelectRegion: (Boolean) -> Unit,
     val onShowNegativeArrivals: (Boolean) -> Unit,
     val onHideAlerts: (Boolean) -> Unit,
@@ -246,6 +249,16 @@ fun SettingsScreen(
                         label = title
                     )
                 }
+                // How long a selected stop (or route / bike station / trip plan) outlives the rider's
+                // last visit before the home screen forgets it (#2294). The stored values are the
+                // enum's stable tokens, not the labels, so the choice survives a locale change.
+                ListPreferenceItem(
+                    title = stringResource(R.string.preferences_focus_timeout_title),
+                    entries = FocusTimeout.entries.map { stringResource(it.labelRes) },
+                    entryValues = FocusTimeout.entries.map { it.value },
+                    selectedValue = state.focusTimeout.value,
+                    onValueSelected = { actions.onFocusTimeout(FocusTimeout.fromPreference(it)) }
+                )
                 SwitchPreferenceItem(
                     title = stringResource(R.string.preferences_show_negative_arrivals_title),
                     summary = stringResource(R.string.preferences_show_negative_arrivals_summary),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -237,6 +237,20 @@ fun SettingsScreen(
                 }
             }
 
+            // What the app does over time, as distinct from what it shows (Display). One row so far.
+            PreferenceCategory(stringResource(R.string.preferences_category_behavior)) {
+                // How long a selected stop (or route / bike station / trip plan) outlives the rider's
+                // last visit before the home screen forgets it (#2294). The stored values are the
+                // enum's stable tokens, not the labels, so the choice survives a locale change.
+                ListPreferenceItem(
+                    title = stringResource(R.string.preferences_focus_timeout_title),
+                    entries = FocusTimeout.entries.map { stringResource(it.labelRes) },
+                    entryValues = FocusTimeout.entries.map { it.value },
+                    selectedValue = state.focusTimeout.value,
+                    onValueSelected = { actions.onFocusTimeout(FocusTimeout.fromPreference(it)) }
+                )
+            }
+
             PreferenceCategory(stringResource(R.string.preferences_category_display)) {
                 Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
                     val title = stringResource(R.string.arrival_display_default)
@@ -249,16 +263,6 @@ fun SettingsScreen(
                         label = title
                     )
                 }
-                // How long a selected stop (or route / bike station / trip plan) outlives the rider's
-                // last visit before the home screen forgets it (#2294). The stored values are the
-                // enum's stable tokens, not the labels, so the choice survives a locale change.
-                ListPreferenceItem(
-                    title = stringResource(R.string.preferences_focus_timeout_title),
-                    entries = FocusTimeout.entries.map { stringResource(it.labelRes) },
-                    entryValues = FocusTimeout.entries.map { it.value },
-                    selectedValue = state.focusTimeout.value,
-                    onValueSelected = { actions.onFocusTimeout(FocusTimeout.fromPreference(it)) }
-                )
                 SwitchPreferenceItem(
                     title = stringResource(R.string.preferences_show_negative_arrivals_title),
                     summary = stringResource(R.string.preferences_show_negative_arrivals_summary),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsUiState.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.settings
 
 import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
+import org.onebusaway.android.ui.home.FocusTimeout
 
 /*
  * Pure (Android-free) state + derivation for the Compose settings screens. The ViewModels read the
@@ -49,7 +50,8 @@ data class SettingsPrefSnapshot(
     val preferredUnits: String?,
     val preferredTempUnits: String?,
     val appTheme: String?,
-    val arrivalDisplayDefault: ArrivalDisplayMode = ArrivalDisplayMode.ROUTE
+    val arrivalDisplayDefault: ArrivalDisplayMode = ArrivalDisplayMode.ROUTE,
+    val focusTimeout: FocusTimeout = FocusTimeout.DEFAULT
 )
 
 /** What the screen needs to know about the current region; null means no region (custom API). */
@@ -86,7 +88,8 @@ data class SettingsUiState(
     val preferredUnits: String?,
     val preferredTempUnits: String?,
     val appTheme: String?,
-    val arrivalDisplayDefault: ArrivalDisplayMode = ArrivalDisplayMode.ROUTE
+    val arrivalDisplayDefault: ArrivalDisplayMode = ArrivalDisplayMode.ROUTE,
+    val focusTimeout: FocusTimeout = FocusTimeout.DEFAULT
 ) {
     val showNotificationsCategory: Boolean
         get() = showLegacyNotificationControls || showTripPlanNotifications
@@ -126,7 +129,8 @@ fun buildSettingsUiState(
     preferredUnits = prefs.preferredUnits,
     preferredTempUnits = prefs.preferredTempUnits,
     appTheme = prefs.appTheme,
-    arrivalDisplayDefault = prefs.arrivalDisplayDefault
+    arrivalDisplayDefault = prefs.arrivalDisplayDefault,
+    focusTimeout = prefs.focusTimeout
 )
 
 // ---------------------------------------------------------------------------------------------

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsViewModel.kt
@@ -40,6 +40,8 @@ import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
 import org.onebusaway.android.ui.arrivals.arrivalDisplayDefault
+import org.onebusaway.android.ui.home.FocusTimeout
+import org.onebusaway.android.ui.home.focusTimeout
 import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.ThemeUtils
 
@@ -92,6 +94,7 @@ class SettingsViewModel @Inject constructor(
 
     private fun readSnapshot() = SettingsPrefSnapshot(
         arrivalDisplayDefault = prefs.arrivalDisplayDefault(),
+        focusTimeout = prefs.focusTimeout(),
         autoSelectRegion = prefs.getBoolean(R.string.preference_key_auto_select_region, true),
         showNegativeArrivals = prefs.getBoolean(R.string.preference_key_show_negative_arrivals, true),
         hideAlerts = prefs.getBoolean(R.string.preference_key_hide_alerts, false),
@@ -120,6 +123,10 @@ class SettingsViewModel @Inject constructor(
 
     fun onArrivalDisplayDefaultChanged(mode: ArrivalDisplayMode) {
         prefs.setString(ArrivalDisplayMode.PREFERENCE_KEY, mode.value)
+    }
+
+    fun onFocusTimeoutChanged(timeout: FocusTimeout) {
+        prefs.setString(FocusTimeout.PREFERENCE_KEY, timeout.value)
     }
 
     // region Toggle actions

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -683,6 +683,14 @@
 
     <string name="preferences_show_rental_button_title">Show bike and scooter button</string>
     <string name="preferences_show_rental_button_summary">Display the bike and scooter layer button on the map</string>
+    <!-- Settings: how long the home screen keeps a selected stop after the rider last left it (#2294) -->
+    <string name="preferences_focus_timeout_title">Remember selected stop for</string>
+    <string name="preferences_focus_timeout_30_minutes">30 minutes</string>
+    <string name="preferences_focus_timeout_1_hour">1 hour</string>
+    <string name="preferences_focus_timeout_2_hours">2 hours</string>
+    <string name="preferences_focus_timeout_4_hours">4 hours</string>
+    <string name="preferences_focus_timeout_8_hours">8 hours</string>
+    <string name="preferences_focus_timeout_always">Always</string>
     <string name="preferences_compact_stop_icons_title">Compact stop icons</string>
     <string name="preferences_compact_stop_icons_summary">Use smaller stop markers without vehicle symbols</string>
     <string name="preferences_show_zoom_controls_title">Show zoom controls</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -647,6 +647,7 @@
 
     <!-- Application Preferences -->
     <string name="preferences_category_location">Location</string>
+    <string name="preferences_category_behavior">Behavior</string>
     <string name="preferences_category_display">Display</string>
     <string name="preferences_category_backup">Backup</string>
     <string name="preferences_category_notifications">Notifications</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/FocusTimeoutTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/FocusTimeoutTest.kt
@@ -62,11 +62,6 @@ class FocusTimeoutTest {
     }
 
     @Test
-    fun `stored values are stable tokens, distinct per entry`() {
-        assertEquals(FocusTimeout.entries.size, FocusTimeout.entries.map { it.value }.toSet().size)
-    }
-
-    @Test
     fun `reads the setting through the preferences repository`() {
         val prefs = FakePreferencesRepository()
         assertEquals(FocusTimeout.DEFAULT, prefs.focusTimeout())

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/FocusTimeoutTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/FocusTimeoutTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.testing.FakePreferencesRepository
+import org.onebusaway.android.time.WallTime
+
+class FocusTimeoutTest {
+
+    private val now = WallTime(1_700_000_000_000L)
+
+    @Test
+    fun `expires once the idle gap reaches the timeout`() {
+        val timeout = FocusTimeout.FOUR_HOURS
+        assertFalse(timeout.hasExpired(now - 4.hours + 1.milliseconds, now))
+        assertTrue(timeout.hasExpired(now - 4.hours, now))
+        assertTrue(timeout.hasExpired(now - 30.hours, now))
+    }
+
+    @Test
+    fun `always never expires`() {
+        assertFalse(FocusTimeout.ALWAYS.hasExpired(now - 30.hours, now))
+    }
+
+    @Test
+    fun `an unmeasured focus is kept`() {
+        assertFalse(FocusTimeout.THIRTY_MINUTES.hasExpired(null, now))
+    }
+
+    @Test
+    fun `a stamp from the future is not expired`() {
+        // A device clock set back: the gap is negative, which is "no idle time", not "forever".
+        assertFalse(FocusTimeout.THIRTY_MINUTES.hasExpired(now + 1.hours, now))
+    }
+
+    @Test
+    fun `preference values round-trip and unknown values fall back to the default`() {
+        for (timeout in FocusTimeout.entries) {
+            assertEquals(timeout, FocusTimeout.fromPreference(timeout.value))
+        }
+        assertEquals(FocusTimeout.FOUR_HOURS, FocusTimeout.fromPreference(null))
+        assertEquals(FocusTimeout.FOUR_HOURS, FocusTimeout.fromPreference("3 hours"))
+    }
+
+    @Test
+    fun `stored values are stable tokens, distinct per entry`() {
+        assertEquals(FocusTimeout.entries.size, FocusTimeout.entries.map { it.value }.toSet().size)
+    }
+
+    @Test
+    fun `reads the setting through the preferences repository`() {
+        val prefs = FakePreferencesRepository()
+        assertEquals(FocusTimeout.DEFAULT, prefs.focusTimeout())
+        prefs.setString(FocusTimeout.PREFERENCE_KEY, FocusTimeout.EIGHT_HOURS.value)
+        assertEquals(FocusTimeout.EIGHT_HOURS, prefs.focusTimeout())
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -1036,7 +1036,7 @@ class HomeViewModelTest {
     /** A handle holding a focused stop the rider last left [ago] before now. */
     private fun handleLeftAgo(ago: Duration): SavedStateHandle {
         val handle = SavedStateHandle()
-        viewModel(savedState = handle).onStopFocused(FocusedStop("42", "Pike St"))
+        CurrentFocusPersistence.write(handle, CurrentFocus.Stop(FocusedStop("42", "Pike St")))
         CurrentFocusPersistence.markActive(handle, WallTime.now() - ago)
         return handle
     }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -16,6 +16,9 @@
 package org.onebusaway.android.ui.home
 
 import androidx.lifecycle.SavedStateHandle
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -42,7 +45,9 @@ import org.onebusaway.android.models.WheelchairBoarding
 import org.onebusaway.android.region.FakeRegionRepository
 import org.onebusaway.android.region.RegionStatus
 import org.onebusaway.android.region.region
+import org.onebusaway.android.testing.FakePreferencesRepository
 import org.onebusaway.android.testing.MainDispatcherRule
+import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.tripresults.AlternativeRouteRef
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
@@ -117,12 +122,14 @@ class HomeViewModelTest {
         startupRepo: FakeStartupPreferencesRepository = FakeStartupPreferencesRepository(),
         regionRepo: FakeRegionRepository = FakeRegionRepository().apply { refreshResult = regionStatus },
         savedState: SavedStateHandle = SavedStateHandle(),
-        locationRepo: FakeLocationRepository = FakeLocationRepository()
+        locationRepo: FakeLocationRepository = FakeLocationRepository(),
+        prefs: FakePreferencesRepository = FakePreferencesRepository()
     ) = HomeViewModel(
         savedState,
         startupRepo,
         regionRepo,
-        locationRepo
+        locationRepo,
+        prefs
     )
 
     // The raw stop payload onArrivalsLoaded forwards to the map; its identity is irrelevant to the
@@ -1022,6 +1029,107 @@ class HomeViewModelTest {
             FocusedStop("1", "Main St"),
             viewModel(savedState = handle).currentFocus.value.focusedStop
         )
+    }
+
+    // --- focus timeout (#2294) ---
+
+    /** A handle holding a focused stop the rider last left [ago] before now. */
+    private fun handleLeftAgo(ago: Duration): SavedStateHandle {
+        val handle = SavedStateHandle()
+        viewModel(savedState = handle).onStopFocused(FocusedStop("42", "Pike St"))
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - ago)
+        return handle
+    }
+
+    @Test
+    fun `a restored focus left longer ago than the timeout is not adopted`() = runTest {
+        val handle = handleLeftAgo(5.hours)
+        val vm = viewModel(savedState = handle)
+
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertFalse(vm.canUndoMapAction.value)
+        // Written back as None: a later recreation under a relaxed timeout must not resurrect it.
+        assertEquals(CurrentFocus.None, CurrentFocusPersistence.read(handle))
+    }
+
+    @Test
+    fun `a restored focus left more recently than the timeout is kept`() = runTest {
+        val handle = handleLeftAgo(30.minutes)
+
+        assertEquals(FocusedStop("42", "Pike St"), viewModel(savedState = handle).currentFocus.value.focusedStop)
+    }
+
+    @Test
+    fun `the focus timeout setting is honored on restore`() = runTest {
+        val always = FakePreferencesRepository().apply { setString(FocusTimeout.PREFERENCE_KEY, FocusTimeout.ALWAYS.value) }
+        val short = FakePreferencesRepository().apply { setString(FocusTimeout.PREFERENCE_KEY, FocusTimeout.THIRTY_MINUTES.value) }
+
+        assertEquals(FocusedStop("42", "Pike St"), viewModel(savedState = handleLeftAgo(5.hours), prefs = always).currentFocus.value.focusedStop)
+        assertEquals(CurrentFocus.None, viewModel(savedState = handleLeftAgo(1.hours), prefs = short).currentFocus.value)
+    }
+
+    @Test
+    fun `a restored focus with no last-active stamp is kept`() = runTest {
+        // A save from before the stamp existed: nothing has been measured, so nothing expires.
+        val handle = SavedStateHandle()
+        viewModel(savedState = handle).onStopFocused(FocusedStop("42", "Pike St"))
+
+        assertEquals(FocusedStop("42", "Pike St"), viewModel(savedState = handle).currentFocus.value.focusedStop)
+    }
+
+    @Test
+    fun `coming back to a focus left longer ago than the timeout forgets it`() = runTest {
+        // The process survived its hours in the background: the VM is still alive, so the check on
+        // return has to clear the live focus, its undo trail, and the map's marker.
+        val handle = SavedStateHandle()
+        val vm = viewModel(savedState = handle)
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        vm.onStopFocused(FocusedStop("42", "Pike St", "577", GeoPoint(47.61, -122.34)))
+        vm.selectArrivalRoute(
+            request = ShowRouteRequest("65", directionStopId = "42", initialDirectionId = 0),
+            shortName = "65",
+            headsign = "Downtown"
+        )
+        advanceUntilIdle()
+        assertTrue(vm.canUndoMapAction.value)
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - 5.hours)
+
+        vm.onHomeForegrounded()
+        advanceUntilIdle()
+
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertFalse(vm.canUndoMapAction.value)
+        assertEquals(1, map.clearFocusCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `coming back within the timeout keeps the focus`() = runTest {
+        val handle = SavedStateHandle()
+        val vm = viewModel(savedState = handle)
+        vm.onStopFocused(FocusedStop("42", "Pike St"))
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - 30.minutes)
+
+        vm.onHomeForegrounded()
+
+        assertEquals(FocusedStop("42", "Pike St"), vm.currentFocus.value.focusedStop)
+    }
+
+    @Test
+    fun `leaving the screen stamps the handle beside the focus`() = runTest {
+        val handle = SavedStateHandle()
+        val vm = viewModel(savedState = handle)
+        vm.onStopFocused(FocusedStop("42", "Pike St"))
+        assertNull(CurrentFocusPersistence.readLastActive(handle))
+
+        vm.onSavingState()
+
+        val stamp = CurrentFocusPersistence.readLastActive(handle)
+        assertTrue(stamp != null && WallTime.now() - stamp < 1.minutes)
+        // A fresh stamp reads as "just left": nothing to forget on the way back in.
+        vm.onHomeForegrounded()
+        assertEquals(FocusedStop("42", "Pike St"), vm.currentFocus.value.focusedStop)
     }
 
     // --- initial focus (restored vs intent deep-link) ---

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -1075,6 +1075,42 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `a stop link applied after expired restoration survives onStart`() = runTest {
+        val handle = handleLeftAgo(5.hours)
+        val vm = viewModel(savedState = handle)
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        val stop = FocusedStop("1", "Main St")
+
+        // HomeActivity.setupMapState applies the incoming stop in onCreate, before onStart checks
+        // expiration again. The expired session must not also expire this new focus.
+        vm.applyInitialFocus(stop)
+        vm.onHomeForegrounded()
+
+        assertEquals(stop, vm.currentFocus.value.focusedStop)
+        assertEquals(stop, CurrentFocusPersistence.read(handle).focusedStop)
+        assertTrue(vm.canUndoMapAction.value)
+    }
+
+    @Test
+    fun `a new route survives repeated foreground checks after live expiration`() = runTest {
+        val handle = SavedStateHandle()
+        val vm = viewModel(savedState = handle)
+        vm.onStopFocused(FocusedStop("42", "Pike St"))
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - 5.hours)
+        vm.onHomeForegrounded()
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertFalse(vm.canUndoMapAction.value)
+
+        vm.focusStandaloneRoute(ShowRouteRequest("65"))
+        vm.onHomeForegrounded()
+
+        val route = CurrentFocus.Route(RouteTarget("65"))
+        assertEquals(route, vm.currentFocus.value)
+        assertEquals(route, CurrentFocusPersistence.read(handle))
+        assertTrue(vm.canUndoMapAction.value)
+    }
+
+    @Test
     fun `a restored focus left more recently than the timeout is kept`() = runTest {
         val handle = handleLeftAgo(30.minutes)
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -1053,6 +1053,28 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `an expired restored route queues a map clear before the map subscribes`() = runTest {
+        val handle = SavedStateHandle()
+        CurrentFocusPersistence.write(handle, CurrentFocus.Route(RouteTarget("65")))
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - 5.hours)
+        val vm = viewModel(savedState = handle)
+
+        // The map restores independently and subscribes after HomeViewModel is constructed.
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        advanceUntilIdle()
+
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertEquals(CurrentFocus.None, CurrentFocusPersistence.read(handle))
+        assertFalse(vm.canUndoMapAction.value)
+        assertEquals(listOf(MapDirective.ClearFocus), map.sent)
+        vm.onHomeForegrounded()
+        advanceUntilIdle()
+        assertEquals(1, map.clearFocusCount)
+        job.cancel()
+    }
+
+    @Test
     fun `a restored focus left more recently than the timeout is kept`() = runTest {
         val handle = handleLeftAgo(30.minutes)
 
@@ -1102,6 +1124,40 @@ class HomeViewModelTest {
         assertFalse(vm.canUndoMapAction.value)
         assertEquals(1, map.clearFocusCount)
         job.cancel()
+    }
+
+    @Test
+    fun `coming back after the timeout clears undo history behind a closed banner`() = runTest {
+        val handle = SavedStateHandle()
+        val vm = viewModel(savedState = handle)
+        vm.onStopFocused(FocusedStop("42", "Pike St"))
+        vm.clearMapFocus()
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertTrue(vm.canUndoMapAction.value)
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - 5.hours)
+
+        vm.onHomeForegrounded()
+
+        assertFalse(vm.canUndoMapAction.value)
+        assertFalse(vm.navigateBackFocus())
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+    }
+
+    @Test
+    fun `coming back within the timeout keeps undo history behind a closed banner`() = runTest {
+        val handle = SavedStateHandle()
+        val vm = viewModel(savedState = handle)
+        val stop = FocusedStop("42", "Pike St")
+        vm.onStopFocused(stop)
+        vm.clearMapFocus()
+        CurrentFocusPersistence.markActive(handle, WallTime.now() - 30.minutes)
+
+        vm.onHomeForegrounded()
+
+        assertEquals(CurrentFocus.None, vm.currentFocus.value)
+        assertTrue(vm.canUndoMapAction.value)
+        assertTrue(vm.navigateBackFocus())
+        assertEquals(stop, vm.currentFocus.value.focusedStop)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/settings/SettingsUiStateTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.onebusaway.android.ui.home.FocusTimeout
 
 /**
  * Pure-logic tests for the settings category-visibility and summary derivation — the branchy
@@ -49,7 +50,8 @@ class SettingsUiStateTest {
 
     private fun build(
         region: RegionSummaryInfo? = RegionSummaryInfo("Puget Sound", hasOtp = true),
-        env: SettingsEnvironment = env()
+        env: SettingsEnvironment = env(),
+        prefs: SettingsPrefSnapshot = this.prefs
     ) = buildSettingsUiState(prefs, region, env, customApiRegionSummary = "Custom API")
 
     @Test
@@ -150,6 +152,8 @@ class SettingsUiStateTest {
         val s = build()
         assertTrue(s.autoSelectRegion)
         assertEquals("System default", s.appTheme)
+        assertEquals(FocusTimeout.FOUR_HOURS, s.focusTimeout)
+        assertEquals(FocusTimeout.ALWAYS, build(prefs = prefs.copy(focusTimeout = FocusTimeout.ALWAYS)).focusTimeout)
     }
 
     // --- advanced settings ---


### PR DESCRIPTION
Returning to the app after hours away can leave yesterday's stop or route selected. Add a Behavior setting, “Remember selected stop for,” with a four-hour default and choices of 30 minutes, 1, 2, 4, or 8 hours, or Always.

Use one expiration path during ViewModel construction and on foreground to clear expired focus and undo history. Queue the map clear during restoration so MapViewModel's separately restored route and vehicle polling are cleared too. Closing the focus banner no longer lets Back resurrect an expired stop. Consume each expiration so a fresh stop link applied during activity creation survives the subsequent foreground check.

Fixes #2294.

Validation:

- 146 targeted tests passed across HomeViewModelTest, FocusTimeoutTest, and SettingsUiStateTest, including restored-route clearing, expiration behind an empty focus, and fresh stop/route selection after expiration.
- `spotlessCheck` and `git diff --check` passed.

PR checklist:

- [x] Format changes with `./gradlew spotlessApply`.
- [ ] Run `./gradlew connectedObaGoogleDebugAndroidTest` (device instrumentation suite not run).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to control how long the home screen remembers a selected stop, from 30 minutes to indefinitely.
  * Home screen focus and undo history now expire according to the selected timeout when returning to the app.
  * Focus state is preserved across backgrounding and restored consistently.

* **Tests**
  * Added coverage for timeout options, preference handling, state restoration, and expiration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
