### PR TITLE
Enable R8 obfuscation for release builds

### DIFF
--- a/onebusaway-android/proguard-project.txt
+++ b/onebusaway-android/proguard-project.txt
@@ -19,8 +19,14 @@
 #   public *;
 #}
 
-# Don't rename class names - this makes stack traces must easier to read/troubleshoot
--dontobfuscate
+# Release builds are obfuscated (Google Play's "App optimization" gate requires it, and it was
+# only ever turned off in 2015 to avoid having to save a mapping file). Readable stack traces now
+# come from the R8 mapping instead: the Crashlytics Gradle plugin uploads it on every release
+# assemble, it is embedded in the App Bundle for Play Console vitals, and the release workflow
+# archives build/outputs/mapping/<variant>/mapping.txt. Keep file + line attributes so those
+# retraced stack traces point at real lines.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
 # For Jackson, using for JSON data binding
 -dontwarn org.w3c.dom.bootstrap.DOMImplementationRegistry
@@ -32,9 +38,6 @@
 -keepclassmembers public final enum org.codehaus.jackson.annotate.JsonAutoDetect$Visibility {
  public static final org.codehaus.jackson.annotate.JsonAutoDetect$Visibility *; }
 
-# Keep all OneBusAway Android classes
--keep class org.onebusaway.android.** { *; }
-
 # Keep all Pelias POJO classes for geocoding
 -keep class edu.usf.cutr.pelias.** { *; }
 
@@ -42,12 +45,6 @@
 -keep class org.geojson.** { *; }
 -keepclassmembers class org.geojson.Feature** { *; }
 -keepclassmembers class org.geojson.jackson.LngLatAltDeserializer** { *; }
-
-# SearchView
--keep class android.support.v7.widget.SearchView { *; }
-
-# "About" activity - see #418
--keep public class * extends android.support.design.widget.CoordinatorLayout$Behavior { *; }
 
 # Below is required to do a release build as of Play Services 8.1 - see #342
 -dontwarn com.google.android.gms.ads.**
@@ -59,10 +56,12 @@
 # Keep Open311 library (needed for unit tests)
 -keep class edu.usf.cutr.open311client.** { *; }
 
-# for AndroidSlidingUpPanel (com.github.hannesa2:AndroidSlidingUpPanel) and compiling with API 28 (see https://github.com/OneBusAway/onebusaway-android/issues/944#issuecomment-446340531)
--dontwarn com.sothree.**
--keep class com.sothree.**
--keep interface com.sothree.**
+# GTFS-realtime bindings (org.mobilitydata:gtfs-realtime-bindings) are generated for the full
+# protobuf-java runtime, whose GeneratedMessage.FieldAccessorTable finds message accessors by name
+# via reflection (toString(), getField(), getDescriptorForType(), ...). Neither jar ships R8 rules,
+# so keep the generated message classes intact rather than let obfuscation rename their members.
+-keep class com.google.transit.realtime.** { *; }
+
 # Flavor-specific Compose map adapters are instantiated by reflection on
 # BuildConfig.MAP_COMPOSE_ADAPTER_CLASS (see ObaComposeMapAdapter.newInstance()), so keep each
 # adapter + its no-arg constructor from being stripped/renamed in release builds.


### PR DESCRIPTION
## Why

Google Play's **App optimization** notice ("Obfuscation (0%)", "Percentages under 25% in any category may impact your visibility and publishing capabilities") is firing on the listing. Minification was already on for release builds, but `proguard-project.txt` carried `-dontobfuscate` (added in 2015 to avoid having to save a mapping file) plus a blanket `-keep class org.onebusaway.android.** { *; }`, so R8 renamed nothing.

## What

All in `onebusaway-android/proguard-project.txt`:

- **Drop `-dontobfuscate` and the app-wide keep.** The 2015 rationale no longer holds: the Crashlytics Gradle plugin uploads the R8 mapping on every release assemble, the App Bundle embeds it for Play Console vitals, and the release workflow already archives `mapping.txt`.
- **Keep `SourceFile`/`LineNumberTable`** and rename the source-file attribute, so retraced stack traces point at real lines.
- **Keep the generated GTFS-realtime protobuf classes** (`com.google.transit.realtime.**`). The full protobuf-java runtime resolves message accessors by name through `FieldAccessorTable` reflection, and neither `gtfs-realtime-bindings` nor `protobuf-java` ships R8 rules.
- **Remove dead rules** for `android.support.*` and the sliding-panel library, neither of which is in the build any more.

Everything else the app relies on by name already carries its own rules: kotlinx.serialization, Room, Hilt, Retrofit and the coordinator-layout behaviors ship consumer rules; manifest components and layout-referenced classes are kept by aapt; preference-backed enums are looked up by explicit value strings; and the only `Class.forName` sites are the flavor map adapter (already kept) and an Activity kept via the manifest.

## Verification

Local `assembleObaGoogleRelease` (including lint-vital) builds clean. The mapping shows:

| | Classes | Renamed |
|---|---|---|
| `org.onebusaway.android` | 2361 | 2349 |
| Whole APK | 11475 | 10347 |

The 12 unrenamed app classes are exactly the manifest components, `AppDatabase`/`AppDatabase_Impl`, and `GoogleComposeAdapter`.

Installed the release APK on a Pixel 7 Pro: boots to the map, region selection, stops and arrivals, trip planning (Pelias/Jackson), service alerts (protobuf) and trip monitoring all work; no class-not-found or serialization errors in logcat, and frames appear as obfuscated names with line numbers.

## After merge

Play recomputes the percentages from the next uploaded bundle, so cutting a release via the **Release to Google Play** workflow is what clears the notice; it should ship before the deadline in the notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpCPcMRjFEWQyAuLygzbCp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Performance**
  * Release builds now support code obfuscation, improving protection of application internals.
  * Crash reports retain source-file and line-number information to support troubleshooting.
  * Updated release configuration to preserve required transit data classes while reducing unnecessary keep rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->