### PR TITLE
Add a Choose Your Layout entry to Help and call the old layout Classic (#2321)

### DIFF
--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceTest.kt
@@ -55,11 +55,11 @@ class SearchWorkflowChoiceTest {
         compose.setContent { ObaTheme { SearchWorkflowChoiceDialog({ saved = it }, {}) } }
         compose.onNodeWithContentDescription("Page 1 of 1").assertIsDisplayed()
         compose.onNodeWithText("Back").assertIsNotEnabled()
-        compose.onNode(hasText("Lists and arrivals") and hasText("Classic layout")).assertIsSelected()
-        compose.onNode(hasText("Map") and hasText("New layout")).assertIsDisplayed()
+        compose.onNode(hasText("List navigation") and hasText("Classic layout")).assertIsSelected()
+        compose.onNode(hasText("Map navigation") and hasText("New layout")).assertIsDisplayed()
         assertTrue(
-            compose.onNodeWithText("Lists and arrivals").getUnclippedBoundsInRoot().top <
-                compose.onNodeWithText("Map").getUnclippedBoundsInRoot().top
+            compose.onNodeWithText("List navigation").getUnclippedBoundsInRoot().top <
+                compose.onNodeWithText("Map navigation").getUnclippedBoundsInRoot().top
         )
         compose.onNodeWithText("Continue").performClick()
         compose.runOnIdle { assertEquals(SearchResultMode.LISTS, saved) }
@@ -70,7 +70,7 @@ class SearchWorkflowChoiceTest {
         var saved: SearchResultMode? = null
         val restoration = StateRestorationTester(compose)
         restoration.setContent { ObaTheme { SearchWorkflowChoiceDialog({ saved = it }, {}) } }
-        compose.onNodeWithText("Map").performScrollTo().performClick()
+        compose.onNodeWithText("Map navigation").performScrollTo().performClick()
         restoration.emulateSavedInstanceStateRestore()
         compose.onNodeWithText("Continue").performClick()
         compose.runOnIdle { assertEquals(SearchResultMode.MAP, saved) }
@@ -109,11 +109,11 @@ class SearchWorkflowChoiceTest {
     fun previewTapSelectsOnlyTheEnclosingChoice() {
         var saved: SearchResultMode? = null
         compose.setContent { ObaTheme { SearchWorkflowChoiceDialog({ saved = it }, {}) } }
-        compose.onNodeWithText("Map").performScrollTo().performClick()
-        compose.onNodeWithText("Lists and arrivals").performScrollTo().performTouchInput {
+        compose.onNodeWithText("Map navigation").performScrollTo().performClick()
+        compose.onNodeWithText("List navigation").performScrollTo().performTouchInput {
             click(Offset(center.x, height * .8f))
         }
-        compose.onNodeWithText("Lists and arrivals").assertIsSelected()
+        compose.onNodeWithText("List navigation").assertIsSelected()
         compose.runOnIdle { assertEquals(null, saved) }
         compose.onNodeWithText("Continue").performClick()
         compose.runOnIdle { assertEquals(SearchResultMode.LISTS, saved) }

--- a/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceTest.kt
+++ b/onebusaway-android/src/androidTest/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceTest.kt
@@ -55,7 +55,7 @@ class SearchWorkflowChoiceTest {
         compose.setContent { ObaTheme { SearchWorkflowChoiceDialog({ saved = it }, {}) } }
         compose.onNodeWithContentDescription("Page 1 of 1").assertIsDisplayed()
         compose.onNodeWithText("Back").assertIsNotEnabled()
-        compose.onNode(hasText("Lists and arrivals") and hasText("Previous layout")).assertIsSelected()
+        compose.onNode(hasText("Lists and arrivals") and hasText("Classic layout")).assertIsSelected()
         compose.onNode(hasText("Map") and hasText("New layout")).assertIsDisplayed()
         assertTrue(
             compose.onNodeWithText("Lists and arrivals").getUnclippedBoundsInRoot().top <

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -424,8 +424,8 @@ class HomeActivity : AppCompatActivity() {
                 viewModel.reportMenuAnalytics(R.string.analytics_label_twitter)
             }
             HelpAction.CONTACT_US -> goToSendFeedBack()
-            // LEGEND / WHATS_NEW open dialogs — handled by HelpFeature against HelpViewModel.
-            HelpAction.LEGEND, HelpAction.WHATS_NEW -> Unit
+            // LEGEND / WHATS_NEW / LAYOUT open dialogs — handled by HelpFeature against HelpViewModel.
+            HelpAction.LEGEND, HelpAction.WHATS_NEW, HelpAction.LAYOUT -> Unit
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalDisplayChoiceDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalDisplayChoiceDialog.kt
@@ -53,9 +53,10 @@ internal fun ArrivalDisplayChoiceDialog(
     onDismiss: () -> Unit,
     page: Int = 1,
     pageCount: Int = 1,
-    onBack: (() -> Unit)? = null
+    onBack: (() -> Unit)? = null,
+    initial: ArrivalDisplayMode = ArrivalDisplayMode.TIME
 ) {
-    var selected by rememberSaveable { mutableStateOf(ArrivalDisplayMode.TIME) }
+    var selected by rememberSaveable(initial) { mutableStateOf(initial) }
     MigrationDialog(
         title = stringResource(R.string.arrival_display_choose_title),
         page = page,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalDisplayChoiceDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalDisplayChoiceDialog.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import java.time.LocalDate
 import java.time.ZoneId
@@ -66,7 +68,7 @@ internal fun ArrivalDisplayChoiceDialog(
         onBack = onBack,
         content = {
             Column(Modifier.verticalScroll(rememberScrollState()).selectableGroup(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(stringResource(R.string.arrival_display_choose_body))
+                Text(AnnotatedString.fromHtml(stringResource(R.string.arrival_display_choose_body)))
                 ArrivalDisplayMode.entries.forEach { mode ->
                     MigrationChoice(
                         title = stringResource(if (mode == ArrivalDisplayMode.TIME) R.string.arrival_display_time else R.string.arrival_display_route),

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalDisplayModeSwitch.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/arrivals/components/ArrivalDisplayModeSwitch.kt
@@ -15,26 +15,17 @@
  */
 package org.onebusaway.android.ui.arrivals.components
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.onebusaway.android.R
 import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
+import org.onebusaway.android.ui.compose.components.SegmentedChoice
 
 @Composable
 fun ArrivalDisplayModeSwitch(
@@ -44,21 +35,15 @@ fun ArrivalDisplayModeSwitch(
     contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp),
     label: String = stringResource(R.string.arrival_display_switch)
 ) {
-    Row(
-        modifier.fillMaxWidth().padding(contentPadding),
-        horizontalArrangement = Arrangement.End
-    ) {
-        SingleChoiceSegmentedButtonRow(Modifier.semantics { contentDescription = label }) {
-            ArrivalDisplayMode.entries.forEachIndexed { index, option ->
-                SegmentedButton(
-                    selected = mode == option,
-                    onClick = { onChange(option) },
-                    shape = SegmentedButtonDefaults.itemShape(index, ArrivalDisplayMode.entries.size),
-                    label = { Text(stringResource(option.labelRes)) }
-                )
-            }
-        }
-    }
+    SegmentedChoice(
+        options = ArrivalDisplayMode.entries,
+        selected = mode,
+        onChange = onChange,
+        label = label,
+        optionLabel = { it.labelRes },
+        modifier = modifier,
+        contentPadding = contentPadding
+    )
 }
 
 internal val ArrivalDisplayMode.labelRes: Int

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/SegmentedChoice.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/compose/components/SegmentedChoice.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.ui.compose.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/** A right-aligned segmented control with one segment per option; [label] names the group for accessibility. */
+@Composable
+fun <T> SegmentedChoice(
+    options: List<T>,
+    selected: T,
+    onChange: (T) -> Unit,
+    label: String,
+    optionLabel: (T) -> Int,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp)
+) {
+    Row(
+        modifier.fillMaxWidth().padding(contentPadding),
+        horizontalArrangement = Arrangement.End
+    ) {
+        SingleChoiceSegmentedButtonRow(Modifier.semantics { contentDescription = label }) {
+            options.forEachIndexed { index, option ->
+                SegmentedButton(
+                    selected = selected == option,
+                    onClick = { onChange(option) },
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                    label = { Text(stringResource(optionLabel(option))) }
+                )
+            }
+        }
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
@@ -46,7 +46,8 @@ import org.onebusaway.android.ui.tutorial.LocalTutorialState
  * (legend / what's-new) are handled by [HelpViewModel]; the rest are Activity operations the host
  * carries out via the `onHelpAction` callback.
  */
-enum class HelpAction { TUTORIALS, LEGEND, WHATS_NEW, AGENCIES, TWITTER, CONTACT_US }
+/** Menu rows, in the order of `R.array.main_help_options` — the array is indexed by ordinal. */
+enum class HelpAction { TUTORIALS, LEGEND, WHATS_NEW, LAYOUT, AGENCIES, TWITTER, CONTACT_US }
 
 /**
  * Self-rendering help feature module: draws the help menu / what's-new / legend dialogs from
@@ -81,6 +82,7 @@ fun HelpFeature(
                 when (action) {
                     HelpAction.LEGEND -> viewModel.showLegend()
                     HelpAction.WHATS_NEW -> viewModel.showWhatsNew()
+                    HelpAction.LAYOUT -> viewModel.showLayoutChoices()
                     else -> {
                         viewModel.dismiss()
                         onHelpAction(action)
@@ -91,6 +93,7 @@ fun HelpFeature(
         )
         HelpDialog.SearchWorkflow -> migrationState.SaveableStateProvider("search") {
             SearchWorkflowChoiceDialog(
+                initial = viewModel.searchWorkflowStart(),
                 onSave = viewModel::chooseSearchResultMode,
                 onDismiss = viewModel::finishMigrationPage,
                 page = migrationPage,
@@ -99,6 +102,7 @@ fun HelpFeature(
         }
         HelpDialog.ArrivalDisplay -> migrationState.SaveableStateProvider("arrivals") {
             ArrivalDisplayChoiceDialog(
+                initial = viewModel.arrivalDisplayStart(),
                 onSave = viewModel::chooseArrivalDisplayDefault,
                 onDismiss = viewModel::finishMigrationPage,
                 page = migrationPage,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpDialogs.kt
@@ -73,8 +73,14 @@ fun HelpFeature(
             viewModel.maybeShowStartup()
         }
     }
+    // Keeps each page's unsaved pick across Back and recreation within one pass through the pages.
+    // Once the pass ends, forget it: a later visit from Help must start on the saved choice, not on
+    // one the rider abandoned by dismissing (rememberSaveable restores regardless of its inputs).
     val migrationState = rememberSaveableStateHolder()
     val migrationPage = state.migrationPages.indexOf(state.dialog) + 1
+    LaunchedEffect(migrationPage > 0) {
+        if (migrationPage == 0) listOf("search", "arrivals").forEach(migrationState::removeState)
+    }
     when (state.dialog) {
         HelpDialog.Menu -> HelpMenuDialog(
             showContactUs = state.showContactUs,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/HelpViewModel.kt
@@ -28,7 +28,9 @@ import org.onebusaway.android.preferences.PreferencesRepository
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.region.RegionState
 import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
+import org.onebusaway.android.ui.arrivals.arrivalDisplayDefault
 import org.onebusaway.android.ui.searchresults.SearchResultMode
+import org.onebusaway.android.ui.searchresults.searchResultMode
 import org.onebusaway.android.ui.tutorial.TutorialPrefs
 
 /** Which help dialog is showing — the dialog state this help feature module owns. */
@@ -46,7 +48,9 @@ sealed interface HelpDialog {
 data class HelpUiState(
     val dialog: HelpDialog = HelpDialog.None,
     val showContactUs: Boolean = true,
-    val migrationPages: List<HelpDialog> = emptyList()
+    val migrationPages: List<HelpDialog> = emptyList(),
+    /** The pages were reopened from Help, so finishing them owes no release notes or tutorial offer. */
+    val revisitingLayout: Boolean = false
 )
 
 /**
@@ -124,9 +128,29 @@ class HelpViewModel @Inject constructor(
         val index = state.migrationPages.indexOf(state.dialog)
         if (index < 0) return
         val next = state.migrationPages.getOrNull(index + 1)
-        _state.update { it.copy(dialog = next ?: HelpDialog.None) }
-        if (next == null && !maybeAutoShowWhatsNew()) maybeShowTutorialOptOut()
+        _state.update { it.copy(dialog = next ?: HelpDialog.None, revisitingLayout = next != null && it.revisitingLayout) }
+        if (next == null && !state.revisitingLayout && !maybeAutoShowWhatsNew()) maybeShowTutorialOptOut()
     }
+
+    /**
+     * "Choose Your Layout" from the Help menu: walk both layout pages again, whatever is saved. The
+     * upgrade sequence shows a page only while its choice is unsaved, so a rider who dismissed it,
+     * picked in a hurry, or installed fresh has no other way back to the illustrated comparison.
+     */
+    fun showLayoutChoices() {
+        _state.update {
+            it.copy(
+                migrationPages = listOf(HelpDialog.SearchWorkflow, HelpDialog.ArrivalDisplay),
+                dialog = HelpDialog.SearchWorkflow,
+                revisitingLayout = true
+            )
+        }
+    }
+
+    /** A page starts on the saved choice; unsaved, it starts on the classic layout, the safer answer for an upgrade. */
+    fun searchWorkflowStart(): SearchResultMode = if (prefs.getString(SearchResultMode.PREFERENCE_KEY, null) == null) SearchResultMode.LISTS else prefs.searchResultMode()
+
+    fun arrivalDisplayStart(): ArrivalDisplayMode = if (prefs.getString(ArrivalDisplayMode.PREFERENCE_KEY, null) == null) ArrivalDisplayMode.TIME else prefs.arrivalDisplayDefault()
 
     // Keep the source across launches before What's New advances its marker, so deferring a
     // choice neither loses upgrade eligibility nor opts a fresh install in.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceDialog.kt
@@ -61,7 +61,7 @@ internal fun SearchWorkflowChoiceDialog(
                 Text(AnnotatedString.fromHtml(stringResource(R.string.search_result_mode_migration_body)))
                 listOf(SearchResultMode.LISTS, SearchResultMode.MAP).forEach { mode ->
                     MigrationChoice(
-                        title = stringResource(if (mode == SearchResultMode.MAP) R.string.search_result_mode_map else R.string.search_result_mode_lists),
+                        title = stringResource(if (mode == SearchResultMode.MAP) R.string.search_result_mode_migration_map else R.string.search_result_mode_migration_lists),
                         description = stringResource(if (mode == SearchResultMode.MAP) R.string.search_result_mode_map_description else R.string.search_result_mode_lists_description),
                         previous = mode == SearchResultMode.LISTS,
                         selected = selected == mode,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceDialog.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/help/SearchWorkflowChoiceDialog.kt
@@ -42,9 +42,10 @@ internal fun SearchWorkflowChoiceDialog(
     onSave: (SearchResultMode) -> Unit,
     onDismiss: () -> Unit,
     page: Int = 1,
-    pageCount: Int = 1
+    pageCount: Int = 1,
+    initial: SearchResultMode = SearchResultMode.LISTS
 ) {
-    var selected by rememberSaveable { mutableStateOf(SearchResultMode.LISTS) }
+    var selected by rememberSaveable(initial) { mutableStateOf(initial) }
     MigrationDialog(
         title = stringResource(R.string.search_result_mode_migration_title),
         page = page,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ import org.onebusaway.android.ui.HomeActivity
 import org.onebusaway.android.ui.arrivals.ArrivalDisplayMode
 import org.onebusaway.android.ui.arrivals.components.ArrivalDisplayModeSwitch
 import org.onebusaway.android.ui.compose.components.ObaTopAppBar
+import org.onebusaway.android.ui.compose.components.SegmentedChoice
 import org.onebusaway.android.ui.compose.findActivity
 import org.onebusaway.android.ui.home.FocusTimeout
 import org.onebusaway.android.ui.searchresults.SearchResultMode
@@ -241,13 +242,20 @@ fun SettingsScreen(
             }
 
             PreferenceCategory(stringResource(R.string.preferences_category_behavior)) {
-                ListPreferenceItem(
-                    title = stringResource(R.string.search_result_mode_title),
-                    entries = listOf(stringResource(R.string.search_result_mode_map), stringResource(R.string.search_result_mode_lists)),
-                    entryValues = SearchResultMode.entries.map { it.value },
-                    selectedValue = state.searchResultMode.value,
-                    onValueSelected = { actions.onSearchResultMode(SearchResultMode.fromPreference(it)) }
-                )
+                Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                    val title = stringResource(R.string.search_result_mode_title)
+                    Text(title, style = MaterialTheme.typography.bodyLarge)
+                    SegmentedChoice(
+                        // Classic layout on the left, new on the right, as in Arrival display default.
+                        options = listOf(SearchResultMode.LISTS, SearchResultMode.MAP),
+                        selected = state.searchResultMode,
+                        onChange = actions.onSearchResultMode,
+                        label = title,
+                        optionLabel = { if (it == SearchResultMode.MAP) R.string.search_result_mode_map else R.string.search_result_mode_list },
+                        modifier = Modifier.padding(top = 8.dp),
+                        contentPadding = PaddingValues(0.dp)
+                    )
+                }
                 ListPreferenceItem(
                     title = stringResource(R.string.preferences_focus_timeout_title),
                     entries = FocusTimeout.entries.map { stringResource(it.labelRes) },

--- a/onebusaway-android/src/main/res/values-es/arrays.xml
+++ b/onebusaway-android/src/main/res/values-es/arrays.xml
@@ -19,6 +19,7 @@
         <item>Aprende con el tutorial</item>
         <item>Leyenda</item>
         <item>Novedades en esta versión</item>
+        <item>Elige tu diseño</item>
         <item>Agencias Soportadas</item>
         <item>Twitter</item>
         <item>Contactanos</item>
@@ -27,6 +28,7 @@
         <item>Aprende con el tutorial</item>
         <item>Leyenda</item>
         <item>Novedades en esta versión</item>
+        <item>Elige tu diseño</item>
         <item>Agencias Soportadas</item>
         <item>Twitter</item>
     </string-array>

--- a/onebusaway-android/src/main/res/values-fi/arrays.xml
+++ b/onebusaway-android/src/main/res/values-fi/arrays.xml
@@ -18,6 +18,7 @@
         <item>Opastus</item>
         <item>Legenda</item>
         <item>Twitter</item>
+        <item>Valitse ulkoasu</item>
         <item>Tuetut liikennöitsijät</item>
         <item>Uutta?</item>
         <item>Ota yhteyttä</item>
@@ -26,6 +27,7 @@
         <item>Opastus</item>
         <item>Legenda</item>
         <item>Twitter</item>
+        <item>Valitse ulkoasu</item>
         <item>Tuetut liikennöitsijät</item>
         <item>Uutta?</item>
     </string-array>

--- a/onebusaway-android/src/main/res/values-fi/arrays.xml
+++ b/onebusaway-android/src/main/res/values-fi/arrays.xml
@@ -17,19 +17,19 @@
     <string-array name="main_help_options">
         <item>Opastus</item>
         <item>Legenda</item>
-        <item>Twitter</item>
+        <item>Uutta?</item>
         <item>Valitse ulkoasu</item>
         <item>Tuetut liikennöitsijät</item>
-        <item>Uutta?</item>
+        <item>Twitter</item>
         <item>Ota yhteyttä</item>
     </string-array>
     <string-array name="main_help_options_no_contact_us">
         <item>Opastus</item>
         <item>Legenda</item>
-        <item>Twitter</item>
+        <item>Uutta?</item>
         <item>Valitse ulkoasu</item>
         <item>Tuetut liikennöitsijät</item>
-        <item>Uutta?</item>
+        <item>Twitter</item>
     </string-array>
     <string-array name="sort_stops">
         <item>Nimi</item>

--- a/onebusaway-android/src/main/res/values-it/arrays.xml
+++ b/onebusaway-android/src/main/res/values-it/arrays.xml
@@ -18,6 +18,7 @@
         <item>Mostra tutorial</item>
         <item>Legenda</item>
         <item>Novità</item>
+        <item>Scegli il layout</item>
         <item>Enti supportati</item>
         <item>Feed di Twitter</item>
         <item>Contattaci</item>
@@ -26,6 +27,7 @@
         <item>Mostra tutorial</item>
         <item>Legenda</item>
         <item>Novità</item>
+        <item>Scegli il layout</item>
         <item>Enti supportati</item>
         <item>Feed di Twitter</item>
     </string-array>

--- a/onebusaway-android/src/main/res/values-pl/arrays.xml
+++ b/onebusaway-android/src/main/res/values-pl/arrays.xml
@@ -19,6 +19,7 @@
         <item>Skorzystaj z samouczka</item>
         <item>Legenda</item>
         <item>Co nowego w tej wersji</item>
+        <item>Wybierz układ</item>
         <item>Obsługiwani przewoźnicy</item>
         <item>Twitter</item>
         <item>Kontakt</item>
@@ -27,6 +28,7 @@
         <item>Skorzystaj z samouczka</item>
         <item>Legenda</item>
         <item>Co nowego w tej wersji</item>
+        <item>Wybierz układ</item>
         <item>Obsługiwani przewoźnicy</item>
         <item>Twitter</item>
     </string-array>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -19,6 +19,7 @@
         <item>Show Tutorial</item>
         <item>Legend</item>
         <item>What’s New?</item>
+        <item>Choose Your Layout</item>
         <item>@string/agencies_title</item>
         <item>Twitter Feed</item>
         <item>Contact Us</item>
@@ -27,6 +28,7 @@
         <item>Show Tutorial</item>
         <item>Legend</item>
         <item>What’s New?</item>
+        <item>Choose Your Layout</item>
         <item>@string/agencies_title</item>
         <item>Twitter Feed</item>
     </string-array>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1561,7 +1561,7 @@
     <string name="migration_back">Back</string>
     <string name="migration_page">Page %1$d of %2$d</string>
     <string name="migration_continue">Continue</string>
-    <string name="migration_previous_layout">Previous layout</string>
+    <string name="migration_previous_layout">Classic layout</string>
     <string name="migration_new_layout">New layout</string>
     <string name="search_result_mode_sample_direction">Mount Baker Transit Center</string>
     <string name="search_result_mode_sample_first_stop">Denny Way &amp; Dexter Ave</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1539,7 +1539,7 @@
     <string name="arrival_display_route">Route</string>
     <string name="arrival_display_default">Arrival display default</string>
     <string name="arrival_display_choose_title">Group arrivals by route?</string>
-    <string name="arrival_display_choose_body">Choose whether to group arrivals by route. You can change this later in Settings.</string>
+    <string name="arrival_display_choose_body">Do you want to see the arrivals for a stop grouped together by &lt;b&gt;route&lt;/b&gt; or ordered by &lt;b&gt;time&lt;/b&gt;? You can change this later in Settings.</string>
     <string name="arrival_display_time_description">Each departure in time order, across all routes.</string>
     <string name="arrival_display_route_description">Departures grouped by route and direction.</string>
     <string name="tutorial_scripted_arrival_time_title">See what comes next</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1555,7 +1555,7 @@
     <string name="search_result_mode_map">Map</string>
     <string name="search_result_mode_lists">Lists and arrivals</string>
     <string name="search_result_mode_migration_title">Map-first navigation?</string>
-    <string name="search_result_mode_migration_body">Choose whether selecting stops and routes opens a &lt;b&gt;map&lt;/b&gt; by default. You can change this later in Settings.</string>
+    <string name="search_result_mode_migration_body">When you tap on a stop or a route, do you want to see it represented as a &lt;b&gt;list&lt;/b&gt; or as a &lt;b&gt;map&lt;/b&gt;? You can change this later in Settings.</string>
     <string name="search_result_mode_migration_map">Map navigation</string>
     <string name="search_result_mode_migration_lists">List navigation</string>
     <string name="search_result_mode_map_description">See the route or stop on a map, with arrivals below.</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1551,9 +1551,9 @@
     <string name="home_map">Map</string>
     <string name="stop_add_star">Add star to stop</string>
     <string name="stop_remove_star">Remove star from stop</string>
-    <string name="search_result_mode_title">Open search results in</string>
+    <string name="search_result_mode_title">Open stop/route info in</string>
     <string name="search_result_mode_map">Map</string>
-    <string name="search_result_mode_lists">Lists and arrivals</string>
+    <string name="search_result_mode_list">List</string>
     <string name="search_result_mode_migration_title">Map-first navigation?</string>
     <string name="search_result_mode_migration_body">When you tap on a stop or a route, do you want to see it represented as a &lt;b&gt;list&lt;/b&gt; or as a &lt;b&gt;map&lt;/b&gt;? You can change this later in Settings.</string>
     <string name="search_result_mode_migration_map">Map navigation</string>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -1554,8 +1554,10 @@
     <string name="search_result_mode_title">Open search results in</string>
     <string name="search_result_mode_map">Map</string>
     <string name="search_result_mode_lists">Lists and arrivals</string>
-    <string name="search_result_mode_migration_title">Use a map for search?</string>
-    <string name="search_result_mode_migration_body">Choose whether to use a &lt;b&gt;map&lt;/b&gt; or &lt;b&gt;list&lt;/b&gt; to select stops and routes. You can change this later in Settings.</string>
+    <string name="search_result_mode_migration_title">Map-first navigation?</string>
+    <string name="search_result_mode_migration_body">Choose whether selecting stops and routes opens a &lt;b&gt;map&lt;/b&gt; by default. You can change this later in Settings.</string>
+    <string name="search_result_mode_migration_map">Map navigation</string>
+    <string name="search_result_mode_migration_lists">List navigation</string>
     <string name="search_result_mode_map_description">See the route or stop on a map, with arrivals below.</string>
     <string name="search_result_mode_lists_description">Choose a direction and stop from lists, then read arrivals without using a map.</string>
     <string name="migration_back">Back</string>

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HelpViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/home/HelpViewModelTest.kt
@@ -30,6 +30,7 @@ import org.onebusaway.android.ui.home.help.HelpDialog
 import org.onebusaway.android.ui.home.help.HelpViewModel
 import org.onebusaway.android.ui.searchresults.SearchResultMode
 import org.onebusaway.android.ui.searchresults.searchResultMode
+import org.onebusaway.android.ui.tutorial.TutorialPrefs
 
 /**
  * Unit tests for [HelpViewModel]'s dialog-state transitions (migrated from HomeViewModelTest when help
@@ -226,6 +227,56 @@ class HelpViewModelTest {
         vm.dismiss()
         vm.maybeShowStartup()
         assertEquals(HelpDialog.WhatsNew, vm.state.value.dialog)
+    }
+
+    @Test
+    fun `choose your layout reopens both pages whatever is saved and finishing owes nothing`() {
+        val prefs = FakePreferencesRepository().apply {
+            setString(SearchResultMode.PREFERENCE_KEY, "lists")
+            setString(ArrivalDisplayMode.PREFERENCE_KEY, "time")
+            // Release notes unread and the tutorial offer still owed: neither may follow a revisit.
+            setInt("whatsNewVer", 0)
+        }
+        val vm = viewModel(prefs)
+        vm.showMenu()
+        vm.showLayoutChoices()
+        assertEquals(listOf(HelpDialog.SearchWorkflow, HelpDialog.ArrivalDisplay), vm.state.value.migrationPages)
+        assertEquals(HelpDialog.SearchWorkflow, vm.state.value.dialog)
+        vm.chooseSearchResultMode(SearchResultMode.MAP)
+        assertEquals(HelpDialog.ArrivalDisplay, vm.state.value.dialog)
+        vm.chooseArrivalDisplayDefault(ArrivalDisplayMode.ROUTE)
+        assertEquals(HelpDialog.None, vm.state.value.dialog)
+        assertEquals(SearchResultMode.MAP, prefs.searchResultMode())
+        assertEquals(ArrivalDisplayMode.ROUTE, prefs.arrivalDisplayDefault())
+        assertEquals(0, prefs.getInt("whatsNewVer", 0))
+        assertTrue(prefs.getBoolean(TutorialPrefs.TUTORIAL_OPT_OUT_DIALOG, true))
+    }
+
+    @Test
+    fun `a dismissed revisit closes without a release-notes or tutorial follow-up`() {
+        val prefs = FakePreferencesRepository().apply { setInt("whatsNewVer", 0) }
+        val vm = viewModel(prefs)
+        vm.showLayoutChoices()
+        vm.finishMigrationPage()
+        vm.finishMigrationPage()
+        assertEquals(HelpDialog.None, vm.state.value.dialog)
+        assertFalse(vm.state.value.revisitingLayout)
+        assertEquals(null, prefs.getString(SearchResultMode.PREFERENCE_KEY, null))
+    }
+
+    @Test
+    fun `pages start on the saved choice and otherwise on the classic layout`() {
+        val unsaved = viewModel(FakePreferencesRepository())
+        assertEquals(SearchResultMode.LISTS, unsaved.searchWorkflowStart())
+        assertEquals(ArrivalDisplayMode.TIME, unsaved.arrivalDisplayStart())
+        val saved = viewModel(
+            FakePreferencesRepository().apply {
+                setString(SearchResultMode.PREFERENCE_KEY, "map")
+                setString(ArrivalDisplayMode.PREFERENCE_KEY, "route")
+            }
+        )
+        assertEquals(SearchResultMode.MAP, saved.searchWorkflowStart())
+        assertEquals(ArrivalDisplayMode.ROUTE, saved.arrivalDisplayStart())
     }
 
     private fun viewModel(


### PR DESCRIPTION
Fixes #2321.

Adds a **Choose Your Layout** row to the Help menu, after What's New, that walks both illustrated layout pages again whatever is saved: "Use a map for search?" then "Group arrivals by route?".

- `HelpViewModel.showLayoutChoices()` sets both pages and flags the run as a revisit in `HelpUiState`. Finishing or dismissing a revisit just closes it; the release-notes dialog and the tutorial opt-out offer stay with the startup sequence.
- Each dialog takes an `initial` selection. A revisit starts on the saved choice; the upgrade flow still starts on the classic layout when nothing is saved.
- The option label **"Previous layout" becomes "Classic layout"**. "Previous" only reads right on the upgrade; from Help a year on it names nothing, while "Classic" names the same layout from either door.
- The menu is a string array indexed by `HelpAction` ordinal, so the row is added to both `main_help_options` arrays in en, es, fi, it and pl, and `HomeActivity.onHelpAction` names the new value.

- **Settings:** "Open search results in" becomes **"Open stop/route info in"**, a List | Map switch like "Arrival display default" instead of a list-in-a-dialog. Classic sits left and new right in both rows. The segmented row moves out of `ArrivalDisplayModeSwitch` into a generic `SegmentedChoice` shared by both.

### Verification

Three new `HelpViewModelTest` cases (20 total, all passing): a revisit with both choices saved shows both pages and saves new picks without advancing `whatsNewVer` or spending the tutorial offer; a dismissed revisit closes cleanly with nothing saved; pages start on the saved choice and otherwise on the classic layout. `SearchWorkflowChoiceTest` asserts the new label. Main and androidTest sources compile with `-PwarningsAsErrors=true`; `spotlessCheck` passes. Not exercised on a device.

One pre-existing oddity noticed on the way, not touched here: `values-fi/arrays.xml` has "Twitter" as its What's New row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk69DWyVVeGFhS9MFuKTLk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Choose Your Layout** option to the Help menu.
  * Users can revisit and update search workflow and arrival display choices.
  * Layout dialogs reopen with saved selections or appropriate defaults.
  * Updated terminology to “Classic layout,” “Map navigation,” and “List navigation.”
  * Added translations for the new option in Spanish, Italian, and Polish, and updated Finnish menu ordering.
  * Clarified arrival display guidance for grouping by route or ordering by time.

* **Tests**
  * Added coverage for revisiting layout choices and preserving preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
