### PR TITLE
Number this release 26.3.0

### DIFF
--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -62,7 +62,7 @@ android {
         // month: 26.1.0 shipped in March. See "Version numbering" in docs/RELEASING.md, and bump it
         // by hand.
         versionCode = 153
-        versionName = "26.2.1"
+        versionName = "26.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to **26.3.0**. That is the only change: the release notes in `src/oba/play/release-notes/en-US/default.txt` and `main_help_whatsnew` stay exactly as they were for 26.2.1. `versionCode` is untouched; Play's AUTO resolution assigns it at release time.

### Everyone upgrading sees the layout migration flow

Checked, not changed. `HelpViewModel.maybeShowStartup` offers the Search-results and Arrival-display choices when:

- the recorded pre-upgrade `whatsNewVer` is positive. Every version back to the Java `HomeActivity` wrote it on the first launch that reached the home screen, and the SharedPreferences→DataStore migration carries it forward for 2.x installs.
- the corresponding preference (`search_result_mode`, `arrival_display_default`) is unset. Neither key existed before #2310, so it is unset for every build through 26.2.1. Nothing writes them implicitly; only the chooser and Settings do.

The source marker is captured before What's New advances `whatsNewVer`, and persists, so a deferred choice is owed again next launch and a fresh install of 26.3.0 is marked out permanently. No alpha has been cut since 26.2.1 (last release run 2026-08-27), so nobody in the field is already past the flow. `HelpViewModelTest` (17 tests) pins eligibility for codes 1, 153–157 and exclusion for fresh installs; it passes on this branch with `-PwarningsAsErrors=true`.

### After merge

1. Run **Release to Google Play** on the squash commit (`track: alpha`, `release_status: completed`).
2. Tag it once the upload succeeds: `git tag -a v26.3.0 -m "26.3.0" <commit> && git push origin v26.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk69DWyVVeGFhS9MFuKTLk
