### PR TITLE
Show a banner when OBA realtime predictions are unavailable (#2301)

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsContent.kt
@@ -74,6 +74,7 @@ import org.onebusaway.android.ui.arrivals.components.ArrivalDisplayModeSwitch
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowAnchors
 import org.onebusaway.android.ui.arrivals.components.ArrivalRowCallbacks
 import org.onebusaway.android.ui.arrivals.components.RouteArrivalRow
+import org.onebusaway.android.ui.compose.components.AlertSeverity
 import org.onebusaway.android.ui.compose.components.AlertSurface
 import org.onebusaway.android.ui.icons.AppIcons
 import org.onebusaway.android.util.DisplayFormat
@@ -222,8 +223,10 @@ internal fun ArrivalsList(
         hadSelection = effectiveSelectedRowKey != null
         if (displayMode == ArrivalDisplayMode.ROUTE && (effectiveSelectedRowKey != null || wasSelected)) {
             val alertsBeforeRoutes = content.hasAlerts && showAlerts
+            val outagesBeforeRoutes = content.realtimeOutages.isNotEmpty()
             val directionBeforeRoutes = showDirection && content.header.direction != null
             val firstRouteIndex = (if (alertsBeforeRoutes) 1 else 0) +
+                (if (outagesBeforeRoutes) 1 else 0) +
                 (if (directionBeforeRoutes) 1 else 0) +
                 (if (onDisplayModeChange != null) 1 else 0)
             listState.scrollToItem(firstRouteIndex)
@@ -246,6 +249,14 @@ internal fun ArrivalsList(
                     onShowAlert = onShowAlert,
                     onHideAlert = onHideAlert,
                     onShowHiddenAlerts = onShowHiddenAlerts,
+                    modifier = Modifier.animateItem()
+                )
+            }
+        }
+        if (content.realtimeOutages.isNotEmpty()) {
+            item(key = "realtime_outages") {
+                RealtimeOutageBanner(
+                    outages = content.realtimeOutages,
                     modifier = Modifier.animateItem()
                 )
             }
@@ -465,6 +476,39 @@ private fun AlertRow(alert: AlertItem, onClick: () -> Unit) {
             )
             Spacer(Modifier.width(12.dp))
             Text(text = alert.summary, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+/**
+ * A compact, nonblocking banner shown when an agency's realtime predictions are unavailable
+ * at the stop being viewed (issue #2301). Renders an info-severity alert card per affected agency.
+ */
+@Composable
+internal fun RealtimeOutageBanner(
+    outages: List<RealtimeOutage>,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        for (outage in outages) {
+            RealtimeOutageRow(outage = outage)
+        }
+    }
+}
+
+@Composable
+private fun RealtimeOutageRow(outage: RealtimeOutage) {
+    AlertSurface(severity = AlertSeverity.INFO) {
+        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_warning_24),
+                contentDescription = null
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.realtime_outage_banner, outage.agencyName),
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsContent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsContent.kt
@@ -483,6 +483,9 @@ private fun AlertRow(alert: AlertItem, onClick: () -> Unit) {
 /**
  * A compact, nonblocking banner shown when an agency's realtime predictions are unavailable
  * at the stop being viewed (issue #2301). Renders an info-severity alert card per affected agency.
+ *
+ * @param outages the list of detected realtime outages affecting agencies at this stop
+ * @param modifier modifier for layout styling and animations
  */
 @Composable
 internal fun RealtimeOutageBanner(
@@ -490,12 +493,20 @@ internal fun RealtimeOutageBanner(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        for (outage in outages) {
-            RealtimeOutageRow(outage = outage)
+        val uniqueOutages = remember(outages) { outages.distinctBy { it.agencyName } }
+        for (outage in uniqueOutages) {
+            key(outage.agencyId) {
+                RealtimeOutageRow(outage = outage)
+            }
         }
     }
 }
 
+/**
+ * An alert card displaying that realtime predictions for a specific agency are unavailable.
+ *
+ * @param outage the outage information containing the agency name to display
+ */
 @Composable
 private fun RealtimeOutageRow(outage: RealtimeOutage) {
     AlertSurface(severity = AlertSeverity.INFO) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -127,7 +127,9 @@ data class ArrivalsData(
     val hideAlertsByDefault: Boolean,
     val stopCode: String?,
     val stopLat: Double,
-    val stopLon: Double
+    val stopLon: Double,
+    /** Realtime outages detected for transit agencies serving this stop (issue #2301). */
+    val realtimeOutages: List<RealtimeOutage> = emptyList()
 )
 
 /** Loads real-time arrivals for a stop and persists the stop / route favorites. */
@@ -357,6 +359,7 @@ class DefaultArrivalsRepository @Inject constructor(
         // The situation ids that are active right now, so a per-arrival alert indicator lights up
         // only for currently-active alerts — matching the banner's active set (issue #1687 Bug 2).
         val activeSituationIds = situations.filter(isActive).mapTo(HashSet()) { it.id }
+        val realtimeOutages = detectRealtimeOutages(arrivals) { agencyNameFor(snapshot, it.routeId) }
         return ArrivalsData(
             arrivals = arrivals,
             // Stable (agency, line, headsign) row order (#1822), not ETA — a row's position shouldn't
@@ -374,7 +377,8 @@ class DefaultArrivalsRepository @Inject constructor(
             preferences.getBoolean(R.string.preference_key_hide_alerts, false),
             stopCode = stop?.stopCode,
             stopLat = stop?.latitude ?: 0.0,
-            stopLon = stop?.longitude ?: 0.0
+            stopLon = stop?.longitude ?: 0.0,
+            realtimeOutages = realtimeOutages
         )
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsRepository.kt
@@ -359,7 +359,7 @@ class DefaultArrivalsRepository @Inject constructor(
         // The situation ids that are active right now, so a per-arrival alert indicator lights up
         // only for currently-active alerts — matching the banner's active set (issue #1687 Bug 2).
         val activeSituationIds = situations.filter(isActive).mapTo(HashSet()) { it.id }
-        val realtimeOutages = detectRealtimeOutages(arrivals) { agencyNameFor(snapshot, it.routeId) }
+        val realtimeOutages = detectRealtimeOutages(arrivals) { agencyFor(snapshot, it.routeId) }
         return ArrivalsData(
             arrivals = arrivals,
             // Stable (agency, line, headsign) row order (#1822), not ETA — a row's position shouldn't
@@ -405,6 +405,14 @@ class DefaultArrivalsRepository @Inject constructor(
      *  reference is missing from the snapshot. Shared by the route-row sort key and [buildActions] so
      *  the two don't independently reimplement the same route→agency lookup. */
     private fun agencyNameFor(snapshot: StopArrivals, routeId: String): String? = snapshot.route(routeId)?.agencyId?.let(snapshot::agencyName)
+
+    /** The operating agency (id and display name) for a route, or null when either the route or its agency
+     *  reference is missing from the snapshot. */
+    private fun agencyFor(snapshot: StopArrivals, routeId: String): OperatingAgency? {
+        val agencyId = snapshot.route(routeId)?.agencyId ?: return null
+        val name = snapshot.agencyName(agencyId) ?: return null
+        return OperatingAgency(id = agencyId, name = name)
+    }
 
     /** Precomputes the navigation/dialog data for each arrival (legacy reads these on menu tap). */
     private fun buildActions(

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsUiState.kt
@@ -105,7 +105,8 @@ sealed interface ArrivalsUiState {
         val hiddenAlertCount: Int = 0,
         val stopCode: String? = null,
         val stopLat: Double = 0.0,
-        val stopLon: Double = 0.0
+        val stopLon: Double = 0.0,
+        val realtimeOutages: List<RealtimeOutage> = emptyList()
     ) : ArrivalsUiState {
         /** True when the stop has any service alert at all — shown *or* hidden — so the header keeps
          *  its alert icon even after the rider hides every alert. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModel.kt
@@ -260,7 +260,8 @@ class ArrivalsViewModel @AssistedInject constructor(
             hiddenAlertCount = hiddenCount,
             stopCode = stopCode,
             stopLat = stopLat,
-            stopLon = stopLon
+            stopLon = stopLon,
+            realtimeOutages = realtimeOutages
         )
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetector.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetector.kt
@@ -23,13 +23,33 @@ package org.onebusaway.android.ui.arrivals
 const val MIN_ARRIVALS_FOR_REALTIME_OUTAGE = 3
 
 /**
+ * An operating transit agency identified by its unique ID and display name.
+ *
+ * @param id the unique agency identifier from GTFS / OBA references
+ * @param name the human-readable display name of the agency
+ */
+data class OperatingAgency(
+    val id: String,
+    val name: String
+)
+
+/**
  * An agency whose realtime predictions appear to be offline at the stop being viewed.
  *
+ * @param agencyId the unique identifier of the affected transit agency
  * @param agencyName the display name of the affected transit agency
  */
 data class RealtimeOutage(
+    val agencyId: String,
     val agencyName: String
-)
+) {
+    /**
+     * Secondary constructor allowing creation with only [agencyName] for testing convenience.
+     *
+     * @param agencyName the display name of the affected transit agency
+     */
+    constructor(agencyName: String) : this(agencyId = agencyName, agencyName = agencyName)
+}
 
 /**
  * Detects whether any transit agency serving the given [arrivals] is experiencing a realtime data
@@ -39,29 +59,38 @@ data class RealtimeOutage(
  * 1. It has at least [MIN_ARRIVALS_FOR_REALTIME_OUTAGE] arrivals at this stop within the time window.
  * 2. None of its arrivals have realtime predictions ([ArrivalInfo.predicted] is false for all).
  *
- * If an agency has even a single predicted arrival, no outage is flagged for it (partial coverage
- * is normal). Agencies with fewer than [MIN_ARRIVALS_FOR_REALTIME_OUTAGE] arrivals or an empty/blank
- * name are ignored to avoid false positives on low-frequency services or incomplete metadata.
+ * Arrivals are grouped by their unique [OperatingAgency.id] so that per-agency thresholds and
+ * prediction checks remain strictly independent, even if two distinct agencies share the same display
+ * name. If an agency has even a single predicted arrival, no outage is flagged for it. Agencies with
+ * fewer than [MIN_ARRIVALS_FOR_REALTIME_OUTAGE] arrivals or missing/blank ID/name are ignored to avoid
+ * false positives.
  *
  * @param arrivals the list of arrivals loaded for the stop
- * @param agencyNameOf resolves an arrival's agency display name from route references
+ * @param agencyOf resolves an arrival's operating agency (ID and display name) from route references
  * @return a list of [RealtimeOutage] objects for affected agencies, ordered alphabetically by agency name
  */
 fun detectRealtimeOutages(
     arrivals: List<ArrivalInfo>,
-    agencyNameOf: (ArrivalInfo) -> String?
+    agencyOf: (ArrivalInfo) -> OperatingAgency?
 ): List<RealtimeOutage> {
     if (arrivals.isEmpty()) return emptyList()
 
     return arrivals
-        .groupBy { agencyNameOf(it) }
-        .mapNotNull { (agencyName, agencyArrivals) ->
-            if (agencyName.isNullOrBlank()) return@mapNotNull null
+        .mapNotNull { arrival ->
+            val agency = agencyOf(arrival)
+            if (agency == null || agency.id.isBlank() || agency.name.isBlank()) {
+                null
+            } else {
+                agency to arrival
+            }
+        }
+        .groupBy(keySelector = { it.first }, valueTransform = { it.second })
+        .mapNotNull { (agency, agencyArrivals) ->
             if (agencyArrivals.size >= MIN_ARRIVALS_FOR_REALTIME_OUTAGE && agencyArrivals.none { it.predicted }) {
-                RealtimeOutage(agencyName = agencyName)
+                RealtimeOutage(agencyId = agency.id, agencyName = agency.name)
             } else {
                 null
             }
         }
-        .sortedBy { it.agencyName }
+        .sortedWith(compareBy({ it.agencyName }, { it.agencyId }))
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetector.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetector.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+/**
+ * Minimum number of arrivals for an agency at a stop before an absence of realtime predictions
+ * is flagged as an outage (issue #2301). Prevents false alarms on stops with only 1–2 scheduled
+ * trips in the window.
+ */
+const val MIN_ARRIVALS_FOR_REALTIME_OUTAGE = 3
+
+/**
+ * An agency whose realtime predictions appear to be offline at the stop being viewed.
+ *
+ * @param agencyName the display name of the affected transit agency
+ */
+data class RealtimeOutage(
+    val agencyName: String
+)
+
+/**
+ * Detects whether any transit agency serving the given [arrivals] is experiencing a realtime data
+ * outage (issue #2301).
+ *
+ * An agency is flagged as having an outage if:
+ * 1. It has at least [MIN_ARRIVALS_FOR_REALTIME_OUTAGE] arrivals at this stop within the time window.
+ * 2. None of its arrivals have realtime predictions ([ArrivalInfo.predicted] is false for all).
+ *
+ * If an agency has even a single predicted arrival, no outage is flagged for it (partial coverage
+ * is normal). Agencies with fewer than [MIN_ARRIVALS_FOR_REALTIME_OUTAGE] arrivals or an empty/blank
+ * name are ignored to avoid false positives on low-frequency services or incomplete metadata.
+ *
+ * @param arrivals the list of arrivals loaded for the stop
+ * @param agencyNameOf resolves an arrival's agency display name from route references
+ * @return a list of [RealtimeOutage] objects for affected agencies, ordered alphabetically by agency name
+ */
+fun detectRealtimeOutages(
+    arrivals: List<ArrivalInfo>,
+    agencyNameOf: (ArrivalInfo) -> String?
+): List<RealtimeOutage> {
+    if (arrivals.isEmpty()) return emptyList()
+
+    return arrivals
+        .groupBy { agencyNameOf(it) }
+        .mapNotNull { (agencyName, agencyArrivals) ->
+            if (agencyName.isNullOrBlank()) return@mapNotNull null
+            if (agencyArrivals.size >= MIN_ARRIVALS_FOR_REALTIME_OUTAGE && agencyArrivals.none { it.predicted }) {
+                RealtimeOutage(agencyName = agencyName)
+            } else {
+                null
+            }
+        }
+        .sortedBy { it.agencyName }
+}

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1085,6 +1085,8 @@
     <string name="service_alert_severity_info">Information</string>
     <string name="service_alert_severity_warning">Warning</string>
     <string name="service_alert_severity_severe">Severe</string>
+    <!-- Realtime outage banner shown on arrivals screen when an agency has an established realtime outage (#2301) -->
+    <string name="realtime_outage_banner">Realtime predictions for %s are currently unavailable. Showing scheduled times.</string>
     <!-- Read after a leg's symbol on an itinerary option card when a service alert affects that leg.
          %1$s is the localized severity label, announced in place so it reads e.g.
          "1 Line, Severe service alert". -->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -179,9 +179,12 @@ class ArrivalsViewModelTest {
         assertEquals(ServerTime(65 * 60_000L), state.windowEnd)
     }
 
+    /**
+     * Verifies that realtimeOutages from repository data is propagated to ArrivalsUiState.Content.
+     */
     @Test
     fun `refresh propagates realtimeOutages to Content state`() = runTest {
-        val outages = listOf(RealtimeOutage("King County Metro"))
+        val outages = listOf(RealtimeOutage("1", "King County Metro"))
         val viewModel = ArrivalsViewModel("1_100", FakeArrivalsRepository(Result.success(data(realtimeOutages = outages))))
 
         viewModel.refresh()

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/ArrivalsViewModelTest.kt
@@ -141,7 +141,8 @@ class ArrivalsViewModelTest {
         minutesAfter: Int = 65,
         isStale: Boolean = false,
         favorite: Boolean = false,
-        hideAlertsByDefault: Boolean = false
+        hideAlertsByDefault: Boolean = false,
+        realtimeOutages: List<RealtimeOutage> = emptyList()
     ) = ArrivalsData(
         arrivals = emptyList(),
         routeGroups = emptyList(),
@@ -154,7 +155,8 @@ class ArrivalsViewModelTest {
         hideAlertsByDefault = hideAlertsByDefault,
         stopCode = null,
         stopLat = 0.0,
-        stopLon = 0.0
+        stopLon = 0.0,
+        realtimeOutages = realtimeOutages
     )
 
     @Test
@@ -175,6 +177,17 @@ class ArrivalsViewModelTest {
         assertEquals("Pine St & 3rd Ave", (state as ArrivalsUiState.Content).header.name)
         // The window-end instant rides through unchanged from ArrivalsData into the Content state.
         assertEquals(ServerTime(65 * 60_000L), state.windowEnd)
+    }
+
+    @Test
+    fun `refresh propagates realtimeOutages to Content state`() = runTest {
+        val outages = listOf(RealtimeOutage("King County Metro"))
+        val viewModel = ArrivalsViewModel("1_100", FakeArrivalsRepository(Result.success(data(realtimeOutages = outages))))
+
+        viewModel.refresh()
+
+        val state = viewModel.state.value as ArrivalsUiState.Content
+        assertEquals(outages, state.realtimeOutages)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
@@ -291,6 +291,74 @@ class DefaultArrivalsRepositoryTest {
     }
 
     @Test
+    fun `a fresh load with all scheduled arrivals for an agency flags realtime outage`() = runTest {
+        val dataSource = FakeStopArrivalsDataSource()
+        val arrivals = listOf(
+            ArrivalDeparture(
+                routeId = "route-1",
+                tripId = "trip-1",
+                stopId = STOP_ID,
+                stopSequence = 3,
+                scheduledArrivalTime = T0 + 10 * 60_000L,
+                scheduledDepartureTime = T0 + 10 * 60_000L,
+                predicted = false
+            ),
+            ArrivalDeparture(
+                routeId = "route-1",
+                tripId = "trip-2",
+                stopId = STOP_ID,
+                stopSequence = 3,
+                scheduledArrivalTime = T0 + 20 * 60_000L,
+                scheduledDepartureTime = T0 + 20 * 60_000L,
+                predicted = false
+            ),
+            ArrivalDeparture(
+                routeId = "route-1",
+                tripId = "trip-3",
+                stopId = STOP_ID,
+                stopSequence = 3,
+                scheduledArrivalTime = T0 + 30 * 60_000L,
+                scheduledDepartureTime = T0 + 30 * 60_000L,
+                predicted = false
+            )
+        )
+        val snapshotWithOutage = StopArrivals(
+            data = EntryWithReferences(
+                entry = ArrivalsForStop(
+                    stopId = STOP_ID,
+                    arrivalsAndDepartures = arrivals
+                ),
+                references = References(
+                    agencies = listOf(AgencyReference(id = "agency-1", name = "Metro")),
+                    stops = listOf(
+                        StopReference(
+                            id = STOP_ID,
+                            name = "Pine St & 3rd Ave",
+                            lat = 47.61,
+                            lon = -122.33,
+                            routeIds = listOf("route-1")
+                        )
+                    ),
+                    routes = listOf(RouteReference(id = "route-1", shortName = "5", agencyId = "agency-1")),
+                    trips = listOf(
+                        TripReference(id = "trip-1", routeId = "route-1", shapeId = "shape-1", directionId = "0"),
+                        TripReference(id = "trip-2", routeId = "route-1", shapeId = "shape-1", directionId = "0"),
+                        TripReference(id = "trip-3", routeId = "route-1", shapeId = "shape-1", directionId = "0")
+                    )
+                )
+            ),
+            currentTime = T0,
+            minutesAfter = 65
+        )
+        dataSource.respond = { Result.success(snapshotWithOutage) }
+        val repository = repository(dataSource)
+
+        val data = repository.getArrivals(STOP_ID, 65).getOrThrow()
+
+        assertEquals(listOf(RealtimeOutage("Metro")), data.realtimeOutages)
+    }
+
+    @Test
     fun `the empty-window widen loop grows the window until arrivals appear`() = runTest {
         val dataSource = FakeStopArrivalsDataSource()
         dataSource.respond = { minutes ->

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/DefaultArrivalsRepositoryTest.kt
@@ -290,6 +290,9 @@ class DefaultArrivalsRepositoryTest {
         )
     }
 
+    /**
+     * Verifies that a fresh load with all scheduled arrivals for an agency flags a realtime outage.
+     */
     @Test
     fun `a fresh load with all scheduled arrivals for an agency flags realtime outage`() = runTest {
         val dataSource = FakeStopArrivalsDataSource()
@@ -355,7 +358,7 @@ class DefaultArrivalsRepositoryTest {
 
         val data = repository.getArrivals(STOP_ID, 65).getOrThrow()
 
-        assertEquals(listOf(RealtimeOutage("Metro")), data.realtimeOutages)
+        assertEquals(listOf(RealtimeOutage("agency-1", "Metro")), data.realtimeOutages)
     }
 
     @Test

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetectorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetectorTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.arrivals
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onebusaway.android.models.ArrivalData
+import org.onebusaway.android.models.FrequencyWindow
+import org.onebusaway.android.models.Occupancy
+import org.onebusaway.android.models.Status
+import org.onebusaway.android.time.ServerTime
+
+class RealtimeOutageDetectorTest {
+
+    private fun arrival(
+        routeId: String = "route-1",
+        predicted: Boolean = false,
+        tripId: String = "trip-1"
+    ): ArrivalInfo {
+        val scheduled = ServerTime(1_000_000L)
+        val predictedTime = if (predicted) ServerTime(1_000_000L) else null
+        val data = FakeArrivalData(
+            predicted = predicted,
+            predictedArrivalTime = predictedTime,
+            scheduledArrivalTime = scheduled,
+            routeId = routeId,
+            tripId = tripId
+        )
+        return ArrivalInfo(
+            context = null,
+            data = data,
+            now = ServerTime(1_000_000L),
+            includeArrivalDepartureInStatusLabel = false
+        )
+    }
+
+    @Test
+    fun `empty arrivals list returns no outage`() {
+        val result = detectRealtimeOutages(emptyList()) { "Metro" }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `agency with all predicted arrivals has no outage`() {
+        val arrivals = listOf(
+            arrival("r1", predicted = true),
+            arrival("r1", predicted = true),
+            arrival("r1", predicted = true)
+        )
+        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `agency with mix of predicted and scheduled arrivals has no outage`() {
+        val arrivals = listOf(
+            arrival("r1", predicted = false),
+            arrival("r1", predicted = true),
+            arrival("r1", predicted = false)
+        )
+        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `agency with at least 3 scheduled-only arrivals flags outage`() {
+        val arrivals = listOf(
+            arrival("r1", predicted = false),
+            arrival("r1", predicted = false),
+            arrival("r2", predicted = false)
+        )
+        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        assertEquals(listOf(RealtimeOutage("Metro")), result)
+    }
+
+    @Test
+    fun `agency with fewer than 3 scheduled-only arrivals does not flag outage`() {
+        val arrivals = listOf(
+            arrival("r1", predicted = false),
+            arrival("r1", predicted = false)
+        )
+        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `multiple agencies with only one affected flags only affected agency`() {
+        val arrivals = listOf(
+            // Metro: 3 arrivals, 0 predicted -> outage
+            arrival("metro-1", predicted = false),
+            arrival("metro-1", predicted = false),
+            arrival("metro-2", predicted = false),
+            // Sound Transit: 3 arrivals, 2 predicted -> no outage
+            arrival("st-1", predicted = true),
+            arrival("st-1", predicted = true),
+            arrival("st-2", predicted = false),
+            // Pierce Transit: 2 arrivals, 0 predicted -> below threshold, no outage
+            arrival("pt-1", predicted = false),
+            arrival("pt-1", predicted = false)
+        )
+        val result = detectRealtimeOutages(arrivals) {
+            when {
+                it.routeId.startsWith("metro") -> "King County Metro"
+                it.routeId.startsWith("st") -> "Sound Transit"
+                it.routeId.startsWith("pt") -> "Pierce Transit"
+                else -> null
+            }
+        }
+        assertEquals(listOf(RealtimeOutage("King County Metro")), result)
+    }
+
+    @Test
+    fun `multiple affected agencies are sorted alphabetically`() {
+        val arrivals = listOf(
+            arrival("st-1", predicted = false),
+            arrival("st-2", predicted = false),
+            arrival("st-3", predicted = false),
+            arrival("kcm-1", predicted = false),
+            arrival("kcm-2", predicted = false),
+            arrival("kcm-3", predicted = false)
+        )
+        val result = detectRealtimeOutages(arrivals) {
+            if (it.routeId.startsWith("st")) "Sound Transit" else "King County Metro"
+        }
+        assertEquals(
+            listOf(
+                RealtimeOutage("King County Metro"),
+                RealtimeOutage("Sound Transit")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `null or blank agency name is ignored`() {
+        val arrivals = listOf(
+            arrival("r1", predicted = false),
+            arrival("r2", predicted = false),
+            arrival("r3", predicted = false)
+        )
+        val resultNull = detectRealtimeOutages(arrivals) { null }
+        assertTrue(resultNull.isEmpty())
+
+        val resultBlank = detectRealtimeOutages(arrivals) { "   " }
+        assertTrue(resultBlank.isEmpty())
+    }
+
+    @Test
+    fun `recovery with predicted arrival clears the outage`() {
+        val outageArrivals = listOf(
+            arrival("r1", predicted = false),
+            arrival("r1", predicted = false),
+            arrival("r2", predicted = false)
+        )
+        assertEquals(1, detectRealtimeOutages(outageArrivals) { "Metro" }.size)
+
+        // After refresh, predictions return for one or more trips
+        val recoveredArrivals = listOf(
+            arrival("r1", predicted = true),
+            arrival("r1", predicted = false),
+            arrival("r2", predicted = false)
+        )
+        assertTrue(detectRealtimeOutages(recoveredArrivals) { "Metro" }.isEmpty())
+    }
+
+    private data class FakeArrivalData(
+        override val predicted: Boolean,
+        override val predictedArrivalTime: ServerTime?,
+        override val scheduledArrivalTime: ServerTime,
+        override val routeId: String = "1_100",
+        override val tripId: String = "1_trip",
+        override val stopId: String = "1_82673",
+        override val headsign: String? = "Downtown",
+        override val shortName: String? = "230",
+        override val routeLongName: String? = null,
+        override val stopSequence: Int = 5,
+        override val serviceDate: Long = 0L,
+        override val vehicleId: String? = null,
+        override val scheduledDepartureTime: ServerTime = ServerTime(0L),
+        override val predictedDepartureTime: ServerTime? = null,
+        override val status: Status? = null,
+        override val frequency: FrequencyWindow? = null,
+        override val situationIds: List<String> = emptyList(),
+        override val historicalOccupancy: Occupancy? = null,
+        override val predictedOccupancy: Occupancy? = null,
+        override val hasTripStatus: Boolean = false,
+        override val scheduleDeviation: Long = 0L,
+        override val lastKnownLat: Double? = null,
+        override val lastKnownLon: Double? = null,
+        override val hasPlottableVehicle: Boolean = false
+    ) : ArrivalData
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetectorTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/arrivals/RealtimeOutageDetectorTest.kt
@@ -24,8 +24,19 @@ import org.onebusaway.android.models.Occupancy
 import org.onebusaway.android.models.Status
 import org.onebusaway.android.time.ServerTime
 
+/**
+ * Unit tests for [detectRealtimeOutages].
+ */
 class RealtimeOutageDetectorTest {
 
+    /**
+     * Builds a minimal [ArrivalInfo] for outage detector tests.
+     *
+     * @param routeId the route identifier for the arrival
+     * @param predicted whether realtime prediction is available
+     * @param tripId the trip identifier
+     * @return a constructed [ArrivalInfo] model
+     */
     private fun arrival(
         routeId: String = "route-1",
         predicted: Boolean = false,
@@ -48,12 +59,18 @@ class RealtimeOutageDetectorTest {
         )
     }
 
+    /**
+     * Verifies that an empty arrivals list produces no outages.
+     */
     @Test
     fun `empty arrivals list returns no outage`() {
-        val result = detectRealtimeOutages(emptyList()) { "Metro" }
+        val result = detectRealtimeOutages(emptyList()) { OperatingAgency("1", "Metro") }
         assertTrue(result.isEmpty())
     }
 
+    /**
+     * Verifies that an agency with all predicted arrivals does not trigger an outage.
+     */
     @Test
     fun `agency with all predicted arrivals has no outage`() {
         val arrivals = listOf(
@@ -61,10 +78,13 @@ class RealtimeOutageDetectorTest {
             arrival("r1", predicted = true),
             arrival("r1", predicted = true)
         )
-        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        val result = detectRealtimeOutages(arrivals) { OperatingAgency("1", "Metro") }
         assertTrue(result.isEmpty())
     }
 
+    /**
+     * Verifies that an agency with a mix of predicted and scheduled arrivals does not trigger an outage.
+     */
     @Test
     fun `agency with mix of predicted and scheduled arrivals has no outage`() {
         val arrivals = listOf(
@@ -72,10 +92,13 @@ class RealtimeOutageDetectorTest {
             arrival("r1", predicted = true),
             arrival("r1", predicted = false)
         )
-        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        val result = detectRealtimeOutages(arrivals) { OperatingAgency("1", "Metro") }
         assertTrue(result.isEmpty())
     }
 
+    /**
+     * Verifies that an agency with at least 3 scheduled-only arrivals triggers an outage.
+     */
     @Test
     fun `agency with at least 3 scheduled-only arrivals flags outage`() {
         val arrivals = listOf(
@@ -83,20 +106,26 @@ class RealtimeOutageDetectorTest {
             arrival("r1", predicted = false),
             arrival("r2", predicted = false)
         )
-        val result = detectRealtimeOutages(arrivals) { "Metro" }
-        assertEquals(listOf(RealtimeOutage("Metro")), result)
+        val result = detectRealtimeOutages(arrivals) { OperatingAgency("1", "Metro") }
+        assertEquals(listOf(RealtimeOutage("1", "Metro")), result)
     }
 
+    /**
+     * Verifies that an agency with fewer than 3 scheduled-only arrivals does not trigger an outage.
+     */
     @Test
     fun `agency with fewer than 3 scheduled-only arrivals does not flag outage`() {
         val arrivals = listOf(
             arrival("r1", predicted = false),
             arrival("r1", predicted = false)
         )
-        val result = detectRealtimeOutages(arrivals) { "Metro" }
+        val result = detectRealtimeOutages(arrivals) { OperatingAgency("1", "Metro") }
         assertTrue(result.isEmpty())
     }
 
+    /**
+     * Verifies that when multiple agencies serve a stop, only the affected agency is flagged.
+     */
     @Test
     fun `multiple agencies with only one affected flags only affected agency`() {
         val arrivals = listOf(
@@ -114,15 +143,68 @@ class RealtimeOutageDetectorTest {
         )
         val result = detectRealtimeOutages(arrivals) {
             when {
-                it.routeId.startsWith("metro") -> "King County Metro"
-                it.routeId.startsWith("st") -> "Sound Transit"
-                it.routeId.startsWith("pt") -> "Pierce Transit"
+                it.routeId.startsWith("metro") -> OperatingAgency("1", "King County Metro")
+                it.routeId.startsWith("st") -> OperatingAgency("40", "Sound Transit")
+                it.routeId.startsWith("pt") -> OperatingAgency("3", "Pierce Transit")
                 else -> null
             }
         }
-        assertEquals(listOf(RealtimeOutage("King County Metro")), result)
+        assertEquals(listOf(RealtimeOutage("1", "King County Metro")), result)
     }
 
+    /**
+     * Verifies that distinct agencies with the same display name do not have their arrivals
+     * merged across agency IDs to falsely trigger an outage (regression test).
+     */
+    @Test
+    fun `distinct agencies with the same display name do not merge arrivals to falsely trigger outage`() {
+        val arrivals = listOf(
+            // Agency 1: 2 arrivals, both scheduled (< 3 threshold)
+            arrival("agency1-r1", predicted = false),
+            arrival("agency1-r2", predicted = false),
+            // Agency 2: 1 arrival, scheduled (< 3 threshold)
+            arrival("agency2-r1", predicted = false)
+        )
+        val result = detectRealtimeOutages(arrivals) {
+            when {
+                it.routeId.startsWith("agency1") -> OperatingAgency("id-1", "Metro")
+                it.routeId.startsWith("agency2") -> OperatingAgency("id-2", "Metro")
+                else -> null
+            }
+        }
+        // Neither agency has >= 3 arrivals, so neither should be flagged
+        assertTrue(result.isEmpty())
+    }
+
+    /**
+     * Verifies that distinct agencies with the same display name evaluate realtime predictions
+     * independently so one agency's live data doesn't suppress another agency's outage.
+     */
+    @Test
+    fun `distinct agencies with the same display name evaluate independently`() {
+        val arrivals = listOf(
+            // Agency 1: 3 arrivals, all scheduled (outage)
+            arrival("agency1-r1", predicted = false),
+            arrival("agency1-r2", predicted = false),
+            arrival("agency1-r3", predicted = false),
+            // Agency 2: 3 arrivals, all predicted (no outage)
+            arrival("agency2-r1", predicted = true),
+            arrival("agency2-r2", predicted = true),
+            arrival("agency2-r3", predicted = true)
+        )
+        val result = detectRealtimeOutages(arrivals) {
+            when {
+                it.routeId.startsWith("agency1") -> OperatingAgency("id-1", "Metro")
+                it.routeId.startsWith("agency2") -> OperatingAgency("id-2", "Metro")
+                else -> null
+            }
+        }
+        assertEquals(listOf(RealtimeOutage("id-1", "Metro")), result)
+    }
+
+    /**
+     * Verifies that multiple affected agencies are sorted alphabetically by agency name.
+     */
     @Test
     fun `multiple affected agencies are sorted alphabetically`() {
         val arrivals = listOf(
@@ -134,19 +216,26 @@ class RealtimeOutageDetectorTest {
             arrival("kcm-3", predicted = false)
         )
         val result = detectRealtimeOutages(arrivals) {
-            if (it.routeId.startsWith("st")) "Sound Transit" else "King County Metro"
+            if (it.routeId.startsWith("st")) {
+                OperatingAgency("40", "Sound Transit")
+            } else {
+                OperatingAgency("1", "King County Metro")
+            }
         }
         assertEquals(
             listOf(
-                RealtimeOutage("King County Metro"),
-                RealtimeOutage("Sound Transit")
+                RealtimeOutage("1", "King County Metro"),
+                RealtimeOutage("40", "Sound Transit")
             ),
             result
         )
     }
 
+    /**
+     * Verifies that null or blank agency IDs or names are ignored.
+     */
     @Test
-    fun `null or blank agency name is ignored`() {
+    fun `null or blank agency info is ignored`() {
         val arrivals = listOf(
             arrival("r1", predicted = false),
             arrival("r2", predicted = false),
@@ -155,10 +244,16 @@ class RealtimeOutageDetectorTest {
         val resultNull = detectRealtimeOutages(arrivals) { null }
         assertTrue(resultNull.isEmpty())
 
-        val resultBlank = detectRealtimeOutages(arrivals) { "   " }
-        assertTrue(resultBlank.isEmpty())
+        val resultBlankName = detectRealtimeOutages(arrivals) { OperatingAgency("1", "   ") }
+        assertTrue(resultBlankName.isEmpty())
+
+        val resultBlankId = detectRealtimeOutages(arrivals) { OperatingAgency("   ", "Metro") }
+        assertTrue(resultBlankId.isEmpty())
     }
 
+    /**
+     * Verifies that when realtime predictions recover on a subsequent poll, the outage clears.
+     */
     @Test
     fun `recovery with predicted arrival clears the outage`() {
         val outageArrivals = listOf(
@@ -166,7 +261,7 @@ class RealtimeOutageDetectorTest {
             arrival("r1", predicted = false),
             arrival("r2", predicted = false)
         )
-        assertEquals(1, detectRealtimeOutages(outageArrivals) { "Metro" }.size)
+        assertEquals(1, detectRealtimeOutages(outageArrivals) { OperatingAgency("1", "Metro") }.size)
 
         // After refresh, predictions return for one or more trips
         val recoveredArrivals = listOf(
@@ -174,9 +269,12 @@ class RealtimeOutageDetectorTest {
             arrival("r1", predicted = false),
             arrival("r2", predicted = false)
         )
-        assertTrue(detectRealtimeOutages(recoveredArrivals) { "Metro" }.isEmpty())
+        assertTrue(detectRealtimeOutages(recoveredArrivals) { OperatingAgency("1", "Metro") }.isEmpty())
     }
 
+    /**
+     * Minimal [ArrivalData] test stub for constructing [ArrivalInfo].
+     */
     private data class FakeArrivalData(
         override val predicted: Boolean,
         override val predictedArrivalTime: ServerTime?,


### PR DESCRIPTION
### Summary
Fixes #2301.

When an agency's realtime data disappears from the OBA backend, the app falls back to scheduled arrivals with no explanation of the broader problem. This PR introduces a compact, non-blocking informational banner on the arrivals view that informs riders when an agency's realtime predictions are unavailable.

---

### Proposed Behavior & Changes
1. **Per-Agency Outage Detection (`RealtimeOutageDetector`)**:
   - Groups arrivals by operating agency (via route -> agencyId lookup).
   - Flags an outage only when an agency has at least $\ge 3$ arrivals at the viewed stop and **zero** of them have realtime predictions (`predicted == false`).
   - Avoids false positives on stops with 1–2 scheduled trips, partial realtime coverage, or missing metadata.
   - Pure, stateless function (`detectRealtimeOutages`) with no Android dependencies.

2. **Repository & UI State Integration**:
   - Added `realtimeOutages: List<RealtimeOutage>` to `ArrivalsData` and `ArrivalsUiState.Content`.
   - Computed fresh per-response in `ArrivalsRepository.toData()`, ensuring automatic recovery when realtime predictions return or when navigating to another stop without requiring an app restart.
   - Handled separately from network failure/device offline states (`isStale` banner).

3. **Arrivals View Banner (`RealtimeOutageBanner`)**:
   - Implemented `RealtimeOutageBanner` using `AlertSurface` with `AlertSeverity.INFO`.
   - Placed above the routes in `ArrivalsList` LazyColumn with `Modifier.animateItem()`.
   - Formatted string: `"Realtime predictions for %s are currently unavailable. Showing scheduled times."`
   - Non-blocking: doesn't prevent browsing or interacting with arrivals.

---

### Verification & Testing
- **Unit Tests**:
  - `RealtimeOutageDetectorTest`: covers empty lists, all predicted, mixed predicted/scheduled, outage detection threshold ($\ge 3$), multiple agencies (only affected agency flagged), sorting, and recovery.
  - `DefaultArrivalsRepositoryTest`: verifies `realtimeOutages` is populated properly from snapshot data.
  - `ArrivalsViewModelTest`: verifies `realtimeOutages` propagates to `ArrivalsUiState.Content`.
- **Formatting & Build**:
  - `./gradlew spotlessCheck` passed cleanly.
  - Tested across both `obaGoogle` and `obaMaplibre` variants (`BUILD SUCCESSFUL`).

---

### Checklist
- [x] Format your changes with `./gradlew spotlessApply`.
- [x] Run the unit tests with `./gradlew testObaGoogleDebugUnitTest` and `./gradlew testObaMaplibreDebugUnitTest`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added realtime outage detection for transit agencies.
  * Arrivals screens now display an informational banner when realtime predictions are unavailable.
  * Scheduled arrival times remain available while affected agencies recover.
  * Outage notices are shown separately for each affected agency.

* **Bug Fixes**
  * Improved arrivals-list navigation to account for outage banners.

* **Tests**
  * Added coverage for outage detection, agency filtering, thresholds, sorting, recovery, and multiple agencies with matching names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->