### PR TITLE
Add map button to trip status screen

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.android.ui.tripdetails
 
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
@@ -22,9 +24,11 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -42,9 +46,11 @@ import org.onebusaway.android.api.data.TripDetails
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.home.HomeMapBackHandler
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.TripMapReveal
 import org.onebusaway.android.ui.nav.consumeTripMapReveal
+import org.onebusaway.android.ui.nav.mapReturnAction
 import org.onebusaway.android.ui.nav.showTripOnMap
 
 class TripDetailsMapTest {
@@ -85,13 +91,29 @@ class TripDetailsMapTest {
     @Test
     fun mapButtonPassesTheCurrentRequestAndBackReturnsToTripStatus() {
         lateinit var nav: NavHostController
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        var mapUndoCount = 0
         val content = mutableStateOf(content(details(active).mapRequest("origin_stop")))
         val mapLabel = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.stop_info_option_showonmap)
         compose.setContent {
             nav = rememberNavController()
+            backDispatcher = requireNotNull(LocalOnBackPressedDispatcherOwner.current).onBackPressedDispatcher
             ObaTheme {
-                NavHost(nav, startDestination = "trip_status") {
-                    composable("trip_status") {
+                NavHost(nav, startDestination = NavRoutes.tripDetails("trip", "origin_stop")) {
+                    composable(
+                        NavRoutes.TRIP_DETAILS,
+                        arguments = listOf(
+                            navArgument(NavRoutes.ARG_TRIP_ID) { type = NavType.StringType },
+                            navArgument(NavRoutes.ARG_STOP_ID) {
+                                type = NavType.StringType
+                                nullable = true
+                            },
+                            navArgument(NavRoutes.ARG_SCROLL_MODE) {
+                                type = NavType.StringType
+                                nullable = true
+                            }
+                        )
+                    ) {
                         TripDetailsScreen(
                             state = content.value,
                             onBack = { nav.popBackStack() },
@@ -101,7 +123,13 @@ class TripDetailsMapTest {
                             onShowOnMap = nav::showTripOnMap
                         )
                     }
-                    composable(NavRoutes.HOME) { Text("Map screen") }
+                    composable(NavRoutes.HOME) {
+                        Text("Map screen")
+                        // Exercise the production Back handler with map undo/sheet history available.
+                        HomeMapBackHandler(nav.mapReturnAction(), canGoBackWithinMap = true) {
+                            mapUndoCount++
+                        }
+                    }
                 }
             }
         }
@@ -111,13 +139,18 @@ class TripDetailsMapTest {
         compose.runOnIdle {
             assertSame(tripEntry, nav.previousBackStackEntry)
             assertEquals(details(active).mapRequest("origin_stop"), nav.currentBackStackEntry!!.savedStateHandle.consumeTripMapReveal())
-            nav.popBackStack()
+            backDispatcher.onBackPressed()
+            assertEquals(0, mapUndoCount)
+            assertSame(tripEntry, nav.currentBackStackEntry)
             // A refresh may replace live data with schedule-only data; the next tap must use it.
             content.value = content(details(null).mapRequest("origin_stop"))
         }
         compose.onNodeWithContentDescription(mapLabel).assertIsDisplayed().performClick()
         compose.runOnIdle {
             assertEquals(details(null).mapRequest("origin_stop"), nav.currentBackStackEntry!!.savedStateHandle.consumeTripMapReveal())
+            backDispatcher.onBackPressed()
+            assertEquals(0, mapUndoCount)
+            assertSame(tripEntry, nav.currentBackStackEntry)
         }
     }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
@@ -43,8 +43,9 @@ import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.nav.NavRoutes
-import org.onebusaway.android.ui.nav.consumeRouteReveal
-import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
+import org.onebusaway.android.ui.nav.TripMapReveal
+import org.onebusaway.android.ui.nav.consumeTripMapReveal
+import org.onebusaway.android.ui.nav.showTripOnMap
 
 class TripDetailsMapTest {
     @get:Rule val compose = createUnconfinedComposeRule()
@@ -67,7 +68,7 @@ class TripDetailsMapTest {
     fun runningTripFocusesItsVehicleWithoutTheOriginatingStop() {
         assertEquals(
             ShowRouteRequest("route", focusTripId = "trip", initialDirectionId = 1),
-            details(active).mapRequest()
+            details(active).mapRequest()?.routeRequest()
         )
         // Scheduled positions are also drawn by the map; prediction availability is not motion.
         assertEquals(details(active).mapRequest(), details(active.copy(predicted = false)).mapRequest())
@@ -76,7 +77,7 @@ class TripDetailsMapTest {
     @Test
     fun tripsWithoutACurrentVehicleOpenTheUnscopedRoute() {
         for (status in listOf(null, active.copy(position = null), active.copy(activeTripId = "previous_trip"), active.copy(status = "CANCELED"))) {
-            assertEquals(ShowRouteRequest("route"), details(status).mapRequest())
+            assertEquals(ShowRouteRequest("route"), details(status).mapRequest()?.routeRequest())
         }
         assertNull(details(active, routeId = "").mapRequest())
     }
@@ -84,7 +85,7 @@ class TripDetailsMapTest {
     @Test
     fun mapButtonPassesTheCurrentRequestAndBackReturnsToTripStatus() {
         lateinit var nav: NavHostController
-        val content = mutableStateOf(content(details(active).mapRequest()))
+        val content = mutableStateOf(content(details(active).mapRequest("origin_stop")))
         val mapLabel = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.stop_info_option_showonmap)
         compose.setContent {
             nav = rememberNavController()
@@ -97,7 +98,7 @@ class TripDetailsMapTest {
                             onRefresh = {},
                             onStopClick = { _, _, _ -> },
                             onSetDestinationReminder = null,
-                            onShowOnMap = nav::showRouteMapFromArrivals
+                            onShowOnMap = nav::showTripOnMap
                         )
                     }
                     composable(NavRoutes.HOME) { Text("Map screen") }
@@ -109,14 +110,14 @@ class TripDetailsMapTest {
         compose.onNodeWithText("Map screen").assertIsDisplayed()
         compose.runOnIdle {
             assertSame(tripEntry, nav.previousBackStackEntry)
-            assertEquals(details(active).mapRequest(), nav.currentBackStackEntry!!.savedStateHandle.consumeRouteReveal())
+            assertEquals(details(active).mapRequest("origin_stop"), nav.currentBackStackEntry!!.savedStateHandle.consumeTripMapReveal())
             nav.popBackStack()
             // A refresh may replace live data with schedule-only data; the next tap must use it.
-            content.value = content(details(null).mapRequest())
+            content.value = content(details(null).mapRequest("origin_stop"))
         }
         compose.onNodeWithContentDescription(mapLabel).assertIsDisplayed().performClick()
         compose.runOnIdle {
-            assertEquals(ShowRouteRequest("route"), nav.currentBackStackEntry!!.savedStateHandle.consumeRouteReveal())
+            assertEquals(details(null).mapRequest("origin_stop"), nav.currentBackStackEntry!!.savedStateHandle.consumeTripMapReveal())
         }
     }
 
@@ -136,7 +137,7 @@ class TripDetailsMapTest {
         compose.onNodeWithContentDescription(mapLabel).assertDoesNotExist()
     }
 
-    private fun content(request: ShowRouteRequest?) = TripDetailsUiState.Content(
+    private fun content(request: TripMapReveal?) = TripDetailsUiState.Content(
         header = TripHeader("8", "Capitol Hill", null, "Metro Transit", null, "Scheduled", R.color.stop_info_scheduled_time, false),
         stops = emptyList(),
         scrollToIndex = -1,

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
@@ -17,8 +17,11 @@ package org.onebusaway.android.ui.tripdetails
 
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -31,6 +34,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Rule
@@ -89,10 +93,11 @@ class TripDetailsMapTest {
     }
 
     @Test
-    fun mapButtonPassesTheCurrentRequestAndBackReturnsToTripStatus() {
+    fun mapButtonPreservesContextAndBackReturnsFromDirectionsOrMap() {
         lateinit var nav: NavHostController
         lateinit var backDispatcher: OnBackPressedDispatcher
         var mapUndoCount = 0
+        var directionsBackCount = 0
         val content = mutableStateOf(content(details(active).mapRequest("origin_stop")))
         val mapLabel = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.stop_info_option_showonmap)
         compose.setContent {
@@ -124,10 +129,18 @@ class TripDetailsMapTest {
                         )
                     }
                     composable(NavRoutes.HOME) {
-                        Text("Map screen")
-                        // Exercise the production Back handler with map undo/sheet history available.
-                        HomeMapBackHandler(nav.mapReturnAction(), canGoBackWithinMap = true) {
+                        val directionsActive = remember { mutableStateOf(false) }
+                        Column {
+                            Text(if (directionsActive.value) "Directions screen" else "Map screen")
+                            Button(onClick = { directionsActive.value = true }) { Text("Directions") }
+                        }
+                        // Match HomeScreen's handler order: directions registers after map undo.
+                        val onBackToSource = nav.mapReturnAction()
+                        HomeMapBackHandler(onBackToSource, canGoBackWithinMap = true) {
                             mapUndoCount++
+                        }
+                        HomeMapBackHandler(onBackToSource, canGoBackWithinMap = directionsActive.value) {
+                            directionsBackCount++
                         }
                     }
                 }
@@ -136,11 +149,14 @@ class TripDetailsMapTest {
         val tripEntry = nav.currentBackStackEntry
         compose.onNodeWithContentDescription(mapLabel).assertIsDisplayed().performClick()
         compose.onNodeWithText("Map screen").assertIsDisplayed()
+        compose.onNodeWithText("Directions").performClick()
+        compose.onNodeWithText("Directions screen").assertIsDisplayed()
         compose.runOnIdle {
             assertSame(tripEntry, nav.previousBackStackEntry)
             assertEquals(details(active).mapRequest("origin_stop"), nav.currentBackStackEntry!!.savedStateHandle.consumeTripMapReveal())
             backDispatcher.onBackPressed()
             assertEquals(0, mapUndoCount)
+            assertEquals(0, directionsBackCount)
             assertSame(tripEntry, nav.currentBackStackEntry)
             // A refresh may replace live data with schedule-only data; the next tap must use it.
             content.value = content(details(null).mapRequest("origin_stop"))
@@ -150,7 +166,47 @@ class TripDetailsMapTest {
             assertEquals(details(null).mapRequest("origin_stop"), nav.currentBackStackEntry!!.savedStateHandle.consumeTripMapReveal())
             backDispatcher.onBackPressed()
             assertEquals(0, mapUndoCount)
+            assertEquals(0, directionsBackCount)
             assertSame(tripEntry, nav.currentBackStackEntry)
+        }
+    }
+
+    @Test
+    fun directionsWithoutASourceStillCancelsPicksAndUnwindsBeforeMapHistory() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val directionsActive = mutableStateOf(true)
+        val pickingEndpoint = mutableStateOf(true)
+        var directionsBackCount = 0
+        var mapUndoCount = 0
+        compose.setContent {
+            backDispatcher = requireNotNull(LocalOnBackPressedDispatcherOwner.current).onBackPressedDispatcher
+            val nav = rememberNavController()
+            NavHost(nav, startDestination = NavRoutes.HOME) {
+                composable(NavRoutes.HOME) {
+                    Text("Directions screen")
+                    HomeMapBackHandler(onBackToSource = null, canGoBackWithinMap = true) { mapUndoCount++ }
+                    HomeMapBackHandler(onBackToSource = null, canGoBackWithinMap = directionsActive.value) {
+                        if (pickingEndpoint.value) pickingEndpoint.value = false else directionsBackCount++
+                    }
+                }
+            }
+        }
+        compose.onNodeWithText("Directions screen").assertIsDisplayed()
+        compose.runOnIdle {
+            backDispatcher.onBackPressed()
+            assertFalse(pickingEndpoint.value)
+            assertEquals(0, directionsBackCount)
+            assertEquals(0, mapUndoCount)
+        }
+        compose.runOnIdle {
+            backDispatcher.onBackPressed()
+            assertEquals(1, directionsBackCount)
+            assertEquals(0, mapUndoCount)
+            directionsActive.value = false
+        }
+        compose.runOnIdle {
+            backDispatcher.onBackPressed()
+            assertEquals(1, mapUndoCount)
         }
     }
 

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/tripdetails/TripDetailsMapTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.tripdetails
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Rule
+import org.junit.Test
+import org.onebusaway.android.R
+import org.onebusaway.android.api.contract.EntryWithReferences
+import org.onebusaway.android.api.contract.Position
+import org.onebusaway.android.api.contract.References
+import org.onebusaway.android.api.contract.TripDetailsEntry
+import org.onebusaway.android.api.contract.TripReference
+import org.onebusaway.android.api.contract.TripStatus
+import org.onebusaway.android.api.data.TripDetails
+import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.ui.compose.createUnconfinedComposeRule
+import org.onebusaway.android.ui.compose.theme.ObaTheme
+import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.nav.consumeRouteReveal
+import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
+
+class TripDetailsMapTest {
+    @get:Rule val compose = createUnconfinedComposeRule()
+
+    private val active = TripStatus(
+        activeTripId = "trip",
+        predicted = true,
+        position = Position(47.6, -122.3)
+    )
+
+    private fun details(status: TripStatus?, routeId: String = "route") = TripDetails(
+        EntryWithReferences(
+            TripDetailsEntry(tripId = "trip", status = status),
+            References(trips = listOf(TripReference(id = "trip", routeId = routeId, directionId = "1")))
+        ),
+        currentTime = 0L
+    )
+
+    @Test
+    fun runningTripFocusesItsVehicleWithoutTheOriginatingStop() {
+        assertEquals(
+            ShowRouteRequest("route", focusTripId = "trip", initialDirectionId = 1),
+            details(active).mapRequest()
+        )
+        // Scheduled positions are also drawn by the map; prediction availability is not motion.
+        assertEquals(details(active).mapRequest(), details(active.copy(predicted = false)).mapRequest())
+    }
+
+    @Test
+    fun tripsWithoutACurrentVehicleOpenTheUnscopedRoute() {
+        for (status in listOf(null, active.copy(position = null), active.copy(activeTripId = "previous_trip"), active.copy(status = "CANCELED"))) {
+            assertEquals(ShowRouteRequest("route"), details(status).mapRequest())
+        }
+        assertNull(details(active, routeId = "").mapRequest())
+    }
+
+    @Test
+    fun mapButtonPassesTheCurrentRequestAndBackReturnsToTripStatus() {
+        lateinit var nav: NavHostController
+        val content = mutableStateOf(content(details(active).mapRequest()))
+        val mapLabel = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.stop_info_option_showonmap)
+        compose.setContent {
+            nav = rememberNavController()
+            ObaTheme {
+                NavHost(nav, startDestination = "trip_status") {
+                    composable("trip_status") {
+                        TripDetailsScreen(
+                            state = content.value,
+                            onBack = { nav.popBackStack() },
+                            onRefresh = {},
+                            onStopClick = { _, _, _ -> },
+                            onSetDestinationReminder = null,
+                            onShowOnMap = nav::showRouteMapFromArrivals
+                        )
+                    }
+                    composable(NavRoutes.HOME) { Text("Map screen") }
+                }
+            }
+        }
+        val tripEntry = nav.currentBackStackEntry
+        compose.onNodeWithContentDescription(mapLabel).assertIsDisplayed().performClick()
+        compose.onNodeWithText("Map screen").assertIsDisplayed()
+        compose.runOnIdle {
+            assertSame(tripEntry, nav.previousBackStackEntry)
+            assertEquals(details(active).mapRequest(), nav.currentBackStackEntry!!.savedStateHandle.consumeRouteReveal())
+            nav.popBackStack()
+            // A refresh may replace live data with schedule-only data; the next tap must use it.
+            content.value = content(details(null).mapRequest())
+        }
+        compose.onNodeWithContentDescription(mapLabel).assertIsDisplayed().performClick()
+        compose.runOnIdle {
+            assertEquals(ShowRouteRequest("route"), nav.currentBackStackEntry!!.savedStateHandle.consumeRouteReveal())
+        }
+    }
+
+    @Test
+    fun mapButtonIsAbsentUntilARouteIsAvailable() {
+        val state = mutableStateOf<TripDetailsUiState>(TripDetailsUiState.Loading)
+        val mapLabel = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.stop_info_option_showonmap)
+        compose.setContent {
+            ObaTheme {
+                TripDetailsScreen(state.value, onBack = {}, onRefresh = {}, onStopClick = { _, _, _ -> }, onSetDestinationReminder = null, onShowOnMap = {})
+            }
+        }
+        compose.onNodeWithContentDescription(mapLabel).assertDoesNotExist()
+        compose.runOnIdle { state.value = TripDetailsUiState.Error("Unavailable") }
+        compose.onNodeWithContentDescription(mapLabel).assertDoesNotExist()
+        compose.runOnIdle { state.value = content(null) }
+        compose.onNodeWithContentDescription(mapLabel).assertDoesNotExist()
+    }
+
+    private fun content(request: ShowRouteRequest?) = TripDetailsUiState.Content(
+        header = TripHeader("8", "Capitol Hill", null, "Metro Transit", null, "Scheduled", R.color.stop_info_scheduled_time, false),
+        stops = emptyList(),
+        scrollToIndex = -1,
+        lineColorArgb = 0,
+        mapRequest = request
+    )
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeMapBackHandler.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeMapBackHandler.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.home
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+
+/** A map opened above another page gives navigation priority over its local undo/sheet history. */
+@Composable
+internal fun HomeMapBackHandler(
+    onBackToSource: (() -> Unit)?,
+    canGoBackWithinMap: Boolean,
+    onBackWithinMap: () -> Unit
+) {
+    BackHandler(enabled = onBackToSource != null || canGoBackWithinMap) {
+        if (onBackToSource != null) onBackToSource() else onBackWithinMap()
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -84,6 +84,7 @@ import org.onebusaway.android.ui.nav.arrivalsMapExitTransition
 import org.onebusaway.android.ui.nav.consumeRouteReveal
 import org.onebusaway.android.ui.nav.consumeStopReveal
 import org.onebusaway.android.ui.nav.consumeTripMapReveal
+import org.onebusaway.android.ui.nav.mapReturnAction
 import org.onebusaway.android.ui.nav.navigateBackOrFinish
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.nav.openSearchRoute
@@ -283,11 +284,7 @@ fun HomeNavHost(
                 arrivalsViewModelFactory = home.arrivalsViewModelFactory,
                 callbacks = callbacks,
                 showHelpDialogs = currentEntry?.id == entry.id,
-                onBackToArrivals = if (navController.previousBackStackEntry?.destination?.route in setOf(NavRoutes.ARRIVALS, NavRoutes.ROUTE_INFO)) {
-                    { navController.popBackStack() }
-                } else {
-                    null
-                }
+                onBackToSource = navController.mapReturnAction()
             )
         }
         // The rest of the graph, grouped by feature (each a NavGraphBuilder extension near its

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeNavHost.kt
@@ -77,11 +77,13 @@ import org.onebusaway.android.ui.nav.NavHelp
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.RESULT_MAP_ROUTE_ID
 import org.onebusaway.android.ui.nav.RESULT_MAP_STOP_ID
+import org.onebusaway.android.ui.nav.RESULT_MAP_TRIP
 import org.onebusaway.android.ui.nav.StopReveal
 import org.onebusaway.android.ui.nav.arrivalsMapEnterTransition
 import org.onebusaway.android.ui.nav.arrivalsMapExitTransition
 import org.onebusaway.android.ui.nav.consumeRouteReveal
 import org.onebusaway.android.ui.nav.consumeStopReveal
+import org.onebusaway.android.ui.nav.consumeTripMapReveal
 import org.onebusaway.android.ui.nav.navigateBackOrFinish
 import org.onebusaway.android.ui.nav.navigateFromHome
 import org.onebusaway.android.ui.nav.openSearchRoute
@@ -175,6 +177,12 @@ fun HomeNavHost(
             // re-fires on recomposition nor survives a later route-focus exit + process death. The
             // HomeViewModel adopts the result as the focus authority and directs the map VM from there.
             val handle = entry.savedStateHandle
+            val revealTrip by handle.getStateFlow<String?>(RESULT_MAP_TRIP, null)
+                .collectAsStateWithLifecycle()
+            LaunchedEffect(revealTrip) {
+                val reveal = handle.consumeTripMapReveal() ?: return@LaunchedEffect
+                home.homeViewModel.revealTripOnMap(reveal, home.mapViewModel.viewport)
+            }
             val revealRouteId by handle.getStateFlow<String?>(RESULT_MAP_ROUTE_ID, null)
                 .collectAsStateWithLifecycle()
             val revealStopId by handle.getStateFlow<String?>(RESULT_MAP_STOP_ID, null)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -252,7 +252,7 @@ fun HomeScreen(
     // `with` so the body references them unqualified.
     callbacks: HomeCallbacks,
     showHelpDialogs: Boolean = true,
-    onBackToArrivals: (() -> Unit)? = null
+    onBackToSource: (() -> Unit)? = null
 ) {
     with(callbacks) {
         with(activityActions) {
@@ -635,6 +635,7 @@ fun HomeScreen(
 
                 // Semantic map actions have HOME-local undo history. An expanded arrivals sheet still
                 // collapses first; every other back gesture restores the preceding focus and viewport.
+                // An explicit map visit returns to its source page before either local action.
                 //
                 // The expansion term is what makes this work for the nearby drawer (#2107), which shows
                 // with *no* focus and so usually has no undo history behind it: without it, back from a
@@ -642,11 +643,7 @@ fun HomeScreen(
                 // drawer consumes nothing — it's ambient, with nothing behind it to go back to — so back
                 // falls through to the system (see [sheetBackAction]).
                 val sheetExpanded = sheetShown && sheetState.currentValue == SheetValue.Expanded
-                BackHandler(enabled = onBackToArrivals != null || canUndoMapAction || sheetExpanded) {
-                    if (onBackToArrivals != null) {
-                        onBackToArrivals()
-                        return@BackHandler
-                    }
+                HomeMapBackHandler(onBackToSource, canUndoMapAction || sheetExpanded) {
                     val sheetAction = if (sheetShown) {
                         sheetBackAction(sheetState.currentValue.toArrivalsSheetState(), sheetContent)
                     } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -843,9 +843,9 @@ fun HomeScreen(
                             // Back cancels an in-progress map pick, then steps out of a drilled-into leg to
                             // the whole trip, and only from the itinerary overview exits directions focus
                             // (to nearby stops). This handler composes inside the undo one above, so it
-                            // registers later and wins every back press while directions is active — the
-                            // one-level walk it delegates to is what keeps that from stranding the trip.
-                            BackHandler(enabled = directionsActive) {
+                            // registers later. It must honor the same source-return priority as the map's
+                            // undo handler; without a source, directions still unwinds one level at a time.
+                            HomeMapBackHandler(onBackToSource, canGoBackWithinMap = directionsActive) {
                                 if (pickTarget != null) {
                                     pickTarget = null
                                 } else {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeViewModel.kt
@@ -50,6 +50,7 @@ import org.onebusaway.android.region.Region
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionStatus
 import org.onebusaway.android.time.WallTime
+import org.onebusaway.android.ui.nav.TripMapReveal
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
 import org.onebusaway.android.ui.tripresults.RouteStopRef
@@ -546,6 +547,27 @@ class HomeViewModel @Inject constructor(
         val focus = CurrentFocus.Route(request.toRouteTarget(), selectedTripId = request.focusTripId)
         pushFocus(focus, undoViewport)
         showRoute(request, focus.selectedTripId)
+    }
+
+    /** Return from trip status at the stop → route → trip level, keeping its arrivals drawer. */
+    fun revealTripOnMap(reveal: TripMapReveal, undoViewport: MapViewport? = null) {
+        val request = reveal.routeRequest()
+        val stopId = reveal.stopId
+        if (stopId == null) {
+            focusStandaloneRoute(request, undoViewport)
+            return
+        }
+        val stop = _currentFocus.value.focusedStop?.takeIf { it.id == stopId } ?: FocusedStop(stopId)
+        val selection = StopRouteSelection(
+            originHeadsign = reveal.headsign,
+            legs = listOf(RouteLeg(reveal.routeId, reveal.shortName, reveal.directionId)),
+            selectedTripId = reveal.tripId
+        )
+        // The newly composed arrivals session restores the stop marker. Its first load must not
+        // replace this action's vehicle/route framing with a stop recenter or another route fit.
+        markPendingMapFocus(preserveViewport = true)
+        pushFocus(CurrentFocus.Stop(stop, selection), undoViewport)
+        showStopRoute(stopId, selection, request)
     }
 
     /** Persist a direction chosen from the standalone route banner (null = the whole route). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/MapReveal.kt
@@ -50,6 +50,13 @@ fun NavController.navigateUpFromArrivals(parentRoute: String) {
     }
 }
 
+/** An explicit map visit returns to its source page before undoing map gestures. */
+internal fun NavController.mapReturnAction(): (() -> Unit)? = if (previousBackStackEntry?.destination?.route in setOf(NavRoutes.ARRIVALS, NavRoutes.ROUTE_INFO, NavRoutes.TRIP_DETAILS)) {
+    { popBackStack() }
+} else {
+    null
+}
+
 /** Open a board without discarding the list that led to it. */
 fun NavController.showArrivals(reveal: StopReveal) = navigate(NavRoutes.arrivals(reveal.stopId, reveal.name)) {
     launchSingleTop = true

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/TripMapReveal.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/nav/TripMapReveal.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.nav
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.onebusaway.android.map.ShowRouteRequest
+
+/** A trip's map action retains its originating stop and arrivals-row identity. */
+@Serializable
+data class TripMapReveal(
+    val tripId: String,
+    val routeId: String,
+    val shortName: String,
+    val headsign: String?,
+    val directionId: Int,
+    val stopId: String?,
+    val hasVehicle: Boolean
+) {
+    fun routeRequest() = ShowRouteRequest(
+        routeId = routeId,
+        directionStopId = stopId,
+        focusTripId = tripId.takeIf { hasVehicle },
+        initialDirectionId = directionId.takeIf { hasVehicle || stopId != null }
+    )
+}
+
+const val RESULT_MAP_TRIP = "mapReveal.trip"
+
+/** Keep the trip page beneath the map so Back returns to it. */
+fun NavController.showTripOnMap(reveal: TripMapReveal) {
+    navigate(NavRoutes.HOME)
+    getBackStackEntry(NavRoutes.HOME).savedStateHandle.putTripMapReveal(reveal)
+}
+
+internal fun SavedStateHandle.putTripMapReveal(reveal: TripMapReveal) {
+    set(RESULT_MAP_TRIP, Json.encodeToString(reveal))
+}
+
+fun SavedStateHandle.consumeTripMapReveal(): TripMapReveal? {
+    val encoded = get<String>(RESULT_MAP_TRIP) ?: return null
+    set(RESULT_MAP_TRIP, null)
+    return Json.decodeFromString<TripMapReveal>(encoded)
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDestinations.kt
@@ -38,6 +38,7 @@ import org.onebusaway.android.ui.dataview.TripTrajectoryViewModel
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.StopReveal
 import org.onebusaway.android.ui.nav.revealStopOnMap
+import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
 import org.onebusaway.android.ui.tripinfo.TripInfoEvent
 import org.onebusaway.android.ui.tripinfo.TripInfoRoute
 import org.onebusaway.android.ui.tripinfo.TripInfoViewModel
@@ -94,6 +95,7 @@ fun NavGraphBuilder.tripGraph(navController: NavHostController) {
                         stopId = tripStopId
                     )
                 },
+                onShowOnMap = navController::showRouteMapFromArrivals,
                 onShowTrajectory = { navController.navigate(NavRoutes.tripTrajectory(tripId)) }
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDestinations.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDestinations.kt
@@ -38,7 +38,7 @@ import org.onebusaway.android.ui.dataview.TripTrajectoryViewModel
 import org.onebusaway.android.ui.nav.NavRoutes
 import org.onebusaway.android.ui.nav.StopReveal
 import org.onebusaway.android.ui.nav.revealStopOnMap
-import org.onebusaway.android.ui.nav.showRouteMapFromArrivals
+import org.onebusaway.android.ui.nav.showTripOnMap
 import org.onebusaway.android.ui.tripinfo.TripInfoEvent
 import org.onebusaway.android.ui.tripinfo.TripInfoRoute
 import org.onebusaway.android.ui.tripinfo.TripInfoViewModel
@@ -95,7 +95,7 @@ fun NavGraphBuilder.tripGraph(navController: NavHostController) {
                         stopId = tripStopId
                     )
                 },
-                onShowOnMap = navController::showRouteMapFromArrivals,
+                onShowOnMap = navController::showTripOnMap,
                 onShowTrajectory = { navController.navigate(NavRoutes.tripTrajectory(tripId)) }
             )
         }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -37,7 +37,6 @@ import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.database.oba.markStopUsed
 import org.onebusaway.android.extrapolation.data.serviceDateOrNull
-import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTrip
@@ -46,6 +45,7 @@ import org.onebusaway.android.models.ObaTripStatus
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.time.ServiceDate
+import org.onebusaway.android.ui.nav.TripMapReveal
 import org.onebusaway.android.util.DisplayFormat
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.ObaRequestErrors
@@ -57,7 +57,7 @@ data class TripDetailsData(
     val stops: List<TripStopItem>,
     val scrollToIndex: Int,
     val lineColorArgb: Int,
-    val mapRequest: ShowRouteRequest?
+    val mapRequest: TripMapReveal?
 )
 
 /** Loads a trip's schedule + real-time status and projects it onto the UI model. */
@@ -216,7 +216,7 @@ class DefaultTripDetailsRepository @Inject constructor(
             stops = stops,
             scrollToIndex = resolveScrollIndex(scrollMode, stopIndex, destinationIndex, nextStopIndex),
             lineColorArgb = lineColorArgb,
-            mapRequest = td.mapRequest()
+            mapRequest = td.mapRequest(stopId)
         )
     }
 
@@ -303,16 +303,20 @@ class DefaultTripDetailsRepository @Inject constructor(
 }
 
 /** Focus a running trip's vehicle; a trip without a current position opens the route overview. */
-internal fun TripDetails.mapRequest(): ShowRouteRequest? {
+internal fun TripDetails.mapRequest(stopId: String? = null): TripMapReveal? {
     val trip = trip ?: return null
     val routeId = trip.routeId.takeIf { it.isNotBlank() } ?: return null
     // status is null when the vehicle is serving a different trip in this block. Predictions alone
     // do not mean a vehicle is on the road (e.g. a delayed trip that has not pulled out yet).
     val status = status
     val hasVehicle = status != null && status.status != Status.CANCELED && status.position != null
-    return ShowRouteRequest(
+    return TripMapReveal(
+        tripId = tripId,
         routeId = routeId,
-        focusTripId = tripId.takeIf { hasVehicle && it.isNotBlank() },
-        initialDirectionId = trip.directionId.takeIf { hasVehicle }
+        shortName = route?.shortName.orEmpty().ifBlank { routeId },
+        headsign = trip.headsign,
+        directionId = trip.directionId,
+        stopId = stopId?.takeIf { it.isNotBlank() },
+        hasVehicle = hasVehicle
     )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsRepository.kt
@@ -37,6 +37,7 @@ import org.onebusaway.android.database.oba.ImportGate
 import org.onebusaway.android.database.oba.StopDao
 import org.onebusaway.android.database.oba.markStopUsed
 import org.onebusaway.android.extrapolation.data.serviceDateOrNull
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.models.ObaRoute
 import org.onebusaway.android.models.ObaStop
 import org.onebusaway.android.models.ObaTrip
@@ -55,7 +56,8 @@ data class TripDetailsData(
     val header: TripHeader,
     val stops: List<TripStopItem>,
     val scrollToIndex: Int,
-    val lineColorArgb: Int
+    val lineColorArgb: Int,
+    val mapRequest: ShowRouteRequest?
 )
 
 /** Loads a trip's schedule + real-time status and projects it onto the UI model. */
@@ -213,7 +215,8 @@ class DefaultTripDetailsRepository @Inject constructor(
             header = buildHeader(td, trip, route, status, isRealtime),
             stops = stops,
             scrollToIndex = resolveScrollIndex(scrollMode, stopIndex, destinationIndex, nextStopIndex),
-            lineColorArgb = lineColorArgb
+            lineColorArgb = lineColorArgb,
+            mapRequest = td.mapRequest()
         )
     }
 
@@ -297,4 +300,19 @@ class DefaultTripDetailsRepository @Inject constructor(
         set(Calendar.SECOND, 0)
         set(Calendar.MILLISECOND, 0)
     }.timeInMillis
+}
+
+/** Focus a running trip's vehicle; a trip without a current position opens the route overview. */
+internal fun TripDetails.mapRequest(): ShowRouteRequest? {
+    val trip = trip ?: return null
+    val routeId = trip.routeId.takeIf { it.isNotBlank() } ?: return null
+    // status is null when the vehicle is serving a different trip in this block. Predictions alone
+    // do not mean a vehicle is on the road (e.g. a delayed trip that has not pulled out yet).
+    val status = status
+    val hasVehicle = status != null && status.status != Status.CANCELED && status.position != null
+    return ShowRouteRequest(
+        routeId = routeId,
+        focusTripId = tripId.takeIf { hasVehicle && it.isNotBlank() },
+        initialDirectionId = trip.directionId.takeIf { hasVehicle }
+    )
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
@@ -70,6 +70,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import org.onebusaway.android.R
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.arrivals.components.RealtimeIndicator
 import org.onebusaway.android.ui.compose.components.LineBadge
@@ -105,6 +106,7 @@ fun TripDetailsRoute(
     onStopClick: (stopId: String, name: String, direction: String?) -> Unit,
     /** Null when destination reminders are off, which removes the long-press affordance. */
     onSetDestinationReminder: ((stopIndex: Int) -> Unit)?,
+    onShowOnMap: (ShowRouteRequest) -> Unit,
     onShowTrajectory: () -> Unit = {}
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -117,6 +119,7 @@ fun TripDetailsRoute(
         onRefresh = viewModel::manualRefresh,
         onStopClick = onStopClick,
         onSetDestinationReminder = onSetDestinationReminder,
+        onShowOnMap = onShowOnMap,
         onShowTrajectory = onShowTrajectory
     )
 }
@@ -130,6 +133,7 @@ fun TripDetailsScreen(
     onRefresh: () -> Unit,
     onStopClick: (String, String, String?) -> Unit,
     onSetDestinationReminder: ((Int) -> Unit)?,
+    onShowOnMap: (ShowRouteRequest) -> Unit,
     onShowTrajectory: () -> Unit = {}
 ) {
     val content = state as? TripDetailsUiState.Content
@@ -137,6 +141,15 @@ fun TripDetailsScreen(
         topBar = {
             ObaTopAppBar(title = stringResource(R.string.trip_status), onBack = onBack) {
                 if (content != null) {
+                    content.mapRequest?.let { request ->
+                        IconButton(onClick = { onShowOnMap(request) }) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_action_location_map),
+                                contentDescription = stringResource(R.string.stop_info_option_showonmap),
+                                tint = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
                     IconButton(onClick = onRefresh, enabled = !refreshing) {
                         if (refreshing) {
                             CircularProgressIndicator(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsScreen.kt
@@ -70,7 +70,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import org.onebusaway.android.R
-import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.ui.arrivals.components.RealtimeIndicator
 import org.onebusaway.android.ui.compose.components.LineBadge
@@ -78,6 +77,7 @@ import org.onebusaway.android.ui.compose.components.LoadingContent
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
 import org.onebusaway.android.ui.compose.theme.ObaTheme
 import org.onebusaway.android.ui.icons.AppIcons
+import org.onebusaway.android.ui.nav.TripMapReveal
 
 /** Refresh interval matching the legacy TripDetailsListFragment (fixed 60s). */
 private const val REFRESH_PERIOD_MS = 60_000L
@@ -106,7 +106,7 @@ fun TripDetailsRoute(
     onStopClick: (stopId: String, name: String, direction: String?) -> Unit,
     /** Null when destination reminders are off, which removes the long-press affordance. */
     onSetDestinationReminder: ((stopIndex: Int) -> Unit)?,
-    onShowOnMap: (ShowRouteRequest) -> Unit,
+    onShowOnMap: (TripMapReveal) -> Unit,
     onShowTrajectory: () -> Unit = {}
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -133,7 +133,7 @@ fun TripDetailsScreen(
     onRefresh: () -> Unit,
     onStopClick: (String, String, String?) -> Unit,
     onSetDestinationReminder: ((Int) -> Unit)?,
-    onShowOnMap: (ShowRouteRequest) -> Unit,
+    onShowOnMap: (TripMapReveal) -> Unit,
     onShowTrajectory: () -> Unit = {}
 ) {
     val content = state as? TripDetailsUiState.Content

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsUiState.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripdetails
 
 import androidx.annotation.ColorRes
+import org.onebusaway.android.map.ShowRouteRequest
 
 /** Where a stop's dot sits on the trip's vertical transit line. */
 enum class LinePosition { FIRST, MIDDLE, LAST }
@@ -70,7 +71,8 @@ sealed interface TripDetailsUiState {
         val header: TripHeader,
         val stops: List<TripStopItem>,
         val scrollToIndex: Int,
-        val lineColorArgb: Int
+        val lineColorArgb: Int,
+        val mapRequest: ShowRouteRequest?
     ) : TripDetailsUiState
 
     data class Error(val message: String) : TripDetailsUiState

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsUiState.kt
@@ -16,7 +16,7 @@
 package org.onebusaway.android.ui.tripdetails
 
 import androidx.annotation.ColorRes
-import org.onebusaway.android.map.ShowRouteRequest
+import org.onebusaway.android.ui.nav.TripMapReveal
 
 /** Where a stop's dot sits on the trip's vertical transit line. */
 enum class LinePosition { FIRST, MIDDLE, LAST }
@@ -72,7 +72,7 @@ sealed interface TripDetailsUiState {
         val stops: List<TripStopItem>,
         val scrollToIndex: Int,
         val lineColorArgb: Int,
-        val mapRequest: ShowRouteRequest?
+        val mapRequest: TripMapReveal?
     ) : TripDetailsUiState
 
     data class Error(val message: String) : TripDetailsUiState

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripdetails/TripDetailsViewModel.kt
@@ -109,6 +109,7 @@ class TripDetailsViewModel @Inject constructor(
         header = header,
         stops = stops,
         scrollToIndex = scrollToIndex,
-        lineColorArgb = lineColorArgb
+        lineColorArgb = lineColorArgb,
+        mapRequest = mapRequest
     )
 }

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HomeViewModelTest.kt
@@ -39,6 +39,7 @@ import org.onebusaway.android.map.RouteFocusRelationship
 import org.onebusaway.android.map.RouteFocusSegment
 import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.map.render.MapViewport
+import org.onebusaway.android.map.render.StopBand
 import org.onebusaway.android.models.FocusedTrip
 import org.onebusaway.android.models.RouteDirectionKey
 import org.onebusaway.android.models.WheelchairBoarding
@@ -48,6 +49,9 @@ import org.onebusaway.android.region.region
 import org.onebusaway.android.testing.FakePreferencesRepository
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.time.WallTime
+import org.onebusaway.android.ui.arrivals.routeRowKey
+import org.onebusaway.android.ui.home.arrivals.selectedArrivalRowKey
+import org.onebusaway.android.ui.nav.TripMapReveal
 import org.onebusaway.android.ui.tripresults.AlternativeRouteRef
 import org.onebusaway.android.ui.tripresults.FocusedLeg
 import org.onebusaway.android.ui.tripresults.RouteLegRef
@@ -1466,6 +1470,76 @@ class HomeViewModelTest {
 
         assertEquals((0 until count).map { "route-$it" }, map.routesShown)
         mapJob.cancel()
+    }
+
+    @Test
+    fun `trip map reveal keeps the stop drawer and selects its route and trip`() = runTest {
+        val savedState = SavedStateHandle()
+        val vm = viewModel(savedState = savedState)
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        val stop = FocusedStop("1", "Main St", "100", GeoPoint(47.6, -122.3))
+        vm.onStopFocused(stop)
+        advanceUntilIdle()
+        map.sent.clear()
+
+        vm.revealTripOnMap(TripMapReveal("trip", "65", "65", "Downtown", 1, "1", true))
+        advanceUntilIdle()
+
+        val focus = vm.currentFocus.value as CurrentFocus.Stop
+        assertEquals(stop, focus.stop)
+        assertEquals(HomeSheetContent.Stop("1"), homeSheetContent(focus, StopBand.DOT, false))
+        assertEquals("trip", focus.selectedRoute?.selectedTripId)
+        assertEquals(routeRowKey("65", 1, "Downtown"), focus.selectedRoute?.selectedArrivalRowKey())
+        assertEquals(ShowRouteRequest("65", "1", "trip", 1), map.routeRequests.single())
+        assertTrue(map.routeCommands.single().stopScoped)
+        assertEquals("trip", map.routeCommands.single().selectedTripId)
+        assertEquals(focus, viewModel(savedState = savedState).currentFocus.value)
+
+        map.sent.clear()
+        vm.onArrivalsLoaded(obaStop, emptyList())
+        advanceUntilIdle()
+        assertFalse(map.focusStops.single().recenter)
+        assertNull(map.routeRequests.single().focusTripId)
+        assertFalse(map.routeCommands.single().frameRoute)
+        assertEquals("trip", map.routeCommands.single().selectedTripId)
+        job.cancel()
+    }
+
+    @Test
+    fun `trip map reveal establishes its originating stop when another or no stop is focused`() = runTest {
+        for (initialStop in listOf(null, FocusedStop("other", "Other stop"))) {
+            val vm = viewModel()
+            initialStop?.let(vm::onStopFocused)
+            vm.revealTripOnMap(TripMapReveal("trip", "65", "65", "Downtown", 1, "1", true))
+            val focus = vm.currentFocus.value as CurrentFocus.Stop
+            assertEquals(FocusedStop("1"), focus.stop)
+            assertEquals("trip", focus.selectedRoute?.selectedTripId)
+            vm.onArrivalsLoaded(obaStop, emptyList())
+            assertEquals("Main St", vm.currentFocus.value.focusedStop?.name)
+        }
+    }
+
+    @Test
+    fun `scheduled trip keeps its drawer focus while framing the route instead of a vehicle`() = runTest {
+        val vm = viewModel()
+        val map = MapDirectiveRecorder(vm)
+        val job = launch { map.collect() }
+        vm.revealTripOnMap(TripMapReveal("trip", "65", "65", "Downtown", 1, "1", false))
+        advanceUntilIdle()
+        assertEquals("trip", (vm.currentFocus.value as CurrentFocus.Stop).selectedRoute?.selectedTripId)
+        assertNull(map.routeRequests.single().focusTripId)
+        assertTrue(map.routeCommands.single().frameRoute)
+        assertTrue(map.routeCommands.single().stopScoped)
+        job.cancel()
+    }
+
+    @Test
+    fun `trip without an originating stop still opens a standalone route`() = runTest {
+        val vm = viewModel()
+        vm.onStopFocused(FocusedStop("unrelated"))
+        vm.revealTripOnMap(TripMapReveal("trip", "65", "65", "Downtown", 1, null, true))
+        assertEquals(CurrentFocus.Route(RouteTarget("65", directionId = 1), "trip"), vm.currentFocus.value)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/MapRevealTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/nav/MapRevealTest.kt
@@ -31,6 +31,17 @@ import org.onebusaway.android.util.GeoPoint
 class MapRevealTest {
 
     @Test
+    fun `trip reveal retains stop and row identity and is consumed once`() {
+        val handle = SavedStateHandle()
+        val reveal = TripMapReveal("trip", "route", "65", "Downtown / Center", 1, "stop", true)
+        handle.putTripMapReveal(reveal)
+        // A restored handle must read only the saved representation, not a retained object.
+        val restored = SavedStateHandle(mapOf(RESULT_MAP_TRIP to handle.get<String>(RESULT_MAP_TRIP)))
+        assertEquals(reveal, restored.consumeTripMapReveal())
+        assertNull(restored.consumeTripMapReveal())
+    }
+
+    @Test
     fun `route reveal round-trips every ShowRouteRequest field`() {
         val handle = SavedStateHandle()
         val request = ShowRouteRequest(

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsViewModelTest.kt
@@ -25,9 +25,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
-import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.ui.nav.NavRoutes
+import org.onebusaway.android.ui.nav.TripMapReveal
 
 private class FakeTripDetailsRepository(
     var result: Result<TripDetailsData>
@@ -73,7 +73,7 @@ class TripDetailsViewModelTest {
         stops = emptyList(),
         scrollToIndex = -1,
         lineColorArgb = 0,
-        mapRequest = ShowRouteRequest("route", focusTripId = "t", initialDirectionId = 1)
+        mapRequest = TripMapReveal("t", "route", "8", "Capitol Hill", 1, "stop", true)
     )
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripdetails/TripDetailsViewModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.onebusaway.android.R
+import org.onebusaway.android.map.ShowRouteRequest
 import org.onebusaway.android.testing.MainDispatcherRule
 import org.onebusaway.android.ui.nav.NavRoutes
 
@@ -71,7 +72,8 @@ class TripDetailsViewModelTest {
         ),
         stops = emptyList(),
         scrollToIndex = -1,
-        lineColorArgb = 0
+        lineColorArgb = 0,
+        mapRequest = ShowRouteRequest("route", focusTripId = "t", initialDirectionId = 1)
     )
 
     @Test
@@ -90,6 +92,7 @@ class TripDetailsViewModelTest {
         val state = viewModel.state.value
         assertTrue(state is TripDetailsUiState.Content)
         assertEquals("Capitol Hill", (state as TripDetailsUiState.Content).header.headsign)
+        assertEquals(data().mapRequest, state.mapRequest)
     }
 
     @Test


### PR DESCRIPTION
Adds a Show on map toolbar button to Trip Status. A running trip frames its vehicle; a trip without a current vehicle position frames its route.

When opened from a stop, the map action preserves that stop’s arrivals drawer and selects the viewed trip within its route row. The navigation payload carries the originating stop and row identity, so this also works when the map has no stop selected or has a different stop selected. An arrivals reload retains the selection without repeating the camera move. Trips opened without a stop retain standalone route behavior. Android Back from this explicit map visit returns directly to the trip page before consuming map undo history or collapsing the arrivals drawer.

Validation: 145 focused JVM tests covering home focus, trip details, and navigation; 4 connected Pixel trip-map tests, including Android Back dispatch with map history available; warnings-as-errors compilation and Spotless. Includes regression coverage for drawer visibility, row/trip selection, saved-state restoration, scheduled trips, and arrivals reloads.

Physically verified on the USB-connected Pixel 7 Pro: stop #29253 → live Route 48 trip status → Show on map displays the selected vehicle and stop, keeps the arrivals drawer open, and highlights both the Route 48 row and the selected trip’s ETA pill.

Also physically verified Route 43 trip status → Show on map → Android Back: returns directly to the same trip page with its scroll position retained.

Fixes #2313.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added trip-specific map navigation from trip details, preserving route, trip, stop, and vehicle context.
  - Trip maps now focus live vehicles when available and fall back to route-focused views for scheduled trips.
  - Returning from the map restores the originating trip-status context.

- **Bug Fixes**
  - Improved back navigation so source pages take priority over map history.

- **Tests**
  - Added coverage for navigation, focus behavior, state restoration, map-button visibility, loading and error states, and back handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->