### PR TITLE
Number this patch release 26.3.1

### DIFF
--- a/onebusaway-android/build.gradle.kts
+++ b/onebusaway-android/build.gradle.kts
@@ -62,7 +62,7 @@ android {
         // month: 26.1.0 shipped in March. See "Version numbering" in docs/RELEASING.md, and bump it
         // by hand.
         versionCode = 153
-        versionName = "26.3.0"
+        versionName = "26.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to **26.3.1**. That is the only change, matching the shape of the 26.2.1 patch: the release notes in `src/oba/play/release-notes/en-US/default.txt` and `main_help_whatsnew` stay exactly as they were for 26.3.0. `versionCode` is untouched; Play's AUTO resolution assigns it at release time.

### What the patch picks up since v26.3.0

- #2320 — Route every stop focus through one mode-aware opener (#2319)
- #2322 — Add a Choose Your Layout entry to Help and call the old layout Classic (#2321)

Both are covered by the existing "Several small bug fixes" line, so the notes are not reworded.

Release plan after merge: dispatch **Release to Google Play** on the merge commit with `track: alpha`, `release_status: completed`, then tag `v26.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U96fA1BcYPAx28VbQbZ4wa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android app version to 26.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->